### PR TITLE
refactor(plugin): drop managed/ compat layer left by PR #126

### DIFF
--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -1091,18 +1091,13 @@ func loadPlugins(engine *pipeline.Engine, runner executor.Runner) []*cobra.Comma
 		}
 	}
 
-	// 1. Load plugins from the legacy managed/ directory (backward compat
-	//    for plugins installed by older CLI builds).
-	managedPlugins := pluginLoader.LoadManaged()
-
-	// 2. Load user plugins (per settings.json)
+	// 1. Load user plugins (per settings.json)
 	userPlugins := pluginLoader.LoadUser()
 
-	// 3. Load dev plugins (registered via `dws plugin dev`)
+	// 2. Load dev plugins (registered via `dws plugin dev`)
 	devPlugins := pluginLoader.LoadDev()
 
-	allPlugins := append(managedPlugins, userPlugins...)
-	allPlugins = append(allPlugins, devPlugins...)
+	allPlugins := append(userPlugins, devPlugins...)
 
 	// 3. Discover tools from streamable-http servers and build CLI commands.
 	//    Third-party servers with auth headers are discovered in parallel
@@ -1213,7 +1208,6 @@ func loadPlugins(engine *pipeline.Engine, runner executor.Runner) []*cobra.Comma
 
 	if len(allPlugins) > 0 {
 		slog.Debug("plugins loaded",
-			"managed", len(managedPlugins),
 			"user", len(userPlugins),
 			"dev", len(devPlugins),
 		)
@@ -1529,17 +1523,12 @@ func buildStdioCommands(p *plugin.Plugin, sc plugin.StdioServerClient, tools []t
 	// Construct virtual endpoint and server descriptor.
 	endpoint := StdioEndpoint(p.Manifest.Name, sc.Key)
 
-	source := "plugin"
-	if p.IsManaged {
-		source = "plugin-managed"
-	}
-
 	descriptor := market.ServerDescriptor{
 		Key:         sc.Key,
 		DisplayName: p.Manifest.Name + "/" + sc.Key,
 		Description: p.Manifest.Description,
 		Endpoint:    endpoint,
-		Source:      source,
+		Source:      "plugin",
 		CLI:         overlay,
 		HasCLIMeta:  true,
 	}

--- a/internal/plugin/converter.go
+++ b/internal/plugin/converter.go
@@ -131,9 +131,6 @@ func (p *Plugin) ToServerDescriptors() []market.ServerDescriptor {
 		}
 
 		source := "plugin"
-		if p.IsManaged {
-			source = "plugin-managed"
-		}
 
 		// Resolve headers: expand environment variable references (e.g. ${DASHSCOPE_API_KEY}).
 		var resolvedHeaders map[string]string

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -56,13 +56,6 @@ type Settings struct {
 	DevPlugins       map[string]string         `json:"devPlugins,omitempty"` // name → absolute path
 }
 
-// LoadManaged scans ~/.dws/plugins/managed/ and returns all valid
-// official plugins. Managed plugins are always enabled.
-func (l *Loader) LoadManaged() []*Plugin {
-	managedDir := filepath.Join(l.PluginsDir, "managed")
-	return l.scanDir(managedDir, true)
-}
-
 // LoadUser scans ~/.dws/plugins/user/ and returns enabled user plugins.
 func (l *Loader) LoadUser() []*Plugin {
 	userDir := filepath.Join(l.PluginsDir, "user")
@@ -86,7 +79,7 @@ func (l *Loader) LoadUser() []*Plugin {
 
 		// Check if this is a direct plugin directory (has plugin.json)
 		if _, err := os.Stat(filepath.Join(entryPath, "plugin.json")); err == nil {
-			p := l.loadPlugin(entryPath, false)
+			p := l.loadPlugin(entryPath)
 			if p != nil && isPluginEnabled(settings, p.Manifest.Name) {
 				plugins = append(plugins, p)
 			}
@@ -103,7 +96,7 @@ func (l *Loader) LoadUser() []*Plugin {
 				continue
 			}
 			subPath := filepath.Join(entryPath, sub.Name())
-			p := l.loadPlugin(subPath, false)
+			p := l.loadPlugin(subPath)
 			if p != nil {
 				qualifiedName := entry.Name() + "/" + p.Manifest.Name
 				if isPluginEnabled(settings, qualifiedName) {
@@ -115,39 +108,15 @@ func (l *Loader) LoadUser() []*Plugin {
 	return plugins
 }
 
-// LoadAll loads both managed and user plugins.
+// LoadAll loads user + dev plugins.
 func (l *Loader) LoadAll() []*Plugin {
-	managed := l.LoadManaged()
 	user := l.LoadUser()
-	return append(managed, user...)
-}
-
-// scanDir reads a directory of plugin subdirectories and loads each one.
-func (l *Loader) scanDir(dir string, isManaged bool) []*Plugin {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			slog.Debug("plugin: cannot read dir", "path", dir, "error", err)
-		}
-		return nil
-	}
-
-	var plugins []*Plugin
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		pluginDir := filepath.Join(dir, entry.Name())
-		p := l.loadPlugin(pluginDir, isManaged)
-		if p != nil {
-			plugins = append(plugins, p)
-		}
-	}
-	return plugins
+	dev := l.LoadDev()
+	return append(user, dev...)
 }
 
 // loadPlugin reads and validates a single plugin directory.
-func (l *Loader) loadPlugin(dir string, isManaged bool) *Plugin {
+func (l *Loader) loadPlugin(dir string) *Plugin {
 	manifestPath := filepath.Join(dir, "plugin.json")
 	manifest, err := ParseManifest(manifestPath)
 	if err != nil {
@@ -163,9 +132,8 @@ func (l *Loader) loadPlugin(dir string, isManaged bool) *Plugin {
 	}
 
 	return &Plugin{
-		Manifest:  *manifest,
-		Root:      dir,
-		IsManaged: isManaged,
+		Manifest: *manifest,
+		Root:     dir,
 	}
 }
 
@@ -211,7 +179,7 @@ func isPluginEnabled(s *Settings, name string) bool {
 type PluginInfo struct {
 	Name        string `json:"name"`
 	Version     string `json:"version"`
-	Type        string `json:"type"` // "managed" or "user"
+	Type        string `json:"type"` // "user" or "dev"
 	Enabled     bool   `json:"enabled"`
 	Path        string `json:"path"`
 	Description string `json:"description,omitempty"`
@@ -221,29 +189,6 @@ type PluginInfo struct {
 func (l *Loader) ListInstalled() []PluginInfo {
 	var result []PluginInfo
 	settings := l.loadSettings()
-
-	// Managed plugins
-	managedDir := filepath.Join(l.PluginsDir, "managed")
-	if entries, err := os.ReadDir(managedDir); err == nil {
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			dir := filepath.Join(managedDir, entry.Name())
-			m, err := ParseManifest(filepath.Join(dir, "plugin.json"))
-			if err != nil {
-				continue
-			}
-			result = append(result, PluginInfo{
-				Name:        m.Name,
-				Version:     m.Version,
-				Type:        "managed",
-				Enabled:     true, // managed plugins always enabled
-				Path:        dir,
-				Description: m.Description,
-			})
-		}
-	}
 
 	// User plugins
 	userDir := filepath.Join(l.PluginsDir, "user")
@@ -348,9 +293,8 @@ func (l *Loader) InstallFromDir(srcDir string) (*Plugin, error) {
 	l.setPluginEnabled(manifest.Name, true)
 
 	return &Plugin{
-		Manifest:  *manifest,
-		Root:      destDir,
-		IsManaged: false,
+		Manifest: *manifest,
+		Root:     destDir,
 	}, nil
 }
 
@@ -411,9 +355,8 @@ func (l *Loader) InstallFromGit(gitURL string) (*Plugin, error) {
 	l.setPluginEnabled(qualifiedName, true)
 
 	return &Plugin{
-		Manifest:  *manifest,
-		Root:      destDir,
-		IsManaged: false,
+		Manifest: *manifest,
+		Root:     destDir,
 	}, nil
 }
 
@@ -463,19 +406,9 @@ func parseGitURL(gitURL string) (workspace, repoName string, err error) {
 	return segments[len(segments)-2], segments[len(segments)-1], nil
 }
 
-// RemovePlugin removes an installed plugin by name. It searches both the
-// user and the legacy managed directories; all plugins are equally
-// removable.
+// RemovePlugin removes an installed plugin by name.
 func (l *Loader) RemovePlugin(name string, keepData bool) error {
 	pluginDir := l.findUserPluginDir(name)
-	if pluginDir == "" {
-		// Fall back to legacy managed/ directory (for plugins installed
-		// by older CLI builds that wrote under ~/.dws/plugins/managed/).
-		legacyDir := filepath.Join(l.PluginsDir, config.PluginManagedDir, name)
-		if _, err := os.Stat(filepath.Join(legacyDir, "plugin.json")); err == nil {
-			pluginDir = legacyDir
-		}
-	}
 	if pluginDir == "" {
 		return fmt.Errorf("plugin %q not found", name)
 	}
@@ -516,12 +449,8 @@ func (l *Loader) purgePluginFromSettings(name string) {
 
 // SetEnabled enables or disables a plugin in settings.json.
 func (l *Loader) SetEnabled(name string, enabled bool) error {
-	// Verify plugin exists
 	if l.findUserPluginDir(name) == "" {
-		managedDir := filepath.Join(l.PluginsDir, "managed", name)
-		if _, err := os.Stat(managedDir); err != nil {
-			return fmt.Errorf("plugin %q not found", name)
-		}
+		return fmt.Errorf("plugin %q not found", name)
 	}
 	l.setPluginEnabled(name, enabled)
 	return nil
@@ -695,7 +624,7 @@ func (l *Loader) LoadDev() []*Plugin {
 				"name", name, "dir", dir)
 			continue
 		}
-		p := l.loadPlugin(dir, false)
+		p := l.loadPlugin(dir)
 		if p != nil {
 			plugins = append(plugins, p)
 			slog.Debug("plugin: loaded dev plugin", "name", name, "dir", dir)

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -93,9 +93,8 @@ type HookEntry struct {
 
 // Plugin is a loaded, validated plugin ready for injection.
 type Plugin struct {
-	Manifest  Manifest
-	Root      string // absolute path to plugin directory
-	IsManaged bool   // true for official (DingTalk-Real-AI) plugins
+	Manifest Manifest
+	Root     string // absolute path to plugin directory
 }
 
 // ParseManifest reads and parses a plugin.json file.

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -199,8 +199,7 @@ func TestPluginToServerDescriptors(t *testing.T) {
 				},
 			},
 		},
-		Root:      "/tmp/plugins/conference",
-		IsManaged: true,
+		Root: "/tmp/plugins/conference",
 	}
 
 	descriptors := p.ToServerDescriptors()
@@ -217,8 +216,8 @@ func TestPluginToServerDescriptors(t *testing.T) {
 	if d.Endpoint != "https://mcp.conference.dingtalk.com" {
 		t.Errorf("endpoint = %q", d.Endpoint)
 	}
-	if d.Source != "plugin-managed" {
-		t.Errorf("source = %q, want plugin-managed", d.Source)
+	if d.Source != "plugin" {
+		t.Errorf("source = %q, want plugin", d.Source)
 	}
 	if d.CLI.ID != "conference" {
 		t.Errorf("cli.id = %q, want conference", d.CLI.ID)
@@ -273,7 +272,7 @@ func TestPluginToServerDescriptorsWithHeaders(t *testing.T) {
 		t.Errorf("AuthHeaders[X-Custom] = %q, want static-value", d.AuthHeaders["X-Custom"])
 	}
 	if d.Source != "plugin" {
-		t.Errorf("source = %q, want plugin (non-managed)", d.Source)
+		t.Errorf("source = %q, want plugin", d.Source)
 	}
 }
 
@@ -354,137 +353,57 @@ func TestLoaderScanEmpty(t *testing.T) {
 		CLIVersion: "1.0.0",
 	}
 
-	managed := loader.LoadManaged()
-	if len(managed) != 0 {
-		t.Errorf("expected 0 managed plugins, got %d", len(managed))
-	}
-
 	user := loader.LoadUser()
 	if len(user) != 0 {
 		t.Errorf("expected 0 user plugins, got %d", len(user))
 	}
 }
 
-func TestLoaderLoadManaged(t *testing.T) {
-	dir := t.TempDir()
-	managedDir := filepath.Join(dir, "managed", "conference")
-	if err := os.MkdirAll(managedDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	manifest := `{
-		"name": "conference",
-		"version": "1.0.0",
-		"type": "managed",
-		"mcpServers": {
-			"conference": {
-				"type": "streamable-http",
-				"endpoint": "https://example.com"
-			}
-		}
-	}`
-	if err := os.WriteFile(filepath.Join(managedDir, "plugin.json"), []byte(manifest), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	loader := &Loader{PluginsDir: dir, CLIVersion: "1.0.0"}
-	plugins := loader.LoadManaged()
-
-	if len(plugins) != 1 {
-		t.Fatalf("expected 1 managed plugin, got %d", len(plugins))
-	}
-	if plugins[0].Manifest.Name != "conference" {
-		t.Errorf("name = %q, want conference", plugins[0].Manifest.Name)
-	}
-	if !plugins[0].IsManaged {
-		t.Error("expected IsManaged = true")
-	}
-}
-
-// TestRemoveLegacyManagedPlugin ensures plugins that were installed under
-// the legacy ~/.dws/plugins/managed/ directory are now freely removable
-// — the old "cannot be removed" privilege has been dropped.
-func TestRemoveLegacyManagedPlugin(t *testing.T) {
-	dir := t.TempDir()
-	managedDir := filepath.Join(dir, "managed", "conference")
-	if err := os.MkdirAll(managedDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(managedDir, "plugin.json"), []byte(`{"name":"conference","version":"1.0.0"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	loader := &Loader{PluginsDir: dir, CLIVersion: "1.0.0"}
-	if err := loader.RemovePlugin("conference", false); err != nil {
-		t.Fatalf("unexpected error removing legacy managed plugin: %v", err)
-	}
-	if _, err := os.Stat(managedDir); !os.IsNotExist(err) {
-		t.Errorf("managed plugin dir should be removed, stat err = %v", err)
-	}
-}
-
 // TestRemovePluginPurgesSettings verifies RemovePlugin fully purges the
 // plugin's settings — both its enabled flag and any pluginConfigs entry —
 // so settings.json does not retain dangling state for a plugin that no
-// longer exists on disk. Covers both the user and legacy managed paths.
+// longer exists on disk.
 func TestRemovePluginPurgesSettings(t *testing.T) {
-	cases := []struct {
-		name    string
-		layout  string // "user" or "legacy"
-		pkgName string
-	}{
-		{name: "user plugin", layout: "user", pkgName: "my-plugin"},
-		{name: "legacy managed plugin", layout: "legacy", pkgName: "conference"},
+	const pkgName = "my-plugin"
+	dir := t.TempDir()
+	pluginDir := filepath.Join(dir, "user", pkgName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			var pluginDir string
-			switch tc.layout {
-			case "user":
-				pluginDir = filepath.Join(dir, "user", tc.pkgName)
-			case "legacy":
-				pluginDir = filepath.Join(dir, "managed", tc.pkgName)
-			}
-			if err := os.MkdirAll(pluginDir, 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"),
-				[]byte(`{"name":"`+tc.pkgName+`","version":"1.0.0"}`), 0o644); err != nil {
-				t.Fatal(err)
-			}
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.json"),
+		[]byte(`{"name":"`+pkgName+`","version":"1.0.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
-			loader := &Loader{PluginsDir: dir, CLIVersion: "1.0.0"}
+	loader := &Loader{PluginsDir: dir, CLIVersion: "1.0.0"}
 
-			// Seed settings.json with an explicit enabled flag and a
-			// pluginConfigs entry to verify both get purged.
-			settings := &Settings{
-				EnabledPlugins: map[string]bool{tc.pkgName: true, "other-plugin": true},
-				PluginConfigs: map[string]map[string]any{
-					tc.pkgName:     {"API_KEY": "secret"},
-					"other-plugin": {"TOKEN": "keep-me"},
-				},
-			}
-			loader.saveSettings(settings)
+	// Seed settings.json with an explicit enabled flag and a
+	// pluginConfigs entry to verify both get purged.
+	settings := &Settings{
+		EnabledPlugins: map[string]bool{pkgName: true, "other-plugin": true},
+		PluginConfigs: map[string]map[string]any{
+			pkgName:        {"API_KEY": "secret"},
+			"other-plugin": {"TOKEN": "keep-me"},
+		},
+	}
+	loader.saveSettings(settings)
 
-			if err := loader.RemovePlugin(tc.pkgName, false); err != nil {
-				t.Fatalf("RemovePlugin: %v", err)
-			}
+	if err := loader.RemovePlugin(pkgName, false); err != nil {
+		t.Fatalf("RemovePlugin: %v", err)
+	}
 
-			reloaded := loader.loadSettings()
-			if _, exists := reloaded.EnabledPlugins[tc.pkgName]; exists {
-				t.Errorf("EnabledPlugins should not retain removed plugin %q", tc.pkgName)
-			}
-			if _, exists := reloaded.PluginConfigs[tc.pkgName]; exists {
-				t.Errorf("PluginConfigs should not retain removed plugin %q", tc.pkgName)
-			}
-			if !reloaded.EnabledPlugins["other-plugin"] {
-				t.Error("unrelated EnabledPlugins entry should be preserved")
-			}
-			if reloaded.PluginConfigs["other-plugin"]["TOKEN"] != "keep-me" {
-				t.Error("unrelated PluginConfigs entry should be preserved")
-			}
-		})
+	reloaded := loader.loadSettings()
+	if _, exists := reloaded.EnabledPlugins[pkgName]; exists {
+		t.Errorf("EnabledPlugins should not retain removed plugin %q", pkgName)
+	}
+	if _, exists := reloaded.PluginConfigs[pkgName]; exists {
+		t.Errorf("PluginConfigs should not retain removed plugin %q", pkgName)
+	}
+	if !reloaded.EnabledPlugins["other-plugin"] {
+		t.Error("unrelated EnabledPlugins entry should be preserved")
+	}
+	if reloaded.PluginConfigs["other-plugin"]["TOKEN"] != "keep-me" {
+		t.Error("unrelated PluginConfigs entry should be preserved")
 	}
 }
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -112,12 +112,6 @@ const (
 // ── Plugin system ──────────────────────────────────────────────────────
 
 const (
-	// PluginManagedDir is a legacy subdirectory under ~/.dws/plugins/
-	// retained so plugins installed by older CLI versions remain loadable.
-	// New installs always go to PluginUserDir; there is no privilege
-	// associated with this directory anymore.
-	PluginManagedDir = "managed"
-
 	// PluginUserDir is the subdirectory under ~/.dws/plugins/ where all
 	// third-party plugins are installed. Every plugin — whether authored
 	// by the DingTalk team or anyone else — lives here with equal status.


### PR DESCRIPTION
## Summary

- PR #126 removed the privileged managed-plugin mechanism but kept `LoadManaged`, `Plugin.IsManaged`, and `~/.dws/plugins/managed/` fallbacks so pre-#126 installs would keep loading. Migration window was ~4 days (2026-04-15 → 2026-04-19), and original installs mostly failed anyway (#124 GitHub Pages HTML response). Compat layer has no real user base to preserve.
- Deletes `LoadManaged`, the `isManaged` params on `scanDir`/`loadPlugin`, the `Plugin.IsManaged` field, the `if p.IsManaged { source = \"plugin-managed\" }` branches in converter/root, the `managed/` branches in `ListInstalled`/`SetEnabled`/`RemovePlugin`, the `config.PluginManagedDir` constant, and the three managed-only tests. Net −173 LOC.
- Kept `Manifest.Type` (\"managed\"|\"user\") because it's a public plugin.json schema field present in third-party manifests; it's validated but never behaviorally consumed, so keeping it does nothing beyond preserving compatibility.

## Migration

Users with an orphaned `~/.dws/plugins/managed/` directory can safely:
```
rm -rf ~/.dws/plugins/managed/
```
The CLI no longer reads that path. To reinstall a plugin, use `dws plugin install --git <url>` which writes to `~/.dws/plugins/user/{workspace}/{name}/`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/plugin/... ./internal/app/... ./pkg/config/...\` passes
- [x] Pre-existing failures in \`test/cli_compat\`, \`test/scripts\`, \`test/unit\` confirmed to exist on main (not caused by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)