### PR TITLE
feat(errors): add ExitCoder/RawStderrError interfaces and ClassifyToolResult hook

### DIFF
--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -15,6 +15,7 @@ package app
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -123,6 +124,11 @@ func flagErrorWithSuggestions(cmd *cobra.Command, err error) error {
 }
 
 func printExecutionError(root *cobra.Command, stdout, stderr io.Writer, err error) error {
+	var raw apperrors.RawStderrError
+	if stderrors.As(err, &raw) {
+		_, writeErr := fmt.Fprintln(stderr, raw.RawStderr())
+		return writeErr
+	}
 	if wantsJSONErrors(root) {
 		return apperrors.PrintJSON(stdout, err)
 	}

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -231,6 +231,12 @@ func (r *runtimeRunner) executeInvocation(ctx context.Context, endpoint string, 
 		return executor.Result{}, err
 	}
 
+	if fn := edition.Get().ClassifyToolResult; fn != nil {
+		if editionErr := fn(callResult.Content); editionErr != nil {
+			return executor.Result{}, editionErr
+		}
+	}
+
 	if callResult.IsError {
 		diag := transport.ExtractServerDiagnosticsFromMap(callResult.Content)
 		logBusinessError(r.transport.FileLogger, "mcp_tool_error", invocation, callResult.Content, diag)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -198,11 +198,30 @@ func NewInternal(message string, opts ...Option) error {
 	return newError(CategoryInternal, message, opts...)
 }
 
+// ExitCoder is implemented by errors that provide their own exit code.
+// Edition-specific error types (e.g. PATError, CLIError) implement this
+// so the framework can resolve exit codes without importing edition packages.
+type ExitCoder interface {
+	ExitCode() int
+}
+
+// RawStderrError is implemented by errors that must output raw content
+// directly to stderr, bypassing all CLI formatting (e.g. "Error:" prefix).
+// PAT authorization errors use this to pass JSON through to the desktop runtime.
+type RawStderrError interface {
+	error
+	RawStderr() string
+}
+
 // ExitCode maps any error to a stable exit code.
 func ExitCode(err error) int {
 	var typed *Error
 	if stderrors.As(err, &typed) {
 		return typed.ExitCode()
+	}
+	var ec ExitCoder
+	if stderrors.As(err, &ec) {
+		return ec.ExitCode()
 	}
 	return 5
 }

--- a/internal/errors/exit_coder_test.go
+++ b/internal/errors/exit_coder_test.go
@@ -8,8 +8,8 @@ import (
 
 type stubExitCoder struct{ code int }
 
-func (s *stubExitCoder) Error() string   { return "stub" }
-func (s *stubExitCoder) ExitCode() int   { return s.code }
+func (s *stubExitCoder) Error() string { return "stub" }
+func (s *stubExitCoder) ExitCode() int { return s.code }
 
 type stubRawStderr struct{ raw string }
 

--- a/internal/errors/exit_coder_test.go
+++ b/internal/errors/exit_coder_test.go
@@ -1,0 +1,59 @@
+package errors
+
+import (
+	stderrors "errors"
+	"strings"
+	"testing"
+)
+
+type stubExitCoder struct{ code int }
+
+func (s *stubExitCoder) Error() string   { return "stub" }
+func (s *stubExitCoder) ExitCode() int   { return s.code }
+
+type stubRawStderr struct{ raw string }
+
+func (s *stubRawStderr) Error() string     { return s.raw }
+func (s *stubRawStderr) RawStderr() string { return s.raw }
+
+func TestExitCode_ExitCoderInterface(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"exit code 4 via interface", &stubExitCoder{code: 4}, 4},
+		{"exit code 1 via interface", &stubExitCoder{code: 1}, 1},
+		{"framework Error takes precedence", NewAPI("api"), 1},
+		{"plain error falls back to 5", stderrors.New("plain"), 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ExitCode(tc.err); got != tc.want {
+				t.Errorf("ExitCode() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExitCode_WrappedExitCoder(t *testing.T) {
+	t.Parallel()
+	wrapped := stderrors.Join(stderrors.New("context"), &stubExitCoder{code: 4})
+	if got := ExitCode(wrapped); got != 4 {
+		t.Errorf("ExitCode(wrapped) = %d, want 4", got)
+	}
+}
+
+func TestRawStderrError_Interface(t *testing.T) {
+	t.Parallel()
+	err := &stubRawStderr{raw: `{"code":"PAT_LOW_RISK_NO_PERMISSION"}`}
+	var raw RawStderrError
+	if !stderrors.As(err, &raw) {
+		t.Fatal("expected errors.As to match RawStderrError")
+	}
+	if !strings.Contains(raw.RawStderr(), "PAT_LOW_RISK_NO_PERMISSION") {
+		t.Errorf("RawStderr() = %q, want PAT code", raw.RawStderr())
+	}
+}

--- a/pkg/edition/edition.go
+++ b/pkg/edition/edition.go
@@ -97,6 +97,13 @@ type Hooks struct {
 	// global setup (OAuth flag overrides, log level, output sink). Overlays use
 	// this for clients that bypass the MCP runner (e.g. A2A gateway).
 	AfterPersistentPreRun func(cmd *cobra.Command, args []string) error
+
+	// ClassifyToolResult is called before the framework's default business-error
+	// detection on MCP tool results. If it returns a non-nil error, that error
+	// is used instead of the generic CategoryAPI business error. Editions use
+	// this to return custom error types with specific exit codes (e.g. PAT
+	// authorization errors with exit code 4).
+	ClassifyToolResult func(content map[string]any) error
 }
 
 var (


### PR DESCRIPTION
Motivation
Edition overlays (e.g. the Real/Wukong platform) need to return custom error types with specific exit codes and raw stderr output from MCP tool results. The current error framework only supports the internal *Error type, making it impossible for editions to influence exit codes or bypass CLI formatting without importing internal packages.
Changes
internal/errors/errors.go – Introduce two new interfaces:
ExitCoder – allows any error type to provide its own exit code.
RawStderrError – allows errors to output raw content directly to stderr, bypassing all CLI formatting (e.g. the "Error:" prefix).
Update ExitCode() to check for the ExitCoder interface before falling back to the default exit code 5.
pkg/edition/edition.go – Add ClassifyToolResult func(content map[string]any) error to Hooks, enabling editions to inspect MCP tool results and return custom error types (e.g. PAT authorization errors with exit code 4).
internal/app/runner.go – Invoke ClassifyToolResult hook after a successful MCP tool call but before the framework's default business-error detection, so edition-specific errors take precedence.
internal/app/root.go – Handle RawStderrError in printExecutionError to write raw JSON directly to stderr for the desktop runtime to consume.
internal/errors/exit_coder_test.go – Add unit tests covering ExitCoder interface resolution (direct, wrapped, precedence over default), and RawStderrError interface matching.