### PR TITLE
feat: sync drive/sheet/aitable skill references and fix array param parsing

### DIFF
--- a/internal/app/legacy.go
+++ b/internal/app/legacy.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/transport"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/spf13/cobra"
@@ -208,23 +209,31 @@ func loadCachedDetailsFast(store *cache.Store, servers []market.ServerDescriptor
 		}
 		details := make([]market.DetailTool, 0, len(snapshot.Tools))
 		for _, tool := range snapshot.Tools {
-			schemaJSON := ""
-			if tool.InputSchema != nil {
-				if data, marshalErr := json.Marshal(tool.InputSchema); marshalErr == nil {
-					schemaJSON = string(data)
-				}
-			}
-			details = append(details, market.DetailTool{
-				ToolName:    tool.Name,
-				ToolTitle:   tool.Title,
-				ToolDesc:    tool.Description,
-				IsSensitive: tool.Sensitive,
-				ToolRequest: schemaJSON,
-			})
+			details = append(details, toolDescriptorToDetail(tool))
 		}
 		result[serverID] = details
 	}
 	return result
+}
+
+// toolDescriptorToDetail converts a transport-level ToolDescriptor (returned by
+// MCP tools/list) into a market.DetailTool by marshalling InputSchema to JSON.
+// Used by both loadCachedDetailsFast (cache fallback) and buildHTTPCommandsFromTools
+// (cold-discovery path) to keep the conversion in one place.
+func toolDescriptorToDetail(tool transport.ToolDescriptor) market.DetailTool {
+	schemaJSON := ""
+	if tool.InputSchema != nil {
+		if data, marshalErr := json.Marshal(tool.InputSchema); marshalErr == nil {
+			schemaJSON = string(data)
+		}
+	}
+	return market.DetailTool{
+		ToolName:    tool.Name,
+		ToolTitle:   tool.Title,
+		ToolDesc:    tool.Description,
+		IsSensitive: tool.Sensitive,
+		ToolRequest: schemaJSON,
+	}
 }
 
 // fetchDetailsByServerID fetches MCP Detail API tool metadata for each server

--- a/internal/app/legacy.go
+++ b/internal/app/legacy.go
@@ -167,6 +167,11 @@ func loadDynamicCommands(ctx context.Context, runner executor.Runner) []*cobra.C
 
 // loadCachedDetailsFast reads Detail API tool metadata from disk cache only —
 // no network calls. Returns whatever is available (fresh or stale).
+//
+// For servers without a Detail API locator (most discovery-driven services),
+// fall back to the per-server tools snapshot persisted by tools/list. This
+// ensures binding-kind upgrades (array/object → ValueJSON) have access to
+// the JSON Schema even when no Detail API is configured.
 func loadCachedDetailsFast(store *cache.Store, servers []market.ServerDescriptor) map[string][]market.DetailTool {
 	result := make(map[string][]market.DetailTool)
 	if store == nil {
@@ -174,23 +179,50 @@ func loadCachedDetailsFast(store *cache.Store, servers []market.ServerDescriptor
 	}
 	partition := config.DefaultPartition
 	for _, server := range servers {
-		if server.DetailLocator.MCPID <= 0 {
-			continue
-		}
 		serverID := strings.TrimSpace(server.CLI.ID)
 		if serverID == "" {
 			continue
 		}
-		snap, _, err := store.LoadDetail(partition, serverID)
-		if err != nil {
+
+		// Primary: Detail API payload (when configured).
+		if server.DetailLocator.MCPID > 0 {
+			if snap, _, err := store.LoadDetail(partition, serverID); err == nil {
+				var payload struct {
+					Tools []market.DetailTool `json:"tools"`
+				}
+				if jsonErr := json.Unmarshal(snap.Payload, &payload); jsonErr == nil && len(payload.Tools) > 0 {
+					result[serverID] = payload.Tools
+					continue
+				}
+			}
+		}
+
+		// Fallback: tools snapshot from tools/list (used by most services).
+		serverKey := strings.TrimSpace(server.Key)
+		if serverKey == "" {
 			continue
 		}
-		var payload struct {
-			Tools []market.DetailTool `json:"tools"`
+		snapshot, _, err := store.LoadTools(partition, serverKey)
+		if err != nil || len(snapshot.Tools) == 0 {
+			continue
 		}
-		if jsonErr := json.Unmarshal(snap.Payload, &payload); jsonErr == nil && len(payload.Tools) > 0 {
-			result[serverID] = payload.Tools
+		details := make([]market.DetailTool, 0, len(snapshot.Tools))
+		for _, tool := range snapshot.Tools {
+			schemaJSON := ""
+			if tool.InputSchema != nil {
+				if data, marshalErr := json.Marshal(tool.InputSchema); marshalErr == nil {
+					schemaJSON = string(data)
+				}
+			}
+			details = append(details, market.DetailTool{
+				ToolName:    tool.Name,
+				ToolTitle:   tool.Title,
+				ToolDesc:    tool.Description,
+				IsSensitive: tool.Sensitive,
+				ToolRequest: schemaJSON,
+			})
 		}
+		result[serverID] = details
 	}
 	return result
 }

--- a/internal/app/legacy_cache_test.go
+++ b/internal/app/legacy_cache_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cache"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/transport"
 	"github.com/spf13/cobra"
 )
 
@@ -544,11 +545,24 @@ func TestLoadDynamicCommandsUsesStaleCacheWithoutBlockingRegistryRefresh(t *test
 
 // TestFetchDetailsByServerIDRunsConcurrently verifies that detail fetches are
 // concurrent, not serial. Uses MCPID path to avoid the localhost SSRF guard.
+//
+// Detection uses a deterministic inflight counter (max number of requests
+// observed in the handler at the same instant) instead of wall-clock timing,
+// which was flaky under -race on slow CI runners.
 func TestFetchDetailsByServerIDRunsConcurrently(t *testing.T) {
 	const numServers = 4
 	const delay = 50 * time.Millisecond
 
+	var current, maxInflight atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cur := current.Add(1)
+		defer current.Add(-1)
+		for {
+			prev := maxInflight.Load()
+			if cur <= prev || maxInflight.CompareAndSwap(prev, cur) {
+				break
+			}
+		}
 		time.Sleep(delay)
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"success": true,
@@ -571,13 +585,10 @@ func TestFetchDetailsByServerIDRunsConcurrently(t *testing.T) {
 		}
 	}
 
-	start := time.Now()
 	result := fetchDetailsByServerID(context.TODO(), market.NewClient(srv.URL, nil), servers, cache.NewStore(t.TempDir()), false)
-	elapsed := time.Since(start)
 
-	serialBound := time.Duration(numServers) * delay
-	if elapsed >= serialBound {
-		t.Errorf("elapsed %v >= serial bound %v: requests appear serial, want concurrent", elapsed, serialBound)
+	if got := maxInflight.Load(); got < 2 {
+		t.Errorf("max concurrent inflight = %d, want >= 2 (requests appear serial)", got)
 	}
 	if len(result) == 0 {
 		t.Errorf("fetchDetailsByServerID() = empty map, want results")
@@ -739,5 +750,89 @@ func TestFetchDetailsByServerIDUsesCacheOnHit(t *testing.T) {
 	}
 	if len(result) == 0 {
 		t.Errorf("fetchDetailsByServerID() returned empty map, want cached tools")
+	}
+}
+
+// Regression: when a server has no Detail API locator (MCPID == 0), the
+// cache fallback path must read schemas from the per-server tools snapshot
+// (cache.Store.SaveTools) so the binding-kind upgrade in BuildDynamicCommands
+// has the JSON Schema available. See PR #154.
+func TestLoadCachedDetailsFastFallsBackToToolsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	store := cache.NewStore(t.TempDir())
+
+	const serverKey = "sheet-key"
+	const serverID = "sheet"
+
+	tools := []transport.ToolDescriptor{
+		{
+			Name:        "update_range",
+			Title:       "Update Range",
+			Description: "Update sheet range",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"values": map[string]any{
+						"type": "array",
+						"items": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := store.SaveTools("default/default", serverKey, cache.ToolsSnapshot{
+		SavedAt:   time.Now().UTC(),
+		ServerKey: serverKey,
+		Tools:     tools,
+	}); err != nil {
+		t.Fatalf("SaveTools error: %v", err)
+	}
+
+	servers := []market.ServerDescriptor{
+		{Key: serverKey, CLI: market.CLIOverlay{ID: serverID}}, // MCPID intentionally zero
+	}
+	result := loadCachedDetailsFast(store, servers)
+
+	got, ok := result[serverID]
+	if !ok || len(got) != 1 {
+		t.Fatalf("expected 1 detail tool for %q, got %#v", serverID, result)
+	}
+	if got[0].ToolName != "update_range" {
+		t.Errorf("ToolName = %q, want update_range", got[0].ToolName)
+	}
+	if !strings.Contains(got[0].ToolRequest, `"values"`) || !strings.Contains(got[0].ToolRequest, `"array"`) {
+		t.Errorf("ToolRequest missing schema, got: %s", got[0].ToolRequest)
+	}
+}
+
+// loadCachedDetailsFast must keep preferring the Detail API payload when
+// MCPID > 0; the tools-snapshot fallback only kicks in for discovery-driven
+// services without a locator.
+func TestLoadCachedDetailsFastDetailAPITakesPriority(t *testing.T) {
+	t.Parallel()
+
+	store := cache.NewStore(t.TempDir())
+	const serverID = "test-server"
+
+	cached := []market.DetailTool{{ToolName: "from_detail_api"}}
+	cachedJSON, _ := json.Marshal(map[string]any{"tools": cached})
+	if err := store.SaveDetail("default/default", serverID, cache.DetailSnapshot{
+		SavedAt: time.Now().UTC(),
+		MCPID:   42,
+		Payload: cachedJSON,
+	}); err != nil {
+		t.Fatalf("SaveDetail error: %v", err)
+	}
+
+	servers := []market.ServerDescriptor{
+		{DetailLocator: market.DetailLocator{MCPID: 42}, CLI: market.CLIOverlay{ID: serverID}},
+	}
+	result := loadCachedDetailsFast(store, servers)
+	if got := result[serverID]; len(got) != 1 || got[0].ToolName != "from_detail_api" {
+		t.Errorf("expected Detail API payload, got %#v", got)
 	}
 }

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -1307,21 +1307,9 @@ func buildHTTPCommandsFromTools(srv market.ServerDescriptor, tools []transport.T
 	}
 
 	detailsByID := make(map[string][]market.DetailTool)
-	var detailTools []market.DetailTool
+	detailTools := make([]market.DetailTool, 0, len(tools))
 	for _, tool := range tools {
-		schemaJSON := ""
-		if tool.InputSchema != nil {
-			if data, marshalErr := json.Marshal(tool.InputSchema); marshalErr == nil {
-				schemaJSON = string(data)
-			}
-		}
-		detailTools = append(detailTools, market.DetailTool{
-			ToolName:    tool.Name,
-			ToolTitle:   tool.Title,
-			ToolDesc:    tool.Description,
-			IsSensitive: tool.Sensitive,
-			ToolRequest: schemaJSON,
-		})
+		detailTools = append(detailTools, toolDescriptorToDetail(tool))
 	}
 	detailsByID[strings.TrimSpace(srv.CLI.ID)] = detailTools
 

--- a/internal/cli/canonical.go
+++ b/internal/cli/canonical.go
@@ -814,7 +814,7 @@ func flagKindForSchema(schema map[string]any) (FlagKind, bool) {
 			return flagNumberList, true
 		case "boolean":
 			return flagBooleanList, true
-		case "object":
+		case "object", "array":
 			return flagJSON, true
 		}
 	}

--- a/internal/cli/canonical_test.go
+++ b/internal/cli/canonical_test.go
@@ -72,6 +72,57 @@ func TestBuildFlagSpecsGeneratesOnlySupportedTopLevelFlags(t *testing.T) {
 	}
 }
 
+// Regression: nested-array params (e.g. sheet update_range.values, a 2-D
+// array of strings) must register as flagJSON so the cli parses the input
+// as JSON instead of forwarding the raw string. See PR #154.
+func TestBuildFlagSpecsNestedArrayMapsToJSON(t *testing.T) {
+	t.Parallel()
+
+	specs := BuildFlagSpecs(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"values": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "array",
+					"items": map[string]any{
+						"type": "string",
+					},
+				},
+			},
+			"records": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+				},
+			},
+			"tags": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "string",
+				},
+			},
+		},
+	}, nil)
+
+	if len(specs) != 3 {
+		t.Fatalf("BuildFlagSpecs() len = %d, want 3", len(specs))
+	}
+	byName := make(map[string]FlagSpec, len(specs))
+	for _, s := range specs {
+		byName[s.PropertyName] = s
+	}
+	if got := byName["values"].Kind; got != flagJSON {
+		t.Errorf("values kind = %q, want flagJSON (nested array of strings)", got)
+	}
+	if got := byName["records"].Kind; got != flagJSON {
+		t.Errorf("records kind = %q, want flagJSON (array of objects)", got)
+	}
+	if got := byName["tags"].Kind; got != flagStringArray {
+		t.Errorf("tags kind = %q, want flagStringArray (flat array of strings)", got)
+	}
+}
+
 func TestFixtureLoaderLoadsCatalog(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compat/dynamic_commands.go
+++ b/internal/compat/dynamic_commands.go
@@ -95,6 +95,13 @@ func BuildDynamicCommands(servers []market.ServerDescriptor, runner executor.Run
 
 			bindings, normalizer := buildOverrideBindings(override)
 
+			// Upgrade binding.Kind from JSON schema: array/object params must
+			// be parsed as JSON, not transmitted as raw strings (otherwise
+			// MCP backends silently accept stringified payloads and drop data).
+			if dt, ok := detailIndex[toolName]; ok && dt.ToolRequest != "" {
+				bindings = upgradeBindingsFromSchema(bindings, dt.ToolRequest)
+			}
+
 			// Resolve Short/Long from Detail API toolTitle/toolDesc;
 			// fallback to overlay description; then to generic cmdName/cliName.
 			short := fmt.Sprintf("%s/%s", cmdName, cliName)
@@ -387,6 +394,38 @@ func resolveNestedGroup(root *cobra.Command, groupPath string, registry map[stri
 	}
 	// Auto-create if not defined in groups
 	return ensureNestedGroup(root, groupPath, groupPath, registry)
+}
+
+// upgradeBindingsFromSchema inspects the MCP toolRequest JSON Schema and
+// promotes ValueString bindings whose schema type is "array" or "object" to
+// ValueJSON. This ensures complex parameters (e.g. sheet update_range.values
+// 2D array) are parsed and forwarded as proper JSON values rather than raw
+// strings — backends that accept stringified payloads silently drop data.
+func upgradeBindingsFromSchema(bindings []FlagBinding, schemaJSON string) []FlagBinding {
+	if len(bindings) == 0 || schemaJSON == "" {
+		return bindings
+	}
+	var schema toolRequestSchema
+	if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
+		return bindings
+	}
+	if len(schema.Properties) == 0 {
+		return bindings
+	}
+	for i := range bindings {
+		if bindings[i].Kind != ValueString {
+			continue
+		}
+		prop, ok := schema.Properties[bindings[i].Property]
+		if !ok {
+			continue
+		}
+		switch prop.Type {
+		case "array", "object":
+			bindings[i].Kind = ValueJSON
+		}
+	}
+	return bindings
 }
 
 // buildOverrideBindings converts CLIToolOverride flags into FlagBindings and

--- a/internal/compat/dynamic_commands_test.go
+++ b/internal/compat/dynamic_commands_test.go
@@ -143,3 +143,67 @@ func TestBuildDynamicCommands_NoParent(t *testing.T) {
 		t.Fatalf("expected 2 top-level commands, got %d", len(cmds))
 	}
 }
