### PR TITLE
feat(auth): add edition overlay auth credentials and token marker for embedded mode

### DIFF
--- a/internal/auth/endpoints.go
+++ b/internal/auth/endpoints.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
 
 const (
@@ -110,7 +112,7 @@ func SetClientIDFromMCP(id string) {
 func IsClientIDFromMCP() bool {
 	clientMu.RLock()
 	defer clientMu.RUnlock()
-	return clientIDFromMCP
+	return clientIDFromMCP || edition.Get().AuthClientFromMCP
 }
 
 // GetUserAccessTokenURL returns the appropriate token exchange URL.
@@ -188,6 +190,9 @@ func ClientID() string {
 	clientMu.RUnlock()
 	if override != "" {
 		return override
+	}
+	if id := edition.Get().AuthClientID; id != "" {
+		return id
 	}
 	// Try loading from persisted app config
 	if id, _ := ResolveAppCredentials(getDefaultConfigDir()); id != "" {

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -20,7 +20,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
 
 // TokenData holds the OAuth token set persisted to disk.
@@ -61,10 +65,46 @@ func (t *TokenData) HasPersistentCode() bool {
 	return t != nil && t.PersistentCode != ""
 }
 
+const tokenJSONFile = "token.json"
+
+// TokenMarker is a lightweight file the host application reads to detect
+// whether the CLI has a valid token without accessing the keychain.
+type TokenMarker struct {
+	UpdatedAt string `json:"updated_at"`
+}
+
+// WriteTokenMarker writes a token.json marker containing only an updated_at
+// timestamp. The host application uses this file's presence and mtime to
+// decide whether it needs to trigger a new auth exchange.
+func WriteTokenMarker(configDir string) error {
+	marker := TokenMarker{UpdatedAt: time.Now().Format(time.RFC3339)}
+	data, _ := json.MarshalIndent(marker, "", "  ")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return err
+	}
+	tmp := filepath.Join(configDir, tokenJSONFile+".tmp")
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, filepath.Join(configDir, tokenJSONFile))
+}
+
+// DeleteTokenMarker removes the token.json marker file.
+func DeleteTokenMarker(configDir string) error {
+	return os.Remove(filepath.Join(configDir, tokenJSONFile))
+}
+
 // SaveTokenData saves TokenData to the platform keychain.
-// Uses the new keychain-based storage with random master key for better security.
+// In embedded mode, it also writes a token.json marker file so the host
+// application can detect authentication state without accessing the keychain.
 func SaveTokenData(configDir string, data *TokenData) error {
-	return SaveTokenDataKeychain(data)
+	if err := SaveTokenDataKeychain(data); err != nil {
+		return err
+	}
+	if edition.Get().IsEmbedded {
+		_ = WriteTokenMarker(configDir)
+	}
+	return nil
 }
 
 // LoadTokenData reads TokenData from the platform keychain.
@@ -91,14 +131,13 @@ func LoadTokenData(configDir string) (*TokenData, error) {
 }
 
 // DeleteTokenData removes token data from both keychain and legacy storage.
+// In embedded mode, it also removes the token.json marker file.
 func DeleteTokenData(configDir string) error {
-	// Delete from keychain
 	keychainErr := DeleteTokenDataKeychain()
-
-	// Also clean up any legacy .data file
 	legacyErr := DeleteSecureData(configDir)
-
-	// Return keychain error if any, otherwise legacy error
+	if edition.Get().IsEmbedded {
+		_ = DeleteTokenMarker(configDir)
+	}
 	if keychainErr != nil {
 		return keychainErr
 	}

--- a/pkg/edition/edition.go
+++ b/pkg/edition/edition.go
@@ -77,6 +77,10 @@ type Hooks struct {
 	OnAuthError   func(configDir string, err error) error
 	TokenProvider func(ctx context.Context, fallback func() (string, error)) (string, error)
 
+	// --- auth credentials (overlay-only) ---
+	AuthClientID      string // non-empty overrides DefaultClientID
+	AuthClientFromMCP bool   // true routes OAuth through MCP endpoints
+
 	// --- product & endpoint ---
 	StaticServers         func() []ServerInfo                          // non-nil → skip Market discovery
 	VisibleProducts       func() []string                              // non-nil → override help visibility


### PR DESCRIPTION
## Summary

This PR enables private overlay editions to supply their own OAuth credentials
and introduces a lightweight token marker mechanism for embedded (host-app)
deployments.

## Changes

### Edition auth credential overrides (`pkg/edition/edition.go`)
- Add `AuthClientID` field to `Hooks` — when non-empty, it overrides the
  built-in `DefaultClientID` so overlays can ship their own OAuth app.
- Add `AuthClientFromMCP` field to `Hooks` — when true, forces OAuth traffic
  through the MCP proxy endpoints regardless of runtime state.

### Credential resolution (`internal/auth/endpoints.go`)
- `ClientID()` now checks `edition.Get().AuthClientID` between runtime flag
  overrides and persisted app config, giving overlays a stable fallback.
- `IsClientIDFromMCP()` now returns true when the edition hook sets
  `AuthClientFromMCP`, ensuring MCP endpoint routing for overlay builds.

### Token marker for embedded mode (`internal/auth/token.go`)
- Introduce `TokenMarker` struct and `WriteTokenMarker` / `DeleteTokenMarker`
  helpers that maintain a minimal `token.json` file containing only an
  `updated_at` timestamp.
- `SaveTokenData` now writes the marker after a successful keychain save when
  `IsEmbedded` is true, allowing the host application to detect auth state
  via file presence/mtime without accessing the platform keychain.
- `DeleteTokenData` now removes the marker file in embedded mode to keep auth
  state consistent.

## Motivation

Overlay editions (e.g. an internal enterprise distribution) need to:
1. Ship pre-configured OAuth credentials without patching core constants.
2. Optionally force MCP-proxied auth flow for environments where direct
   DingTalk API access is restricted.
3. Let a host application (e.g. Electron wrapper) detect CLI auth state
   cheaply — reading a JSON file is far simpler and more portable than
   querying the OS keychain from a different process.