### PR TITLE
feat(skills): 新增钉钉文档与 AI 听记 skill 参考

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dws
-description: 管理钉钉产品能力(AI表格/日历/通讯录/群聊与机器人/待办/审批/考勤/日志/DING消息/工作台/开放平台文档等)。当用户需要操作表格数据、管理日程会议、查询通讯录、管理群聊、机器人发消息、创建待办、提交审批、查看考勤、提交日报周报（钉钉日志模版）时使用。
+description: 管理钉钉产品能力(AI表格/日历/通讯录/群聊与机器人/待办/审批/考勤/日志/DING消息/工作台/开放平台文档/钉钉文档/AI听记等)。当用户需要操作表格数据、管理日程会议、查询通讯录、管理群聊、机器人发消息、创建待办、提交审批、查看考勤、提交日报周报（钉钉日志模版）、读写钉钉文档、查询听记纪要时使用。
 cli_version: ">=1.0.6"
 ---
 
@@ -32,6 +32,8 @@ cli_version: ">=1.0.6"
 | `contact`         | 通讯录：用户查询(当前用户/搜索/详情)/部门查询(搜索/子部门/成员列表)               | [contact.md](./references/products/contact.md)                 |
 | `devdoc`          | 开放平台文档：搜索开发文档                                        | [simple.md](./references/products/simple.md)                   |
 | `ding`            | DING消息：发送/撤回（应用内/短信/电话）                              | [ding.md](./references/products/ding.md)                       |
+| `doc`             | 钉钉文档：搜索/浏览/读写/块级编辑/评论                                | [doc.md](./references/products/doc.md)                         |
+| `minutes`         | AI听记：听记列表/摘要/关键词/转写/待办/思维导图/发言人/热词                    | [minutes.md](./references/products/minutes.md)                 |
 | `report`          | 日志：按模版创建/收件箱/已发送/模版查看/详情/已读统计                         | [report.md](./references/products/report.md)                   |
 | `todo`            | 待办：创建(含优先级/截止时间)/查询/修改/标记完成/删除                       | [todo.md](./references/products/todo.md)                       |
 | `workbench`       | 工作台：应用管理                                             | [workbench.md](./references/products/workbench.md)             |
@@ -46,6 +48,8 @@ cli_version: ">=1.0.6"
 用户提到"通讯录/同事/部门/组织架构" → `contact`
 用户提到"开发/API/调用错误 文档" → `devdoc`
 用户提到"DING/紧急消息/电话提醒" → `ding`
+用户提到"钉钉文档/云文档/知识库/读写文档/块级编辑/文档评论" → `doc`
+用户提到"听记/AI听记/会议纪要/转写/摘要/思维导图/发言人/热词" → `minutes`
 用户提到"日志/日报/周报/日志统计/写日报/提交周报/发日志/填日志" → `report`
 用户提到"待办/TODO/任务提醒" → `todo`
 用户提到"工作台/应用管理" → `workbench`
@@ -69,6 +73,8 @@ cli_version: ">=1.0.6"
 | `calendar` | `participant delete` | 移除日程参与者 |
 | `calendar` | `room delete` | 取消会议室预定 |
 | `chat` | `group members remove` | 移除群成员 |
+| `doc` | `delete` | 删除钉钉文档（不可恢复） |
+| `doc` | `block delete` | 删除文档块 |
 | `todo` | `task delete` | 删除待办 |
 
 ### 确认流程