+
+// Regression: bindings whose schema type is array/object must be promoted
+// from ValueString (the buildOverrideBindings default) to ValueJSON so the
+// cli parses input as JSON instead of forwarding raw strings to MCP — the
+// backend silently drops stringified payloads on params it expects as arrays.
+// See PR #154.
+func TestUpgradeBindingsFromSchema(t *testing.T) {
+	t.Parallel()
+
+	bindings := []FlagBinding{
+		{FlagName: "values", Property: "values", Kind: ValueString},
+		{FlagName: "node-id", Property: "nodeId", Kind: ValueString},
+		{FlagName: "records", Property: "records", Kind: ValueString},
+		{FlagName: "remind-type", Property: "remindType", Kind: ValueString},
+		{FlagName: "criteria", Property: "criteria", Kind: ValueString},
+		// Already non-string: must NOT be downgraded.
+		{FlagName: "page", Property: "page", Kind: ValueInt},
+	}
+
+	schemaJSON := `{
+		"properties": {
+			"values":     {"type": "array", "items": {"type": "array", "items": {"type": "string"}}},
+			"nodeId":     {"type": "string"},
+			"records":    {"type": "array", "items": {"type": "object"}},
+			"remindType": {"type": "number"},
+			"criteria":   {"type": "object"},
+			"page":       {"type": "integer"}
+		}
+	}`
+
+	got := upgradeBindingsFromSchema(bindings, schemaJSON)
+	want := map[string]ValueKind{
+		"values":     ValueJSON,
+		"nodeId":     ValueString,
+		"records":    ValueJSON,
+		"remindType": ValueString,
+		"criteria":   ValueJSON,
+		"page":       ValueInt,
+	}
+	for _, b := range got {
+		if w, ok := want[b.Property]; ok && b.Kind != w {
+			t.Errorf("%s kind = %q, want %q", b.Property, b.Kind, w)
+		}
+	}
+}
+
+func TestUpgradeBindingsFromSchema_GuardClauses(t *testing.T) {
+	t.Parallel()
+
+	bindings := []FlagBinding{{FlagName: "v", Property: "v", Kind: ValueString}}
+
+	if got := upgradeBindingsFromSchema(nil, `{"properties":{"v":{"type":"array"}}}`); got != nil {
+		t.Errorf("nil bindings should return nil, got %v", got)
+	}
+	if got := upgradeBindingsFromSchema(bindings, ""); got[0].Kind != ValueString {
+		t.Errorf("empty schema should keep ValueString, got %q", got[0].Kind)
+	}
+	if got := upgradeBindingsFromSchema(bindings, "not-json"); got[0].Kind != ValueString {
+		t.Errorf("invalid schema should keep ValueString, got %q", got[0].Kind)
+	}
+	if got := upgradeBindingsFromSchema(bindings, `{"properties":{"other":{"type":"array"}}}`); got[0].Kind != ValueString {
+		t.Errorf("unknown property should keep ValueString, got %q", got[0].Kind)
+	}
+}

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dws
-description: 管理钉钉产品能力(AI表格/日历/通讯录/群聊与机器人/待办/审批/考勤/日志/DING消息/工作台/开放平台文档/钉钉文档/AI听记等)。当用户需要操作表格数据、管理日程会议、查询通讯录、管理群聊、机器人发消息、创建待办、提交审批、查看考勤、提交日报周报（钉钉日志模版）、读写钉钉文档、查询听记纪要时使用。
+description: 管理钉钉产品能力(AI表格/电子表格/钉盘/日历/通讯录/群聊与机器人/待办/审批/考勤/日志/DING消息/工作台/开放平台文档/钉钉文档/AI听记等)。当用户需要操作表格数据、管理日程会议、查询通讯录、管理群聊、机器人发消息、创建待办、提交审批、查看考勤、提交日报周报（钉钉日志模版）、读写钉钉文档、查询听记纪要、操作电子表格、上传下载钉盘文件时使用。
 cli_version: ">=1.0.6"
 ---
 
