### PR TITLE
Version unify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Post-release packaging
         run: ./scripts/release/post-goreleaser.sh
+        env:
+          DWS_PACKAGE_VERSION: ${{ github.ref_name }}
 
       - name: Upload dws-skills.zip to release
         env:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.8
 require (
 	github.com/fatih/color v1.18.0
 	github.com/google/uuid v1.6.0
+	github.com/itchyny/gojq v0.12.18
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.49.0
@@ -15,7 +16,6 @@ require (
 require (
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
-	github.com/itchyny/gojq v0.12.18 // indirect
 	github.com/itchyny/timefmt-go v0.1.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/scripts/dev/test-release.sh
+++ b/scripts/dev/test-release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+VERSION="v1.0.6"
+
+echo "==> Running GoReleaser snapshot..."
+goreleaser release --snapshot --clean
+
+echo "==> Running post-goreleaser.sh..."
+DWS_PACKAGE_VERSION=$VERSION ./scripts/release/post-goreleaser.sh
+
+echo "==> Verifying artifacts..."
+echo "Binary version:"
+./dist/dws-darwin-arm64/dws version 2>/dev/null || ./dist/dws-linux-amd64/dws version
+
+echo "npm package.json:"
+cat dist/npm/dingtalk-workspace-cli/package.json | grep '"version"'
+
+echo "dws-skills.zip:"
+ls -lh dist/dws-skills.zip
+
+echo "==> npm publish dry-run..."
+cd dist/npm/dingtalk-workspace-cli
+npm publish --access public --dry-run
+
+echo "==> All checks passed!"

--- a/scripts/release/post-goreleaser.sh
+++ b/scripts/release/post-goreleaser.sh
@@ -53,14 +53,23 @@ detect_arch() {
 }
 
 resolve_version() {
+  # Priority 1: Use DWS_PACKAGE_VERSION environment variable (set by CI)
   if [ -n "$PACKAGE_VERSION" ]; then
-    printf '%s\n' "$PACKAGE_VERSION"
+    # Strip leading 'v' if present for semver compatibility
+    printf '%s\n' "$PACKAGE_VERSION" | sed 's/^v//'
     return
   fi
 
+  # Priority 2: Get version from git tag (for local snapshot builds with tag)
+  if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+    git describe --tags --exact-match HEAD | sed 's/^v//'
+    return
+  fi
+
+  # Priority 3: Read from version.go (for local development without tag)
   version_line="$(sed -n 's/^var version = "v\{0,1\}\([^"]*\)".*/\1/p' "$ROOT/internal/app/version.go" | head -1)"
-  if [ -z "$version_line" ]; then
-    err "could not resolve package version from internal/app/version.go"
+  if [ -z "$version_line" ] || [ "$version_line" = "dev" ]; then
+    err "could not resolve package version - set DWS_PACKAGE_VERSION or create a git tag"
   fi
   printf '%s\n' "$version_line"
 }


### PR DESCRIPTION
fix: unify version management with Git tag as single source of truth

Changes:
- README.md/README_zh.md: replace static badge with dynamic shields.io badge
- internal/app/version.go: change hardcoded version to "dev"
- .github/workflows/release.yml: pass DWS_PACKAGE_VERSION from git tag
- scripts/release/post-goreleaser.sh: enhance resolve_version() to strip v prefix

Version resolution priority:
1. DWS_PACKAGE_VERSION env var (CI sets from git tag)
2. Git tag (local builds with tag)
3. version.go fallback (errors if "dev")

This fixes:
- npm publish failing with "Invalid version: dev"
- README badge not auto-updating
- Multiple version sources requiring manual sync