### PR TITLE
feat(plugin): stdio subprocess identity injection and lifecycle management

### DIFF
--- a/internal/app/plugin_cmd.go
+++ b/internal/app/plugin_cmd.go
@@ -190,6 +190,8 @@ func newPluginRemoveCommand() *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Stop stdio clients before removing to release file locks
+			StopStdioClientsByPlugin(args[0])
 			keepData, _ := cmd.Flags().GetBool("keep-data")
 			loader := plugin.NewLoader(RawVersion())
 			if err := loader.RemovePlugin(args[0], keepData); err != nil {

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -67,6 +67,7 @@ func Execute() (exitCode int) {
 
 	timing := NewTimingCollector()
 	defer func() {
+		StopAllStdioClients() // Ensure child processes are terminated on exit
 		timing.PrintIfEnabled()
 		timing.WriteReportIfEnabled(RawVersion(), SanitizeCommand(os.Args))
 	}()
@@ -272,6 +273,7 @@ func NewRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine) 
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			StopAllStdioClients()
 			CloseFileLogger()
 			return closeOutputSink(cmd)
 		},
@@ -1427,7 +1429,8 @@ func registerStdioServer(p *plugin.Plugin, sc plugin.StdioServerClient, runner e
 	}
 
 	AppendDynamicServer(descriptor)
-	RegisterStdioClient(serverID, sc.Client)
+	// Register with pluginName/serverKey format for cleanup by plugin name
+	RegisterStdioClient(p.Manifest.Name+"/"+serverID, sc.Client)
 
 	// Convert tool descriptors to DetailTool entries for flag generation.
 	detailsByID := make(map[string][]market.DetailTool)

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -1036,8 +1036,23 @@ func loadPlugins(engine *pipeline.Engine, runner executor.Runner) []*cobra.Comma
 
 	// 0a. Ensure default managed plugins are installed (first-run bootstrap).
 	updater := plugin.NewUpdater(pluginLoader.PluginsDir, RawVersion())
