### PR TITLE
fix(compat,helpers): json_parse YAML fallback + send-by-bot product routing

### DIFF
--- a/internal/compat/transform.go
+++ b/internal/compat/transform.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 )
 
@@ -110,6 +112,18 @@ func transformCSVToArray(value any) (any, error) {
 	return result, nil
 }
 
+// transformJSONParse parses a CLI string into a structured value so callers can
+// pass complex payloads (JSON arrays/objects) through a single flag.
+//
+// Two input dialects are accepted, in order:
+//  1. Strict JSON  — `[{"fieldName":"x","type":"text"}]`
+//  2. YAML (flow)  — `[{fieldName: x, type: text}]`
+//
+// YAML is a superset of JSON that permits unquoted keys and strings, which
+// dramatically reduces the need for shell-level escaping. Users can therefore
+// write `--fields '[{fieldName: 标题, type: text}]'` instead of piling quotes
+// around every token. The output shape is the same either way; downstream
+// consumers see the parsed Go value, not the original dialect.
 func transformJSONParse(value any) (any, error) {
 	s, ok := toString(value)
 	if !ok {
@@ -119,11 +133,22 @@ func transformJSONParse(value any) (any, error) {
 	if s == "" {
 		return value, nil
 	}
+	// Strict JSON first — fast path and unambiguous type promotion (numbers
+	// stay numbers, etc.).
 	var parsed any
-	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
-		return nil, apperrors.NewValidation(fmt.Sprintf("json_parse: invalid JSON: %v", err))
+	if err := json.Unmarshal([]byte(s), &parsed); err == nil {
+		return parsed, nil
 	}
-	return parsed, nil
+	// YAML (flow) fallback — accepts `{key: value}` without surrounding
+	// quotes, which is the natural form when typing at a shell prompt.
+	if err := yaml.Unmarshal([]byte(s), &parsed); err == nil {
+		return parsed, nil
+	}
+	return nil, apperrors.NewValidation(
+		"json_parse: input is not valid JSON or YAML; " +
+			"quote the whole value and use `[{key: value, ...}]` for ad-hoc input, " +
+			"or pass `@path/to/file.json` to read from a file",
+	)
 }
 
 func transformEnumMap(value any, args map[string]any) (any, error) {

--- a/internal/compat/transform_test.go
+++ b/internal/compat/transform_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compat
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestJSONParse_StrictJSON covers the primary path: callers passing
+// canonical JSON (as generated programmatically or by agents).
+func TestJSONParse_StrictJSON(t *testing.T) {
+	t.Parallel()
+
+	input := `[{"fieldName":"title","type":"text"},{"fieldName":"count","type":"number"}]`
+	got, err := ApplyTransform(input, "json_parse", nil)
+	if err != nil {
+		t.Fatalf("strict JSON should parse, got err: %v", err)
+	}
+	arr, ok := got.([]any)
+	if !ok || len(arr) != 2 {
+		t.Fatalf("expected []any of length 2, got %T %v", got, got)
+	}
+}
+
+// TestJSONParse_YAMLFlowFallback is the motivating case: a user types an
+// ad-hoc JSON-shaped array without quoting every key and value. YAML flow
+// syntax accepts it and the parsed output is indistinguishable from the
+// strict-JSON equivalent.
+func TestJSONParse_YAMLFlowFallback(t *testing.T) {
+	t.Parallel()
+
+	// Intentionally unquoted keys, unquoted string values, and Chinese
+	// identifiers — typical of what humans type at a shell.
+	input := `[{fieldName: 标题, type: text}, {fieldName: 数量, type: number, config: {formatter: INT}}, {fieldName: 状态, type: singleSelect, config: {options: [{name: 待办}, {name: 进行中}, {name: 已完成}]}}, {fieldName: 已确认, type: checkbox}]`
+
+	got, err := ApplyTransform(input, "json_parse", nil)
+	if err != nil {
+		t.Fatalf("YAML-flow input should parse, got err: %v", err)
+	}
+	arr, ok := got.([]any)
+	if !ok {
+		t.Fatalf("expected []any, got %T", got)
+	}
+	if len(arr) != 4 {
+		t.Fatalf("expected 4 field definitions, got %d", len(arr))
+	}
+
+	// Spot-check the third entry, which is the most deeply nested.
+	third, ok := arr[2].(map[string]any)
+	if !ok {
+		t.Fatalf("arr[2] expected map[string]any, got %T", arr[2])
+	}
+	if third["fieldName"] != "状态" {
+		t.Errorf("arr[2].fieldName: want 状态, got %v", third["fieldName"])
+	}
+	config, ok := third["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("arr[2].config expected map, got %T", third["config"])
+	}
+	options, ok := config["options"].([]any)
+	if !ok || len(options) != 3 {
+		t.Fatalf("arr[2].config.options: want 3 items, got %v", config["options"])
+	}
+}
+
+// TestJSONParse_EmptyString preserves the legacy behaviour of returning the
+// original value untouched when the caller passes an empty / whitespace-only
+// string, matching how other transforms treat empty input.
+func TestJSONParse_EmptyString(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"", "   ", "\n\t"}
+	for _, in := range cases {
+		got, err := ApplyTransform(in, "json_parse", nil)
+		if err != nil {
+			t.Errorf("empty input %q should not error: %v", in, err)
+			continue
+		}
+		if !reflect.DeepEqual(got, in) {
+			t.Errorf("empty input %q should pass through, got %v", in, got)
+		}
+	}
+}
+
+// TestJSONParse_NonString passes through non-string inputs (already-parsed
+// values flowing through the pipeline).
+func TestJSONParse_NonString(t *testing.T) {
+	t.Parallel()
+
+	preParsed := []any{map[string]any{"k": "v"}}
+	got, err := ApplyTransform(preParsed, "json_parse", nil)
+	if err != nil {
+		t.Fatalf("non-string should pass through: %v", err)
+	}
+	if !reflect.DeepEqual(got, preParsed) {
+		t.Errorf("non-string should pass through unchanged, got %v", got)
+	}
+}
+
+// TestJSONParse_InvalidInput verifies that genuine garbage is still rejected
+// with a user-facing validation error that nudges towards `@file` syntax.
+func TestJSONParse_InvalidInput(t *testing.T) {
+	t.Parallel()
+
+	// Unterminated bracket — neither valid JSON nor valid YAML flow.
+	_, err := ApplyTransform("[{fieldName:", "json_parse", nil)
+	if err == nil {
+		t.Fatal("expected error for malformed input")
+	}
+	if msg := err.Error(); msg == "" {
+		t.Fatal("error message should be non-empty")
+	}
+}

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -95,7 +95,7 @@ func newChatMessageSendByBotCommand(runner executor.Runner) *cobra.Command {
 
 			invocation := executor.NewHelperInvocation(
 				cobracmd.LegacyCommandPath(cmd),
-				"chat",
+				"bot",
 				tool,
 				params,
 			)

--- a/internal/helpers/chat_test.go
+++ b/internal/helpers/chat_test.go
@@ -43,4 +43,55 @@ func TestChatMessageSendByBotIgnoresLegacyRealBuildModeEnv(t *testing.T) {
 	if got := runner.last.Params["robotCode"]; got != "robot-001" {
 		t.Fatalf("robotCode = %#v, want robot-001", got)
 	}
+	if got := runner.last.CanonicalProduct; got != "bot" {
+		t.Fatalf("CanonicalProduct = %q, want bot", got)
+	}
+}
+
+func TestChatMessageSendByBotRoutesToBotProduct(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantTool string
+	}{
+		{
+			name: "single-chat",
+			args: []string{
+				"--users", "user-001",
+				"--robot-code", "robot-001",
+				"--title", "t",
+				"--text", "x",
+			},
+			wantTool: "batch_send_robot_msg_to_users",
+		},
+		{
+			name: "group-chat",
+			args: []string{
+				"--group", "cid-xyz",
+				"--robot-code", "robot-001",
+				"--title", "t",
+				"--text", "x",
+			},
+			wantTool: "send_robot_group_message",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &captureRunner{}
+			cmd := newChatMessageSendByBotCommand(runner)
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+			}
+			if got := runner.last.CanonicalProduct; got != "bot" {
+				t.Fatalf("CanonicalProduct = %q, want bot", got)
+			}
+			if got := runner.last.Tool; got != tc.wantTool {
+				t.Fatalf("Tool = %q, want %q", got, tc.wantTool)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Two unrelated but small fixes bundled in one PR.

### 1. `json_parse` transform: accept YAML flow as a fallback

`dws aitable table create --fields [{fieldName: ..., type: ...}]` fails at
the shell layer (`zsh: bad pattern: [{fieldName:`) and, even once quoted,
the strict-JSON parser rejects the natural form that omits quotes around
keys and string values.

This patch teaches the `json_parse` CLI transform to fall back to
YAML flow syntax when strict JSON parsing fails. YAML is a superset of
JSON that accepts `{key: value}` without surrounding quotes, so one pair
of outer quotes is enough:

```
dws aitable table create \
  --base-id BASE \
  --name RecordTest \
  --fields '[{fieldName: 标题, type: text}, {fieldName: 数量, type: number, config: {formatter: INT}}]'
```

Already-valid strict JSON and the `@path/to/file.json` override are
unaffected.

### 2. `chat message send-by-bot`: route invocation to `bot` product

`chat message send-by-bot` previously stamped its invocation with
`CanonicalProduct="chat"`, sending it through the chat product's auth
and server dispatch even though it is semantically a bot operation.
Switched the canonical product to `"bot"` so auth-client selection,
MCP server targeting, and downstream routing all line up with the
actual tool.

## Commits

| Commit | Scope |
|--------|-------|
| `fix(compat): accept YAML flow as a fallback for json_parse transform` | `internal/compat/transform.go`, `internal/compat/transform_test.go` |
| `fix(helpers): route chat send-by-bot to bot product` | `internal/helpers/chat.go`, `internal/helpers/chat_test.go` |

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/compat/...` — strict JSON, YAML flow, empty, non-string, invalid input
- [x] `go test ./internal/helpers/...` — single-chat + group-chat routing assertions
- [x] `go test ./internal/cli/...` — canonical layer passes (same transform pipeline)
- [x] Regression: strict-JSON inputs still parse identically