### PR TITLE
fix(auth): restore device_code polling when flowId is absent

### DIFF
--- a/internal/app/pat_auth_retry.go
+++ b/internal/app/pat_auth_retry.go
@@ -284,27 +284,6 @@ func retryWithPatAuthRetry(ctx context.Context, runner executor.Runner, invocati
 	return runner.Run(ctx, invocation)
 }
 
-// loadMCPClientIDIfNeeded ensures we have a client ID for device flow.
-// Priority: in-memory runtime value → DWS_CLIENT_ID env → MCP remote fetch.
-func loadMCPClientIDIfNeeded(ctx context.Context, configDir string) string {
-	clientID := authpkg.ClientID()
-	if clientID != "" {
-		return clientID
-	}
-	// Fallback: read from environment variable (set by previous PAT auth or caller).
-	if envID := os.Getenv("DWS_CLIENT_ID"); envID != "" {
-		authpkg.SetClientIDFromMCP(envID)
-		return envID
-	}
-	// Last resort: fetch from MCP server.
-	mcpClientID, err := authpkg.FetchClientIDFromMCP(ctx)
-	if err == nil && mcpClientID != "" {
-		authpkg.SetClientIDFromMCP(mcpClientID)
-		return mcpClientID
-	}
-	return ""
-}
-
 // ---- handlePatAuthCheck (runner.go entry point) -----------------------------
 
 const (

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -185,11 +185,6 @@ func (p *DeviceFlowProvider) loginOnce(ctx context.Context, attempt int) (*Token
 	if err != nil {
 		return nil, err
 	}
-	if tokenResult == nil {
-		// FlowID was empty — no polling happened; authorization URL was already
-		// printed, so the user can handle it manually.
-		return nil, nil
-	}
 
 	_, _ = fmt.Fprintln(p.output(), "")
 	dfPrintStep(p.output(), 3, i18n.T("使用授权码换取 Access Token..."), 0)
@@ -377,15 +372,15 @@ func (p *DeviceFlowProvider) pollDeviceStatus(ctx context.Context, flowID string
 }
 
 func (p *DeviceFlowProvider) waitForAuthorization(ctx context.Context, auth *DeviceAuthResponse) (*DeviceTokenResponse, error) {
-	// No FlowID from server — cannot poll status; return immediately so the
-	// user can still see the authorization URL printed earlier and handle it
-	// manually (same pattern as pat_auth_retry.go L451).
 	if auth.FlowID == "" {
-		dfPrintDim(p.output(), i18n.T("  服务端未返回 flowId，跳过轮询，请在浏览器中手动完成授权后重试"))
-		_, _ = fmt.Fprintln(p.output(), "")
-		return nil, nil
+		// Keep the pre-flowId device-code polling path for regular device flow
+		// login responses that do not include terminal polling metadata.
+		return p.waitForAuthorizationByDeviceCode(ctx, auth)
 	}
+	return p.waitForAuthorizationByFlowID(ctx, auth)
+}
 
+func (p *DeviceFlowProvider) waitForAuthorizationByFlowID(ctx context.Context, auth *DeviceAuthResponse) (*DeviceTokenResponse, error) {
 	startTime := time.Now()
 	interval := time.Duration(auth.Interval) * time.Second
 	deadline := time.Duration(auth.ExpiresIn) * time.Second
@@ -431,6 +426,63 @@ func (p *DeviceFlowProvider) waitForAuthorization(ctx context.Context, auth *Dev
 			return nil, errors.New(i18n.T("设备授权码已过期"))
 		default:
 			dfPrintPollResult(p.output(), "unknown", fmt.Sprintf(i18n.T("未知状态: %s"), pollResp.Data.Status))
+		}
+	}
+}
+
+func (p *DeviceFlowProvider) waitForAuthorizationByDeviceCode(ctx context.Context, auth *DeviceAuthResponse) (*DeviceTokenResponse, error) {
+	startTime := time.Now()
+	interval := time.Duration(auth.Interval) * time.Second
+	deadline := time.Duration(auth.ExpiresIn) * time.Second
+	pollCount := 0
+
+	for {
+		elapsed := time.Since(startTime)
+		if elapsed >= maxPollTotalWait || elapsed >= deadline {
+			_, _ = fmt.Fprintln(p.output(), "")
+			return nil, fmt.Errorf("%s", i18n.Tf("设备授权码已过期（%d 秒），请重试", auth.ExpiresIn))
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(interval):
+		}
+
+		pollCount++
+		elapsedSec := int(time.Since(startTime).Seconds())
+		dfPrintPollStatus(p.output(), pollCount, elapsedSec)
+
+		resp, err := p.pollDeviceToken(ctx, auth.DeviceCode)
+		if err != nil {
+			dfPrintPollResult(p.output(), "network_error", i18n.T("网络错误，继续重试..."))
+			if p.logger != nil {
+				p.logger.Debug("poll error", "error", err)
+			}
+			continue
+		}
+
+		if resp.Error == "" {
+			dfPrintPollResult(p.output(), "authorized", i18n.T("授权成功!"))
+			return resp, nil
+		}
+		switch resp.Error {
+		case "authorization_pending":
+			dfPrintPollResult(p.output(), "pending", i18n.T("等待用户授权..."))
+		case "slow_down":
+			interval += 5 * time.Second
+			if interval > maxPollInterval*time.Second {
+				interval = maxPollInterval * time.Second
+			}
+			dfPrintPollResult(p.output(), "slow_down", fmt.Sprintf(i18n.T("轮询过快，间隔增加至 %ds"), int(interval.Seconds())))
+		case "access_denied":
+			_, _ = fmt.Fprintln(p.output(), "")
+			return nil, errors.New(i18n.T("用户拒绝了授权请求"))
+		case "expired_token":
+			_, _ = fmt.Fprintln(p.output(), "")
+			return nil, errors.New(i18n.T("设备授权码已过期"))
+		default:
+			dfPrintPollResult(p.output(), "unknown", fmt.Sprintf(i18n.T("未知错误: %s"), resp.Error))
 		}
 	}
 }

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -17,6 +17,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -25,6 +27,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/i18n"
 )
 
 func newDeviceFlowTestLogger() *slog.Logger {
@@ -180,8 +184,11 @@ func TestWaitForAuthorizationFallsBackToDeviceCodeWhenFlowIDMissing(t *testing.T
 	if calls.Load() != 3 {
 		t.Fatalf("poll calls = %d, want 3", calls.Load())
 	}
-	if strings.Contains(output.String(), "服务端未返回 flowId") {
-		t.Fatalf("unexpected PAT-only no-flowId hint in device flow output: %q", output.String())
+	if !strings.Contains(output.String(), i18n.T("等待用户授权...")) {
+		t.Fatalf("expected device-code path to emit pending output, got %q", output.String())
+	}
+	if !strings.Contains(output.String(), i18n.T("授权成功!")) {
+		t.Fatalf("expected device-code path to emit success output, got %q", output.String())
 	}
 }
 
@@ -211,5 +218,107 @@ func TestWaitForAuthorizationHonorsContextCancellation(t *testing.T) {
 		Interval:  1,
 	}); err == nil {
 		t.Fatal("waitForAuthorization() error = nil, want context cancellation")
+	}
+}
+
+func TestWaitForAuthorizationByDeviceCodeHonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeServiceResult(w, true, DeviceTokenResponse{Error: "authorization_pending"}, "", "")
+	}))
+	defer server.Close()
+
+	provider := NewDeviceFlowProvider(t.TempDir(), newDeviceFlowTestLogger())
+	provider.Output = io.Discard
+	provider.SetBaseURL(server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	_, err := provider.waitForAuthorization(ctx, &DeviceAuthResponse{
+		DeviceCode: "legacy-device-code",
+		ExpiresIn:  60,
+		Interval:   1,
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waitForAuthorization() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestWaitForAuthorizationByDeviceCodeErrorStates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		timeout    time.Duration
+		responses  []DeviceTokenResponse
+		wantErr    string
+		wantErrIs  error
+		wantOutput string
+	}{
+		{
+			name:       "slow_down_then_context_cancelled",
+			timeout:    1500 * time.Millisecond,
+			responses:  []DeviceTokenResponse{{Error: "slow_down"}},
+			wantErrIs:  context.DeadlineExceeded,
+			wantOutput: fmt.Sprintf(i18n.T("轮询过快，间隔增加至 %ds"), 6),
+		},
+		{
+			name:       "access_denied",
+			timeout:    5 * time.Second,
+			responses:  []DeviceTokenResponse{{Error: "access_denied"}},
+			wantErr:    i18n.T("用户拒绝了授权请求"),
+			wantOutput: fmt.Sprintf(i18n.T("[%d] 轮询中... (%ds)"), 1, 1),
+		},
+		{
+			name:       "expired_token",
+			timeout:    5 * time.Second,
+			responses:  []DeviceTokenResponse{{Error: "expired_token"}},
+			wantErr:    i18n.T("设备授权码已过期"),
+			wantOutput: fmt.Sprintf(i18n.T("[%d] 轮询中... (%ds)"), 1, 1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				idx := int(calls.Add(1)) - 1
+				if idx >= len(tt.responses) {
+					idx = len(tt.responses) - 1
+				}
+				writeServiceResult(w, true, tt.responses[idx], "", "")
+			}))
+			defer server.Close()
+
+			provider := NewDeviceFlowProvider(t.TempDir(), newDeviceFlowTestLogger())
+			var output bytes.Buffer
+			provider.Output = &output
+			provider.SetBaseURL(server.URL)
+
+			ctx, cancel := context.WithTimeout(context.Background(), tt.timeout)
+			defer cancel()
+
+			_, err := provider.waitForAuthorization(ctx, &DeviceAuthResponse{
+				DeviceCode: "legacy-device-code",
+				ExpiresIn:  60,
+				Interval:   1,
+			})
+
+			if tt.wantErrIs != nil {
+				if !errors.Is(err, tt.wantErrIs) {
+					t.Fatalf("waitForAuthorization() error = %v, want %v", err, tt.wantErrIs)
+				}
+			} else if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("waitForAuthorization() error = %v, want %q", err, tt.wantErr)
+			}
+
+			if !strings.Contains(output.String(), tt.wantOutput) {
+				t.Fatalf("expected output to contain %q, got %q", tt.wantOutput, output.String())
+			}
+		})
 	}
 }

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -14,6 +14,7 @@
 package auth
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -135,6 +136,52 @@ func TestWaitForAuthorizationSucceedsAfterPending(t *testing.T) {
 	}
 	if calls.Load() != 3 {
 		t.Fatalf("poll calls = %d, want 3", calls.Load())
+	}
+}
+
+func TestWaitForAuthorizationFallsBackToDeviceCodeWhenFlowIDMissing(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm() error = %v", err)
+		}
+		if got := r.FormValue("device_code"); got != "legacy-device-code" {
+			t.Fatalf("device_code = %q, want legacy-device-code", got)
+		}
+		if calls.Add(1) <= 2 {
+			writeServiceResult(w, true, DeviceTokenResponse{Error: "authorization_pending"}, "", "")
+			return
+		}
+		writeServiceResult(w, true, DeviceTokenResponse{AuthCode: "legacy-auth-code"}, "", "")
+	}))
+	defer server.Close()
+
+	provider := NewDeviceFlowProvider(t.TempDir(), newDeviceFlowTestLogger())
+	var output bytes.Buffer
+	provider.Output = &output
+	provider.SetBaseURL(server.URL)
+
+	resp, err := provider.waitForAuthorization(context.Background(), &DeviceAuthResponse{
+		DeviceCode: "legacy-device-code",
+		ExpiresIn:  10,
+		Interval:   1,
+	})
+	if err != nil {
+		t.Fatalf("waitForAuthorization() error = %v", err)
+	}
+	if resp.AuthCode != "legacy-auth-code" {
+		t.Fatalf("auth code = %q, want legacy-auth-code", resp.AuthCode)
+	}
+	if calls.Load() != 3 {
+		t.Fatalf("poll calls = %d, want 3", calls.Load())
+	}
+	if strings.Contains(output.String(), "服务端未返回 flowId") {
+		t.Fatalf("unexpected PAT-only no-flowId hint in device flow output: %q", output.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep the PAT no-flowId passthrough behavior unchanged
- restore the legacy device_code polling path for regular device flow responses that do not include flowId
- add focused regression coverage for the no-flowId device-code path, including cancellation and error-state branches

## Testing
- go test ./internal/auth -run 'TestWaitForAuthorization'
- go test ./internal/app -run 'TestHandlePatAuthCheck_EmptyFlowID_FallsBackToPATError'