### PR TITLE
docs: simplify getting started section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,11 @@ cp dws ~/.local/bin/         # install to PATH
 ## Getting Started
 
 ```bash
-dws auth login
+dws auth login            # browser opens automatically
+dws auth login --device   # for headless environments (Docker, SSH, CI)
 ```
 
-The browser opens automatically — select your organization and authorize. That's it.
-
-<p align="center">
-  <img src="https://img.alicdn.com/imgextra/i2/O1CN01c6blXk28YrsF8rqDt_!!6000000007945-2-tps-2244-762.png" alt="Authorization Successful" width="600">
-</p>
+Select your organization and authorize. That's it.
 
 > If your organization hasn't enabled CLI access, you'll be prompted to send an access request to your admin. Once approved, re-run `dws auth login`.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -88,14 +88,11 @@ cp dws ~/.local/bin/         # 安装到 PATH
 ## 开始使用
 
 ```bash
-dws auth login
+dws auth login            # 自动唤起浏览器
+dws auth login --device   # 无浏览器环境（Docker、SSH、CI）
 ```
 
-浏览器自动打开 — 选择组织并授权即可。
-
-<p align="center">
-  <img src="https://img.alicdn.com/imgextra/i2/O1CN01c6blXk28YrsF8rqDt_!!6000000007945-2-tps-2244-762.png" alt="授权成功" width="600">
-</p>
+选择组织并授权即可。
 
 > 如果组织尚未开启 CLI 访问权限，系统会引导你向管理员发送申请。审批通过后重新执行 `dws auth login` 即可。
 


### PR DESCRIPTION
## Summary
- Show both `dws auth login` and `dws auth login --device` commands upfront in Getting Started
- Remove authorization screenshot image for cleaner layout
- Apply same changes to both README.md and README_zh.md

## Test plan
- [x] `go vet` and `staticcheck` pass
- [x] All 6 test suites pass