### PR TITLE
fix: treat PAT authorization uri as opaque

### DIFF
--- a/internal/app/pat_auth_retry.go
+++ b/internal/app/pat_auth_retry.go
@@ -293,6 +293,8 @@ const (
 	patPollTimeout = 10 * time.Minute
 )
 
+var openBrowserFunc = tryOpenBrowser
+
 // patRetryingKey is a context key to prevent recursive PAT auth checks.
 // After APPROVED, the retry should not trigger another PAT flow.
 type patRetryingKeyType struct{}
@@ -303,6 +305,17 @@ var patRetryingKey = patRetryingKeyType{}
 func IsPatRetrying(ctx context.Context) bool {
 	v, _ := ctx.Value(patRetryingKey).(bool)
 	return v
+}
+
+func openPATAuthorizationURI(rawURI string) error {
+	if rawURI == "" {
+		return nil
+	}
+	// The PAT service returns the complete authorization URL. Treat it as an
+	// opaque string and open it verbatim instead of parsing/rebuilding it
+	// locally, because required parameters may live in query, hash, or
+	// fragment sections.
+	return openBrowserFunc(rawURI)
 }
 
 // handlePatAuthCheck is called by runner.executeInvocation when a PAT
@@ -383,7 +396,7 @@ func handlePatAuthCheck(
 	if patData.Data.URI != "" {
 		fmt.Fprintf(output, "  %s %s\n\n", dim("🔗"), cyan(patData.Data.URI))
 		// Best-effort browser open.
-		_ = tryOpenBrowser(patData.Data.URI)
+		_ = openPATAuthorizationURI(patData.Data.URI)
 	}
 
 	// If no flowId, we can't poll — fall back to returning PATError for host-app.

--- a/internal/app/pat_auth_retry_test.go
+++ b/internal/app/pat_auth_retry_test.go
@@ -484,6 +484,10 @@ func setupHandlePATServer(t *testing.T, terminalStatus string, authCode string) 
 }
 
 func makePATErrorJSON(flowID, clientID string) string {
+	return makePATErrorJSONWithURI(flowID, clientID, "")
+}
+
+func makePATErrorJSONWithURI(flowID, clientID, uri string) string {
 	type patData struct {
 		Desc     string `json:"desc"`
 		FlowID   string `json:"flowId"`
@@ -498,7 +502,7 @@ func makePATErrorJSON(flowID, clientID string) string {
 		Data: patData{
 			Desc:     "test auth",
 			FlowID:   flowID,
-			URI:      "", // empty to avoid opening browser in test
+			URI:      uri,
 			ClientID: clientID,
 		},
 	}
@@ -602,5 +606,46 @@ func TestHandlePatAuthCheck_EmptyFlowID_FallsBackToPATError(t *testing.T) {
 	// Should return the original PATError.
 	if _, ok := err.(*apperrors.PATError); !ok {
 		t.Errorf("expected *PATError, got %T: %v", err, err)
+	}
+}
+
+func TestHandlePatAuthCheck_OpensOpaqueURIWithoutRebuild(t *testing.T) {
+	server, configDir := setupHandlePATServer(t, "APPROVED", "test-auth-code")
+	defer server.Close()
+
+	rawURI := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D50dff7654b7444e88ced7489b07cce8d%26userCode%3DQ8RY-X6E9#/personalAuthorization?flowId=50dff7654b7444e88ced7489b07cce8d&userCode=Q8RY-X6E9"
+	var opened string
+	origOpenBrowser := openBrowserFunc
+	openBrowserFunc = func(rawURL string) error {
+		opened = rawURL
+		return nil
+	}
+	t.Cleanup(func() { openBrowserFunc = origOpenBrowser })
+
+	var retryCalled bool
+	mock := &mockRunner{
+		runFunc: func(ctx context.Context, inv executor.Invocation) (executor.Result, error) {
+			retryCalled = true
+			return executor.Result{Response: map[string]any{"ok": true}}, nil
+		},
+	}
+
+	runner := &runtimeRunner{fallback: mock}
+	patErr := &apperrors.PATError{RawJSON: makePATErrorJSONWithURI("flow-opaque", "test-client-id", rawURI)}
+
+	var buf bytes.Buffer
+	_, err := handlePatAuthCheck(context.Background(), runner, executor.Invocation{
+		CanonicalProduct: "test",
+		Tool:             "test_tool",
+	}, patErr, configDir, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !retryCalled {
+		t.Fatal("expected retry to run after approved PAT flow")
+	}
+	if opened != rawURI {
+		t.Fatalf("opened url = %q, want verbatim %q", opened, rawURI)
 	}
 }

--- a/internal/errors/pat.go
+++ b/internal/errors/pat.go
@@ -25,8 +25,13 @@ const ExitCodePermission = 4
 
 // PATError represents a PAT (Personal Action Token) authorization failure
 // that should be passed through to stderr as raw JSON without any CLI-layer
-// wrapping.  The host application (e.g. RewindDesktop) parses the JSON to
+// wrapping. The host application (e.g. RewindDesktop) parses the JSON to
 // display its own authorisation UI.
+//
+// When the payload includes data.uri, that URL is the authoritative
+// server-provided authorization link. Hosts must treat it as opaque and open
+// it verbatim instead of parsing and reconstructing it locally, because
+// required parameters may live in query, encoded hash, or fragment sections.
 type PATError struct {
 	RawJSON string
 }
@@ -220,6 +225,9 @@ func cleanPATJSON(body map[string]any, code string) string {
 		"code":    code,
 	}
 	if data, ok := body["data"]; ok {
+		// Keep data.uri exactly as returned by the service. Host consumers open
+		// that link directly, so local normalization would risk dropping
+		// parameters embedded in query/hash/fragment sections.
 		out["data"] = stripClassFields(data)
 	} else {
 		fallback := map[string]any{}

--- a/internal/errors/pat_test.go
+++ b/internal/errors/pat_test.go
@@ -14,6 +14,7 @@
 package errors
 
 import (
+	"encoding/json"
 	stderrors "errors"
 	"strings"
 	"testing"
@@ -440,6 +441,31 @@ func TestCleanPATJSON_WithoutData(t *testing.T) {
 	// Top-level stripped fields should not appear
 	if strings.Contains(result, `"message"`) {
 		t.Errorf("expected message to be stripped from top level, got: %s", result)
+	}
+}
+
+func TestCleanPATJSON_PreservesOpaqueURIVerbatim(t *testing.T) {
+	t.Parallel()
+	rawURI := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D50dff7654b7444e88ced7489b07cce8d%26userCode%3DQ8RY-X6E9#/personalAuthorization?flowId=50dff7654b7444e88ced7489b07cce8d&userCode=Q8RY-X6E9"
+	body := map[string]any{
+		"success": false,
+		"code":    "PAT_MEDIUM_RISK_NO_PERMISSION",
+		"data": map[string]any{
+			"desc":   "在浏览器中打开以下链接进行认证",
+			"flowId": "50dff7654b7444e88ced7489b07cce8d",
+			"uri":    rawURI,
+		},
+	}
+
+	result := cleanPATJSON(body, "PAT_MEDIUM_RISK_NO_PERMISSION")
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("unmarshal cleanPATJSON output: %v\nraw=%s", err, result)
+	}
+	data, _ := parsed["data"].(map[string]any)
+	if got, _ := data["uri"].(string); got != rawURI {
+		t.Fatalf("data.uri = %q, want verbatim %q", got, rawURI)
 	}
 }
 


### PR DESCRIPTION
## Summary
- accept PAT/device-flow poll payloads from both `data.*` and `result.*` envelopes
- prevent valid `PENDING` poll responses from being misread as empty status and exiting as `未知授权状态`
- keep temporary raw-response debug output so unexpected poll payloads can be inspected directly from the terminal

## Changes
- add normalized poll-response access in `internal/auth/device_flow.go` so status/authCode/flowId can be resolved from either `data` or `result`
- update regular device-flow polling to use the normalized poll payload instead of reading `data.status` directly
- update PAT retry polling in `internal/app/pat_auth_retry.go` to use the same normalized poll payload
- keep the temporary debug printing in PAT polling for raw HTTP 200 response bodies when parse/state handling is abnormal
- add regression coverage in `internal/auth/device_flow_test.go` for `result.status` / `result.authCode`
- add regression coverage in `internal/app/pat_auth_retry_test.go` for PAT poll compatibility with `result` envelopes

## Why
The real poll endpoint returned payloads like:

```json
{"result":{"status":"PENDING"},"success":true}
```

But the CLI only read `data.status`, so the parsed status became empty even though the server had actually returned a valid `PENDING` state.

That mismatch caused the PAT flow to:
- enter polling successfully
- receive a valid HTTP 200 response
- misread the status as empty
- exit early as `未知授权状态`

This change hardens the polling contract at the CLI boundary:
- the poll endpoint may return fields under either `data` or `result`
- CLI must normalize both shapes before interpreting authorization state
- valid `PENDING` / `APPROVED` states should continue to work regardless of envelope shape

## Testing
- `go test ./internal/auth -run 'TestWaitForAuthorization(SucceedsAfterPending|AcceptsResultEnvelope|FallsBackToDeviceCodeWhenFlowIDMissing|HonorsContextCancellation)|TestWaitForAuthorizationByDeviceCode|TestPollDeviceStatus'`
- `go test ./internal/app -run 'TestHandlePatAuthCheck_(Approved|Rejected|EmptyFlowID|OpensOpaqueURIWithoutRebuild)|TestPollPatDeviceFlow_'`

## Scope
This change does not alter the server-side PAT or device-flow protocol.
It only makes the CLI compatible with both observed poll response envelopes and preserves temporary debugging output for further validation.
