### PR TITLE
fix(chat,cmdutil): route chat message send by destination flag

### DIFF
--- a/internal/app/legacy.go
+++ b/internal/app/legacy.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/cmdutil"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/spf13/cobra"
@@ -52,32 +53,36 @@ func newLegacyPublicCommands(ctx context.Context, runner executor.Runner) []*cob
 	return mergeTopLevelCommands(pickCommands(dynamicCmds, helperCmds))
 }
 
-// pickCommands returns the union of dynamic and helpers commands, with
-// same-named helpers dropped so discovery envelopes remain the authority.
+// pickCommands returns the union of dynamic and helpers commands. For
+// same-named top-level products, helper-only leaves are grafted into the
+// dynamic tree via cmdutil.MergeHardcodedLeaves so the discovery envelope
+// remains the authority for leaves it declares, while hardcoded helpers can
+// still fill gaps the envelope did not cover (e.g. `chat message send-by-bot`
+// alongside the envelope's `chat message send`).
 //
 // Why this exists: mergeTopLevelCommands below calls cobracmd.MergeCommandTree
 // on same-named top-level commands, which — at leaf conflicts — falls back to
 // "more local flags wins" via ShouldReplaceLeaf. Hardcoded helpers commands
 // typically expose more flags than the corresponding dynamic overlay leaves,
 // so a naive append would silently promote helper leaves over their dynamic