--- a/skills/references/products/doc.md
+++ b/skills/references/products/doc.md
@@ -1,0 +1,462 @@
+# 文档 (doc) 命令参考
+
+## 命令总览
+
+### 搜索文档
+```
+Usage:
+  dws doc search [flags]
+Example:
+  dws doc search --query "会议纪要"
+  dws doc search
+  dws doc search --extensions pdf,docx
+  dws doc search --query "方案" --created-from 1700000000000 --created-to 1710000000000
+  dws doc search --creator-uids uid1,uid2
+  dws doc search --workspace-ids wsId1,wsId2
+Flags:
+      --query string              搜索关键词 (不传则返回最近访问)
+      --extensions strings        按文件扩展名过滤，不含点号，逗号分隔 (如 pdf,docx,png)。支持的在线文档类型后缀名: adoc=文字, axls=表格, appt=演示文稿, awbd=白板, adraw=画板, amind=脑图, able=多维表格, aform=收集表
+      --created-from int          创建时间起始 (毫秒时间戳，含)
+      --created-to int            创建时间截止 (毫秒时间戳，含)
+      --visited-from int          访问时间起始 (毫秒时间戳，含)
+      --visited-to int            访问时间截止 (毫秒时间戳，含)
+      --creator-uids strings      按创建者用户 ID 过滤，逗号分隔
+      --editor-uids strings       按编辑者用户 ID 过滤，逗号分隔
+      --mentioned-uids strings    按 @提及的用户 ID 过滤，逗号分隔
+      --workspace-ids strings     按知识库 ID 过滤，支持知识库 URL，逗号分隔
+      --page-size int             每页数量 (默认 10，最大 30)
+      --page-token string         分页游标 (从上次结果的 nextPageToken 获取)
+```
+
+### 遍历文件列表
+```
+Usage:
+  dws doc list [flags]
+Example:
+  dws doc list
+  dws doc list --folder <FOLDER_ID>
+  dws doc list --workspace <WS_ID> --page-size 20
+Flags:
+      --folder string       文件夹 ID 或 URL
+      --workspace string    知识库 ID
+      --page-size int       每页数量 (默认 50，最大 50)
+      --page-token string   分页游标 (从上次结果的 nextPageToken 获取)
+```
+
+### 获取文档元信息
+```
+Usage:
+  dws doc info [flags]
+Example:
+  dws doc info --node <DOC_ID>
+  dws doc info --node "https://alidocs.dingtalk.com/i/nodes/<DOC_UUID>"
+Flags:
+      --node string   文档 ID 或 URL (必填)
+```
+
+### 读取文档内容
+```
+Usage:
+  dws doc read [flags]
+Example:
+  dws doc read --node <DOC_ID>
+  dws doc read --node "https://alidocs.dingtalk.com/i/nodes/<DOC_UUID>"
+Flags:
+      --node string   文档 ID 或 URL (必填)
+```
+
+### 创建文档
+```
+Usage:
+  dws doc create [flags]
+Example:
+  dws doc create --name "项目周报"
+  dws doc create --name "Q1 总结" --markdown "# Q1 总结" --folder <FOLDER_ID>
+  dws doc create --name "知识库文档" --workspace <WS_ID>
+Flags:
+      --name string        文档名称 (必填)
+      --folder string      目标文件夹 ID 或 URL
+      --workspace string   目标知识库 ID
+      --markdown string    文档初始 Markdown 内容
+```
+
+### 更新文档内容
+```
+Usage:
+  dws doc update [flags]
+Example:
+  dws doc update --node <DOC_ID> --markdown "# 追加内容" --mode append
+  dws doc update --node <DOC_ID> --markdown "# 完整替换" --mode overwrite
+Flags:
+      --node string       文档 ID 或 URL (必填)
+      --markdown string   Markdown 内容 (必填)
+      --mode string       更新模式: overwrite=覆盖, append=追加 (默认 append)
+```
+
+### 上传文件到钉钉文档或钉钉知识库
+```
+Usage:
+  dws doc upload [flags]
+Example:
+  dws doc upload --file ./report.pdf
+  dws doc upload --file ./slides.pptx --name "Q1汇报.pptx" --folder <FOLDER_ID>
+  dws doc upload --file ./data.xlsx --workspace <WS_ID> --convert
+Flags:
+      --file string        本地文件路径 (必填)
+      --name string        文件显示名称 (默认使用文件名)
+      --folder string      目标文件夹 ID 或 URL
+      --workspace string   目标知识库 ID
+      --convert            是否转换为钉钉在线文档
+```
+
+### 下载文件到本地
+```
+Usage:
+  dws doc download [flags]
+Example:
+  dws doc download --node <NODE_ID>
+  dws doc download --node <NODE_ID> --output ./report.pdf
+  dws doc download --node "https://alidocs.dingtalk.com/i/nodes/<DOC_UUID>" --output ~/downloads/
+Flags:
+      --node string     文件节点 ID 或 URL (必填)
+      --output string   本地保存路径 (文件路径或目录，必填)
+```
+
+### 创建文件夹
+```
+Usage:
+  dws doc folder create [flags]
+Example:
+  dws doc folder create --name "项目资料"
+  dws doc folder create --name "子文件夹" --folder <PARENT_FOLDER_ID>
+Flags:
+      --name string        文件夹名称 (必填)
+      --folder string      父文件夹 ID 或 URL
+      --workspace string   目标知识库 ID
+```
+
+### 查询块元素
+```
+Usage:
+  dws doc block list [flags]
+Example:
+  dws doc block list --node <DOC_ID>
+  dws doc block list --node <DOC_ID> --start-index 0 --end-index 5
+  dws doc block list --node <DOC_ID> --block-type heading
+Flags:
+      --node string         文档 ID 或 URL (必填)
+      --start-index int     起始位置 (从 0 开始)
+      --end-index int       终止位置 (含)
+      --block-type string   按块类型过滤
+```
+
+### 插入块元素
+```
+Usage:
+  dws doc block insert [flags]
+Example:
+  dws doc block insert --node <DOC_ID> --text "这是一段文字"
+  dws doc block insert --node <DOC_ID> --heading "二级标题" --level 2
+  dws doc block insert --node <DOC_ID> --element '{"blockType":"paragraph","paragraph":{"text":"内容"}}'
+  dws doc block insert --node <DOC_ID> --text "在此处之前插入" --ref-block <BLOCK_ID> --where before
+Flags:
+      --node string        文档 ID 或 URL (必填)
+      --text string        快捷: 段落文本内容
+      --heading string     快捷: 标题文本
+      --level int          标题级别 1-6 (配合 --heading，默认 1)
+      --element string     块元素 JSON (高级)
+      --index int          参照位置索引 (从 0 开始)
+      --where string       插入方向: before / after (默认 after)
+      --ref-block string   参照块 ID (优先级高于 --index)
+```
+
+### 更新块元素
+```
+Usage:
+  dws doc block update [flags]
+Example:
+  dws doc block update --node <DOC_ID> --block-id <BLOCK_ID> --text "新内容"
+  dws doc block update --node <DOC_ID> --block-id <BLOCK_ID> --element '{"blockType":"heading","heading":{"text":"新标题","level":1}}'
+Flags:
+      --node string        文档 ID 或 URL (必填)
+      --block-id string    目标块 ID (必填)
+      --text string        快捷: 段落文本内容
+      --heading string     快捷: 标题文本
+      --level int          标题级别 1-6 (配合 --heading，默认 1)
+      --element string     块元素 JSON (高级)
+```
+
+### 删除块元素
+
+> **CAUTION:** 不可逆操作 — 执行前必须向用户确认。
+
+```
+Usage:
+  dws doc block delete [flags]
+Example:
+  dws doc block delete --node <DOC_ID> --block-id <BLOCK_ID> --yes
+Flags:
+      --node string        文档 ID 或 URL (必填)
+      --block-id string    目标块 ID (必填)
+```
+
+### 查询文档评论列表
+```
+Usage:
+  dws doc comment list [flags]
+Example:
+  dws doc comment list --node <DOC_ID>
+  dws doc comment list --node <DOC_ID> --type inline --resolve-status unresolved
+  dws doc comment list --node <DOC_ID> --page-size 20 --next-token <TOKEN>
+Flags:
+      --node string            目标文档的标识，支持传入 URL 或 ID (必填)
+      --page-size int          每页返回的评论数量，默认 50，最大 50
+      --next-token string      分页游标，从上一次请求的返回结果中获取 (首次请求不传)
+      --type string            按评论类型过滤: global (全文评论) / inline (划词评论)
+      --resolve-status string  按解决状态过滤: resolved (已解决) / unresolved (未解决)
+```
+
+### 创建文档评论
+```
+Usage:
+  dws doc comment create [flags]
+Example:
+  dws doc comment create --node <DOC_ID> --content "这里需要修改"
+  dws doc comment create --node <DOC_ID> --content "请review" --mention uid1,uid2
+Flags:
+      --node string      目标文档的标识，支持传入 URL 或 ID (必填)
+      --content string   评论的文字内容，纯文本 (必填)
+      --mention string   被 @ 的用户 uid 列表，逗号分隔
+```
+
+### 回复文档评论
+```
+Usage:
+  dws doc comment reply [flags]
+Example:
+  dws doc comment reply --node <DOC_ID> --comment-key <COMMENT_KEY> --content "同意"
+  dws doc comment reply --node <DOC_ID> --comment-key <COMMENT_KEY> --content "比心" --emoji
+  dws doc comment reply --node <DOC_ID> --comment-key <COMMENT_KEY> --content "请确认" --mention uid1,uid2
+Flags:
+      --node string         目标文档的标识，支持传入 URL 或 ID (必填)
+      --content string      回复的文字内容，表情回复时填写表情名称 (必填)
+      --comment-key string  被回复评论的 commentKey，格式: {13位毫秒时间戳}{32位UUID}，可从 list/create 结果获取 (必填)
+      --emoji               设为 true 时作为表情贴图回复 (默认 false)
+      --mention string      被 @ 的用户 uid 列表，逗号分隔
+```
+
+## URL 识别与 DOC_ID 提取
+
+当用户输入包含钉钉文档 URL 时，**必须先识别并提取 DOC_ID**，再判断意图。
+
+### 支持的 URL 格式
+
+| 格式 | 示例 | DOC_ID 提取方式 |
+|------|------|----------------|
+| `alidocs.dingtalk.com/i/nodes/{id}` | `https://alidocs.dingtalk.com/i/nodes/9E05BDRVQePjzLkZt2p2vE7kV63zgkYA` | 取 URL 路径最后一段：`9E05BDRVQePjzLkZt2p2vE7kV63zgkYA` |
+| `alidocs.dingtalk.com/i/nodes/{id}?queryParams` | `https://alidocs.dingtalk.com/i/nodes/abc123?doc_type=wiki_doc` | 忽略 query 参数，取路径最后一段：`abc123` |
+
+### 提取规则
+
+1. 匹配 URL 中 `alidocs.dingtalk.com` 域名
+2. 取 URL path 的最后一段作为 DOC_ID（去掉 query string 和 fragment）
+3. 提取出的 DOC_ID 可直接用于所有 `--node` 参数，也可将完整 URL 传给 `--node`（CLI 会自动解析）
+
+### 处理流程
+
+```
+用户输入含 alidocs.dingtalk.com URL
+  → 提取 DOC_ID（URL 路径最后一段）
+  → 结合用户意图选择命令（默认 read）
+  → 将 DOC_ID 传给 --node 参数
+```
+
+## 意图判断
+
+用户说"找文档/搜文档/最近文档":
+- 搜索 → `search`
+- 浏览 → `list`
+
+用户说"看文档/读内容/文档内容":
+- 读取 → `read` (需文档 ID 或 URL)
+- 元信息 → `info`
+
+用户说"写文档/创建文档":
+- 新建 → `create`
+- 追加内容 → `update --mode append`
+- 覆盖替换 → `update --mode overwrite`
+
+用户说"建文件夹/新建目录":
+- 创建 → `folder create`
+
+用户说"上传文件/传文件/上传到文档/上传到知识库":
+- 上传 → `upload`（需本地文件路径）
+- 上传并转换 → `upload --convert`
+
+用户说"下载文件/导出文件/下载到本地":
+- 下载 → `download`（需文件节点 ID 或 URL）
+
+用户说"编辑块/改段落/插入标题/删除块":
+- 查看结构 → `block list`
+- 插入 → `block insert`
+- 修改 → `block update`
+- 删除 → `block delete`
+
+**用户直接粘贴文档 URL（无其他指令）**:
+- 默认 → `read`（读取文档内容）
+- 如 URL 明显是文件夹 → `list`（列出文件夹内容）
+
+**用户粘贴 URL + 附加指令**:
+- "帮我看看这个文档" → `read`
+- "这个文档的信息" → `info`
+- "往这个文档追加内容" → `update --mode append`
+- "编辑这个文档的标题" → `block update`
+
+关键区分: doc(文档编辑/阅读) vs aitable(数据表格操作) vs drive(钉盘文件管理)
+
+## 核心工作流
+
+```bash
+# ── 工作流 1: 浏览并阅读文档 ──
+
+# 1. 浏览我的文档根目录
+dws doc list --format json
+
+# 2. 浏览子文件夹
+dws doc list --folder <FOLDER_ID> --format json
+
+# 3. 获取文档元信息 (标题、类型、权限)
+dws doc info --node <DOC_ID> --format json
+
+# 4. 读取文档内容 (Markdown 格式)
+dws doc read --node <DOC_ID> --format json
+
+# ── 工作流 2: 创建文档并写入内容 ──
+
+# 1. (可选) 创建文件夹 — 提取 nodeId
+dws doc folder create --name "项目资料" --format json
+
+# 2. 创建文档 — 提取 nodeId
+dws doc create --name "项目周报" --folder <FOLDER_ID> --format json
+
+# 3. 写入内容 (追加模式)
+dws doc update --node <DOC_ID> --markdown "# 本周总结\n\n- 完成了 A\n- 推进了 B" --mode append --format json
+
+# ── 工作流 3: 一步创建带内容的文档 ──
+
+dws doc create --name "会议纪要" --markdown "# 会议纪要\n\n## 议题\n\n1. ..." --format json
+
+# ── 工作流 4: 上传本地文件到钉钉文档/知识库 ──
+
+# 1. 上传到"我的文档"根目录
+dws doc upload --file ./report.pdf
+
+# 2. 上传到指定文件夹
+dws doc upload --file ./slides.pptx --name "Q1汇报.pptx" --folder <FOLDER_ID>
+
+# 3. 上传到知识库并转换为在线文档
+dws doc upload --file ./data.xlsx --workspace <WS_ID> --convert
+
+# ── 工作流 5: 下载文件到本地 ──
+
+# 1. 下载到当前目录 (自动推断文件名)
+dws doc download --node <NODE_ID>
+
+# 2. 下载到指定路径
+dws doc download --node <NODE_ID> --output ./report.pdf
+
+# 3. 下载到指定目录 (自动推断文件名)
+dws doc download --node <NODE_ID> --output ~/downloads/
+
+# ── 工作流 6: 块级精细编辑 ──
+
+# 1. 查看文档块结构 — 获取 blockId
+dws doc block list --node <DOC_ID> --format json
+
+# 2. 在文档末尾插入段落
+dws doc block insert --node <DOC_ID> --text "新增内容"
+
+# 3. 在指定块之前插入标题
+dws doc block insert --node <DOC_ID> --heading "新章节" --level 2 --ref-block <BLOCK_ID> --where before
+
+# 4. 更新某个块的内容
+dws doc block update --node <DOC_ID> --block-id <BLOCK_ID> --text "修改后的内容"
+
+# 5. 删除块
+dws doc block delete --node <DOC_ID> --block-id <BLOCK_ID> --yes
+
+# ── 工作流 7: 文档评论管理 ──
+
+# 1. 查看文档的所有评论
+dws doc comment list --node <DOC_ID> --format json
+
+# 2. 在文档上创建评论
+dws doc comment create --node <DOC_ID> --content "这里需要补充数据来源" --format json
+
+# 3. 创建评论并 @ 相关人
+#    先搜索用户: dws contact user search --query "张三" --format json → 提取 userId
+#    再将 userId 传入 --mention
+dws doc comment create --node <DOC_ID> --content "请确认这部分内容" --mention <userId1>,<userId2> --format json
+
+# 4. 回复某条评论（commentKey 从 list 或 create 返回中获取）
+dws doc comment reply --node <DOC_ID> --comment-key <COMMENT_KEY> --content "已修改" --format json
+
+# 5. 用表情回复评论
+dws doc comment reply --node <DOC_ID> --comment-key <COMMENT_KEY> --content "比心" --emoji --format json
+```
+
+## 上下文传递表
+
+| 操作 | 从返回中提取 | 用于 |
+|------|-------------|------|
+| `list` | `nodes[].nodeId` | read / info / update / block 操作的 --node |
+| `list` | folder 类型的 `nodeId` | list 的 --folder, create 的 --folder |
+| `search` | 文档 `nodeId` / URL / `createTime` / `creatorUid` | read / info / update 的 --node；创建时间与创建者信息 |
+| `create` | `nodeId` | update / block 操作的 --node |
+| `folder create` | `nodeId` | create / list / upload 的 --folder |
+| `block list` | `blockId` | block insert 的 --ref-block, block update/delete 的 --block-id |
+| `upload` | `nodeId` / URL | 上传后文件的访问链接 |
+| `download` | 本地文件路径 | 下载后的文件保存位置 |
+| `comment list` | `commentList[].commentKey` | comment reply 的 --comment-key |
+| `comment create` | `commentKey` | comment reply 的 --comment-key |
+| `contact user search` | `userId` | comment create/reply 的 --mention |
+
+## nodeId 双格式说明
+
+所有 `--node` 参数同时支持两种格式，系统自动识别：
+- **文档 ID**: 字母数字字符串，如 `9E05BDRVQePjzLkZt2p2vE7kV63zgkYA`
+- **文档 URL**: `https://alidocs.dingtalk.com/i/nodes/{dentryUuid}`，如 `https://alidocs.dingtalk.com/i/nodes/9E05BDRVQePjzLkZt2p2vE7kV63zgkYA`
+
+两种方式等价，以下命令效果相同：
+```bash
+dws doc read --node 9E05BDRVQePjzLkZt2p2vE7kV63zgkYA
+dws doc read --node "https://alidocs.dingtalk.com/i/nodes/9E05BDRVQePjzLkZt2p2vE7kV63zgkYA"
+```
+
+`--folder` 参数同样支持文件夹 URL 或 ID。
+
+## 注意事项
+
+- `update --mode overwrite` 会**清空原内容后重写**，⚠️ 谨慎使用；默认 `--mode append` (追加) 更安全
+- `read` 返回 Markdown 格式的文档内容，仅限有"下载"权限的文档
+- `create` 不传 `--folder` 和 `--workspace` 时，默认创建在"我的文档"根目录
+- `block list/insert/update/delete` 是块级精细编辑，适合结构化修改；简单内容追加建议用 `update --mode append`
+- `block insert` 优先使用 `--text` 或 `--heading` 快捷方式；复杂块类型 (table, callout 等) 使用 `--element` JSON
+- `markdown` 参数中的换行必须使用**真实换行符**（即实际的换行字符，Unicode `U+000A`），而不是字面量字符串 `\n`（反斜杠加字母 n）。在通过程序或大模型构造此参数时，请确保字符串在发送前已正确反转义。如果传入的是两个字符的字面量 `\n`，所有内容将渲染在同一行，导致标题、段落和表格格式全部错乱。
+- 块类型包括: paragraph, heading, blockquote, callout, columns, orderedList, unorderedList, table, sheet, attachment, slot
+- 关键区分: doc(文档编辑/阅读) vs aitable(数据表格操作) vs drive(钉盘文件管理)
+- `upload` 支持上传任意类型文件 (PDF、Office、图片等) 到钉钉文档空间或知识库；`--convert` 可将 Office 文件转换为钉钉在线文档
+- `upload` 是三步自动完成的流程 (获取凭证 → OSS 上传 → 提交入库)，无需手动分步操作
+- `download` 是两步自动完成的流程 (获取下载链接 → HTTP GET 下载)，支持自动推断文件名；`--output` 可指定文件路径或目录
+
+## 自动化脚本
+
+| 脚本 | 场景 | 用法 |
+|------|------|------|
+| [doc_create_and_write.py](../../scripts/doc_create_and_write.py) | 创建文档并写入 Markdown 内容 | `python doc_create_and_write.py --name "周报" --content "# 本周总结"` |
+
+## 相关产品
+
+- [aitable](./aitable.md) — 结构化数据表格（行列/字段/记录），不是富文本文档
+- [drive](./drive.md) — 钉盘文件存储/上传/下载，不是文档内容编辑
+- [report](./report.md) — 钉钉日志系统（日报/周报模版），不是在线文档