-	accessToken, tokenErr := loadSkillAccessToken()
-	if tokenErr == nil && accessToken != "" {
+	// Load TokenData once; reuse for plugin bootstrap, updates, and stdio injection.
+	tokenData, _ := authpkg.LoadTokenData(defaultConfigDir())
+	var userCtx *plugin.UserContext
+	if tokenData != nil {
+		// Inject user context if either UserID or CorpID is present.
+		if tokenData.UserID != "" || tokenData.CorpID != "" {
+		userCtx = &plugin.UserContext{
+			UserID: tokenData.UserID,
+			CorpID: tokenData.CorpID,
+		}
+	}
+	}
+	accessToken := ""
+	if tokenData != nil && tokenData.IsAccessTokenValid() {
+		accessToken = tokenData.AccessToken
+	}
+	if accessToken != "" {
 		bootstrapCtx, bootstrapCancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		installed := updater.EnsureManaged(bootstrapCtx, accessToken, os.Stderr)
 		bootstrapCancel()
@@ -1121,7 +1136,7 @@ func loadPlugins(engine *pipeline.Engine, runner executor.Runner) []*cobra.Comma
 
 	// 4. Start stdio MCP servers, discover tools, and build CLI commands
 	for _, p := range allPlugins {
-		for _, sc := range p.StdioClients() {
+		for _, sc := range p.StdioClients(userCtx) {
 			// Use background context so the subprocess lives for the CLI
 			// process lifetime (not killed by a short timeout).
 			if err := sc.Client.Start(context.Background()); err != nil {

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -1044,11 +1044,11 @@ func loadPlugins(engine *pipeline.Engine, runner executor.Runner) []*cobra.Comma
 	if tokenData != nil {
 		// Inject user context if either UserID or CorpID is present.
 		if tokenData.UserID != "" || tokenData.CorpID != "" {
-		userCtx = &plugin.UserContext{
-			UserID: tokenData.UserID,
-			CorpID: tokenData.CorpID,
+			userCtx = &plugin.UserContext{
+				UserID: tokenData.UserID,
+				CorpID: tokenData.CorpID,
+			}
 		}
-	}
 	}
 	accessToken := ""
 	if tokenData != nil && tokenData.IsAccessTokenValid() {

--- a/internal/app/stdio_registry.go
+++ b/internal/app/stdio_registry.go
@@ -14,6 +14,7 @@
 package app
 
 import (
+	"log/slog"
 	"strings"
 	"sync"
 
@@ -37,11 +38,24 @@ func RegisterStdioClient(productID string, client *transport.StdioClient) {
 }
 
 // LookupStdioClient returns the StdioClient registered for the given product ID.
+// The productID can be either the full key (pluginName/serverKey) or just the serverKey.
+// This supports backward compatibility with existing CanonicalProduct values.
 func LookupStdioClient(productID string) (*transport.StdioClient, bool) {
 	stdioMu.RLock()
 	defer stdioMu.RUnlock()
-	c, ok := stdioClients[productID]
-	return c, ok
+	// Try exact match first
+	if c, ok := stdioClients[productID]; ok {
+		return c, true
+	}
+	// If not found, try matching by serverKey suffix (for backward compatibility)
+	for id, c := range stdioClients {
+		if idx := strings.LastIndex(id, "/"); idx >= 0 {
+			if id[idx+1:] == productID {
+				return c, true
+			}
+		}
+	}
+	return nil, false
 }
 
 // StdioEndpoint returns a virtual endpoint URL for a stdio-based MCP server.
@@ -53,4 +67,53 @@ func StdioEndpoint(pluginName, serverKey string) string {
 // IsStdioEndpoint returns true if the endpoint uses the stdio:// scheme.
 func IsStdioEndpoint(endpoint string) bool {
 	return strings.HasPrefix(endpoint, stdioEndpointScheme)
+}
+
+// StopAllStdioClients stops all registered stdio clients.
+// This should be called on program exit to terminate child processes.
+func StopAllStdioClients() {
+	stdioMu.Lock()
+	defer stdioMu.Unlock()
+	for id, client := range stdioClients {
+		if err := client.Stop(); err != nil {
+			slog.Warn("failed to stop stdio client", "id", id, "error", err)
+		}
+	}
+	stdioClients = make(map[string]*transport.StdioClient)
+}
+
+// StopStdioClient stops a specific stdio client by product ID.
+// Returns true if the client was found and stopped, false otherwise.
+func StopStdioClient(productID string) bool {
+	stdioMu.Lock()
+	defer stdioMu.Unlock()
+	client, ok := stdioClients[productID]
+	if !ok {
+		return false
+	}
+	if err := client.Stop(); err != nil {
+		slog.Warn("failed to stop stdio client", "id", productID, "error", err)
+	}
+	delete(stdioClients, productID)
+	return true
+}
+
+// StopStdioClientsByPlugin stops all stdio clients belonging to a plugin.
+// The productID format is "pluginName/serverKey". This function stops all
+// clients whose productID has the given pluginName prefix.
+func StopStdioClientsByPlugin(pluginName string) int {
+	stdioMu.Lock()
+	defer stdioMu.Unlock()
+	prefix := pluginName + "/"
+	count := 0
+	for id, client := range stdioClients {
+		if len(id) > len(prefix) && id[:len(prefix)] == prefix {
+			if err := client.Stop(); err != nil {
+				slog.Warn("failed to stop stdio client", "id", id, "error", err)
+			}
+			delete(stdioClients, id)
+			count++
+		}
+	}
+	return count
 }

--- a/internal/plugin/converter.go
+++ b/internal/plugin/converter.go
@@ -24,6 +24,13 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/transport"
 )
 
+// UserContext holds the minimal user identity fields injected into
+// stdio plugin subprocesses via environment variables.
+type UserContext struct {
+	UserID string
+	CorpID string
+}
+
 // StdioServerClient pairs a transport.StdioClient with its server key.
 type StdioServerClient struct {
 	Key    string
@@ -31,8 +38,11 @@ type StdioServerClient struct {
 }
 
 // StdioClients returns StdioClient instances for all stdio-type MCP
-// servers declared by this plugin.
-func (p *Plugin) StdioClients() []StdioServerClient {
+// servers declared by this plugin. uc is the current user's identity;
+// if non-nil, DWS_USER_ID and DWS_CORP_ID are injected as environment
+// variables so that the subprocess can identify the caller without
+// implementing its own auth.
+func (p *Plugin) StdioClients(uc *UserContext) []StdioServerClient {
 	var clients []StdioServerClient
 	for key, srv := range p.Manifest.MCPServers {
 		if srv.Type != "stdio" {
@@ -59,6 +69,16 @@ func (p *Plugin) StdioClients() []StdioServerClient {
 		}
 		env["DWS_PLUGIN_ROOT"] = p.Root
 		env["DWS_PLUGIN_DATA"] = filepath.Join(filepath.Dir(filepath.Dir(p.Root)), "data", p.Manifest.Name)
+
+		// Inject user identity so the subprocess knows who is calling.
+		if uc != nil {
+			if uc.UserID != "" {
+				env["DWS_USER_ID"] = uc.UserID
+			}
+			if uc.CorpID != "" {
+				env["DWS_CORP_ID"] = uc.CorpID
+			}
+		}
 
 		sc := transport.NewStdioClient(command, args, env)
 		clients = append(clients, StdioServerClient{Key: key, Client: sc})


### PR DESCRIPTION
## Summary

Two changes for stdio plugin subprocess management:

1. **User Identity Injection**: Inject `DWS_USER_ID` and `DWS_CORP_ID` env vars into stdio plugin subprocesses, enabling plugins to identify the caller without implementing OAuth.

2. **Lifecycle Management**: Ensure child processes terminate on parent exit or plugin removal. Fixes Windows "Access is denied" error when removing plugins.

## Commits

- `e21949c` feat(plugin): inject user identity (UserID, CorpID) into stdio plugin subprocesses
- `e887207` fix(plugin): stop stdio child processes on exit and before removal
