### PR TITLE
fix: defensively reset credentials before login to prevent stale clientId errors (#155)

### DIFF
--- a/internal/auth/credential_reset_test.go
+++ b/internal/auth/credential_reset_test.go
@@ -1,0 +1,319 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// resetAppConfigCache clears cached app config so tests get a fresh load.
+func resetAppConfigCache() {
+	cachedAppConfigMu.Lock()
+	cachedAppConfig = nil
+	cachedAppConfigMu.Unlock()
+	cachedAppConfigOnce = sync.Once{}
+
+	cachedResolvedMu.Lock()
+	cachedResolvedValid = false
+	cachedResolvedID = ""
+	cachedResolvedSecret = ""
+	cachedResolvedMu.Unlock()
+}
+
+// ─── Issue #155: Defensive credential reset ────────────────────────────
+//
+// These tests verify that both DeviceFlowProvider and OAuthProvider always
+// reset credential state and re-fetch clientID from MCP, regardless of what
+// previous login methods left in app.json or runtime state.
+
+func TestIssue155V2_OAuthLoginNoSource_ThenDeviceLogin_ResetsAndFetches(t *testing.T) {
+	// Scenario: OAuth login saved app.json WITHOUT Source field (the original bug).
+	// Device flow should ignore the stale clientID, reset state, and re-fetch from MCP.
+
+	dir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", dir)
+	t.Setenv("DWS_CLIENT_ID", "")
+	t.Setenv("DWS_CLIENT_SECRET", "")
+
+	SetClientID("")
+	SetClientSecret("")
+	resetClientIDFromMCP()
+	resetAppConfigCache()
+	t.Cleanup(func() {
+		SetClientID("")
+		SetClientSecret("")
+		resetClientIDFromMCP()
+		resetAppConfigCache()
+	})
+
+	// Simulate OAuth login: saved app.json with clientId but NO Source field
+	oauthAppJSON := `{"clientId":"ding-oauth-stale","clientSecret":"","createdAt":"2026-04-24T00:00:00+08:00"}`
+	if err := os.WriteFile(filepath.Join(dir, appConfigFile), []byte(oauthAppJSON), 0o600); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	// Verify precondition: ClientID() loads stale value from app.json
+	resetAppConfigCache()
+	gotID := ClientID()
+	if gotID != "ding-oauth-stale" {
+		t.Fatalf("precondition: ClientID() = %q, want 'ding-oauth-stale'", gotID)
+	}
+	if IsClientIDFromMCP() {
+		t.Fatal("precondition: IsClientIDFromMCP() should be false for app.json without Source")
+	}
+
+	// Now create a DeviceFlowProvider — it should pick up the stale clientID
+	provider := NewDeviceFlowProvider(dir, nil)
+	if provider.clientID != "ding-oauth-stale" {
+		t.Fatalf("provider.clientID = %q, want 'ding-oauth-stale' (from app.json)", provider.clientID)
+	}
+
+	// Key assertion: after prepareCredentials(), the provider should have
+	// cleared the stale clientID and be ready for MCP fetch.
+	// We can't call Login() directly (needs real MCP server), but we can
+	// verify the reset logic by calling the new method directly.
+	provider.resetCredentialState()
+
+	if provider.clientID != "" {
+		t.Fatalf("after resetCredentialState: provider.clientID = %q, want empty", provider.clientID)
+	}
+	if IsClientIDFromMCP() {
+		t.Fatal("after resetCredentialState: IsClientIDFromMCP() should be false")
+	}
+}
+
+func TestIssue155V2_LegacyAppJson_ThenDeviceLogin_ResetsAndFetches(t *testing.T) {
+	// Scenario: Legacy app.json (no Source field at all) exists from an old CLI version.
+	// Device flow should reset and re-fetch.
+
+	dir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", dir)
+	t.Setenv("DWS_CLIENT_ID", "")
+	t.Setenv("DWS_CLIENT_SECRET", "")
+
+	SetClientID("")
+	SetClientSecret("")
+	resetClientIDFromMCP()
+	resetAppConfigCache()
+	t.Cleanup(func() {
+		SetClientID("")
+		SetClientSecret("")
+		resetClientIDFromMCP()
+		resetAppConfigCache()
+	})
+
+	// Write legacy app.json
+	legacyJSON := `{"clientId":"ding-legacy-old","clientSecret":"","createdAt":"2026-01-01T00:00:00+08:00"}`
+	if err := os.WriteFile(filepath.Join(dir, appConfigFile), []byte(legacyJSON), 0o600); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	resetAppConfigCache()
+	provider := NewDeviceFlowProvider(dir, nil)
+
+	// Verify stale clientID was loaded
+	if provider.clientID != "ding-legacy-old" {
+		t.Fatalf("provider.clientID = %q, want 'ding-legacy-old'", provider.clientID)
+	}
+
+	// Reset should clear it
+	provider.resetCredentialState()
+
+	if provider.clientID != "" {
+		t.Fatalf("after resetCredentialState: provider.clientID = %q, want empty", provider.clientID)
+	}
+}
+
+func TestIssue155V2_DirectAppJson_ThenDeviceLogin_ResetsAndFetches(t *testing.T) {
+	// Scenario: User previously logged in with --client-id + --client-secret (direct mode).
+	// app.json has a different clientId. Device flow should reset and re-fetch from MCP.
+
+	dir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", dir)
+	t.Setenv("DWS_CLIENT_ID", "")
+	t.Setenv("DWS_CLIENT_SECRET", "")
+
+	SetClientID("")
+	SetClientSecret("")
+	resetClientIDFromMCP()
+	resetAppConfigCache()
+	t.Cleanup(func() {
+		SetClientID("")
+		SetClientSecret("")
+		resetClientIDFromMCP()
+		resetAppConfigCache()
+	})
+
+	// Simulate direct-mode app.json with clientSecret stored
+	if err := SaveAppConfig(dir, &AppConfig{
+		ClientID:     "ding-direct-custom",
+		ClientSecret: PlainSecret("some-secret"),
+	}); err != nil {
+		t.Fatalf("SaveAppConfig error: %v", err)
+	}
+
+	resetAppConfigCache()
+	provider := NewDeviceFlowProvider(dir, nil)
+
+	// Verify the direct clientID was loaded
+	if provider.clientID != "ding-direct-custom" {
+		t.Fatalf("provider.clientID = %q, want 'ding-direct-custom'", provider.clientID)
+	}
+
+	// Reset should clear it
+	provider.resetCredentialState()
+
+	if provider.clientID != "" {
+		t.Fatalf("after resetCredentialState: provider.clientID = %q, want empty", provider.clientID)
+	}
+	if IsClientIDFromMCP() {
+		t.Fatal("after resetCredentialState: IsClientIDFromMCP() should be false")
+	}
+}
+
+func TestIssue155V2_MCPFlagAlreadySet_ThenDeviceLogin_StillResets(t *testing.T) {
+	// Scenario: MCP flag is already set from a previous device login in same process.
+	// Device flow should still reset and re-fetch to ensure freshness.
+
+	dir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", dir)
+	t.Setenv("DWS_CLIENT_ID", "")
+	t.Setenv("DWS_CLIENT_SECRET", "")
+
+	// Simulate: MCP flag is already set from previous login
+	SetClientIDFromMCP("ding-old-mcp")
+	t.Cleanup(func() {
+		SetClientID("")
+		SetClientSecret("")
+		resetClientIDFromMCP()
+		resetAppConfigCache()
+	})
+
+	provider := NewDeviceFlowProvider(dir, nil)
+	if provider.clientID != "ding-old-mcp" {
+		t.Fatalf("provider.clientID = %q, want 'ding-old-mcp'", provider.clientID)
+	}
+
+	// Reset should clear both clientID and MCP flag
+	provider.resetCredentialState()
+
+	if provider.clientID != "" {
+		t.Fatalf("after resetCredentialState: provider.clientID = %q, want empty", provider.clientID)
+	}
+	if IsClientIDFromMCP() {
+		t.Fatal("after resetCredentialState: IsClientIDFromMCP() should be false after reset")
+	}
+}
+
+func TestIssue155V2_NoAppJson_DeviceLogin_StillWorks(t *testing.T) {
+	// Scenario: No app.json exists (first time login). Device flow should work normally.
+
+	dir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", dir)
+	t.Setenv("DWS_CLIENT_ID", "")
+	t.Setenv("DWS_CLIENT_SECRET", "")
+
+	SetClientID("")
+	SetClientSecret("")
+	resetClientIDFromMCP()
+	resetAppConfigCache()
+	t.Cleanup(func() {
+		SetClientID("")
+		SetClientSecret("")
+		resetClientIDFromMCP()
+		resetAppConfigCache()
+	})
+
+	provider := NewDeviceFlowProvider(dir, nil)
+
+	// clientID should already be empty
+	if provider.clientID != "" {
+		t.Fatalf("provider.clientID = %q, want empty (no app.json)", provider.clientID)
+	}
+
+	// Reset should be a no-op but not crash
+	provider.resetCredentialState()
+
+	if provider.clientID != "" {
+		t.Fatalf("after resetCredentialState: provider.clientID = %q, want empty", provider.clientID)
+	}
+	if IsClientIDFromMCP() {
+		t.Fatal("after resetCredentialState: IsClientIDFromMCP() should be false")
+	}
+}
+
+// ─── OAuthProvider defensive reset (--force login) ─────────────────────
+
+func TestIssue155V2_OAuthForceLogin_ResetsStaleCredentials(t *testing.T) {
+	// Scenario: Previous login saved app.json with MCP-fetched clientID but
+	// no Source marker. OAuth --force login should reset and re-fetch.
+
+	dir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", dir)
+	t.Setenv("DWS_CLIENT_ID", "")
+	t.Setenv("DWS_CLIENT_SECRET", "")
+
+	SetClientID("")
+	SetClientSecret("")
+	resetClientIDFromMCP()
+	resetAppConfigCache()
+	t.Cleanup(func() {
+		SetClientID("")
+		SetClientSecret("")
+		resetClientIDFromMCP()
+		resetAppConfigCache()
+	})
+
+	// Simulate previous login: app.json with clientId but no Source
+	staleJSON := `{"clientId":"ding-stale-oauth","clientSecret":"","createdAt":"2026-04-24T00:00:00+08:00"}`
+	if err := os.WriteFile(filepath.Join(dir, appConfigFile), []byte(staleJSON), 0o600); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	resetAppConfigCache()
+	provider := NewOAuthProvider(dir, nil)
+
+	// Verify stale clientID was loaded
+	if provider.clientID != "ding-stale-oauth" {
+		t.Fatalf("provider.clientID = %q, want 'ding-stale-oauth'", provider.clientID)
+	}
+
+	// Reset should clear it
+	provider.resetCredentialState()
+
+	if provider.clientID != "" {
+		t.Fatalf("after resetCredentialState: provider.clientID = %q, want empty", provider.clientID)
+	}
+	if IsClientIDFromMCP() {
+		t.Fatal("after resetCredentialState: IsClientIDFromMCP() should be false")
+	}
+}
+
+func TestIssue155V2_OAuthForceLogin_MCPFlagSet_StillResets(t *testing.T) {
+	// Scenario: MCP flag is already set. OAuth --force login should still reset.
+
+	dir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", dir)
+	t.Setenv("DWS_CLIENT_ID", "")
+	t.Setenv("DWS_CLIENT_SECRET", "")
+
+	SetClientIDFromMCP("ding-old-mcp-oauth")
+	t.Cleanup(func() {
+		SetClientID("")
+		SetClientSecret("")
+		resetClientIDFromMCP()
+		resetAppConfigCache()
+	})
+
+	provider := NewOAuthProvider(dir, nil)
+
+	provider.resetCredentialState()
+
+	if provider.clientID != "" {
+		t.Fatalf("after resetCredentialState: provider.clientID = %q, want empty", provider.clientID)
+	}
+	if IsClientIDFromMCP() {
+		t.Fatal("after resetCredentialState: IsClientIDFromMCP() should be false after reset")
+	}
+}

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -127,22 +127,38 @@ type serviceResult struct {
 	ErrorMsg  string          `json:"errorMsg"`
 }
 
+// resetCredentialState clears any stale credential state inherited from
+// previous login methods (OAuth, PAT, etc.) so that device flow always
+// starts fresh by fetching clientID from MCP.
+//
+// This is a defensive measure: no matter what a prior login wrote to
+// app.json or runtime globals, device flow will re-fetch from MCP and
+// set the correct clientIDFromMCP flag, ensuring exchangeCode() uses
+// the MCP proxy path (which doesn't require clientSecret).
+func (p *DeviceFlowProvider) resetCredentialState() {
+	p.clientID = ""
+	clientMu.Lock()
+	clientIDFromMCP = false
+	clientMu.Unlock()
+}
+
 func (p *DeviceFlowProvider) Login(ctx context.Context) (*TokenData, error) {
-	// Ensure we have a valid client ID (fetch from MCP if not available)
-	if p.clientID == "" {
-		if p.logger != nil {
-			p.logger.Debug("client ID not configured, fetching from MCP server")
-		}
-		mcpClientID, mcpErr := FetchClientIDFromMCP(ctx)
-		if mcpErr != nil {
-			return nil, fmt.Errorf("%s: %w", i18n.T("获取 Client ID 失败"), mcpErr)
-		}
-		p.clientID = mcpClientID
-		// Mark that clientID is from MCP
-		SetClientIDFromMCP(mcpClientID)
-		if p.logger != nil {
-			p.logger.Debug("fetched client ID from MCP server", "clientID", mcpClientID)
-		}
+	// Defensive reset: clear any stale credential state from previous login
+	// methods (OAuth scan, PAT, etc.) so we always re-fetch from MCP.
+	// This ensures --device login works regardless of what app.json contains.
+	p.resetCredentialState()
+
+	if p.logger != nil {
+		p.logger.Debug("fetching client ID from MCP server (device flow always re-fetches)")
+	}
+	mcpClientID, mcpErr := FetchClientIDFromMCP(ctx)
+	if mcpErr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("获取 Client ID 失败"), mcpErr)
+	}
+	p.clientID = mcpClientID
+	SetClientIDFromMCP(mcpClientID)
+	if p.logger != nil {
+		p.logger.Debug("fetched client ID from MCP server", "clientID", mcpClientID)
 	}
 
 	const maxAttempts = 3

--- a/internal/auth/oauth_provider.go
+++ b/internal/auth/oauth_provider.go
@@ -55,6 +55,16 @@ func NewOAuthProvider(configDir string, logger *slog.Logger) *OAuthProvider {
 	}
 }
 
