### PR TITLE
fix(app): graft hardcoded helpers into dynamic tree instead of dropping

### DIFF
--- a/internal/app/legacy.go
+++ b/internal/app/legacy.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/cmdutil"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/spf13/cobra"
@@ -52,32 +53,36 @@ func newLegacyPublicCommands(ctx context.Context, runner executor.Runner) []*cob
 	return mergeTopLevelCommands(pickCommands(dynamicCmds, helperCmds))
 }
 
-// pickCommands returns the union of dynamic and helpers commands, with
-// same-named helpers dropped so discovery envelopes remain the authority.
+// pickCommands returns the union of dynamic and helpers commands. For
+// same-named top-level products, helper-only leaves are grafted into the
+// dynamic tree via cmdutil.MergeHardcodedLeaves so the discovery envelope
+// remains the authority for leaves it declares, while hardcoded helpers can
+// still fill gaps the envelope did not cover (e.g. `chat message send-by-bot`
+// alongside the envelope's `chat message send`).
 //
 // Why this exists: mergeTopLevelCommands below calls cobracmd.MergeCommandTree
 // on same-named top-level commands, which — at leaf conflicts — falls back to
 // "more local flags wins" via ShouldReplaceLeaf. Hardcoded helpers commands
 // typically expose more flags than the corresponding dynamic overlay leaves,
 // so a naive append would silently promote helper leaves over their dynamic
