### PR TITLE
fix: stabilize PAT frontend contract

### DIFF
--- a/docs/pat-integration.md
+++ b/docs/pat-integration.md
@@ -1,0 +1,70 @@
+# PAT Frontend Integration Guide
+
+This note is for desktop integrator teams that consume `dws` CLI PAT authorization failures and render a first-class auth flow.
+
+## What the CLI emits
+
+When `dws` hits a PAT authorization failure, it writes the raw JSON payload to `stderr` and does not wrap it in the normal CLI error formatter.
+
+The CLI normalizes the payload to a small envelope:
+
+```json
+{
+  "success": false,
+  "code": "PAT_NO_PERMISSION",
+  "data": {
+    "requiredScopes": ["..."],
+    "grantOptions": ["..."],
+    "authRequestId": "...",
+    "flowId": "..."
+  }
+}
+```
+
+The backend may also surface the same error selector under `error_code` in some responses. Frontends should accept both `code` and `error_code`.
+Wrapper keys such as `success`, `message`, `error`, `trace_id`, and `class` should be treated as transport noise, not the contract surface.
+
+Known PAT selectors in the CLI:
+
+- `PAT_NO_PERMISSION`
+- `PAT_LOW_RISK_NO_PERMISSION`
+- `PAT_MEDIUM_RISK_NO_PERMISSION`
+- `PAT_HIGH_RISK_NO_PERMISSION`
+- `AGENT_CODE_NOT_EXISTS`
+
+## Fields to expect
+
+- `code` / `error_code`: stable selector for PAT-related failures. Treat it as the primary machine-readable discriminator.
+- `success`: always `false` for this path.
+- `data.requiredScopes`: the scopes that are missing or need approval.
+- `data.grantOptions`: one or more authorization choices the UI can present to the user.
+- `data.authRequestId`: correlation id for the auth request. Keep it unchanged in logs, UI state, and follow-up actions.
+- `data.flowId`: device-flow or approval-flow identifier. Use it to poll authorization status when present.
+
+Additional fields may appear in `data` depending on the upstream service. Preserve unknown fields for diagnostics.
+
+## Exit behavior
+
+- PAT authorization failures exit with code `4`.
+- The CLI sends the raw JSON payload to `stderr`.
+- If `flowId` is missing, the CLI cannot poll and will return the PAT payload to the host app instead of continuing locally.
+- For non-PAT auth failures, do not assume exit code `4`; PAT handling is a separate path.
+
+## Recommended frontend behavior
+
+Follow a RewindDesktop-style pattern:
+
+1. Detect the PAT payload as soon as `stderr` is available.
+2. Treat it as a recoverable authorization event, not a generic error toast.
+3. Open a dedicated authorization surface with the requested scopes and any grant options.
+4. If `flowId` is present, poll the approval status using that id.
+5. If `authRequestId` is present, bind the UI state to it so retries and logs stay correlated.
+6. If the user approves, resume the original command path.
+7. If the user rejects, the flow expires, or the request is cancelled, close the auth UI and show a retryable failure.
+
+## Practical parsing rules
+
+- Prefer `code` first, then fall back to `error_code`.
+- Do not depend on top-level `message` or other wrapper fields; keep the JSON payload intact and read from `data`.
+- Ignore unknown keys so the contract can evolve without breaking the frontend.
+- If the payload includes both `requiredScopes` and `grantOptions`, render `requiredScopes` as the reason and `grantOptions` as the action set.

--- a/docs/pat-integration.md
+++ b/docs/pat-integration.md
@@ -2,6 +2,13 @@
 
 This note is for desktop integrator teams that consume `dws` CLI PAT authorization failures and render a first-class auth flow.
 
+## Audience map
+
+- Frontend/Desktop team: parse PAT stderr JSON, render the approval UI, resume the original task.
+- CLI/Backend team: keep the PAT JSON envelope stable and avoid mixing human-readable text into passthrough payloads.
+- QA team: validate exit code, stderr JSON shape, retry behavior, and legacy `error_code` compatibility.
+- Product/Integration owner: use the selector matrix below to decide which approval UX to build first.
+
 ## What the CLI emits
 
 When `dws` hits a PAT authorization failure, it writes the raw JSON payload to `stderr` and does not wrap it in the normal CLI error formatter.
@@ -68,3 +75,24 @@ Follow a RewindDesktop-style pattern:
 - Do not depend on top-level `message` or other wrapper fields; keep the JSON payload intact and read from `data`.
 - Ignore unknown keys so the contract can evolve without breaking the frontend.
 - If the payload includes both `requiredScopes` and `grantOptions`, render `requiredScopes` as the reason and `grantOptions` as the action set.