--- a/skills/references/products/minutes.md
+++ b/skills/references/products/minutes.md
@@ -1,0 +1,274 @@
+# AI听记 (minutes) 命令参考
+
+## 命令总览
+
+### 查询我创建的听记列表
+```
+Usage:
+  dws minutes list mine [flags]
+Example:
+  dws minutes list mine
+  dws minutes list mine --max 10
+  dws minutes list mine --max 10 --next-token <nextToken>
+  dws minutes list mine --query "周会"
+Flags:
+      --max float         查询的听记篇数 (默认 10)
+      --next-token string 分页 token (首页留空，后续填写前次返回的 nextToken)
+      --query string      关键字筛选 (可选)
+      --start string      开始时间 ISO-8601 (可选)
+      --end string        结束时间 ISO-8601 (可选)
+```
+
+查询我创建的听记列表，支持 `--max` 和 `--next-token` 分页，支持按关键字和时间范围筛选。
+
+### 查询他人共享给我的听记列表
+```
+Usage:
+  dws minutes list shared [flags]
+Example:
+  dws minutes list shared
+  dws minutes list shared --max 20
+  dws minutes list shared --max 5 --next-token <nextToken>
+Flags:
+      --max float         查询的听记篇数 (默认 10)
+      --next-token string 分页 token (首页留空，后续填写前次返回的 nextToken)
+      --query string      关键字筛选 (可选)
+      --start string      开始时间 ISO-8601 (可选)
+      --end string        结束时间 ISO-8601 (可选)
+```
+
+查询他人共享给我的听记列表，支持 `--max` 和 `--next-token` 分页，支持按关键字和时间范围筛选。
+
+### 查询我有权限访问的所有听记列表
+```
+Usage:
+  dws minutes list all [flags]
+Example:
+  dws minutes list all
+  dws minutes list all --max 20
+  dws minutes list all --query "周会" --max 20
+  dws minutes list all --start "2026-03-01T00:00:00+08:00" --end "2026-03-20T23:59:59+08:00"
+  dws minutes list all --max 10 --next-token <nextToken>
+Flags:
+      --end string        结束时间 ISO-8601 (可选)
+      --query string      关键字筛选 (可选)
+      --max float         查询的听记篇数 (默认 10)
+      --next-token string 分页 token (首页留空，后续填写前次返回的 nextToken)
+      --start string      开始时间 ISO-8601 (可选)
+```
+
+查询我有权限访问的所有听记列表（包括我创建的、他人共享给我的等所有有权限的听记）。支持按关键字和时间范围筛选。时间范围和关键字为可选参数，不传则返回所有有权限的听记。支持使用 `--max` 和 `--next-token` 进行分页查询。
+
+### 获取听记基础信息
+```
+Usage:
+  dws minutes get info [flags]
+Example:
+  dws minutes get info --id <taskUuid>
+Flags:
+      --id string   听记 taskUuid (必填)，取值逻辑参考 ## 注意事项
+```
+
+返回字段: 创建人、开始时间、截止时间、听记标题、听记访问链接URL
+
+### 获取听记 AI 摘要
+```
+Usage:
+  dws minutes get summary [flags]
+Example:
+  dws minutes get summary --id <taskUuid>
+Flags:
+      --id string   听记 taskUuid (必填)，取值逻辑参考 ## 注意事项
+```
+
+返回 Markdown 格式摘要，涵盖会议主题、核心结论、关键讨论点等
+
+### 获取听记关键字列表
+```
+Usage:
+  dws minutes get keywords [flags]
+Example:
+  dws minutes get keywords --id <taskUuid>
+Flags:
+      --id string   听记 taskUuid (必填)，取值逻辑参考 ## 注意事项
+```
+
+### 获取听记语音转写原文
+```
+Usage:
+  dws minutes get transcription [flags]
+Example:
+  dws minutes get transcription --id <taskUuid>
+  dws minutes get transcription --id <taskUuid> --direction 1
+Flags:
+      --direction string   排序方向: 0=正序, 1=倒序 (默认 0)
+      --id string          听记 taskUuid (必填)，取值逻辑参考 ## 注意事项
+      --next-token string 下一页的token 首次查询可空 后续查询需填写前次请求返回的nextToken
+```
+
+每条记录包含: 发言人信息、转写文本、对应时间戳
+
+### 获取听记中提取的待办事项
+```
+Usage:
+  dws minutes get todos [flags]
+Example:
+  dws minutes get todos --id <taskUuid>
+Flags:
+      --id string   听记 taskUuid (必填)，取值逻辑参考 ## 注意事项
+```
+
+每条记录包含: 待办内容、待办唯一ID、参与人信息、待办时间
+
+### 批量查询听记详情
+```
+Usage:
+  dws minutes get batch [flags]
+Example:
+  dws minutes get batch --ids uuid1,uuid2,uuid3
+Flags:
+      --ids string   听记 taskUuid 列表，逗号分隔 (必填)
+```
+
+返回字段: 听记标题、时长、参与人列表、创建时间、taskUuid、听记状态
+
+### 修改听记标题
+```
+Usage:
+  dws minutes update title [flags]
+Example:
+  dws minutes update title --id <taskUuid> --title "Q2 复盘会议"
+Flags:
+      --id string      听记 taskUuid (必填)，取值逻辑参考 ## 注意事项
+      --title string   新标题 (必填)
+```
+
+### 发起听记（开始录音）
+```
+Usage:
+  dws minutes record start [flags]
+Example:
+  dws minutes record start
+  dws minutes record start --session-id <sessionId>
+Flags:
+      --session-id string   AI 助理会话 ID (可选)
+```
+
+### 暂停听记录音
+```
+Usage:
+  dws minutes record pause [flags]
+Example:
+  dws minutes record pause --id <taskUuid>
+  dws minutes record pause --id <taskUuid> --session-id <sessionId>
+Flags:
+      --id string           听记 taskUuid (必填)
+      --session-id string   AI 助理会话 ID (可选)
+```
+
+### 恢复听记录音
+```
+Usage:
+  dws minutes record resume [flags]
+Example:
+  dws minutes record resume --id <taskUuid>
+  dws minutes record resume --id <taskUuid> --session-id <sessionId>
+Flags:
+      --id string           听记 taskUuid (必填)
+      --session-id string   AI 助理会话 ID (可选)
+```
+
+### 结束听记录音
+```
+Usage:
+  dws minutes record stop [flags]
+Example:
+  dws minutes record stop --id <taskUuid>
+  dws minutes record stop --id <taskUuid> --session-id <sessionId>
+Flags:
+      --id string           听记 taskUuid (必填)
+      --session-id string   AI 助理会话 ID (可选)
+```
+
+## 意图判断
+
+用户说"我的听记/我创建的听记" → `list mine`（可附加 `--query`、`--start`、`--end` 筛选）
+用户说"别人给我的听记/共享听记" → `list shared`（可附加 `--query`、`--start`、`--end` 筛选）
+用户说"有权限的听记/我能访问的听记/所有听记" → `list all`（可附加 `--query`、`--start`、`--end` 筛选）
+用户说"某时间段内的听记/按时间查听记/按关键词查听记" → 根据所属范围选择 `list mine`/`list shared`/`list all`，附加 `--start`、`--end`、`--query` 参数
+用户说"听记详情/听记信息" → `get info`
+用户说"摘要/总结/会议纪要" → `get summary`
+用户说"关键字/关键词" → `get keywords`
+用户说"原文/转写/录音文字" → `get transcription`
+用户说"会议待办/听记待办" → `get todos`
+用户说"改听记标题/重命名听记" → `update title`
+用户说"发起听记/开始录音" → `record start`
+用户说"暂停听记/暂停录音" → `record pause`
+用户说"继续听记/恢复录音" → `record resume`
+用户说"结束听记/结束录音" → `record stop`
+用户传入听记 URL（如 `https://shanji.dingtalk.com/app/transcribes/xxx`），从 URL 提取 taskUuid，再执行对应的 get/update 操作
+
+## 核心工作流
+
+```bash
+# 0. 发起听记（开始录音）
+dws minutes record start --format json
+
+# 1. 查看我的听记列表 — 提取 taskUuid
+dws minutes list mine --format json
+dws minutes list mine --max 10 --next-token <nextToken> --format json
+dws minutes list mine --query "周会" --format json
+
+# 1b. 查看共享给我的听记
+dws minutes list shared --max 20 --format json
+dws minutes list shared --query "日报" --format json
+
+# 1c. 查看我有权限访问的所有听记（支持关键字和时间范围筛选）
+dws minutes list all --format json
+dws minutes list all --query "周会" --start "2026-03-01T00:00:00+08:00" --end "2026-03-20T23:59:59+08:00" --format json
+
+# 2. 获取 AI 摘要
+dws minutes get summary --id <taskUuid> --format json
+
+# 3. 查看完整转写原文
+dws minutes get transcription --id <taskUuid> --format json
+
+# 4. 提取待办事项
+dws minutes get todos --id <taskUuid> --format json
+
+# 5. 修改标题
+dws minutes update title --id <taskUuid> --title "新标题" --format json
+
+# 6. 录音控制（基于 start 返回的 taskUuid）
+dws minutes record pause --id <taskUuid> --format json
+dws minutes record resume --id <taskUuid> --format json
+dws minutes record stop --id <taskUuid> --format json
+```
+
+## 上下文传递表
+
+| 操作 | 从返回中提取 | 用于 |
+|------|-------------|------|
+| `list mine` | `taskUuid`、`nextToken` | get/update 的 --id；翻页时 --next-token |
+| `list shared` | `taskUuid`、`nextToken` | get/update 的 --id；翻页时 --next-token |
+| `list all` | `taskUuid`、`nextToken` | get/update 的 --id；翻页时 --next-token |
+| `get batch` | 各听记 `taskUuid` | 进一步查询详情 |
+
+## 注意事项
+- `taskUuid` 是听记的唯一标识，所有 get/update 操作均以此为入参
+- `record start` 对应 MCP 工具 `execute_listening_note_command` 的 `cmd=create`，通常会返回可继续控制录音的 `taskUuid/uuid`
+- `record pause` / `record resume` / `record stop` 对应 `cmd=pause/resume/end`，需要传入 `--id`（映射 MCP 入参 `uuid`）
+- 如果用户传入听记 URL（格式: `https://shanji.dingtalk.com/app/transcribes/<taskUuid>`），直接从路径末段提取 taskUuid 作为 `--id` 参数，无需再调用 list 查询
+- `list mine`、`list shared`、`list all` 统一走 `list_by_keyword_and_time_range` 链路，通过 `belongingConditionId` 区分（`created` / `shared` / `noLimit`）
+- 三个 list 命令均支持 `--max`、`--next-token` 分页及 `--query`、`--start`、`--end` 筛选
+- `list mine`、`list shared` 默认每页 20 条，`list all` 默认每页 10 条
+- `get summary` 返回 AI 生成的结构化 Markdown 摘要
+- `get transcription` 的 `--direction` 控制时间排序: 0=正序(默认), 1=倒序
+- `get batch` 支持一次查询多个听记，用逗号分隔 taskUuid
+
+## 自动化脚本
+
+| 脚本 | 场景 | 用法 |
+|------|------|------|
+| [minutes_recent_summary.py](../../scripts/minutes_recent_summary.py) | 获取最近听记的 AI 摘要并合并 | `python minutes_recent_summary.py --max 5` |
+| [minutes_extract_todos.py](../../scripts/minutes_extract_todos.py) | 从听记中提取待办事项汇总 | `python minutes_extract_todos.py --max 5` |


### PR DESCRIPTION
## Summary

参考 `dws-wukong/dingtalk-workspace` 中 `minutes` 与 `doc` 两个 skill 参考文档的写法，在本仓补齐对应 skill 能力。

## Changes

- `skills/references/products/minutes.md`：新增，AI 听记命令参考（列表 / 详情 / 摘要 / 转写 / 待办 / 思维导图 / 发言人 / 热词）
- `skills/references/products/doc.md`：新增，钉钉文档命令参考（搜索 / 浏览 / 读写 / 块级编辑 / 评论）
- `skills/SKILL.md`：
  - `description` 补充"钉钉文档 / AI 听记"关键词
  - 产品总览新增 `doc` / `minutes` 行
  - 意图决策树补充听记 / 文档关键词路由
  - 危险操作表新增 `doc delete` / `doc block delete`

## Test plan

- [x] SKILL.md 引用链接完整性校验（17/17 refs 可达）
- [ ] 手工验证 `dws doc search` / `dws minutes get info` 典型路径按文档表述可达