-// counterparts and append helper-only siblings into the dynamic subtree.
-// By shadowing same-named helpers upfront we keep the dynamic subtree intact
-// and let helpers only fill in products the discovery envelope did not cover.
+// counterparts. MergeHardcodedLeaves avoids that by letting dynamic win every
+// leaf conflict, and only adding subtrees the dynamic side lacks.
 func pickCommands(dynamic, helpers []*cobra.Command) []*cobra.Command {
-	dynNames := make(map[string]bool, len(dynamic))
+	dynByName := make(map[string]*cobra.Command, len(dynamic))
 	out := make([]*cobra.Command, 0, len(dynamic)+len(helpers))
 	for _, c := range dynamic {
 		if c == nil {
 			continue
 		}
-		dynNames[c.Name()] = true
+		dynByName[c.Name()] = c
 		out = append(out, c)
 	}
 	for _, h := range helpers {
 		if h == nil {
 			continue
 		}
-		if dynNames[h.Name()] {
+		if dyn := dynByName[h.Name()]; dyn != nil {
+			cmdutil.MergeHardcodedLeaves(dyn, h)
 			continue
 		}
 		out = append(out, h)

--- a/internal/app/legacy_test.go
+++ b/internal/app/legacy_test.go
@@ -19,28 +19,77 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TestPickCommands_DynamicShadowsSameNamedHelpers verifies that when the
-// discovery envelope produces a dynamic command with the same top-level name
-// as a helpers-registered hardcoded command, the helper is dropped and the
-// dynamic command is kept verbatim. This prevents mergeTopLevelCommands from
-// mixing helper leaves into the dynamic subtree via MergeCommandTree's
-// LocalFlagCount-based arbitration.
-func TestPickCommands_DynamicShadowsSameNamedHelpers(t *testing.T) {
+// TestPickCommands_DynamicWinsLeafConflicts verifies that when the discovery
+// envelope produces a dynamic leaf and a helper registers the same-named leaf,
+// the dynamic one wins — envelopes remain the runtime authority for behaviour
+// they declare. The helper subtree must not slip in via
+// mergeTopLevelCommands's LocalFlagCount-based arbitration.
+func TestPickCommands_DynamicWinsLeafConflicts(t *testing.T) {
+	dynTask := &cobra.Command{Use: "task", Short: "dynamic-task", Run: func(*cobra.Command, []string) {}}
 	dyn := &cobra.Command{Use: "todo", Short: "dynamic"}
-	dyn.AddCommand(&cobra.Command{Use: "task"})
+	dyn.AddCommand(dynTask)
 	dynamic := []*cobra.Command{dyn}
 
+	hlpTask := &cobra.Command{Use: "task", Short: "helper-task", Run: func(*cobra.Command, []string) {}}
 	hlp := &cobra.Command{Use: "todo", Short: "helper"}
-	hlp.AddCommand(&cobra.Command{Use: "task"})
+	hlp.AddCommand(hlpTask)
 	helpers := []*cobra.Command{hlp}
 
 	got := pickCommands(dynamic, helpers)
 
-	if len(got) != 1 {
-		t.Fatalf("pickCommands returned %d commands, want 1", len(got))
+	if len(got) != 1 || got[0] != dyn {
+		t.Fatalf("pickCommands returned %v, want [dyn]", got)
 	}
-	if got[0] != dyn {
-		t.Fatalf("pickCommands returned helpers command, want dynamic")
+	// The dynamic leaf must still be the one we find under the top-level name.
+	var found *cobra.Command
+	for _, c := range got[0].Commands() {
+		if c.Name() == "task" {
+			found = c
+		}
+	}
+	if found != dynTask {
+		t.Fatalf("leaf conflict resolved to helper; want dynamic to win")
+	}
+}
+
+// TestPickCommands_HelperOnlyLeavesAreGrafted verifies that when a helper
+// registers siblings the discovery envelope did NOT declare (e.g.
+// `chat message send-by-bot`, `chat message recall-by-bot` next to the
+// envelope's `chat message send`), those helper-only leaves are grafted into
+// the dynamic subtree instead of being dropped. This is a regression guard:
+// prior to this fix, pickCommands silently dropped the entire helper subtree
+// whenever the top-level product name collided, which disappeared every
+// helper-only leaf the envelope didn't cover.
+func TestPickCommands_HelperOnlyLeavesAreGrafted(t *testing.T) {
+	dynMessage := &cobra.Command{Use: "message"}
+	dynMessage.AddCommand(&cobra.Command{Use: "send", Run: func(*cobra.Command, []string) {}})
+	dyn := &cobra.Command{Use: "chat"}
+	dyn.AddCommand(dynMessage)
+	dynamic := []*cobra.Command{dyn}
+
+	helperOnlyLeaf := &cobra.Command{Use: "send-by-bot", Run: func(*cobra.Command, []string) {}}
+	hlpMessage := &cobra.Command{Use: "message"}
+	hlpMessage.AddCommand(helperOnlyLeaf)
+	hlp := &cobra.Command{Use: "chat"}
+	hlp.AddCommand(hlpMessage)
+	helpers := []*cobra.Command{hlp}
+
+	got := pickCommands(dynamic, helpers)
+
+	if len(got) != 1 || got[0] != dyn {
+		t.Fatalf("pickCommands returned %v, want [dyn]", got)
+	}
+	var grafted *cobra.Command
+	for _, child := range dynMessage.Commands() {
+		if child.Name() == "send-by-bot" {
+			grafted = child
+		}
+	}
+	if grafted == nil {
+		t.Fatalf("helper-only leaf send-by-bot was not grafted into dynamic.chat.message")
+	}
+	if grafted != helperOnlyLeaf {
+		t.Fatalf("grafted leaf identity differs from helper-registered leaf")
 	}
 }
 

--- a/internal/cobracmd/priority.go
+++ b/internal/cobracmd/priority.go
@@ -14,37 +14,18 @@
 package cobracmd
 
 import (
-	"strconv"
-	"strings"
-
 	"github.com/spf13/cobra"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/cmdutil"
 )
 
-const overridePriorityAnnotation = "dws.override-priority"
-
-// SetOverridePriority sets the override priority annotation on cmd.
+// SetOverridePriority delegates to cmdutil.SetOverridePriority so internal and
+// external call sites share one annotation key.
 func SetOverridePriority(cmd *cobra.Command, priority int) {
-	if cmd == nil {
-		return
-	}
-	if cmd.Annotations == nil {
-		cmd.Annotations = map[string]string{}
-	}
-	cmd.Annotations[overridePriorityAnnotation] = strconv.Itoa(priority)
+	cmdutil.SetOverridePriority(cmd, priority)
 }
 
-// OverridePriority returns the override priority annotation value, or 0.
+// OverridePriority delegates to cmdutil.OverridePriority.
 func OverridePriority(cmd *cobra.Command) int {
-	if cmd == nil || cmd.Annotations == nil {
-		return 0
-	}
-	raw := strings.TrimSpace(cmd.Annotations[overridePriorityAnnotation])
-	if raw == "" {
-		return 0
-	}
-	value, err := strconv.Atoi(raw)
-	if err != nil {
-		return 0
-	}
-	return value
+	return cmdutil.OverridePriority(cmd)
 }

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -60,6 +60,7 @@ func (chatHandler) Command(runner executor.Runner) *cobra.Command {
 		},
 	}
 	message.AddCommand(
+		newChatMessageSendCommand(runner),
 		newChatMessageSendByBotCommand(runner),
 		newChatMessageRecallByBotCommand(runner),
 		newChatMessageSendByWebhookCommand(runner),
@@ -79,6 +80,123 @@ func (chatHandler) Command(runner executor.Runner) *cobra.Command {
 
 	root.AddCommand(message, newChatSearchCommand(runner), newChatGroupCommand(runner), bot)
 	return root
+}
+
+func newChatMessageSendCommand(runner executor.Runner) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "send",
+		Short: "以当前用户身份发送消息 (--group 群聊 / --user 或 --open-dingtalk-id 单聊)",
+		Long: `以当前用户身份发送群消息或单聊消息。
+
+--group 指定群聊 openConversationId 发群消息；--user 指定 userId 发单聊；
+--open-dingtalk-id 指定 openDingTalkId 发单聊 (适用于无法获取 userId 的场景)。
+三者只能选其一，不能同时指定。
+
+消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。可选 --title 作为消息标题。`,
+		Example: `  dws chat message send --group <openconversation_id> --text "hello"
+  dws chat message send --user <userId> --text "请查收"
+  dws chat message send --open-dingtalk-id <openDingTalkId> --title "提醒" --text "请确认"
+  dws chat message send --group <openconversation_id> "hello"`,
+		Args:              cobra.MaximumNArgs(1),
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params, tool, err := buildChatMessageSendInvocation(cmd, args)
+			if err != nil {
+				return err
+			}
+			invocation := executor.NewHelperInvocation(
+				cobracmd.LegacyCommandPath(cmd),
+				"chat",
+				tool,
+				params,
+			)
+			invocation.DryRun = commandDryRun(cmd)
+			result, err := runner.Run(cmd.Context(), invocation)
+			if err != nil {
+				return err
+			}
+			return writeCommandPayload(cmd, result)
+		},
+	}
+	preferLegacyLeaf(cmd)
+
+	cmd.Flags().String("group", "", "群会话 openConversationId (群聊三选一)")
+	cmd.Flags().String("user", "", "接收人 userId (单聊三选一)")
+	cmd.Flags().String("open-dingtalk-id", "", "接收人 openDingTalkId (单聊三选一)")
+	cmd.Flags().String("text", "", "消息内容，支持 Markdown (也可作位置参数)")
+	cmd.Flags().String("title", "", "消息标题 (可选)")
+	return cmd
+}
+
+func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[string]any, string, error) {
+	guard := cli.NewStdinGuard()
+
+	group, err := cmd.Flags().GetString("group")
+	if err != nil {
+		return nil, "", apperrors.NewInternal("failed to read --group")
+	}
+	user, err := cmd.Flags().GetString("user")
+	if err != nil {
+		return nil, "", apperrors.NewInternal("failed to read --user")
+	}
+	openID, err := cmd.Flags().GetString("open-dingtalk-id")
+	if err != nil {
+		return nil, "", apperrors.NewInternal("failed to read --open-dingtalk-id")
+	}
+	title, err := resolveStringFlag(cmd, "title", guard, false)
+	if err != nil {
+		return nil, "", err
+	}
+	// --text is the primary content flag: receives stdin pipe and positional
+	// fallback when empty.
+	text, err := resolveStringFlag(cmd, "text", guard, true)
+	if err != nil {
+		return nil, "", err
+	}
+	if strings.TrimSpace(text) == "" && len(args) > 0 {
+		text = args[0]
+	}
+
+	hasGroup := strings.TrimSpace(group) != ""
+	hasUser := strings.TrimSpace(user) != ""
+	hasOpenID := strings.TrimSpace(openID) != ""
+	specified := 0
+	if hasGroup {
+		specified++
+	}
+	if hasUser {
+		specified++
+	}
+	if hasOpenID {
+		specified++
+	}
+	switch specified {
+	case 0:
+		return nil, "", apperrors.NewValidation("one of --group, --user, or --open-dingtalk-id is required")
+	case 1:
+	default:
+		return nil, "", apperrors.NewValidation("--group, --user, and --open-dingtalk-id are mutually exclusive")
+	}
+	if strings.TrimSpace(text) == "" {
+		return nil, "", apperrors.NewValidation("--text (or positional argument) is required")
+	}
+
+	params := map[string]any{"text": text}
+	if strings.TrimSpace(title) != "" {
+		params["title"] = title
+	}
+
+	switch {
+	case hasGroup:
+		params["openConversation_id"] = group
+		return params, "send_message_as_user", nil
+	case hasUser:
+		params["receiverUserId"] = user
+		return params, "send_direct_message_as_user", nil
+	default:
+		params["receiverOpenDingTalkId"] = openID
+		return params, "send_direct_message_as_user", nil
+	}
 }
 
 func newChatMessageSendByBotCommand(runner executor.Runner) *cobra.Command {

--- a/internal/helpers/chat_test.go
+++ b/internal/helpers/chat_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
@@ -45,6 +46,108 @@ func TestChatMessageSendByBotIgnoresLegacyRealBuildModeEnv(t *testing.T) {
 	}
 	if got := runner.last.CanonicalProduct; got != "bot" {
 		t.Fatalf("CanonicalProduct = %q, want bot", got)
+	}
+}
+
+func TestChatMessageSendRoutesByDestination(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantTool  string
+		wantKey   string
+		wantValue string
+	}{
+		{
+			name:      "group",
+			args:      []string{"--group", "cid-xyz", "--text", "hello"},
+			wantTool:  "send_message_as_user",
+			wantKey:   "openConversation_id",
+			wantValue: "cid-xyz",
+		},
+		{
+			name:      "user-direct",
+			args:      []string{"--user", "034766", "--text", "hi"},
+			wantTool:  "send_direct_message_as_user",
+			wantKey:   "receiverUserId",
+			wantValue: "034766",
+		},
+		{
+			name:      "open-dingtalk-id-direct",
+			args:      []string{"--open-dingtalk-id", "OP123", "--text", "hi"},
+			wantTool:  "send_direct_message_as_user",
+			wantKey:   "receiverOpenDingTalkId",
+			wantValue: "OP123",
+		},
+		{
+			name:      "positional-text",
+			args:      []string{"--group", "cid-xyz", "hello from positional"},
+			wantTool:  "send_message_as_user",
+			wantKey:   "text",
+			wantValue: "hello from positional",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &captureRunner{}
+			cmd := newChatMessageSendCommand(runner)
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+			}
+			if got := runner.last.Tool; got != tc.wantTool {
+				t.Fatalf("Tool = %q, want %q", got, tc.wantTool)
+			}
+			if got := runner.last.CanonicalProduct; got != "chat" {
+				t.Fatalf("CanonicalProduct = %q, want chat", got)
+			}
+			if got, ok := runner.last.Params[tc.wantKey]; !ok || got != tc.wantValue {
+				t.Fatalf("Params[%q] = %#v, want %q", tc.wantKey, got, tc.wantValue)
+			}
+		})
+	}
+}
+
+func TestChatMessageSendRejectsInvalidDestination(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no-destination",
+			args:    []string{"--text", "hi"},
+			wantErr: "one of --group, --user, or --open-dingtalk-id is required",
+		},
+		{
+			name:    "group-and-user",
+			args:    []string{"--group", "cid-x", "--user", "034766", "--text", "hi"},
+			wantErr: "--group, --user, and --open-dingtalk-id are mutually exclusive",
+		},
+		{
+			name:    "empty-text",
+			args:    []string{"--group", "cid-x"},
+			wantErr: "--text (or positional argument) is required",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &captureRunner{}
+			cmd := newChatMessageSendCommand(runner)
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error, got nil; output: %s", out.String())
+			}
+			if got := err.Error(); !strings.Contains(got, tc.wantErr) {
+				t.Fatalf("error = %q, want to contain %q", got, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/pkg/cmdutil/leaf_merge.go
+++ b/pkg/cmdutil/leaf_merge.go
@@ -20,11 +20,20 @@ import (
 )
 
 // MergeHardcodedLeaves grafts leaves from hardcodedRoot onto dynamicRoot when
-// the same-named path does not already exist. Groups recurse. On conflicts the
-// dynamic side always wins, because the discovery envelope is the runtime
-// authority: hardcoded commands are retained only as a leaf-level fallback for
-// behaviour the envelope explicitly does not declare. See
-// _docs/discovery-overlay-authority.md.
+// the same-named path does not already exist. Groups recurse. On leaf
+// conflicts the dynamic side wins by default, because the discovery envelope
+// is the runtime authority — hardcoded commands are retained only as a
+// leaf-level fallback for behaviour the envelope explicitly does not
+// declare. See _docs/discovery-overlay-authority.md.
+//
+// Explicit opt-in override: a hardcoded leaf may promote itself over a
+// same-named dynamic leaf by carrying a strictly higher OverridePriority
+// (see SetOverridePriority / OverridePriority). This exists for the narrow
+// case where the envelope exposes one dispatch path but the hardcoded leaf
+// needs richer flag-based routing (e.g. `chat message send` fanning out to
+// multiple MCP tools depending on --group vs --user), which the envelope
+// cannot currently express. Helpers without the annotation still lose to
+// the envelope, so the default authority contract is preserved.
 //
 // PRECONDITION: dynamicRoot must be envelope-sourced (carry the
 // SourceAnnotation=SourceEnvelope marker set by BuildDynamicCommands via
@@ -37,13 +46,14 @@ import (
 //
 // Conflict resolution table:
 //
-//	dynamic  hardcoded  →  action
-//	-------  ---------  -----------------------------
-//	absent   anything      graft hardcoded subtree
-//	leaf     leaf          dynamic wins (no-op)
-//	group    group         recurse
-//	leaf     group         dynamic wins, warn
-//	group    leaf          dynamic wins, warn
+//	dynamic  hardcoded                          →  action
+//	-------  ---------------------------------  -----------------------------
+//	absent   anything                              graft hardcoded subtree
+//	leaf     leaf (hc priority ≤ dyn)              dynamic wins (no-op)
+//	leaf     leaf (hc priority > dyn)              hardcoded replaces dynamic
+//	group    group                                 recurse
+//	leaf     group                                 dynamic wins, warn
+//	group    leaf                                  dynamic wins, warn
 //
 // MergeHardcodedLeaves mutates dynamicRoot in place and returns it so callers
 // can chain. hardcodedRoot is treated as a donor: grafted children are
@@ -63,7 +73,12 @@ func MergeHardcodedLeaves(dynamicRoot, hardcodedRoot *cobra.Command) *cobra.Comm
 			hardcodedRoot.RemoveCommand(hc)
 			dynamicRoot.AddCommand(hc)
 		case IsLeafCmd(hc) && IsLeafCmd(dyn):
-			// Envelope is authority; hardcoded leaf is ignored.
+			if OverridePriority(hc) > OverridePriority(dyn) {
+				hardcodedRoot.RemoveCommand(hc)
+				dynamicRoot.RemoveCommand(dyn)
+				dynamicRoot.AddCommand(hc)
+			}
+			// else: envelope is authority; hardcoded leaf is ignored.
 		case !IsLeafCmd(hc) && !IsLeafCmd(dyn):
 			MergeHardcodedLeaves(dyn, hc)
 		default:

--- a/pkg/cmdutil/leaf_merge_test.go
+++ b/pkg/cmdutil/leaf_merge_test.go
@@ -88,6 +88,45 @@ func TestMergeHardcodedLeaves_DynamicLeafWins(t *testing.T) {
 	}
 }
 
+func TestMergeHardcodedLeaves_HigherPriorityHardcodedOverridesDynamic(t *testing.T) {
+	t.Parallel()
+	dynLeaf := newLeaf("shared", "dynamic")
+	dyn := newGroup("root", dynLeaf)
+	hcLeaf := newLeaf("shared", "hardcoded")
+	SetOverridePriority(hcLeaf, 100)
+	hc := newGroup("root", hcLeaf)
+
+	MergeHardcodedLeaves(dyn, hc)
+
+	got := findChildByName(dyn, "shared")
+	if got == nil {
+		t.Fatal("expected shared leaf on dyn after merge")
+	}
+	if got != hcLeaf {
+		t.Fatalf("expected hardcoded leaf to replace dynamic; got Short=%q", got.Short)
+	}
+	if findChildByName(hc, "shared") != nil {
+		t.Fatal("expected hardcoded.shared to be moved off hardcodedRoot after replacement")
+	}
+}
+
+func TestMergeHardcodedLeaves_EqualPriorityKeepsDynamic(t *testing.T) {
+	t.Parallel()
+	dynLeaf := newLeaf("shared", "dynamic")
+	SetOverridePriority(dynLeaf, 100)
+	dyn := newGroup("root", dynLeaf)
+	hcLeaf := newLeaf("shared", "hardcoded")
+	SetOverridePriority(hcLeaf, 100)
+	hc := newGroup("root", hcLeaf)
+
+	MergeHardcodedLeaves(dyn, hc)
+
+	got := findChildByName(dyn, "shared")
+	if got != dynLeaf {
+		t.Fatalf("equal priorities must keep dynamic; got Short=%q", got.Short)
+	}
+}
+
 func TestMergeHardcodedLeaves_RecurseGroups(t *testing.T) {
 	t.Parallel()
 	dyn := newGroup("root",

--- a/pkg/cmdutil/override_priority.go
+++ b/pkg/cmdutil/override_priority.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdutil
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// OverridePriorityAnnotation is the cobra.Command.Annotations key used to
+// declare a command's merge-time override priority. Higher values win when
+// same-named leaves collide during merge. Exported so overlays and helpers
+// can reference the same key as the core merge logic without spelling drift.
+const OverridePriorityAnnotation = "dws.override-priority"
+
+// SetOverridePriority stamps the override priority annotation on cmd. A
+// positive value asks the merge layer to promote this command over a
+// same-named leaf with a lower (or unset) priority.
+func SetOverridePriority(cmd *cobra.Command, priority int) {
+	if cmd == nil {
+		return
+	}
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[OverridePriorityAnnotation] = strconv.Itoa(priority)
+}
+
+// OverridePriority returns the override priority annotation value on cmd,
+// or 0 if the annotation is absent or malformed.
+func OverridePriority(cmd *cobra.Command) int {
+	if cmd == nil || cmd.Annotations == nil {
+		return 0
+	}
+	raw := strings.TrimSpace(cmd.Annotations[OverridePriorityAnnotation])
+	if raw == "" {
+		return 0
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0
+	}
+	return value
+}


### PR DESCRIPTION
## Summary

`dws chat message send --user <userId>` failed on the open edition with
`不合法的参数`. The envelope-generated dynamic command maps every
destination to the group-only tool `send_message_as_user`, so `--user`
reached a tool that didn't recognise the parameter. Only `--group` was
usable end-to-end; single-chat via `--user` / `--open-dingtalk-id` has
never worked on the open binary, despite the skill reference promising
all three.

## Fix (two parts)

### 1. `internal/helpers/chat.go` — new `chat message send` helper

Mirrors the closed-source wukong overlay's `chatMessageSendCmd`:

- `--group` → `send_message_as_user` (existing dynamic behaviour)
- `--user` → `send_direct_message_as_user` with `receiverUserId`
- `--open-dingtalk-id` → `send_direct_message_as_user` with
  `receiverOpenDingTalkId`

Mutual exclusion + `--text` / positional-arg + `--title` handled the
same way as other chat helpers. Marked `preferLegacyLeaf` (priority
100) so the merge layer knows this helper intentionally overrides the
envelope leaf.

### 2. `pkg/cmdutil/leaf_merge.go` — opt-in priority override

`MergeHardcodedLeaves` previously hardcoded "dynamic wins leaf
conflicts" to preserve envelope authority. That's still the default,
but now a hardcoded leaf carrying a strictly higher `OverridePriority`
(e.g. via `preferLegacyLeaf`) can replace the dynamic one. This is the
narrow escape hatch for cases where the envelope exposes a single
dispatch path but the hardcoded leaf needs richer flag-based routing
— exactly the `chat message send` situation. Helpers without the
annotation still lose; the authority contract is preserved for every
existing helper that has not opted in.

As part of this, `OverridePriority` / `SetOverridePriority` move to
`pkg/cmdutil` so the annotation key is single-sourced across the merge
layer and helpers. `internal/cobracmd/priority.go` now delegates.

## Depends on

Stacks on PR #169 (graft hardcoded helpers into dynamic tree). Without
#169, the helper subtree is dropped upstream of the merge layer and
this priority override never runs.

## Test plan

- [x] `go vet ./...`
- [x] Unit: `TestChatMessageSendRoutesByDestination` covers group /
      user / open-dingtalk-id / positional-text
- [x] Unit: `TestChatMessageSendRejectsInvalidDestination` covers
      no-destination / mutually-exclusive / empty-text
- [x] Unit: `TestMergeHardcodedLeaves_HigherPriorityHardcodedOverridesDynamic`
      proves opt-in takes effect
- [x] Unit: `TestMergeHardcodedLeaves_EqualPriorityKeepsDynamic`
      proves default authority is preserved
- [x] `go test ./internal/...` — full internal suite clean
- [x] End-to-end live API on freshly built open-edition binary:
      - `send --user 034766 --text …` → `send_direct_message_as_user` → `success: true`
      - `send --group <cid> --text …` → `send_message_as_user` → `success: true` (no regression)