@@ -33,8 +33,10 @@ cli_version: ">=1.0.6"
 | `devdoc`          | 开放平台文档：搜索开发文档                                        | [simple.md](./references/products/simple.md)                   |
 | `ding`            | DING消息：发送/撤回（应用内/短信/电话）                              | [ding.md](./references/products/ding.md)                       |
 | `doc`             | 钉钉文档：搜索/浏览/读写/块级编辑/评论                                | [doc.md](./references/products/doc.md)                         |
+| `drive`           | 钉盘：浏览文件/元数据/下载/创建文件夹/上传文件                            | [drive.md](./references/products/drive.md)                     |
 | `minutes`         | AI听记：听记列表/摘要/关键词/转写/待办/思维导图/发言人/热词                    | [minutes.md](./references/products/minutes.md)                 |
 | `report`          | 日志：按模版创建/收件箱/已发送/模版查看/详情/已读统计                         | [report.md](./references/products/report.md)                   |
+| `sheet`           | 电子表格：创建表格/工作表管理/单元格数据读写/公式/超链接                      | [sheet.md](./references/products/sheet.md)                     |
 | `todo`            | 待办：创建(含优先级/截止时间)/查询/修改/标记完成/删除                       | [todo.md](./references/products/todo.md)                       |
 | `workbench`       | 工作台：应用管理                                             | [workbench.md](./references/products/workbench.md)             |
 
@@ -49,12 +51,15 @@ cli_version: ">=1.0.6"
 用户提到"开发/API/调用错误 文档" → `devdoc`
 用户提到"DING/紧急消息/电话提醒" → `ding`
 用户提到"钉钉文档/云文档/知识库/读写文档/块级编辑/文档评论" → `doc`
+用户提到"钉盘/网盘/我的文件/上传文件/下载文件" → `drive`
 用户提到"听记/AI听记/会议纪要/转写/摘要/思维导图/发言人/热词" → `minutes`
 用户提到"日志/日报/周报/日志统计/写日报/提交周报/发日志/填日志" → `report`
+用户提到"电子表格/Excel/单元格/公式/工作表/sheet" → `sheet`
 用户提到"待办/TODO/任务提醒" → `todo`
 用户提到"工作台/应用管理" → `workbench`
 
-关键区分: aitable(数据表格) vs todo(待办任务)
+关键区分: aitable(AI多维表/结构化记录) vs sheet(电子表格/单元格读写) vs doc(文档编辑)
+关键区分: drive(钉盘文件存储/上传/下载) vs doc(钉钉文档内容读写/知识库空间)
 关键区分: report(钉钉日志/日报周报) vs todo(待办任务)
 关键区分: chat send-by-bot(机器人身份发消息) vs send-by-webhook(自定义机器人Webhook告警)
 
@@ -68,6 +73,7 @@ cli_version: ">=1.0.6"
 | 产品 | 命令 | 说明 |
 |------|------|------|
 | `aitable` | `base delete` | 删除整个 AI 表格，含全部数据表和记录 |
+| `aitable` | `table delete` | 删除数据表，含全部记录 |
 | `aitable` | `record delete` | 删除记录（支持批量） |
 | `calendar` | `event delete` | 删除日程，所有参与者同步取消 |
 | `calendar` | `participant delete` | 移除日程参与者 |

--- a/skills/references/products/aitable.md
+++ b/skills/references/products/aitable.md
@@ -9,7 +9,7 @@
 | Base 文档 | `https://alidocs.dingtalk.com/i/nodes/{baseId}` |
 | 模板预览 | `https://docs.dingtalk.com/table/template/{templateId}` |
 
-> 💡 **操作后请返回文档 URI**：每次执行 base list/search/create/get 操作后，从返回数据中提取 `baseId`，拼接为 `https://alidocs.dingtalk.com/i/nodes/{baseId}` 返回给用户，方便直接点击打开。
+> **操作后请返回文档 URI**：每次执行 base list/search/create/get 操作后，从返回数据中提取 `baseId`，拼接为 `https://alidocs.dingtalk.com/i/nodes/{baseId}` 返回给用户，方便直接点击打开。
 
 ## 命令总览
 
@@ -31,7 +31,7 @@ Flags:
 
 > 📎 **操作后返回文档链接**：遍历返回的每个 base，拼接 `https://alidocs.dingtalk.com/i/nodes/{baseId}` 返回给用户。
 
-> ⚠️ **重要**：`base list` 仅返回**最近访问过**的 Base，**不是全部 Base**。
+> **重要**：`base list` 仅返回**最近访问过**的 Base，**不是全部 Base**。
 > 如需查找表格，**请优先使用 `base search`**；`base list` 仅作为浏览最近表格的辅助手段。
 > 如果刚创建完，直接使用 `create` 返回的 `baseId` 即可。
 
@@ -56,12 +56,12 @@ Flags:
       --base-id string   Base 唯一标识 (必填)
 ```
 
-> 💡 **用户提供 URL 时**：如果用户给出了链接如 `https://alidocs.dingtalk.com/i/nodes/ABC123`，请提取末尾的 `ABC123` 作为 `--base-id` 传入。详见下方「URL → baseId 提取」章节。
+> **用户提供 URL 时**：如果用户给出了链接如 `https://alidocs.dingtalk.com/i/nodes/ABC123`，请提取末尾的 `ABC123` 作为 `--base-id` 传入。详见下方「URL → baseId 提取」章节。
 
 返回 baseName、tables、dashboards 的 summary 信息（不含字段与记录详情）。
 后续如需 tableId，优先从这里读取。
 
-> 📎 **文档地址**：`https://alidocs.dingtalk.com/i/nodes/{baseId}`
+>  **文档地址**：`https://alidocs.dingtalk.com/i/nodes/{baseId}`
 
 #### 创建 AI 表格
 ```
@@ -74,10 +74,10 @@ Flags:
       --template-id string   模板 ID (可选，可通过 template search 获取)
 ```
 
-> 💡 **创建后直接使用返回的 `baseId`**，无需再调用 `base list` 或 `base search` 查找。
+>  **创建后直接使用返回的 `baseId`**，无需再调用 `base list` 或 `base search` 查找。
 > 后续可直接 `base get --base-id <返回的baseId>` 获取 tableId，或 `table create --base-id <返回的baseId>` 创建数据表。
 >
-> 📎 **文档地址**：`https://alidocs.dingtalk.com/i/nodes/{返回的baseId}`
+> **文档地址**：`https://alidocs.dingtalk.com/i/nodes/{返回的baseId}`
 
 #### 更新 AI 表格
 ```
@@ -120,7 +120,7 @@ Flags:
 
 返回 tableId、tableName、description、fields 目录、views 目录。不传 table-ids 返回全部表。
 
-> 📎 **文档地址**：`https://alidocs.dingtalk.com/i/nodes/{baseId}`
+>  **文档地址**：`https://alidocs.dingtalk.com/i/nodes/{baseId}`
 
 #### 创建数据表
 ```
@@ -132,13 +132,13 @@ Example:
 Flags:
       --base-id string   目标 Base ID (必填)
       --fields string    初始字段 JSON 数组，至少 1 个，单次最多 15 个 (必填)
-      --name string      表格名称，1-100 字符 (必填)
+      --name string      表格名称，1-100 字符 (必填)，别名: --table-name
 ```
 
-> 💡 **创建后直接使用返回的 `tableId`**，无需再调 `table get` 查找。
+>  **创建后直接使用返回的 `tableId`**，无需再调 `table get` 查找。
 > 后续可直接 `field create --table-id <返回的tableId>` 补充字段，或 `record create` 写入数据。
 >
-> 📎 **文档地址**：`https://alidocs.dingtalk.com/i/nodes/{baseId}`
+>  **文档地址**：`https://alidocs.dingtalk.com/i/nodes/{baseId}`
 
 #### 更新数据表
 ```
@@ -188,24 +188,45 @@ Flags:
 Usage:
   dws aitable field create [flags]
 Example:
-  # 单字段模式
   dws aitable field create --base-id <BASE_ID> --table-id <TABLE_ID> \
     --name "状态" --type "singleSelect" --config '{"options":[{"name":"待办"},{"name":"进行中"},{"name":"已完成"}]}'
-
-  # 批量模式
+  
+  # 或者使用批量创建模式:
   dws aitable field create --base-id <BASE_ID> --table-id <TABLE_ID> \
     --fields '[{"fieldName":"状态","type":"singleSelect","config":{"options":[{"name":"待办"}]}}]'
 Flags:
       --base-id string    Base ID (必填)
-      --name string       单字段名称（与 --type 配合使用，替代 --fields）
-      --type string       单字段类型（参考 table create 字段类型）
-      --config string     单字段配置 JSON（可选，如 options）
-      --fields string     批量新增字段 JSON 数组，单次最多 15 个（与 --name/--type 二选一）
+      --name string       要创建的单字段名称（与 --type 配合使用，替代 --fields）
+      --type string       要创建的单字段类型（参考 table create 字段类型）
+      --config string     单字段配置，如 options（可选）
+      --ai-config string  单字段 AI 配置 JSON（可选，用于创建 AI 字段）
+      --fields string     批量新增字段 JSON 数组，单次最多 15 个 (与 --name/--type 二选一)
       --table-id string   Table ID (必填)
 ```
 
 允许部分成功，返回结果逐项标明成功/失败状态。
