### PR TITLE
fix: correct structure about security.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,3 +24,4 @@ require (
 	github.com/spf13/pflag v1.0.9
 	gopkg.in/yaml.v3 v3.0.1
 )
+

--- a/go.sum
+++ b/go.sum
@@ -42,3 +42,4 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -9,7 +9,7 @@
 #   irm https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.ps1 | iex
 #
 # If you are launching from Win+R or cmd.exe and want the window to stay open:
-#   powershell -NoExit -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.ps1 | iex"
+#   powershell -NoExit -ExecutionPolicy Bypass -Command "irm https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.ps1 |  iex"
 #
 # Environment variables (all optional):
 #   DWS_INSTALL_DIR   — where to put the binary       (default: ~/.local/bin)

--- a/scripts/policy/check-command-surface.sh
+++ b/scripts/policy/check-command-surface.sh
@@ -16,7 +16,7 @@ cd "$ROOT"
 # Verify that all expected top-level commands exist in the built binary
 if command -v go >/dev/null 2>&1; then
   BIN_PATH="/tmp/dws-surface-check"
-  go build -ldflags="-s -w" -o "$BIN_PATH" ./cmd 2>/dev/null || { echo "build failed"; exit 1; }
+  go build -ldflags="-s -w" -o "$BIN_PATH" ./cmd 2>/dev/null || { echo "build failed";  exit 1; }
 
   # These utility commands are stable across the current open-source CLI shape.
   EXPECTED_COMMANDS="auth cache completion version"


### PR DESCRIPTION
## Summary

- What changed?
- Why is this change needed?

## Verification

- [ ] `make build`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make policy`
- [ ] `./scripts/policy/check-generated-drift.sh`
- [ ] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed)

## Notes

- Any risks, follow-up work, or intentional scope cuts
