### PR TITLE
fix: -f json模式下错误JSON从stdout改为输出到stderr

### DIFF
--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -147,7 +147,7 @@ func printExecutionError(root *cobra.Command, stdout, stderr io.Writer, err erro
 		return writeErr
 	}
 	if wantsJSONErrors(root) {
-		return apperrors.PrintJSON(stdout, err)
+		return apperrors.PrintJSON(stderr, err)
 	}
 	return apperrors.PrintHumanAt(stderr, err, resolveVerbosity(root))
 }

--- a/internal/app/root_execute_test.go
+++ b/internal/app/root_execute_test.go
@@ -51,11 +51,11 @@ func TestPrintExecutionErrorDefaultsToJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("printExecutionError() error = %v", err)
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty for JSON error output", stderr.String())
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty when errors go to stderr", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "\"category\": \"validation\"") {
-		t.Fatalf("stdout = %q, want JSON error payload", stdout.String())
+	if !strings.Contains(stderr.String(), "\"category\": \"validation\"") {
+		t.Fatalf("stderr = %q, want JSON error payload", stderr.String())
 	}
 }
 
@@ -73,11 +73,11 @@ func TestPrintExecutionErrorUsesJSONWhenFormatIsJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("printExecutionError() error = %v", err)
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty for JSON error output", stderr.String())
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty when errors go to stderr", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "\"category\": \"validation\"") {
-		t.Fatalf("stdout = %q, want JSON error payload", stdout.String())
+	if !strings.Contains(stderr.String(), "\"category\": \"validation\"") {
+		t.Fatalf("stderr = %q, want JSON error payload", stderr.String())
 	}
 }
 
@@ -105,11 +105,11 @@ func TestPrintExecutionErrorUsesJSONWhenCommandSetsJSONFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("printExecutionError() error = %v", err)
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty for JSON error output", stderr.String())
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty when errors go to stderr", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "\"category\": \"validation\"") {
-		t.Fatalf("stdout = %q, want JSON error payload", stdout.String())
+	if !strings.Contains(stderr.String(), "\"category\": \"validation\"") {
+		t.Fatalf("stderr = %q, want JSON error payload", stderr.String())
 	}
 }
 


### PR DESCRIPTION
修复背景：
CI测试脚本通过检查stderr中是否包含错误关键词来判断命令是否失败。
但-f json模式下，printExecutionError将错误JSON输出到stdout，
导致stderr为空，测试断言失败。

改动：
- root.go:150: apperrors.PrintJSON(stdout, err) → apperrors.PrintJSON(stderr, err)
- root_execute_test.go: 3处断言方向同步调整（stdout↔stderr）

影响范围：
仅影响-f json模式下的错误输出流向，正常输出不受影响。
符合Unix惯例：错误信息输出到stderr，正常结果输出到stdout。

## Summary

- What changed?
- Why is this change needed?

## Verification

- [ ] `make build`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make policy`
- [ ] `./scripts/policy/check-generated-drift.sh`
- [ ] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed)

## Notes

- Any risks, follow-up work, or intentional scope cuts
