### PR TITLE
docs: add doc and minutes to Key Services table

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,13 +358,13 @@ dws chat message send-by-bot --robot-code BOT_CODE --group GROUP_ID \
 | Attendance | `attendance` | 4 | `record` `shift` `summary` `rules` | Clock-in records, shift schedules, attendance summary, group rules |
 | Ding | `ding` | 2 | `message` | Send/recall DING messages |
 | Report | `report` | 7 | `create` `list` `detail` `template` `stats` `sent` | Create reports, sent/received list, templates, statistics |
-| AITable | `aitable` | 20 | `base` `table` `record` `field` `attachment` `template` | Full CRUD for bases/tables/records/fields, templates |
+| AITable | `aitable` | 37 | `base` `table` `record` `field` `attachment` `template` `chart` `dashboard` `export` `import` `view` | Full CRUD for bases/tables/records/fields; charts/dashboards; data import/export; views; templates |
 | Doc | `doc` | 16 | `search` `list` `info` `read` `create` `update` `upload` `download` `folder` `block` `comment` | Search, read, create/update documents; block-level editing; file upload/download; comments |
-| Minutes | `minutes` | 14 | `list` `get` `update` `record` | List and search AI meeting transcripts; summaries, transcriptions, todos; recording control |
+| Minutes | `minutes` | 22 | `list` `get` `update` `record` `hot-word` `mind-graph` `replace-text` `speaker` `upload` | List/search AI meeting transcripts; summaries, transcriptions, todos, mind-maps; recording control; speaker management, hot-words, file upload |
 | Workbench | `workbench` | 2 | `app` | Batch query app details |
 | DevDoc | `devdoc` | 1 | `article` | Search platform docs and error codes |
 
-> 116 commands across 14 products. Run `dws --help` for the full list, or `dws <service> --help` for subcommands.
+> 141 commands across 14 products. Run `dws --help` for the full list, or `dws <service> --help` for subcommands.
 
 <details>
 <summary>Coming soon</summary>

--- a/README.md
+++ b/README.md
@@ -359,15 +359,17 @@ dws chat message send-by-bot --robot-code BOT_CODE --group GROUP_ID \
 | Ding | `ding` | 2 | `message` | Send/recall DING messages |
 | Report | `report` | 7 | `create` `list` `detail` `template` `stats` `sent` | Create reports, sent/received list, templates, statistics |
 | AITable | `aitable` | 20 | `base` `table` `record` `field` `attachment` `template` | Full CRUD for bases/tables/records/fields, templates |
+| Doc | `doc` | 16 | `search` `list` `info` `read` `create` `update` `upload` `download` `folder` `block` `comment` | Search, read, create/update documents; block-level editing; file upload/download; comments |
+| Minutes | `minutes` | 14 | `list` `get` `update` `record` | List and search AI meeting transcripts; summaries, transcriptions, todos; recording control |
 | Workbench | `workbench` | 2 | `app` | Batch query app details |
 | DevDoc | `devdoc` | 1 | `article` | Search platform docs and error codes |
 
-> 86 commands across 12 products. Run `dws --help` for the full list, or `dws <service> --help` for subcommands.
+> 116 commands across 14 products. Run `dws --help` for the full list, or `dws <service> --help` for subcommands.
 
 <details>
 <summary>Coming soon</summary>
 
-`doc` (documents) · `mail` (email) · `minutes` (AI transcription) · `drive` (cloud drive) · `conference` (video) · `tb` (Teambition) · `aiapp` (AI apps) · `live` (streaming) · `skill` (marketplace)
+`mail` (email) · `drive` (cloud drive) · `conference` (video) · `tb` (Teambition) · `aiapp` (AI apps) · `live` (streaming) · `skill` (marketplace)
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add `doc` (16 commands) to Key Services table: search/list/read/create/update/upload/download/folder/block/comment
- Add `minutes` (14 commands) to Key Services table: list/get/update/record (AI meeting transcripts, summaries, todos, recording control)
- Remove `doc` and `minutes` from Coming soon
- Update total count: 86 → 116 commands, 12 → 14 products