+
+## Team checklist
+
+### Frontend/Desktop
+
+- Treat exit code `4` as a recoverable PAT event.
+- Parse stderr as JSON before showing any generic failure UI.
+- Persist `authRequestId` and `flowId` in local UI state so the retry path stays correlated.
+- Keep unknown `data.*` fields for diagnostics rather than dropping them.
+
+### CLI/Backend
+
+- Keep raw PAT passthrough on stderr clean for no-`flowId` cases.
+- Continue accepting upstream `code`, `errorCode`, and `error_code`.
+- Do not silently rename `data.requiredScopes`, `data.grantOptions`, `data.authRequestId`, or `data.flowId`.
+
+### QA
+
+- Verify both `code` and `error_code` inputs trigger PAT classification.
+- Verify no-`flowId` PAT responses contain only JSON on stderr.
+- Verify `flowId` responses still enter the local retry flow when the CLI owns the auth loop.

--- a/internal/app/pat_auth_retry.go
+++ b/internal/app/pat_auth_retry.go
@@ -362,6 +362,7 @@ func handlePatAuthCheck(
 
 	// Inject clientId/clientSecret from PAT response as runtime credentials
 	// so that subsequent device flow auth uses the server-assigned app identity.
+	var appCfg *authpkg.AppConfig
 	if patData.Data.ClientID != "" {
 		if patData.Data.ClientSecret != "" {
 			// When both clientId and clientSecret are provided, use direct mode
@@ -377,12 +378,24 @@ func handlePatAuthCheck(
 		// Persist clientId (and optionally secret) to ~/.dws/app.json so that
 		// future process invocations can load it at startup and populate
 		// DWS_CLIENT_ID env before the first MCP request.
-		appCfg := &authpkg.AppConfig{
+		appCfg = &authpkg.AppConfig{
 			ClientID: patData.Data.ClientID,
 		}
 		if patData.Data.ClientSecret != "" {
 			appCfg.ClientSecret = authpkg.PlainSecret(patData.Data.ClientSecret)
 		}
+	}
+
+	// If no flowId, the host expects a raw PAT JSON passthrough. Do not emit
+	// any human-readable output before returning the original PAT error.
+	if patData.Data.FlowID == "" {
+		if appCfg != nil {
+			_ = authpkg.SaveAppConfig(configDir, appCfg)
+		}
+		return executor.Result{}, patErr
+	}
+
+	if appCfg != nil {
 		if err := authpkg.SaveAppConfig(configDir, appCfg); err != nil {
 			slog.Warn("failed to persist app config from PAT", "error", err)
 			fmt.Fprintf(output, "  \u26a0 保存应用配置失败: %v (下次启动可能需要重新授权)\n", err)
@@ -405,12 +418,6 @@ func handlePatAuthCheck(
 		fmt.Fprintf(output, "  %s %s\n\n", dim("🔗"), cyan(patData.Data.URI))
 		// Best-effort browser open.
 		_ = tryOpenBrowser(patData.Data.URI)
-	}
-
-	// If no flowId, we can't poll — fall back to returning PATError for host-app.
-	if patData.Data.FlowID == "" {
-		fmt.Fprintln(output)
-		return executor.Result{}, patErr
 	}
 
 	// Poll the device flow status until user authorizes, rejects, or timeout.

--- a/internal/app/pat_auth_retry_test.go
+++ b/internal/app/pat_auth_retry_test.go
@@ -603,4 +603,39 @@ func TestHandlePatAuthCheck_EmptyFlowID_FallsBackToPATError(t *testing.T) {
 	if _, ok := err.(*apperrors.PATError); !ok {
 		t.Errorf("expected *PATError, got %T: %v", err, err)
 	}
+	if got := strings.TrimSpace(buf.String()); got != "" {
+		t.Fatalf("expected no human-readable output for raw PAT passthrough, got %q", got)
+	}
+}
+
+func TestHandlePatAuthCheck_EmptyFlowID_LegacyErrorCode_NoOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", tmpDir)
+
+	mock := &mockRunner{
+		runFunc: func(ctx context.Context, inv executor.Invocation) (executor.Result, error) {
+			t.Fatal("runner should not be called when flowId is empty")
+			return executor.Result{}, nil
+		},
+	}
+
+	runner := &runtimeRunner{fallback: mock}
+	patErr := &apperrors.PATError{RawJSON: `{"error_code":"PAT_LOW_RISK_NO_PERMISSION","data":{"clientId":"test-client-id"}}`}
+
+	ctx := context.Background()
+	var buf bytes.Buffer
+	_, err := handlePatAuthCheck(ctx, runner, executor.Invocation{
+		CanonicalProduct: "test",
+		Tool:             "test_tool",
+	}, patErr, tmpDir, &buf)
+
+	if err == nil {
+		t.Fatal("expected PATError when flowId is empty")
+	}
+	if _, ok := err.(*apperrors.PATError); !ok {
+		t.Errorf("expected *PATError, got %T: %v", err, err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "" {
+		t.Fatalf("expected no output for legacy error_code passthrough, got %q", got)
+	}
 }

--- a/internal/errors/pat.go
+++ b/internal/errors/pat.go
@@ -65,6 +65,17 @@ func IsPATNoPermissionCode(code string) bool {
 	return patNoPermissionCodes[code]
 }
 
+// getPATErrorCode extracts a PAT error code from a map.
+// Supports legacy error_code alongside code and errorCode.
+func getPATErrorCode(body map[string]any) (string, bool) {
+	for _, key := range []string{"code", "errorCode", "error_code"} {
+		if code, ok := body[key].(string); ok && patNoPermissionCodes[code] {
+			return code, true
+		}
+	}
+	return "", false
+}
+
 // ---- DWS gateway auth errors (shared between PAT & general auth) ----------
 
 // dwsGatewayErrors is the set of DWS gateway-level auth error codes.
@@ -124,10 +135,8 @@ func ClassifyToolResultContent(content map[string]any) error {
 			WithHint(authExpiredHint()),
 		)
 	}
-	for _, key := range []string{"code", "errorCode"} {
-		if code, ok := content[key].(string); ok && patNoPermissionCodes[code] {
-			return &PATError{RawJSON: cleanPATJSON(content, code)}
-		}
+	if code, ok := getPATErrorCode(content); ok {
+		return &PATError{RawJSON: cleanPATJSON(content, code)}
 	}
 	return nil
 }
@@ -158,10 +167,8 @@ func ClassifyMCPResponseText(text string) error {
 		)
 	}
 
-	for _, key := range []string{"code", "errorCode"} {
-		if code, ok := body[key].(string); ok && patNoPermissionCodes[code] {
-			return &PATError{RawJSON: cleanPATJSON(body, code)}
-		}
+	if code, ok := getPATErrorCode(body); ok {
+		return &PATError{RawJSON: cleanPATJSON(body, code)}
 	}
 
 	if isBusinessError(body) {
@@ -247,11 +254,9 @@ func cleanPATJSON(body map[string]any, code string) string {
 // Content map for PAT permission codes and auth-required codes.  Returns a
 // non-nil *PATError when the content carries a recognised PAT/auth error.
 func ClassifyPatAuthCheck(content map[string]any) *PATError {
-	for _, key := range []string{"code", "errorCode"} {
-		if code, ok := content[key].(string); ok {
-			if patNoPermissionCodes[code] || patAuthRequiredCodes[code] {
-				return &PATError{RawJSON: cleanPATJSON(content, code)}
-			}
+	for _, key := range []string{"code", "errorCode", "error_code"} {
+		if code, ok := content[key].(string); ok && (patNoPermissionCodes[code] || patAuthRequiredCodes[code]) {
+			return &PATError{RawJSON: cleanPATJSON(content, code)}
 		}
 	}
 	return nil

--- a/internal/errors/pat_test.go
+++ b/internal/errors/pat_test.go
@@ -234,6 +234,25 @@ func TestClassifyToolResultContent_PATPermission(t *testing.T) {
 	}
 }
 
+func TestClassifyToolResultContent_PATPermissionLegacyErrorCode(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{
+		"error_code": "PAT_LOW_RISK_NO_PERMISSION",
+		"data":       map[string]any{"desc": "需要授权"},
+	}
+	err := ClassifyToolResultContent(content)
+	if err == nil {
+		t.Fatal("expected non-nil error for legacy error_code PAT permission")
+	}
+	var patErr *PATError
+	if !stderrors.As(err, &patErr) {
+		t.Fatalf("expected *PATError, got %T", err)
+	}
+	if !strings.Contains(patErr.RawJSON, "PAT_LOW_RISK_NO_PERMISSION") {
+		t.Errorf("RawJSON should contain PAT_LOW_RISK_NO_PERMISSION, got: %s", patErr.RawJSON)
+	}
+}
+
 func TestClassifyToolResultContent_NoError(t *testing.T) {
 	t.Parallel()
 	content := map[string]any{"success": true, "data": "ok"}
@@ -294,6 +313,22 @@ func TestClassifyMCPResponseText_PATPermission(t *testing.T) {
 	}
 }
 
+func TestClassifyMCPResponseText_PATPermissionLegacyErrorCode(t *testing.T) {
+	t.Parallel()
+	text := `{"error_code":"PAT_MEDIUM_RISK_NO_PERMISSION","data":{"desc":"legacy"}}`
+	err := ClassifyMCPResponseText(text)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	var patErr *PATError
+	if !stderrors.As(err, &patErr) {
+		t.Fatalf("expected *PATError, got %T", err)
+	}
+	if !strings.Contains(patErr.RawJSON, "PAT_MEDIUM_RISK_NO_PERMISSION") {
+		t.Errorf("RawJSON should contain legacy code, got: %s", patErr.RawJSON)
+	}
+}
+
 func TestClassifyMCPResponseText_BusinessError(t *testing.T) {
 	t.Parallel()
 	text := `{"success":false,"errorMsg":"搜索内容不能为空"}`
@@ -342,6 +377,18 @@ func TestClassifyPatAuthCheck_PATNoPermission(t *testing.T) {
 	}
 	if !strings.Contains(patErr.RawJSON, "PAT_NO_PERMISSION") {
 		t.Errorf("RawJSON should contain code, got: %s", patErr.RawJSON)
+	}
+}
+
+func TestClassifyPatAuthCheck_LegacyErrorCode(t *testing.T) {
+	t.Parallel()
+	content := map[string]any{"error_code": "PAT_HIGH_RISK_NO_PERMISSION", "data": map[string]any{"flowId": "f1"}}
+	patErr := ClassifyPatAuthCheck(content)
+	if patErr == nil {
+		t.Fatal("expected non-nil *PATError for legacy error_code")
+	}
+	if !strings.Contains(patErr.RawJSON, "PAT_HIGH_RISK_NO_PERMISSION") {
+		t.Errorf("RawJSON should contain PAT_HIGH_RISK_NO_PERMISSION, got: %s", patErr.RawJSON)
 	}
 }
 


### PR DESCRIPTION
PR from fork: https://github.com/shangguanxuan633-lab/dingtalk-workspace-cli/tree/codex/pat-frontend-contract  
PR: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pull/128

## Summary

**What changed?**
- PAT 兼容性补齐：在 `internal/errors/pat.go` 里统一 PAT 错误码提取，新增对旧协议 `error_code` 的兼容，同时继续支持 `code` / `errorCode`
- PAT 分类链路收敛：`ClassifyToolResultContent`、`ClassifyMCPResponseText`、`ClassifyPatAuthCheck` 都改为走同一套 PAT code 提取逻辑，避免不同入口识别不一致
- Raw PAT passthrough 修复：在 `internal/app/pat_auth_retry.go` 中把无 `flowId` 场景的返回前置，确保 host/frontend 拿到的是干净的 raw PAT JSON，不会被 CLI 的人类提示文案污染
- 保留运行时身份写入：无 `flowId` 时仍会保留必要的 `clientId/clientSecret -> app config` 写入，但不再输出 banner / polling 文案
- PAT 回归测试补齐：在 `internal/errors/pat_test.go` 和 `internal/app/pat_auth_retry_test.go` 新增 legacy `error_code` 与 silent passthrough 覆盖
- 接入文档补齐：新增 `docs/pat-integration.md`，面向 frontend / CLI / QA 说明 PAT JSON 合同、退出码、字段和推荐处理流

**Why?**
- 当前 PAT 前台接入依赖 `exit code 4 + stderr raw JSON` 这条合同；如果 CLI 在 raw JSON 前输出“需要 PAT 授权”之类的人类文案，前台按 JSON 解析会直接失败
- 上游/历史链路并不只发 `code`，还会出现 `error_code`；如果开源核心不兼容，PAT 拦截会漏判，导致前台拿不到可恢复的授权事件
- 这次不做大架构改造，只把“开源 CLI 作为 PAT 原始合同提供方”这件事补稳，让 RewindDesktop 或其他 agent 前台能可靠继续后续授权/重试逻辑
- 文档补齐是为了让不同接入团队拿到统一口径，而不是继续靠代码猜字段

## Verification

- [ ] `make build`
- [ ] `make lint`
- [ ] `make test`
- [x] `go test ./internal/errors -run 'TestClassify(ToolResultContent|MCPResponseText|PatAuthCheck)'`
- [x] `go test ./internal/app -run 'TestHandlePatAuthCheck_(Approved|Rejected|EmptyFlowID)'`
- [ ] `make policy`
- [ ] `./scripts/policy/check-generated-drift.sh`
- [x] 命令面无变更

## Notes

- 本次没有改 richer frontend UI contract 本身；`RewindDesktop` 更完整的 PAT 卡片桥接仍主要在它的 `origin/develop`
- 本次目标是把开源 CLI 侧的基础合同补稳：识别要准，透传要干净
- 全量 `go test ./internal/app` 在当前仓库里有既存无关失败，所以只用本次改动命中的测试作为 gate
- 我尝试了把接入文档发布成钉钉文档，但当前本机 `dws mcp` 发现面没有 `doc` 产品，`dws mcp doc create_document` 返回 `unknown command "doc"`，所以这一步没法在当前环境完成
