### PR TITLE
fix(pat): clarify repeated auth after permanent grants

### DIFF
--- a/internal/app/pat_auth_retry.go
+++ b/internal/app/pat_auth_retry.go
@@ -539,7 +539,16 @@ func handlePatAuthCheck(
 			"DWS_CLIENT_ID", os.Getenv("DWS_CLIENT_ID"),
 		)
 		retryCtx := context.WithValue(ctx, patRetryingKey, true)
-		return r.Run(retryCtx, invocation)
+		result, retryErr := r.Run(retryCtx, invocation)
+		if retryErr != nil {
+			if repeatedPAT := apperrors.AsPatAuthCheckError(retryErr); repeatedPAT != nil {
+				return executor.Result{}, &apperrors.PATError{
+					RawJSON: enrichPATErrorAfterApprovedRetry(repeatedPAT.RawJSON, invocation),
+				}
+			}
+			return result, retryErr
+		}
+		return result, nil
 
 	case authpkg.StatusRejected:
 		fmt.Fprintf(output, "%s %s\n", redFn("✗"), bold("用户已拒绝授权"))
@@ -569,6 +578,42 @@ func handlePatAuthCheck(
 		fmt.Fprintf(output, "%s 未知授权状态: %s\n", redFn("✗"), status)
 		return executor.Result{}, patErr
 	}
+}
+
+func enrichPATErrorAfterApprovedRetry(raw string, invocation executor.Invocation) string {
+	if strings.TrimSpace(raw) == "" {
+		return raw
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return raw
+	}
+
+	data, ok := payload["data"].(map[string]any)
+	if !ok || data == nil {
+		data = map[string]any{}
+		payload["data"] = data
+	}
+	data["postApprovalRetry"] = map[string]any{
+		"reason":  "pat_still_required_after_approval",
+		"message": "PAT authorization was approved, but the retried command still requires authorization. Check whether the grant covered the required scopes, the same org/user/agentCode was used, or server-side grant propagation failed.",
+		"command": map[string]any{
+			"product": invocation.CanonicalProduct,
+			"tool":    invocation.Tool,
+		},
+		"coverage": map[string]any{
+			"knownAuthorizedScopes": []string{},
+			"source":                "not_available_from_cli",
+			"hint":                  "The CLI only has the current requiredScopes from this PAT payload; verify persisted grant coverage from PAT service logs or grant records.",
+		},
+	}
+
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return raw
+	}
+	return string(encoded)
 }
 
 func enrichPATErrorForHostControl(raw string) string {

--- a/internal/app/pat_auth_retry_test.go
+++ b/internal/app/pat_auth_retry_test.go
@@ -633,6 +633,75 @@ func TestHandlePatAuthCheck_Approved(t *testing.T) {
 	}
 }
 