-`--name/--type/--config` 为单字段模式；`--fields` 为批量模式；两种模式二选一。
+
+#### AI 字段创建示例（可直接复用）
+
+```bash
+dws aitable field create --base-id <BASE_ID> --table-id <TABLE_ID> \
+  --name "AI摘要" --type text \
+  --ai-config '{
+    "outputType":"text",
+    "prompt":[
+      {"type":"text","value":"请将下面内容总结成不超过80字的中文摘要："},
+      {"type":"fieldRef","fieldId":"fld_content"}
+    ],
+    "autoRecompute":true,
+    "enableWebSearch":false,
+    "enableThinking":true
+  }' --format json
+```
+
+说明：
+- `outputType` 与字段类型需一致（如 `outputType=text` 配 `--type text`）
+- `prompt` 里通过 `fieldRef` 引用已有字段（示例中的 `fld_content`）
+- `autoRecompute=true` 表示引用字段变化后自动重算
 
 #### 更新字段
 ```
@@ -217,12 +238,30 @@ Example:
 Flags:
       --base-id string    Base ID (必填)
       --config string     字段配置 JSON (不修改时省略)
+      --ai-config string  AI 配置 JSON (不修改时省略)
       --field-id string   Field ID (必填)
       --name string       新字段名称 (不修改时省略)
       --table-id string   Table ID (必填)
 ```
 
 不可变更字段类型。更新 singleSelect/multipleSelect 的 options 时需传入完整列表，已有选项应回传原 id。
+`--name` / `--config` / `--ai-config` 至少传一个。
+
+#### AI 字段更新示例（可直接复用）
+
+```bash
+dws aitable field update --base-id <BASE_ID> --table-id <TABLE_ID> --field-id <FIELD_ID> \
+  --ai-config '{
+    "outputType":"text",
+    "prompt":[
+      {"type":"text","value":"请提炼3个要点，每点不超过20字："},
+      {"type":"fieldRef","fieldId":"fld_content"}
+    ],
+    "autoRecompute":true,
+    "enableWebSearch":false,
+    "enableThinking":true
+  }' --format json
+```
 
 #### 删除字段
 ```
@@ -253,7 +292,7 @@ Flags:
       --cursor string       分页游标，首次不传
       --field-ids string    返回字段 ID 列表，逗号分隔，单次最多 100 个
       --filters string      结构化过滤条件 JSON
-      --query string        全文关键词搜索
+      --query string      全文关键词搜索
       --limit int           单次最大记录数，默认 100，最大 100
       --record-ids string   指定记录 ID 列表，逗号分隔，单次最多 100 个
       --sort string         排序条件 JSON 数组
@@ -262,16 +301,17 @@ Flags:
 
 两种模式: 按 ID 取（传 record-ids，忽略 filters/sort）或条件查（filters+sort+cursor 分页）。
 
-> ⚠️ **排序参数规范（关键）**：`--sort` 需要传 JSON 数组，排序方向字段必须是 `direction`（`asc` 或 `desc`），**不要使用 `order`**。
+> **排序参数规范（关键）**：`--sort` 需要传 JSON 数组，排序方向字段必须是 `direction`（`asc` 或 `desc`），不要使用 `order`。
 >
-> 正确示例：`--sort '[{"fieldId":"wm8ns9bw2vmucb45xj3ix","direction":"desc"}]'`
+> 正确示例：
+> `--sort '[{"fieldId":"wm8ns9bw2vmucb45xj3ix","direction":"desc"}]'`
 
 filters 结构：`{"operator":"and|or","operands":[{"operator":"<op>","operands":["<fieldId>","<value>"]}]}`
 
-> 💡 **singleSelect/multipleSelect 过滤**：filters 中可传 option id 或 option name，但建议优先用 **option id**（通过 `field get` 获取），更可靠。
+>  **singleSelect/multipleSelect 过滤**：filters 中可传 option id 或 option name，但建议优先用 **option id**（通过 `field get` 获取），更可靠。
 > 写入时（record create/update）可直接传 option name。
 
-> 💡 **减少响应体积**：字段较多时，用 `--field-ids` 仅返回需要的字段，可显著减少返回数据量。
+>  **减少响应体积**：字段较多时，用 `--field-ids` 仅返回需要的字段，可显著减少返回数据量。
 
 #### 新增记录
 ```
@@ -286,7 +326,7 @@ Flags:
       --table-id string   Table ID (必填)
 ```
 
-> ⚠️ **常见错误（严格避免）**：
+> ️ **常见错误（严格避免）**：
 > - **参数名是 `--records`**，不是 `--data`
 > - **cells 的 key 必须是 fieldId**（如 `fldXXX`），**不是字段名称**（如 `"课程名称"`）
 > - 必须先 `table get` 获取 fieldId，再写入记录
@@ -332,7 +372,7 @@ Flags:
 
 ### attachment (附件管理)
 
-> 🛑 **STOP — 不要使用钉盘 (drive) 上传！** 钉盘 fileId 无法写入 attachment 字段。必须使用以下流程。
+>  **STOP — 不要使用钉盘 (drive) 上传！** 钉盘 fileId 无法写入 attachment 字段。必须使用以下流程。
 
 #### 准备附件上传
 ```
@@ -360,7 +400,7 @@ dws aitable record create --base-id <BASE_ID> --table-id <TABLE_ID> \
   --records '[{"cells":{"fldAttachId":[{"fileToken":"ft_xxx"}]}}]' --format json
 ```
 
-> ⚠️ `uploadUrl` 有时效性（`expiresAt`），脚本会自动在获取后立即上传。
+>  `uploadUrl` 有时效性（`expiresAt`），脚本会自动在获取后立即上传。
 
 ### template (模板搜索)
 
@@ -378,7 +418,7 @@ Flags:
 
 返回 templateId 可用于 `base create --template-id`。
 
-> 📎 **模板预览地址**：`https://docs.dingtalk.com/table/template/{templateId}`
+>  **模板预览地址**：`https://docs.dingtalk.com/table/template/{templateId}`
 
 ## 复杂操作
 
@@ -486,7 +526,7 @@ dws aitable record create --base-id <BASE_ID> --table-id <TABLE_ID> \
 - 所有操作使用 ID（baseId/tableId/fieldId/recordId），不使用名称
 - records 的 cells key 是 fieldId，不是字段名称
 
-## `--filters` 筛选语法排错与使用规范（极易出错）
+## `--filters` 筛选语法排错与使用规范 ( 极易出错)
 
 调用 `record query` 时，如果条件筛选**完全失效（查询返回了所有记录）**，通常是因为 `--filters` JSON 语法错误，API 默默丢弃了不合规的 filter。
 
@@ -496,7 +536,7 @@ dws aitable record create --base-id <BASE_ID> --table-id <TABLE_ID> \
 3. `singleSelect` 和 `multipleSelect` 字段，推荐使用 **选项的 exact String 名称 (name)** 作为比较值，而不是 ID。
 4. **内层比较操作符语义**：支持 `eq`(等于)、`not_eq`(不等于)、`contain`(包含/模糊搜索)、`not_contain`(不包含)、`gt/gte`(大于/大于等于)、`lt/lte`(小于/小于等于)、`is_empty/is_not_empty`(为空/不为空，对应 operands 内只传单个 fieldId)。
 
-**精简防呆模板与 4 种衍生情况**
+ **精简防呆模板与 4 种衍生情况**
 ```json
 {
   "operator": "and",       // 情况 4 (OR 查询): 这里改为 "or"
@@ -510,12 +550,12 @@ dws aitable record create --base-id <BASE_ID> --table-id <TABLE_ID> \
 }
 ```
 
-**错误示例 1：缺失根节点 and/or**（API 将忽略该 filter，返回全表）
+ **错误示例 1：缺失根节点 and/or** (API 将忽略该 filter，返回全表)
 ```json
 {"operator":"eq","operands":["fldXXX","本科"]}
 ```
 
-**错误示例 2：传入选项 ID 而非名称**（可能导致匹配不到 0 记录）
+ **错误示例 2：传入选项 ID 而非名称** (可能导致匹配不到 0 记录)
 ```json
 {"operator":"and","operands":[{"operator":"eq","operands":["fldXXX","CXzrOHK9JI"]}]}
 ```