-// counterparts and append helper-only siblings into the dynamic subtree.
-// By shadowing same-named helpers upfront we keep the dynamic subtree intact
-// and let helpers only fill in products the discovery envelope did not cover.
+// counterparts. MergeHardcodedLeaves avoids that by letting dynamic win every
+// leaf conflict, and only adding subtrees the dynamic side lacks.
 func pickCommands(dynamic, helpers []*cobra.Command) []*cobra.Command {
-	dynNames := make(map[string]bool, len(dynamic))
+	dynByName := make(map[string]*cobra.Command, len(dynamic))
 	out := make([]*cobra.Command, 0, len(dynamic)+len(helpers))
 	for _, c := range dynamic {
 		if c == nil {
 			continue
 		}
-		dynNames[c.Name()] = true
+		dynByName[c.Name()] = c
 		out = append(out, c)
 	}
 	for _, h := range helpers {
 		if h == nil {
 			continue
 		}
-		if dynNames[h.Name()] {
+		if dyn := dynByName[h.Name()]; dyn != nil {
+			cmdutil.MergeHardcodedLeaves(dyn, h)
 			continue
 		}
 		out = append(out, h)

--- a/internal/app/legacy_test.go
+++ b/internal/app/legacy_test.go
@@ -19,28 +19,77 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TestPickCommands_DynamicShadowsSameNamedHelpers verifies that when the
-// discovery envelope produces a dynamic command with the same top-level name
-// as a helpers-registered hardcoded command, the helper is dropped and the
-// dynamic command is kept verbatim. This prevents mergeTopLevelCommands from
-// mixing helper leaves into the dynamic subtree via MergeCommandTree's
-// LocalFlagCount-based arbitration.
-func TestPickCommands_DynamicShadowsSameNamedHelpers(t *testing.T) {
+// TestPickCommands_DynamicWinsLeafConflicts verifies that when the discovery
+// envelope produces a dynamic leaf and a helper registers the same-named leaf,
+// the dynamic one wins — envelopes remain the runtime authority for behaviour
+// they declare. The helper subtree must not slip in via
+// mergeTopLevelCommands's LocalFlagCount-based arbitration.
+func TestPickCommands_DynamicWinsLeafConflicts(t *testing.T) {
+	dynTask := &cobra.Command{Use: "task", Short: "dynamic-task", Run: func(*cobra.Command, []string) {}}
 	dyn := &cobra.Command{Use: "todo", Short: "dynamic"}
-	dyn.AddCommand(&cobra.Command{Use: "task"})
+	dyn.AddCommand(dynTask)
 	dynamic := []*cobra.Command{dyn}
 
+	hlpTask := &cobra.Command{Use: "task", Short: "helper-task", Run: func(*cobra.Command, []string) {}}
 	hlp := &cobra.Command{Use: "todo", Short: "helper"}
-	hlp.AddCommand(&cobra.Command{Use: "task"})
+	hlp.AddCommand(hlpTask)
 	helpers := []*cobra.Command{hlp}
 
 	got := pickCommands(dynamic, helpers)
 
-	if len(got) != 1 {
-		t.Fatalf("pickCommands returned %d commands, want 1", len(got))
+	if len(got) != 1 || got[0] != dyn {
+		t.Fatalf("pickCommands returned %v, want [dyn]", got)
 	}
-	if got[0] != dyn {
-		t.Fatalf("pickCommands returned helpers command, want dynamic")
+	// The dynamic leaf must still be the one we find under the top-level name.
+	var found *cobra.Command
+	for _, c := range got[0].Commands() {
+		if c.Name() == "task" {
+			found = c
+		}
+	}
+	if found != dynTask {
+		t.Fatalf("leaf conflict resolved to helper; want dynamic to win")
+	}
+}
+
+// TestPickCommands_HelperOnlyLeavesAreGrafted verifies that when a helper
+// registers siblings the discovery envelope did NOT declare (e.g.
+// `chat message send-by-bot`, `chat message recall-by-bot` next to the
+// envelope's `chat message send`), those helper-only leaves are grafted into
+// the dynamic subtree instead of being dropped. This is a regression guard:
+// prior to this fix, pickCommands silently dropped the entire helper subtree
+// whenever the top-level product name collided, which disappeared every
+// helper-only leaf the envelope didn't cover.
+func TestPickCommands_HelperOnlyLeavesAreGrafted(t *testing.T) {
+	dynMessage := &cobra.Command{Use: "message"}
+	dynMessage.AddCommand(&cobra.Command{Use: "send", Run: func(*cobra.Command, []string) {}})
+	dyn := &cobra.Command{Use: "chat"}
+	dyn.AddCommand(dynMessage)
+	dynamic := []*cobra.Command{dyn}
+
+	helperOnlyLeaf := &cobra.Command{Use: "send-by-bot", Run: func(*cobra.Command, []string) {}}
+	hlpMessage := &cobra.Command{Use: "message"}
+	hlpMessage.AddCommand(helperOnlyLeaf)
+	hlp := &cobra.Command{Use: "chat"}
+	hlp.AddCommand(hlpMessage)
+	helpers := []*cobra.Command{hlp}
+
+	got := pickCommands(dynamic, helpers)
+
+	if len(got) != 1 || got[0] != dyn {
+		t.Fatalf("pickCommands returned %v, want [dyn]", got)
+	}
+	var grafted *cobra.Command
+	for _, child := range dynMessage.Commands() {
+		if child.Name() == "send-by-bot" {
+			grafted = child
+		}
+	}
+	if grafted == nil {
+		t.Fatalf("helper-only leaf send-by-bot was not grafted into dynamic.chat.message")
+	}
+	if grafted != helperOnlyLeaf {
+		t.Fatalf("grafted leaf identity differs from helper-registered leaf")
 	}
 }
 


### PR DESCRIPTION
## Summary

`pickCommands` in `internal/app/legacy.go` previously dropped an entire
helper subtree whenever a top-level product name collided with the
dynamic overlay. The intent was to keep the discovery envelope as the
runtime authority for leaves it declared, but the side effect was that
every helper-only sibling disappeared too.

On main (since PR #156), the following helper commands have been
silently missing from the open edition, even though they remain in
`internal/helpers/chat.go`:

- `dws chat message send-by-bot`
- `dws chat message recall-by-bot`
- `dws chat message send-by-webhook`
- `dws chat group members add-bot`

This also makes PR #161's Fix #2 (send-by-bot routing through
`canonical_product=bot`) **unreachable** for open-source users — the
routing logic is correct but the command it's attached to has been
elided before users can invoke it. The v1.0.15 tagged binary does not
exhibit this regression; the divergence was introduced between
`9739082..ad33a46` and isolated to the pickCommands drop loop.

## Fix

For same-named top-level products, invoke
`cmdutil.MergeHardcodedLeaves(dynamic, helper)` instead of silently
dropping the helper subtree. Dynamic side still wins every leaf
conflict (envelope authority preserved); only helper-only subtrees are
grafted onto the dynamic tree, which matches the documented conflict
table in `pkg/cmdutil/leaf_merge.go`.

## Commits

| Commit | Scope |
|--------|-------|
| `fix(app): graft hardcoded helpers into dynamic tree instead of dropping` | `internal/app/legacy.go`, `internal/app/legacy_test.go` |

## Test plan

- [x] `go vet ./...`
- [x] `go test ./internal/app/... -run TestPickCommands` — 5/5 pass,
      including a new `TestPickCommands_HelperOnlyLeavesAreGrafted`
      regression guard
- [x] `go test ./internal/...` — full internal suite clean
- [x] `make build` → fresh open-edition binary
- [x] End-to-end live API call:
      `dws chat message send-by-bot --robot-code ... --users ... --text ...`
      returns `success: true` with a real `processQueryKey`, routed via
      `canonical_product: bot` through `helper_override` — matches the
      v1.0.15 baseline behaviour

## Out of scope (follow-up)

- `dws chat message send --user <userId>` (single-chat) still returns
  `不合法的参数` because the dynamic `send` command maps to
  `send_message_as_user` (group-only) for all destinations. Fixing this
  requires envelope/compat-layer flag-based tool dispatch rather than a
  helper override — tracked separately.