### PR TITLE
docs(skills,chat): clarify --title is required for chat message send

### DIFF
--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -92,7 +92,7 @@ func newChatMessageSendCommand(runner executor.Runner) *cobra.Command {
 --open-dingtalk-id 指定 openDingTalkId 发单聊 (适用于无法获取 userId 的场景)。
 三者只能选其一，不能同时指定。
 
-消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。可选 --title 作为消息标题。`,
+消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。必须提供 --title 作为消息标题。`,
 		Example: `  dws chat message send --group <openconversation_id> --text "hello"
   dws chat message send --user <userId> --text "请查收"
   dws chat message send --open-dingtalk-id <openDingTalkId> --title "提醒" --text "请确认"

--- a/skills/references/products/chat.md
+++ b/skills/references/products/chat.md
@@ -181,7 +181,7 @@ Flags:
 
 ## message send — 以当前用户身份发消息
 
---group 指定群聊 ID 发群消息；--user 指定用户 userId 发单聊；--open-dingtalk-id 指定用户 openDingTalkId 发单聊。三者只能选其一，不能同时指定。消息内容为位置参数（恰好 1 个），支持 Markdown。可选 --title 作为消息标题。
+--group 指定群聊 ID 发群消息；--user 指定用户 userId 发单聊；--open-dingtalk-id 指定用户 openDingTalkId 发单聊。三者只能选其一，不能同时指定。消息内容为位置参数（恰好 1 个），支持 Markdown。必须提供 --title 作为消息标题。
 --群聊时可选 --at-all @所有人，或 --at-users 指定成员（仅群聊时生效）。
 --发送图片消息：指定 --media-id（通过 dt_media_upload 工具上传获得），自动设置 msgType=image，此时不需要传文本内容。
 
@@ -203,7 +203,7 @@ Flags:
       --group string             群聊 openconversation_id（群聊时必填）
       --user string              接收人 userId（单聊时与 --open-dingtalk-id 二选一）
       --open-dingtalk-id string  接收人 openDingTalkId（单聊时与 --user 二选一，适用于三方应用等无法获取 userId 的场景）
-      --title string             消息标题（可选，默认「消息」）
+      --title string             消息标题（必填）
       --at-all                   @所有人（仅群聊时生效，可选，默认 false）
       --at-users string          @指定成员的 userId 列表，逗号分隔（仅群聊时生效，可选）
       --media-id string          图片 mediaId（通过 dt_media_upload 工具上传获得，需从返回链接中去除 _宽_高.格式 后缀并加上 @ 前缀），指定后发送图片消息，不需要传文本内容
@@ -601,10 +601,10 @@ dws chat message list-unread-conversations --count 20 --format json
 dws chat message send --group <openconversation_id> --title "周报提醒" "请大家本周五前提交周报" --format json
 
 # 4. 以个人身份单聊（通过 userId）
-dws chat message send --user <userId> "你好" --format json
+dws chat message send --user <userId> --title "问候" "你好" --format json
 
 # 4b. 以个人身份单聊（通过 openDingTalkId，三方应用等无法获取 userId 时使用）
-dws chat message send --open-dingtalk-id <openDingTalkId> "你好" --format json
+dws chat message send --open-dingtalk-id <openDingTalkId> --title "问候" "你好" --format json
 
 # 5. 机器人发群消息（Markdown）
 dws chat message send-by-bot --robot-code <robot-code> \


### PR DESCRIPTION
## Summary

Closes #173.

The backend MCP tools `send_direct_message_as_user` and `send_message_as_user` both require `title` as a required field. However, the skill documentation and `--help` Long text described `--title` as "optional", causing AI models to omit it and trigger a vague `business error: success=false`.

## Changes

- `skills/references/products/chat.md`: Update `--title` description from "optional" to "required"
- `internal/helpers/chat.go`: Update command `Long` text to state `--title` is required
- Update core workflow examples to include `--title` in single-chat samples

## Test plan

- [x] `go test ./internal/helpers/...` passes
- [x] No code logic changed; only documentation/help text updated