@@ -541,7 +581,7 @@ https://alidocs.dingtalk.com/i/nodes/{baseId}?xxx=yyy
 → 执行: dws aitable base get --base-id ABC123XYZ --format json
 ```
 
-> 💡 **注意**：URL 中的 nodeId 在 AI 表格场景下等同于 baseId，可以直接作为 `--base-id` 使用。
+>  **注意**：URL 中的 nodeId 在 AI 表格场景下等同于 baseId，可以直接作为 `--base-id` 使用。
 
 ### cells 写入/读取格式速查
 
@@ -554,12 +594,21 @@ https://alidocs.dingtalk.com/i/nodes/{baseId}?xxx=yyy
 | date | `"2026-03-13"` 或时间戳 | ISO 日期字符串 |
 | checkbox | `true`/`false` | `true`/`false` |
 | user | `[{"userId":"xxx"}]` | `[{"corpId":"xxx","userId":"xxx"}]` |
-| attachment | `[{"fileToken":"ft_xxx"}]` ⚠️需先走 attachment upload 3步流程 | `[{"url":"...","filename":"...","size":N}]` |
+| attachment | `[{"fileToken":"ft_xxx"}]` 需先走 attachment upload 3步流程 | `[{"url":"...","filename":"...","size":N}]` |
 | url | `{"text":"显示文本","link":"https://..."}` | 同写入 |
 | richText | `{"markdown":"**加粗**"}` | `{"markdown":"..."}` |
 | group | `[{"cid":"xxx"}]` (注意: key 是 cid，不是 openConversationId) | 同写入 |
 
 - 详见 [field-rules.md](../field-rules.md) 和 [error-codes.md](../error-codes.md)
+
+## 自动化脚本
+
+| 脚本 | 场景 | 用法 |
+|------|------|------|
+| [bulk_add_fields.py](../../scripts/bulk_add_fields.py) | 批量添加字段到数据表 | `python bulk_add_fields.py --base-id <ID> --table-id <ID> --fields fields.json` |
+| [import_records.py](../../scripts/import_records.py) | 从 JSON/CSV 批量导入记录 | `python import_records.py --base-id <ID> --table-id <ID> --file data.json` |
+| [aitable_export_via_task.py](../../scripts/aitable_export_via_task.py) | 文件导出任务（export_data 轮询 + 下载） | `python aitable_export_via_task.py <baseId> --scope table --table-id <tableId>` |
+| [upload_attachment.py](../../scripts/upload_attachment.py) | 上传附件到 AI 表格记录 | `python upload_attachment.py --base-id <ID> --file image.png` |
 
 ## 相关产品
 

--- a/skills/references/products/drive.md
+++ b/skills/references/products/drive.md
@@ -1,0 +1,147 @@
+# 钉盘 (drive) 命令参考
+
+## 命令总览
+
+### 获取文件/文件夹列表
+
+```
+Usage:
+  dws drive list [flags]
+Example:
+  dws drive list --max 20
+  dws drive list --max 20 --parent-id <dentryUuid> --order-by name --order asc
+Flags:
+      --max int             每页返回数量 (默认 20，最大 100)，别名: --limit
+      --next-token string   分页游标，首次不传 (可选)
+      --order string        排序方向: asc|desc，默认 desc (可选)
+      --order-by string     排序字段: createTime|modifyTime|name (可选)
+      --parent-id string    父节点 ID (dentryUuid)，不传则列出空间根目录 (可选)
+      --space-id string     空间 ID，不传则使用「我的文件」对应 spaceId (可选)
+      --thumbnail           是否返回缩略图信息 (可选)
+```
+
+### 获取文件元数据信息
+
+```
+Usage:
+  dws drive info [flags]
+Example:
+  dws drive info --file-id <dentryUuid>
+Flags:
+      --file-id string    节点 ID (dentryUuid) (必填)
+      --space-id string   节点所属空间 ID (可选)
+```
+
+### 获取文件下载链接
+
+```
+Usage:
+  dws drive download [flags]
+Example:
+  dws drive download --file-id <dentryUuid>
+Flags:
+      --file-id string    文件 ID (dentryUuid) (必填)
+      --space-id string   文件所属空间 ID (可选)
+```
+
+### 创建文件夹
+
+```
+Usage:
+  dws drive mkdir [flags]
+Example:
+  dws drive mkdir --name "项目资料"
+  dws drive mkdir --name "子目录" --parent-id <dentryUuid>
+Flags:
+      --name string        文件夹名称，最长 50 字符 (必填)
+      --parent-id string   父节点 ID (dentryUuid)，不传则在空间根目录下创建 (可选)
+      --space-id string    目标空间 ID，不传则使用「我的文件」 (可选)
+```
+
+### 上传本地文件到钉盘
+
+> **⚠️ 上传文件必须使用 `dws drive upload` 命令，禁止使用 `upload-info` + `curl` + `commit` 三步流程。**
+
+```
+Usage:
+  dws drive upload [flags]
+Example:
+  dws drive upload --file ./report.pdf
+  dws drive upload --file ./slides.pptx --file-name "Q1汇报.pptx"
+  dws drive upload --file ./data.xlsx --parent-id <dentryUuid>
+Flags:
+      --file string        本地文件路径 (必填)
+      --file-name string   文件显示名称 (默认使用文件名)
+      --space-id string    目标空间 ID，不传则使用「我的文件」 (可选)
+      --mime-type string   文件 MIME 类型，不传则自动推断 (可选)
+      --parent-id string   父节点 ID (dentryUuid)，不传则上传到空间根目录 (可选)
+```
+
+`upload` 命令内部自动完成三步流程（获取凭证 → OSS PUT → 提交入库），无需手动分步操作。
+
+## 意图判断
+
+用户说"我的文件/钉盘/网盘/云盘" → `list`
+用户说"文件详情/文件信息" → `info`
+用户说"下载文件" → `download`
+用户说"新建文件夹/创建目录" → `mkdir`
+用户说"上传文件/传文件到钉盘" → `upload`（必须使用此命令，自动完成三步流程）
+
+关键区分: drive(钉盘文件管理) vs doc(文档内容读写)
+
+**drive upload vs doc upload**: 用户提到"钉盘/网盘/我的文件"→ `drive upload`；提到"知识库/文档空间/workspace"→ `doc upload`；未明确目标时默认 `drive upload`
+
+## 核心工作流
+
+```bash
+# 1. 浏览「我的文件」根目录
+dws drive list --max 20 --format json
+
+# 2. 进入子目录 — 提取 dentryUuid 作为 parent-id
+dws drive list --max 20 --parent-id <dentryUuid> --format json
+
+# 3. 查看文件元数据
+dws drive info --file-id <dentryUuid> --format json
+
+# 4. 获取下载链接
+dws drive download --file-id <dentryUuid> --format json
+
+# 5. 创建文件夹
+dws drive mkdir --name "项目资料" --format json
+
+# 6. 上传文件（必须使用 upload 命令，禁止手动分步操作）
+dws drive upload --file ./报告.pdf --format json
+dws drive upload --file ./报告.pdf --parent-id <dentryUuid> --format json
+```
+
+## 上下文传递表
+
+
+| 操作            | 从返回中提取                       | 用于                                                       |
+| ------------- | ---------------------------- | -------------------------------------------------------- |
+| `list`        | `dentryUuid`                 | info / download / mkdir / list 的 --file-id 或 --parent-id |
+| `list`        | `spaceId`                    | info / download / mkdir / commit 的 --space-id            |
+| `mkdir`       | `dentryUuid`                 | list 的 --parent-id                                       |
+
+
+## 注意事项
+
+- 不传 `--space-id` 时默认使用「我的文件」空间
+- 不传 `--parent-id` 时默认操作空间根目录
+- `--order-by` 支持: `createTime`、`modifyTime`、`name`
+- **上传文件必须使用 `dws drive upload` 命令**，禁止使用 `upload-info` + `curl` + `commit` 三步手动流程
+- `--file-name` 必须包含扩展名（如 `report.pdf`）
+
+## 自动化脚本
+
+
+| 脚本                                                     | 场景          | 用法                                    |
+| ------------------------------------------------------ | ----------- | ------------------------------------- |
+| [drive_tree_list.py](../../scripts/drive_tree_list.py) | 递归列出钉盘目录树结构 | `python drive_tree_list.py --depth 2` |
+
+
+## 相关产品
+
+- [doc](./doc.md) — 文档内容读写/知识库空间，不是文件存储
+- [chat](./chat.md) — 上传文件到 drive 后可通过 Markdown 语法发送图片/文件消息
+

--- a/skills/references/products/drive.md
+++ b/skills/references/products/drive.md
@@ -1,5 +1,7 @@
 # 钉盘 (drive) 命令参考
 
+> ⚠️ **命令名以 `dws drive --help` 实际输出为准**：本文档的命令命名（如 `drive list` / `drive upload`）来自上游 wukong CLI 的层级 overlay；当前 cli 暴露的可能是扁平 MCP tool 名（如 `drive list-files` / `drive get-upload-info`）。用户实际操作前请用 `dws drive --help` / `dws drive <cmd> --help` 确认子命令名与参数名。
+
 ## 命令总览
 
 ### 获取文件/文件夹列表

--- a/skills/references/products/sheet.md
+++ b/skills/references/products/sheet.md
@@ -1,0 +1,265 @@
+# 电子表格 (sheet) 命令参考
+
+## 命令总览
+
+### 创建钉钉表格文档
+```
+Usage:
+  dws sheet create [flags]
+Example:
+  dws sheet create --name "销售数据"
+  dws sheet create --name "Q1 数据" --folder <FOLDER_ID>
+  dws sheet create --name "知识库表格" --workspace <WS_ID>
+Flags:
+      --name string        表格名称 (必填)
+      --folder string      目标文件夹 ID 或 URL
+      --workspace string   目标知识库 ID
+```
+
+### 获取全部工作表列表
+```
+Usage:
+  dws sheet list [flags]
+Example:
+  dws sheet list --node <NODE_ID>
+  dws sheet list --node "https://alidocs.dingtalk.com/i/nodes/<DOC_UUID>"
+Flags:
+      --node string   表格文档 ID 或 URL (必填)
+```
+
+### 获取指定工作表详情
+```
+Usage:
+  dws sheet info [flags]
+Example:
+  dws sheet info --node <NODE_ID>
+  dws sheet info --node <NODE_ID> --sheet-id <SHEET_ID>
+  dws sheet info --node <NODE_ID> --sheet-id "Sheet1"
+Flags:
+      --node string       表格文档 ID 或 URL (必填)
+      --sheet-id string   工作表 ID 或名称 (不传则返回第一个工作表)
+```
+
+### 新建工作表
+```
+Usage:
+  dws sheet new [flags]
+Example:
+  dws sheet new --node <NODE_ID> --name "Sheet2"
+  dws sheet new --node <NODE_ID> --name "数据汇总"
+Flags:
+      --node string   表格文档 ID (必填)
+      --name string   工作表名称 (必填)
+```
+
+### 读取工作表数据
+```
+Usage:
+  dws sheet range read [flags]
+Example:
+  dws sheet range read --node <NODE_ID>
+  dws sheet range read --node <NODE_ID> --sheet-id <SHEET_ID>
+  dws sheet range read --node <NODE_ID> --sheet-id "Sheet1" --range "A1:D10"
+  dws sheet range read --node <NODE_ID> --range "Sheet1!A1:D10"
+Flags:
+      --node string       表格文档 ID 或 URL (必填)
+      --sheet-id string   工作表 ID 或名称 (不传则默认第一个工作表)
+      --range string      读取范围，A1 表示法 (如 A1:D10，不传则读取全部数据)
+```
+
+### 更新工作表指定区域内容
+```
+Usage:
+  dws sheet range update [flags]
+Example:
+  # 写入值
+  dws sheet range update --node <NODE_ID> --sheet-id <SHEET_ID> --range "A1:B2" \
+    --values '[["姓名","分数"],["张三",90]]'
+
+  # 写入公式
+  dws sheet range update --node <NODE_ID> --sheet-id <SHEET_ID> --range "C2" \
+    --values '[["=A2&B2"]]'
+
+  # 写入超链接
+  dws sheet range update --node <NODE_ID> --sheet-id <SHEET_ID> --range "A1" \
+    --hyperlinks '[[{"type":"path","link":"https://dingtalk.com","text":"钉钉"}]]'
+
+  # 清空区域
+  dws sheet range update --node <NODE_ID> --sheet-id <SHEET_ID> --range "A1:B3" \
+    --values '[[null,null],[null,null],["保留",null]]'
+Flags:
+      --node string            表格文档 ID (必填)
+      --sheet-id string        工作表 ID 或名称 (必填)
+      --range string           目标单元格区域地址，如 A1:B3 (必填)
+      --values string          单元格值，二维 JSON 数组 (与 --hyperlinks 至少传一项)
+      --hyperlinks string      超链接，二维 JSON 数组 (与 --values 至少传一项)
+      --number-format string   数字格式，如 General/@/#,##0/0%/yyyy/m/d 等
+```
+
+## URL 识别与 NODE_ID 提取
+
+当用户输入包含钉钉文档 URL 时，**必须先识别并提取 NODE_ID**，再判断意图。
+
+### 支持的 URL 格式
+
+| 格式 | 示例 | NODE_ID 提取方式 |
+|------|------|----------------|
+| `alidocs.dingtalk.com/i/nodes/{id}` | `https://alidocs.dingtalk.com/i/nodes/9E05BDRVQePjzLkZt2p2vE7kV63zgkYA` | 取 URL 路径最后一段 |
+| `alidocs.dingtalk.com/i/nodes/{id}?queryParams` | `https://alidocs.dingtalk.com/i/nodes/abc123?doc_type=wiki_doc` | 忽略 query 参数，取路径最后一段 |
+
+### 提取规则
+
+1. 匹配 URL 中 `alidocs.dingtalk.com` 域名
+2. 取 URL path 的最后一段作为 NODE_ID（去掉 query string 和 fragment）
+3. 提取出的 NODE_ID 可直接用于所有 `--node` 参数，也可将完整 URL 传给 `--node`（CLI 会自动解析）
+
+## 意图判断
+
+用户说"创建表格/新建电子表格":
+- 创建表格文档 → `create`
+
+用户说"看工作表/有哪些工作表/表格结构":
+- 列出工作表 → `list`
+- 工作表详情 → `info`
+
+用户说"加工作表/新增Sheet":
+- 新建工作表 → `new`
+
+用户说"读数据/看表格内容/导出数据":
+- 读取数据 → `range read`
+
+用户说"写数据/填表/更新单元格/写入公式":
+- 更新数据 → `range update`
+
+**用户直接粘贴表格 URL（无其他指令）**:
+- 默认 → `list`（列出工作表）+ `range read`（读取第一个工作表数据）
+
+**用户粘贴 URL + 附加指令**:
+- "帮我看看这个表格有什么数据" → `range read`
+- "这个表格有哪些工作表" → `list`
+- "往这个表格写入数据" → `range update`
+
+关键区分: sheet(电子表格/单元格读写) vs aitable(AI多维表/结构化记录) vs doc(文档编辑/阅读)
+
+## 核心工作流
+
+```bash
+# ── 工作流 1: 创建表格并写入数据 ──
+
+# 1. 创建表格文档 — 提取 nodeId
+dws sheet create --name "销售数据" --format json
+
+# 2. 查看工作表列表 — 提取 sheetId
+dws sheet list --node <NODE_ID> --format json
+
+# 3. 写入表头和数据
+dws sheet range update --node <NODE_ID> --sheet-id <SHEET_ID> --range "A1:C1" \
+  --values '[["姓名","部门","销售额"]]' --format json
+
+dws sheet range update --node <NODE_ID> --sheet-id <SHEET_ID> --range "A2:C4" \
+  --values '[["张三","销售部",50000],["李四","市场部",38000],["王五","销售部",62000]]' --format json
+
+# ── 工作流 2: 读取已有表格数据 ──
+
+# 1. 获取工作表列表
+dws sheet list --node <NODE_ID> --format json
+
+# 2. 查看工作表详情（行列数、最后非空位置等）
+dws sheet info --node <NODE_ID> --sheet-id <SHEET_ID> --format json
+
+# 3. 读取全部数据
+dws sheet range read --node <NODE_ID> --sheet-id <SHEET_ID> --format json
+
+# 4. 读取指定区域
+dws sheet range read --node <NODE_ID> --sheet-id <SHEET_ID> --range "A1:D10" --format json
+
+# ── 工作流 3: 多工作表管理 ──
+
+# 1. 新建工作表
+dws sheet new --node <NODE_ID> --name "汇总" --format json
+
+# 2. 在新工作表中写入汇总公式
+dws sheet range update --node <NODE_ID> --sheet-id <NEW_SHEET_ID> --range "A1:B1" \
+  --values '[["指标","数值"]]' --format json
+
+dws sheet range update --node <NODE_ID> --sheet-id <NEW_SHEET_ID> --range "A2:B2" \
+  --values '[["总销售额","=SUM(Sheet1!C2:C100)"]]' --format json
+
+# ── 工作流 4: 批量更新与格式化 ──
+
+# 1. 写入数据
+dws sheet range update --node <NODE_ID> --sheet-id <SHEET_ID> --range "A1:C3" \
+  --values '[["商品","单价","数量"],["苹果",5.5,100],["香蕉",3.2,200]]' --format json
+
+# 2. 设置数字格式（人民币）
+dws sheet range update --node <NODE_ID> --sheet-id <SHEET_ID> --range "B2:B3" \
+  --values '[[5.5],[3.2]]' --number-format "¥#,##0.00" --format json
+
+# 3. 写入超链接
+dws sheet range update --node <NODE_ID> --sheet-id <SHEET_ID> --range "D1" \
+  --hyperlinks '[[{"type":"path","link":"https://dingtalk.com","text":"详情"}]]' --format json
+```
+
+## 上下文传递表
+
+| 操作 | 从返回中提取 | 用于 |
+|------|-------------|------|
+| `create` | `nodeId` | list / info / new / range read / range update 的 --node |
+| `list` | 工作表的 `sheetId` | info / range read / range update 的 --sheet-id |
+| `new` | 新工作表的 `sheetId` | range read / range update 的 --sheet-id |
+| `info` | `rowCount` / `lastNonEmptyRow` | 确定数据范围、追加写入起始行 |
+
+## nodeId 双格式说明
+
+所有 `--node` 参数同时支持两种格式，系统自动识别：
+- **文档 ID**: 字母数字字符串，如 `9E05BDRVQePjzLkZt2p2vE7kV63zgkYA`
+- **文档 URL**: `https://alidocs.dingtalk.com/i/nodes/{dentryUuid}`
+
+两种方式等价，以下命令效果相同：
+```bash
+dws sheet list --node 9E05BDRVQePjzLkZt2p2vE7kV63zgkYA
+dws sheet list --node "https://alidocs.dingtalk.com/i/nodes/9E05BDRVQePjzLkZt2p2vE7kV63zgkYA"
+```
+
+## values 参数格式说明
+
+`--values` 为二维 JSON 数组，第一维为行，第二维为列：
+- 字符串值: `"文本"`
+- 数字值: `100` 或 `3.14`
+- 公式: `"=SUM(B2:B4)"`（以 `=` 开头的字符串自动识别为公式）
+- 清空单元格: `null`
+
+维度必须与 `--range` 范围一致，例如 `--range "A1:B3"` 需要 3 行 2 列的数组。
+
+## hyperlinks 参数格式说明
+
+`--hyperlinks` 为二维 JSON 数组，每个元素为对象或 null：
+- `type`: 链接类型，可选 `path`（外部链接）、`sheet`（工作表跳转）、`range`（单元格跳转）
+- `link`: 链接地址
+- `text`: 显示文本
+
+与 `--values` 共存时，hyperlinks 优先级更高。
+
+## number-format 常用值
+
+| 格式代码 | 说明 | 示例 |
+|----------|------|------|
+| `General` | 常规 | 1234.5 |
+| `@` | 文本 | 001234 |
+| `#,##0` | 整数千分位 | 1,235 |
+| `#,##0.00` | 两位小数 | 1,234.50 |
+| `0%` | 百分比 | 85% |
+| `yyyy/m/d` | 日期 | 2026/3/15 |
+| `hh:mm:ss` | 时间 | 14:30:00 |
+| `¥#,##0` | 人民币 | ¥1,235 |
+
+## 注意事项
+
+- `create` 不传 `--folder` 和 `--workspace` 时，默认创建在"我的文档"根目录
+- `list` 返回所有工作表的 ID 和名称，是后续操作的必要前置步骤
+- `info` 不传 `--sheet-id` 时默认返回第一个工作表的详情
+- `range read` 不传 `--range` 时默认读取整个工作表的全部非空数据
+- `range read` 的 `--range` 支持 `Sheet1!A1:D10` 格式直接指定工作表（此时忽略 `--sheet-id`）
+- `range update` 的 `--values` 和 `--hyperlinks` 至少传入一项
+- `new` 创建工作表时，如名称与已有工作表重复，系统会自动重命名
+- 关键区分: sheet(电子表格/单元格读写) vs aitable(AI多维表/结构化记录/字段定义) vs doc(文档编辑/阅读)