+// resetCredentialState clears any stale credential state inherited from
+// previous login methods so that OAuth flow always starts fresh by
+// fetching clientID from MCP.
+func (p *OAuthProvider) resetCredentialState() {
+	p.clientID = ""
+	clientMu.Lock()
+	clientIDFromMCP = false
+	clientMu.Unlock()
+}
+
 func (p *OAuthProvider) output() io.Writer {
 	if p != nil && p.Output != nil {
 		return p.Output
@@ -94,21 +104,22 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 	}
 
 	// Fall through: full browser OAuth flow.
-	// Ensure we have a valid client ID (fetch from MCP if not available)
-	if p.clientID == "" {
-		if p.logger != nil {
-			p.logger.Debug("client ID not configured, fetching from MCP server")
-		}
-		mcpClientID, mcpErr := FetchClientIDFromMCP(ctx)
-		if mcpErr != nil {
-			return nil, fmt.Errorf("%s: %w", i18n.T("获取 Client ID 失败"), mcpErr)
-		}
-		p.clientID = mcpClientID
-		// Mark that clientID is from MCP, so we use MCP OAuth endpoints
-		SetClientIDFromMCP(mcpClientID)
-		if p.logger != nil {
-			p.logger.Debug("fetched client ID from MCP server", "clientID", mcpClientID)
-		}
+	// Defensive reset: clear any stale credential state from previous login
+	// methods so we always re-fetch clientID from MCP. This ensures
+	// --force login works regardless of what app.json contains.
+	p.resetCredentialState()
+
+	if p.logger != nil {
+		p.logger.Debug("fetching client ID from MCP server (OAuth flow always re-fetches)")
+	}
+	mcpClientID, mcpErr := FetchClientIDFromMCP(ctx)
+	if mcpErr != nil {
+		return nil, fmt.Errorf("%s: %w", i18n.T("获取 Client ID 失败"), mcpErr)
+	}
+	p.clientID = mcpClientID
+	SetClientIDFromMCP(mcpClientID)
+	if p.logger != nil {
+		p.logger.Debug("fetched client ID from MCP server", "clientID", mcpClientID)
 	}
 
 	// Find a free port for the callback server.


### PR DESCRIPTION
## Problem

When `app.json` already exists from a previous login, running `dws auth login --device` or `dws auth login --force` fails with `clientId或者clientSecret错误`.

## Root Cause

Both device flow and OAuth flow reused the stale `clientId` from `app.json` (written by a previous login) without setting the `clientIDFromMCP` flag. This caused `exchangeCode()` to use the direct DingTalk API path which requires `clientSecret`, but `clientSecret` was empty → DingTalk API returned error.

The issue occurs in **any** cross-login-method scenario:
- OAuth scan login → device login
- Device login → OAuth `--force` login
- PAT auth → device / OAuth login
- Any future login method → device / OAuth login

## Fix

**Defensive reset at login entry**: Both `DeviceFlowProvider.Login()` and `OAuthProvider.Login()` now always clear stale credential state and re-fetch `clientId` from MCP server before proceeding, regardless of what previous login methods left in `app.json` or runtime globals.

This is a **future-proof** fix — no matter what new login methods are added, login will always work correctly.

### Changes

- **`internal/auth/device_flow.go`**: Add `resetCredentialState()` method. `Login()` calls it unconditionally before fetching from MCP.
- **`internal/auth/oauth_provider.go`**: Add `resetCredentialState()` method. `Login()` calls it before the browser OAuth flow (after silent refresh attempts).
- **`internal/auth/device_flow_reset_test.go`**: 7 new tests covering all cross-login scenarios for both providers.

## Tests

7 new test cases covering:
- OAuth login (stale app.json) → device login works
- Legacy app.json (old CLI version) → device login works
- Direct mode app.json (with clientSecret) → device login works
- MCP flag already set → device login still resets and re-fetches
- No app.json (first time) → device login works
- Stale app.json → OAuth `--force` login works
- MCP flag already set → OAuth `--force` login still resets

All existing auth tests pass with zero regression.

Closes #155