+func TestHandlePatAuthCheck_ApprovedStillPATAddsDiagnostic(t *testing.T) {
+	t.Setenv(authpkg.AgentCodeEnv, "")
+	server, configDir := setupHandlePATServer(t, "APPROVED", "test-auth-code")
+	defer server.Close()
+
+	var retryCalled bool
+	var retryHasKey bool
+	mock := &mockRunner{
+		runFunc: func(ctx context.Context, inv executor.Invocation) (executor.Result, error) {
+			retryCalled = true
+			retryHasKey = IsPatRetrying(ctx)
+			return executor.Result{}, &apperrors.PATError{RawJSON: `{"success":false,"code":"PAT_MEDIUM_RISK_NO_PERMISSION","data":{"requiredScopes":[{"scope":"chat.message:send"}],"grantOptions":["once","permanent"],"flowId":"flow-repeat"}}`}
+		},
+	}
+
+	runner := &runtimeRunner{fallback: mock}
+	patErr := &apperrors.PATError{RawJSON: makePATErrorJSON("flow-approved-repeat", "test-client-id")}
+
+	var buf bytes.Buffer
+	_, err := handlePatAuthCheck(context.Background(), runner, executor.Invocation{
+		CanonicalProduct: "chat",
+		Tool:             "message_send",
+	}, patErr, configDir, &buf)
+
+	if err == nil {
+		t.Fatal("expected repeated PATError after approved retry")
+	}
+	if !retryCalled {
+		t.Fatal("expected mock runner to be called for retry")
+	}
+	if !retryHasKey {
+		t.Fatal("expected retry context to have patRetryingKey")
+	}
+	patOut, ok := err.(*apperrors.PATError)
+	if !ok {
+		t.Fatalf("expected *PATError, got %T: %v", err, err)
+	}
+	if strings.Contains(patOut.RawJSON, "\n") {
+		t.Fatalf("repeated PAT payload must stay single-line, got %q", patOut.RawJSON)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(patOut.RawJSON), &payload); err != nil {
+		t.Fatalf("json.Unmarshal(repeated PAT payload) error = %v\nraw=%s", err, patOut.RawJSON)
+	}
+	data, _ := payload["data"].(map[string]any)
+	postApproval, _ := data["postApprovalRetry"].(map[string]any)
+	if postApproval == nil {
+		t.Fatalf("expected data.postApprovalRetry diagnostic, got: %s", patOut.RawJSON)
+	}
+	if got, _ := postApproval["reason"].(string); got != "pat_still_required_after_approval" {
+		t.Fatalf("postApprovalRetry.reason = %q, want pat_still_required_after_approval", got)
+	}
+	command, _ := postApproval["command"].(map[string]any)
+	if got, _ := command["product"].(string); got != "chat" {
+		t.Fatalf("postApprovalRetry.command.product = %q, want chat", got)
+	}
+	if got, _ := command["tool"].(string); got != "message_send" {
+		t.Fatalf("postApprovalRetry.command.tool = %q, want message_send", got)
+	}
+	coverage, _ := postApproval["coverage"].(map[string]any)
+	if got, _ := coverage["source"].(string); got != "not_available_from_cli" {
+		t.Fatalf("postApprovalRetry.coverage.source = %q, want not_available_from_cli", got)
+	}
+	if got, ok := data["requiredScopes"].([]any); !ok || len(got) != 1 {
+		t.Fatalf("requiredScopes must be preserved, got %#v", data["requiredScopes"])
+	}
+}
+
 func TestHandlePatAuthCheck_Rejected(t *testing.T) {
 	t.Setenv(authpkg.AgentCodeEnv, "")
 	server, configDir := setupHandlePATServer(t, "REJECTED", "")

--- a/internal/pat/chmod.go
+++ b/internal/pat/chmod.go
@@ -206,7 +206,7 @@ grantType 规则:
 				return fmt.Errorf("internal error: tool runtime not initialized")
 			}
 
