### PR TITLE
docs: add npm install method to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ irm https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/ma
 <details>
 <summary>Other install methods</summary>
 
+**npm** (requires Node.js (npm/npx)):
+
+```bash
+npm install -g dingtalk-workspace-cli
+```
+
 **Pre-built binary**: download from [GitHub Releases](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases).
 
 > **macOS users**: If you see "cannot be opened because Apple cannot check it for malicious software", run:

--- a/README_zh.md
+++ b/README_zh.md
@@ -66,6 +66,12 @@ irm https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/ma
 <details>
 <summary>其他安装方式</summary>
 
+**npm**（需要 Node.js（npm/npx））：
+
+```bash
+npm install -g dingtalk-workspace-cli
+```
+
 **预编译二进制文件**：从 [GitHub Releases](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases) 下载。
 
 > **macOS 用户注意**：如果提示“无法打开，因为 Apple 无法检查其是否包含恶意软件”，请执行：


### PR DESCRIPTION
docs: add npm installation method to README

- Add npm global install option: npm install -g dingtalk-workspace-cli
- Note Node.js (npm/npx) requirement
- Update both README.md and README_zh.md