--- a/skills/references/products/sheet.md
+++ b/skills/references/products/sheet.md
@@ -1,5 +1,7 @@
 # 电子表格 (sheet) 命令参考
 
+> ⚠️ **命令名以 `dws sheet --help` 实际输出为准**：本文档的命令命名（如 `sheet list` / `sheet range read`）来自上游 wukong CLI 的层级 overlay；当前 cli 暴露的可能是扁平 MCP tool 名（如 `sheet get-all-sheets` / `sheet get-range`）。用户实际操作前请用 `dws sheet --help` / `dws sheet <cmd> --help` 确认子命令名与参数名。
+
 ## 命令总览
 
 ### 创建钉钉表格文档

--- a/skills/scripts/aitable_export_via_task.py
+++ b/skills/scripts/aitable_export_via_task.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+通过 MCP 导出任务（export_data）导出 AI 表格，并可自动下载文件。
+
+与普通命令的区别：
+- 自动处理 taskId 轮询（直到拿到 downloadUrl 或达到轮询上限）。
+- 自动保存导出文件到本地（可选 --output）。
+
+用法:
+    python scripts/aitable_export_via_task.py <baseId> --scope all
+    python scripts/aitable_export_via_task.py <baseId> --scope table --table-id <tableId>
+    python scripts/aitable_export_via_task.py <baseId> --scope view --table-id <tableId> --view-id <viewId>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+RESOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{8,128}$")
+ALLOWED_FORMATS = {"excel", "attachment", "excel_and_attachment", "excel_with_inline_images"}
+
+
+def validate_resource_id(resource_id: str) -> bool:
+    return bool(resource_id and RESOURCE_ID_PATTERN.match(resource_id.strip()))
+
+
+def run_dws(dws_bin: str, args: list[str], timeout_sec: int = 120) -> Tuple[int, str, str]:
+    cmd = [dws_bin] + args
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_sec)
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 124, "", f"dws command timeout after {timeout_sec}s"
+    except FileNotFoundError:
+        return 127, "", f"dws binary not found: {dws_bin}"
+
+
+def parse_json_output(raw: str) -> Optional[Dict[str, Any]]:
+    try:
+        obj = json.loads(raw)
+        return obj if isinstance(obj, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def normalize_download_url(url: str) -> str:
+    if url.startswith("http://") or url.startswith("https://"):
+        return url
+    return f"https://{url}"
+
+
+def download_file(url: str, output_path: Path) -> Tuple[bool, str]:
+    req = Request(url, method="GET")
+    try:
+        with urlopen(req, timeout=180) as resp:
+            if resp.status != 200:
+                return False, f"download http status: {resp.status}"
+            output_path.write_bytes(resp.read())
+            return True, ""
+    except HTTPError as e:
+        body = e.read().decode("utf-8", "ignore")
+        return False, f"HTTP {e.code}: {body[:300]}"
+    except URLError as e:
+        return False, f"URL error: {e.reason}"
+
+
+def fail(msg: str, code: int = 1) -> None:
+    print(f"错误：{msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def build_start_args(args: argparse.Namespace) -> list[str]:
+    cmd = [
+        "aitable",
+        "export",
+        "data",
+        "--base-id",
+        args.base_id,
+        "--scope",
+        args.scope,
+        "--format",
+        args.export_format,
+        "--timeout-ms",
+        str(args.timeout_ms),
+    ]
+    if args.table_id:
+        cmd.extend(["--table-id", args.table_id])
+    if args.view_id:
+        cmd.extend(["--view-id", args.view_id])
+    return cmd
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="通过 MCP 导出任务导出 AI 表格")
+    parser.add_argument("base_id", help="目标 AI 表格 baseId")
+    parser.add_argument("--scope", choices=["all", "table", "view"], required=True, help="导出范围")
+    parser.add_argument("--table-id", help="scope=table/view 时必填")
+    parser.add_argument("--view-id", help="scope=view 时必填")
+    parser.add_argument("--export-format", default="excel", choices=sorted(ALLOWED_FORMATS), help="导出格式")
+    parser.add_argument("--timeout-ms", type=int, default=1000, help="单次等待毫秒数，默认 1000")
+    parser.add_argument("--poll-timeout-ms", type=int, default=3000, help="轮询等待毫秒数，默认 3000")
+    parser.add_argument("--max-polls", type=int, default=10, help="最大轮询次数，默认 10")
+    parser.add_argument("--output", help="本地保存路径（不传则按 fileName 保存到当前目录）")
+    parser.add_argument("--dws", default="dws", help="dws 可执行文件路径，默认 dws")
+    parser.add_argument("--no-download", action="store_true", help="仅返回 downloadUrl，不下载文件")
+    args = parser.parse_args()
+
+    if not validate_resource_id(args.base_id):
+        fail("无效的 baseId 格式")
+    if args.scope in ("table", "view") and not args.table_id:
+        fail("scope=table/view 时必须传 --table-id")
+    if args.scope == "view" and not args.view_id:
+        fail("scope=view 时必须传 --view-id")
+
+    print("[1/2] start export task", file=sys.stderr)
+    rc, out, err = run_dws(args.dws, build_start_args(args), timeout_sec=120)
+    if rc != 0:
+        fail(f"export_data 启动失败: {err or out}", rc)
+    obj = parse_json_output(out)
+    if not obj:
+        fail(f"export_data 返回非 JSON: {out[:300]}")
+
+    data = obj.get("data", {}) or {}
+    status = obj.get("status")
+    if status == "error":
+        fail(f"export_data 返回失败: {json.dumps(obj, ensure_ascii=False)}")
+
+    download_url = data.get("downloadUrl")
+    task_id = data.get("taskId")
+    file_name = data.get("fileName") or "export_result.bin"
+
+    polls = 0
+    while not download_url and task_id and polls < args.max_polls:
+        polls += 1
+        print(f"[2/2] polling task ({polls}/{args.max_polls})", file=sys.stderr)
+        rc2, out2, err2 = run_dws(
+            args.dws,
+            [
+                "aitable",
+                "export",
+                "data",
+                "--base-id",
+                args.base_id,
+                "--task-id",
+                task_id,
+                "--timeout-ms",
+                str(args.poll_timeout_ms),
+            ],
+            timeout_sec=max(120, int(args.poll_timeout_ms / 1000) + 60),
+        )
+        if rc2 != 0:
+            fail(f"export_data 轮询失败: {err2 or out2}", rc2)
+        obj2 = parse_json_output(out2)
+        if not obj2:
+            fail(f"export_data 轮询返回非 JSON: {out2[:300]}")
+        if obj2.get("status") == "error":
+            fail(f"export_data 轮询返回失败: {json.dumps(obj2, ensure_ascii=False)}")
+        d2 = obj2.get("data", {}) or {}
+        download_url = d2.get("downloadUrl") or download_url
+        file_name = d2.get("fileName") or file_name
+        task_id = d2.get("taskId") or task_id
+        if not download_url:
+            time.sleep(0.2)
+
+    result: Dict[str, Any] = {
+        "baseId": args.base_id,
+        "scope": args.scope,
+        "exportFormat": args.export_format,
+        "taskId": task_id,
+        "fileName": file_name,
+        "downloadUrl": download_url,
+        "polledTimes": polls,
+    }
+
+    if not download_url:
+        result["status"] = "pending"
+        result["summary"] = "导出任务仍在处理中，请继续用 taskId 轮询。"
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        sys.exit(3)
+
+    if args.no_download:
+        result["status"] = "success"
+        result["summary"] = "导出完成（未下载文件）。"
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return
+
+    norm_url = normalize_download_url(download_url)
+    output_path = Path(args.output).expanduser().resolve() if args.output else Path.cwd() / file_name
+    ok, dl_err = download_file(norm_url, output_path)
+    if not ok:
+        fail(f"downloadUrl 下载失败: {dl_err}")
+
+    result["status"] = "success"
+    result["summary"] = "导出完成并已下载。"
+    result["savedPath"] = str(output_path)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/scripts/aitable_import_via_task.py
+++ b/skills/scripts/aitable_import_via_task.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+通过 MCP 文件导入任务（prepare_import_upload -> PUT -> import_data）导入 AI 表格。
+
+与 import_records.py 的区别：
+- 本脚本：走“文件导入任务”链路，通常会新建导入数据表。
+- import_records.py：走 create_records，写入已有 table。
+
+用法:
+    python scripts/aitable_import_via_task.py <baseId> <filePath>
+    python scripts/aitable_import_via_task.py <baseId> <filePath> --timeout 30
+    python scripts/aitable_import_via_task.py <baseId> <filePath> --dws /tmp/dws
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+RESOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{8,128}$")
+ALLOWED_EXTENSIONS = {".csv", ".xlsx", ".xls"}
+
+
+def validate_resource_id(resource_id: str) -> bool:
+    return bool(resource_id and RESOURCE_ID_PATTERN.match(resource_id.strip()))
+
+
+def run_dws(dws_bin: str, args: list[str], timeout_sec: int = 120) -> Tuple[int, str, str]:
+    cmd = [dws_bin] + args
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_sec)
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 124, "", f"dws command timeout after {timeout_sec}s"
+    except FileNotFoundError:
+        return 127, "", f"dws binary not found: {dws_bin}"
+
+
+def parse_json_output(raw: str) -> Optional[Dict[str, Any]]:
+    try:
+        obj = json.loads(raw)
+        return obj if isinstance(obj, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def put_file(upload_url: str, file_path: Path) -> Tuple[bool, str]:
+    payload = file_path.read_bytes()
+    req = Request(upload_url, data=payload, method="PUT")
+    # 关键：清空 Content-Type，避免 SignatureDoesNotMatch。
+    req.add_header("Content-Type", "")
+    try:
+        with urlopen(req, timeout=180) as resp:
+            if resp.status == 200:
+                return True, ""
+            return False, f"unexpected HTTP status: {resp.status}"
+    except HTTPError as e:
+        body = e.read().decode("utf-8", "ignore")
+        return False, f"HTTP {e.code}: {body[:300]}"
+    except URLError as e:
+        return False, f"URL error: {e.reason}"
+
+
+def fail(msg: str, exit_code: int = 1) -> None:
+    print(f"错误：{msg}", file=sys.stderr)
+    sys.exit(exit_code)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="通过文件导入任务导入 AI 表格")
+    parser.add_argument("base_id", help="目标 AI 表格 baseId")
+    parser.add_argument("file_path", help="待导入文件路径（.csv/.xlsx/.xls）")
+    parser.add_argument("--timeout", type=int, default=30, help="import_data 等待秒数，默认 30")
+    parser.add_argument("--dws", default="dws", help="dws 可执行文件路径，默认 dws")
+    args = parser.parse_args()
+
+    base_id = args.base_id.strip()
+    file_path = Path(args.file_path).expanduser().resolve()
+
+    if not validate_resource_id(base_id):
+        fail("无效的 baseId 格式")
+    if not file_path.exists() or not file_path.is_file():
+        fail(f"文件不存在或不可读: {file_path}")
+    if file_path.suffix.lower() not in ALLOWED_EXTENSIONS:
+        fail(f"仅支持 {sorted(ALLOWED_EXTENSIONS)}，当前文件: {file_path.name}")
+
+    file_size = file_path.stat().st_size
+    if file_size <= 0:
+        fail("文件为空")
+
+    print(f"[1/3] prepare import upload: {file_path.name} ({file_size} bytes)", file=sys.stderr)
+    rc, out, err = run_dws(
+        args.dws,
+        [
+            "aitable",
+            "import",
+            "upload",
+            "--base-id",
+            base_id,
+            "--file-name",
+            file_path.name,
+            "--file-size",
+            str(file_size),
+            "--format",
+            "json",
+        ],
+    )
+    if rc != 0:
+        fail(f"prepare_import_upload 失败: {err or out}", rc)
+    prepare_obj = parse_json_output(out)
+    if not prepare_obj:
+        fail(f"prepare_import_upload 返回非 JSON: {out[:300]}")
+    if prepare_obj.get("status") != "success":
+        fail(f"prepare_import_upload 返回失败: {json.dumps(prepare_obj, ensure_ascii=False)}")
+
+    pdata = prepare_obj.get("data") or {}
+    upload_url = pdata.get("uploadUrl")
+    import_id = pdata.get("importId")
+    if not upload_url or not import_id:
+        fail(f"prepare_import_upload 缺少 uploadUrl/importId: {json.dumps(pdata, ensure_ascii=False)}")
+
+    print("[2/3] upload file bytes via PUT", file=sys.stderr)
+    ok, put_err = put_file(upload_url, file_path)
+    if not ok:
+        fail(f"PUT 上传失败: {put_err}")
+
+    print("[3/3] trigger import_data", file=sys.stderr)
+    rc2, out2, err2 = run_dws(
+        args.dws,
+        [
+            "aitable",
+            "import",
+            "data",
+            "--import-id",
+            import_id,
+            "--timeout",
+            str(args.timeout),
+            "--format",
+            "json",
+        ],
+        timeout_sec=max(120, args.timeout + 30),
+    )
+    if rc2 != 0:
+        fail(f"import_data 调用失败: {err2 or out2}", rc2)
+    import_obj = parse_json_output(out2)
+    if not import_obj:
+        fail(f"import_data 返回非 JSON: {out2[:300]}")
+
+    result = {
+        "baseId": base_id,
+        "fileName": file_path.name,
+        "fileSize": file_size,
+        "importId": import_id,
+        "status": import_obj.get("status"),
+        "summary": import_obj.get("summary"),
+        "data": import_obj.get("data", {}),
+        "error": import_obj.get("error", {}),
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+    if import_obj.get("status") != "success":
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/scripts/drive_tree_list.py
+++ b/skills/scripts/drive_tree_list.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+递归列出钉盘目录树结构（可指定深度）
+
+用法:
+    python drive_tree_list.py                   # 列出根目录
+    python drive_tree_list.py --depth 2         # 递归 2 层
+    python drive_tree_list.py --parent-id <id>  # 指定目录
+    python drive_tree_list.py --dry-run
+"""
+
+import sys
+import json
+import subprocess
+import argparse
+from typing import List, Any, Optional
+
+
+def run_dws(
+    args: List[str], dry_run: bool = False,
+) -> Optional[Any]:
+    cmd = ['dws'] + args
+    if dry_run:
+        print(f"[dry-run] {' '.join(cmd)}")
+        return None
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=60
+        )
+        if result.returncode != 0:
+            print(f"错误：{result.stderr.strip()}", file=sys.stderr)
+            return None
+        return json.loads(result.stdout)
+    except (subprocess.TimeoutExpired, json.JSONDecodeError,
+            FileNotFoundError) as e:
+        print(f"错误：{e}", file=sys.stderr)
+        return None
+
+
+def list_dir(
+    parent_id: str = '', dry_run: bool = False,
+) -> list:
+    cmd_args = [
+        'drive', 'list', '--max', '50', '--format', 'json',
+    ]
+    if parent_id:
+        cmd_args.extend(['--parent-id', parent_id])
+    data = run_dws(cmd_args, dry_run=dry_run)
+    if not data:
+        return []
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        inner = data.get('result', data)
+        if isinstance(inner, dict):
+            return inner.get('items', inner.get('dentryList', []))
+        if isinstance(inner, list):
+            return inner
+    return []
+
+
+def print_tree(
+    items: list, depth: int, max_depth: int,
+    prefix: str = '', dry_run: bool = False,
+):
+    for i, item in enumerate(items):
+        is_last = (i == len(items) - 1)
+        connector = '└── ' if is_last else '├── '
+        name = item.get('name') or item.get('fileName', '?')
+        item_type = item.get('type') or item.get('dentryType', '')
+        is_dir = str(item_type).lower() in (
+            'folder', 'directory', '1', 'FOLDER'
+        )
+        icon = '📁' if is_dir else '📄'
+        size_str = ''
+        size = item.get('size') or item.get('fileSize')
+        if size and not is_dir:
+            size = int(size)
+            if size > 1024 * 1024:
+                size_str = f" ({size / 1024 / 1024:.1f}MB)"
+            elif size > 1024:
+                size_str = f" ({size / 1024:.1f}KB)"
+            else:
+                size_str = f" ({size}B)"
+
+        print(f"{prefix}{connector}{icon} {name}{size_str}")
+
+        if is_dir and depth < max_depth:
+            child_prefix = prefix + ('    ' if is_last else '│   ')
+            dentry_id = (item.get('dentryUuid')
+                         or item.get('id', ''))
+            if dentry_id:
+                children = list_dir(dentry_id, dry_run=dry_run)
+                print_tree(
+                    children, depth + 1, max_depth,
+                    child_prefix, dry_run,
+                )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='递归列出钉盘目录树'
+    )
+    parser.add_argument(
+        '--parent-id', default='', help='起始目录 ID'
+    )
+    parser.add_argument(
+        '--depth', type=int, default=1,
+        help='递归深度 (默认 1, 最大 5)',
+    )
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+    args.depth = min(args.depth, 5)
+
+    root_name = args.parent_id or '我的文件'
+    print(f"📁 {root_name}")
+
+    items = list_dir(args.parent_id, dry_run=args.dry_run)
+    if args.dry_run:
+        return
+    if not items:
+        print('  (空目录)')
+        return
+
+    print_tree(items, 0, args.depth, '', args.dry_run)
+    print(f"\n共 {len(items)} 个项目 (根目录)")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Aligns the Drive, Sheet, and AI Table product skills in `dingtalk-workspace-cli` with `dws-wukong/dingtalk-workspace`, and fixes a CLI bug surfaced during end-to-end verification where array/object parameters were silently dropped by the MCP backend.

### Skill sync (commits 1, 3)

- Add `drive.md` (Drive: list / info / download / mkdir / upload)
- Add `sheet.md` (Sheet: create / list / info / new / range read|update)
- Realign `aitable.md` (AI field create/update examples, `--ai-config`, dashboards/charts, export data, automation scripts; bit-for-bit aligned with dws-wukong)
- Add 3 companion scripts:
  - `scripts/drive_tree_list.py` — recursive Drive directory tree
  - `scripts/aitable_export_via_task.py` — AI table file export task (poll + download)
  - `scripts/aitable_import_via_task.py` — AI table file import task

### SKILL.md updates

- description: add Sheet / Drive
- product overview: add `drive` / `sheet` rows
- intent decision tree: add Drive / Sheet routing
- key distinctions: aitable vs sheet vs doc, drive vs doc
- danger ops: add `aitable table delete`

### Difference vs dws-wukong

- `attendance.md` keeps the cli wording (cli has no `aisearch` product; retain `contact user search` guidance; remainder matches wukong)

### CLI fix (commit 4)

End-to-end testing revealed `dws sheet update-range` returned `success: true` but data was not persisted (`lastNonEmptyRow: -1`).

**Root cause**: cli was forwarding `--values '[[...]]'` to MCP as a raw string (`"values":"[[..]]"`) instead of an array. The backend leniently accepted the stringified payload but dropped the data silently.

Three contributing bugs:

1. `internal/cli/canonical.go` — `flagKindForSchema`'s `array` branch did not handle nested arrays, falling through to the string default.
2. `internal/compat/dynamic_commands.go` — `buildOverrideBindings` registered every override flag as `ValueString`, never consulting the JSON Schema. New `upgradeBindingsFromSchema` helper promotes array/object params to `ValueJSON`.
3. `internal/app/legacy.go` — `loadCachedDetailsFast` only loaded schemas for services with a Detail API locator. Now falls back to the `tools/list` snapshot so all discovery-driven services have schemas available.

**Verification**:

| Before | After |
|--------|-------|
| `payload: {"values":"[[..]]"}` (string) | `payload: {"values":[[..]]}` (array) |
| `lastNonEmptyRow: -1`, cells empty | write succeeds, read-back matches input |

Affected surface: every MCP tool that takes array/object schema params benefits — `sheet update-range / append-rows / find-cells / set-filter-criteria`, `aitable record create` with `records[]`, etc.

## Test plan

- [x] `go build ./...` passes
- [x] `dws attendance record get` end-to-end passes
- [x] `dws drive list-files / list-spaces` (read path) passes; write path requires PAT medium-risk authorization (DingTalk security policy, not a cli issue)
- [x] `dws sheet create-workspace-sheet` + `update-range` + `get-range` round-trip persists data correctly after the fix
- [x] Pre-prod branch `test/pre-mcp-discovery` merged + verified locally