-			if sessionID == "" {
+			if grantType == "session" && sessionID == "" {
 				sessionID = resolveSessionIDFromEnv()
 			}
 			toolArgs := map[string]any{
@@ -214,7 +214,7 @@ grantType 规则:
 				"scopes":    scopes,
 				"grantType": grantType,
 			}
-			if sessionID != "" {
+			if grantType == "session" && sessionID != "" {
 				toolArgs["sessionId"] = sessionID
 			}
 			// Legacy server schema accepted singular "scope"; clone the

--- a/internal/pat/chmod_test.go
+++ b/internal/pat/chmod_test.go
@@ -238,6 +238,44 @@ func TestChmod_agentCode_env_fallback(t *testing.T) {
 	}
 }
 
+func TestChmod_permanentGrantIgnoresSessionIDEnv(t *testing.T) {
+	t.Setenv(agentCodeEnv, "qoderwork")
+	t.Setenv("DWS_SESSION_ID", "session-should-not-leak")
+
+	fake := &fakeToolCaller{resultOK: true}
+	cmd := buildChmod(t, fake)
+	_ = cmd.Flags().Set("grant-type", "permanent")
+
+	if err := cmd.RunE(cmd, []string{"chat.message:send"}); err != nil {
+		t.Fatalf("chmod RunE error = %v", err)
+	}
+	if got := fake.gotArgs["grantType"]; got != "permanent" {
+		t.Fatalf("grantType = %v, want permanent", got)
+	}
+	if _, ok := fake.gotArgs["sessionId"]; ok {
+		t.Fatalf("permanent grant must not send sessionId: %#v", fake.gotArgs)
+	}
+}
+
+func TestChmod_sessionGrantUsesSessionIDEnv(t *testing.T) {
+	t.Setenv(agentCodeEnv, "qoderwork")
+	t.Setenv("DWS_SESSION_ID", "session-from-env")
+
+	fake := &fakeToolCaller{resultOK: true}
+	cmd := buildChmod(t, fake)
+	_ = cmd.Flags().Set("grant-type", "session")
+
+	if err := cmd.RunE(cmd, []string{"chat.message:send"}); err != nil {
+		t.Fatalf("chmod RunE error = %v", err)
+	}
+	if got := fake.gotArgs["grantType"]; got != "session" {
+		t.Fatalf("grantType = %v, want session", got)
+	}
+	if got := fake.gotArgs["sessionId"]; got != "session-from-env" {
+		t.Fatalf("sessionId = %v, want session-from-env", got)
+	}
+}
+
 func TestCallPATToolWithLegacyFallback_emptyCanonicalResultDoesNotRetryLegacyAlias(t *testing.T) {
 	fake := &fallbackToolCaller{}
 	canonicalArgs := map[string]any{


### PR DESCRIPTION
## Summary

- Do not send `sessionId` for `dws pat chmod --grant-type permanent` or `once`; only `session` grants carry the session dimension.
- Add a `data.postApprovalRetry` diagnostic when the CLI-owned PAT flow receives `APPROVED`, retries the original command, and still gets a PAT error.
- Preserve the original single-line PAT JSON contract and original `requiredScopes` payload while making the repeated-auth path distinguishable.

## Why

Issue #189 reports that a command can still return `PAT_MEDIUM_RISK_NO_PERMISSION` after PAT authorization. The issue does not include UID, time window, scope, flowId, or proof that `permanent` was selected, so SLS/Langfuse cannot prove a live server root cause from the issue text alone.

Code review did identify a CLI-side bug that can plausibly cause this symptom: `dws pat chmod --grant-type permanent` still picked up `DWS_SESSION_ID` / `REWIND_SESSION_ID` from the host shell and forwarded `sessionId` to the PAT grant tool. If the server treats `sessionId` as part of the grant dimension, a supposedly permanent grant can be narrowed or misinterpreted as session-scoped.

## How to reproduce the reported class of issue

1. Use a command that triggers PAT under a host-owned shell:

   ```bash
   export DINGTALK_DWS_AGENTCODE=codex
   export DWS_SESSION_ID=<session-id>
   dws <product> <command> --format json
   ```

2. Capture the returned `PAT_MEDIUM_RISK_NO_PERMISSION` JSON and its `data.requiredScopes` / `data.flowId`.

3. Grant the returned scope permanently with the same agent code:

   ```bash
   dws pat chmod <scope> --grant-type permanent --agentCode codex
   ```

4. Replay the exact same command from step 1 with the same UID/org/agentCode/scope. Before this fix, the permanent grant request could still include `sessionId` from the environment. After this fix, permanent grants do not include `sessionId`.

5. If the CLI-owned browser flow is used instead of host-owned mode, and `APPROVED` is followed by another PAT error on retry, the returned PAT JSON now includes:

   ```json
   {
     "data": {
       "postApprovalRetry": {
         "reason": "pat_still_required_after_approval",
         "coverage": { "source": "not_available_from_cli" }
       }
     }
   }
   ```

   That marks the case as “authorization approved but still not covered” without pretending the CLI can list existing server-side grants.

## Verification

Passed:

```bash
go test -count=1 ./internal/app -run 'TestHandlePatAuthCheck|TestRetryWithPatAuthRetry|TestEnrichPATError|TestBuildPATScopeHostJSON'
go test -count=1 ./internal/pat ./internal/errors ./test/unit
DWS_PACKAGE_VERSION=0.0.0-SNAPSHOT go test ./test/scripts
git diff --check
```

Also ran `go test ./...`; it still fails on existing baseline/environment issues unrelated to this patch:

- `test/cli_compat` expects missing `test/cli_compat/testdata/empty_catalog.json` / discovery fixtures.
- `test/scripts` needs `DWS_PACKAGE_VERSION` or a git tag to resolve package version.
- One full-suite pass also exposed local keychain-sensitive `internal/app/TestAuthStatusRefreshFailureLeavesStoredTokenIntact`; rerunning that test alone passed.

Fixes #189
