### PR TITLE
feat(skills): 同步 aitable 参考 — 补充仪表盘/图表与导出数据章节

### DIFF
--- a/skills/references/products/aitable.md
+++ b/skills/references/products/aitable.md
@@ -380,6 +380,44 @@ Flags:
 
 > 📎 **模板预览地址**：`https://docs.dingtalk.com/table/template/{templateId}`
 
+## 复杂操作
+
+### 仪表盘 / 图表（建议顺序）
+
+```bash
+# 1) 先看配置模板（JSONC）
+dws aitable dashboard config-example --format json
+dws aitable chart widgets-example --format json
+
+# 2) 先拿 dashboard，再拿 chart 详情
+dws aitable dashboard get --base-id <BASE_ID> --dashboard-id <DASHBOARD_ID> --format json
+dws aitable chart get --base-id <BASE_ID> --dashboard-id <DASHBOARD_ID> --chart-id <CHART_ID> --format json
+```
+
+要点：
+
+- `dashboard get` 返回的 `charts[].chartId` 可直接给 `chart get` 使用。
+- `dashboard share get` 可能返回 `404`（资源不存在或未开通），需按可重试错误处理，不要误判为参数拼错。
+- `chart share get` 可正常返回 `enabled/shareUrl`，用于分享状态判断。
+
+### 导出数据（两阶段轮询）
+
+`export data` 常见为异步任务：首次调用可能只返回 `taskId`，需要继续轮询。
+
+```bash
+# 第一步：创建任务（按 scope 传必要参数）
+dws aitable export data --base-id <BASE_ID> --scope table --table-id <TABLE_ID> --format excel --timeout-ms 1000
+
+# 第二步：拿 taskId 继续轮询，直到返回 downloadUrl
+dws aitable export data --base-id <BASE_ID> --task-id <TASK_ID> --timeout-ms 3000
+```
+
+参数约束
+
+- `scope=all`：只需 `base-id`
+- `scope=table`：必须 `table-id`
+- `scope=view`：必须同时 `table-id + view-id`
+
 ## 意图判断
 
 用户说"表格/多维表/AI表格":


### PR DESCRIPTION
## 背景

对照 `dws-wukong/dingtalk-workspace/references/products/` 检查 aitable、doc、minutes、doc comment 四个 skill 参考的同步状态。

## 同步结论

| 产品 | 状态 | 说明 |
|------|------|------|
| **aitable** | ⚠️ 部分缺失 | 缺少仪表盘/图表、导出数据两节 |
| **doc** | ✅ 对齐 | copy/move/rename/create-inline 在 CLI 二进制中不存在，不同步 |
| **minutes** | ✅ 完全一致 | 无需变更 |
| **doc comment** | ✅ 对齐 | 非独立文件，基础 comment 操作已在 doc.md 中，create-inline 不在二进制中 |

## 本 PR 变更

在 `skills/references/products/aitable.md` 中补充两节（均已通过 `dws aitable --help` 验证命令存在）：

1. **仪表盘 / 图表**：`dashboard`/`chart` 命令使用顺序、`dashboard share get` 404 注意事项
2. **导出数据（两阶段轮询）**：`export data` taskId 轮询流程、`scope` 参数约束（all/table/view）

## 未同步项（有意排除）

- `--ai-config` flag（field create/update）— 二进制不支持
- `doc copy/move/rename` — 二进制不支持
- `doc comment create-inline` — 二进制不支持
- 自动化 Python 脚本节 — CLI 项目无对应脚本目录

🤖 Generated with [Claude Code](https://claude.com/claude-code)