### PR TITLE
feat: active discovery for skill directories (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Raw DingTalk OpenAPI access lands as a new `dws api` surface for both `api.dingt
 
 ### Changed
 
+- **Active discovery for skill directories** (#188) — `dws upgrade` and `SyncSkills` now dynamically scan `$HOME` for any `*/skills/` directories instead of relying solely on a hardcoded list. New AI agents are automatically covered without code changes. The hardcoded `knownSkillDirs` list is retained as a fallback. Symlink destinations are handled safely (only the link is removed, not the target).
 - **README raw API guide** (#184) — English and Chinese READMEs now document custom-app prerequisites, api/oapi examples, auto-pagination, dry-run, jq filtering, security properties, and the new Raw API service-table row.
 - **Raw API token retrieval path** (#184) — token lookup now goes through a single app-token interface; stale auth-refresh retry helpers were removed from the raw API path.
 - **PAT stderr JSON classifier** (#142) — recognizes `code`, `errorCode`, and `error_code`, including `PAT_NO_PERMISSION`, risk-tier PAT errors, `PAT_SCOPE_AUTH_REQUIRED`, and `AGENT_CODE_NOT_EXISTS`.

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/upgrade"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
 )
 
@@ -669,14 +670,9 @@ func SyncSkills(plugins []*Plugin) {
 		return
 	}
 
-	// Known agent skill directories (subset of upgrade/paths.go knownSkillDirs).
-	agentDirs := []string{
-		".agents/skills",
-		".claude/skills",
-		".cursor/skills",
-		".qoder/skills",
-		".codex/skills",
-	}
+	// Use active discovery to find all agent skill directories.
+	// Falls back to the hardcoded knownSkillDirs via DiscoverSkillDirs.
+	agentDirs := upgrade.DiscoverSkillDirs(homeDir)
 
 	for _, p := range plugins {
 		skillsDir := p.SkillsDir()

--- a/internal/upgrade/paths.go
+++ b/internal/upgrade/paths.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 )
 
 // Permission constants following Unix best practices.
@@ -18,7 +19,8 @@ const (
 	filePermConfig os.FileMode = 0o644
 )
 
-// knownSkillDirs lists all known Agent skill directories (relative to $HOME).
+// knownSkillDirs lists well-known Agent skill directories (relative to $HOME).
+// Used as a fallback when active discovery misses entries.
 // Kept in sync with build/npm/install.js AGENT_DIRS.
 // The first entry (.agents/skills) is always updated; subsequent entries are
 // only updated when their parent directory already exists.
@@ -42,6 +44,92 @@ var knownSkillDirs = []string{
 // external mechanisms (e.g. IDE extensions) and must NOT be touched by upgrade.
 var skillDirBlacklist = []string{
 	".real",
+}
+
+// DiscoverSkillDirs scans homeDir for agent skill directories by looking for
+// any first-level subdirectory that contains a "skills" subdirectory.
+// Returns relative paths (e.g. ".claude/skills") suitable for skill installation.
+//
+// This enables automatic coverage of any new AI agent without requiring
+// code changes — any directory matching ~/xxx/skills/ is detected.
+func DiscoverSkillDirs(homeDir string) []string {
+	entries, err := os.ReadDir(homeDir)
+	if err != nil {
+		return nil
+	}
+
+	var discovered []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		// Build the relative path: .claude/skills, .hermes/skills, etc.
+		relPath := filepath.ToSlash(filepath.Join(name, "skills"))
+		// Check if the "skills" subdirectory exists
+		skillsDir := filepath.Join(homeDir, name, "skills")
+		if info, err := os.Stat(skillsDir); err == nil && info.IsDir() {
+			if !isBlacklisted(relPath) {
+				discovered = append(discovered, relPath)
+			}
+		}
+	}
+
+	return discovered
+}
+
+// mergeSkillDirs combines discovered and known directories, deduplicating
+// while preserving order: primary (.agents/skills) always first, then
+// discovered dirs, then any known dirs not already included.
+func mergeSkillDirs(discovered, known []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+
+	// Ensure .agents/skills is always first
+	primary := ".agents/skills"
+	result = append(result, primary)
+	seen[primary] = true
+
+	// Add discovered dirs (skip primary, already added)
+	for _, d := range discovered {
+		if !seen[d] {
+			result = append(result, d)
+			seen[d] = true
+		}
+	}
+
+	// Add known dirs not yet included (fallback for undiscovered agents)
+	for _, d := range known {
+		if !seen[d] {
+			result = append(result, d)
+			seen[d] = true
+		}
+	}
+
+	// Sort everything after the primary entry
+	if len(result) > 1 {
+		sort.Strings(result[1:])
+	}
+
+	return result
+}
+
+// removeAllSafe removes a directory safely. If the path is a symlink,
+// only the symlink itself is removed (not the target), preventing
+// accidental destruction of linked source content.
+func removeAllSafe(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	// If it's a symlink, remove just the link (not the target)
+	if info.Mode()&os.ModeSymlink != 0 {
+		return os.Remove(path)
+	}
+	return os.RemoveAll(path)
 }
 
 // SkillDirStatus describes the installation outcome for a single skill directory.
@@ -91,11 +179,13 @@ func (r *SkillUpgradeResult) Failed() []SkillDirResult {
 // UpgradeSkillLocations installs skills from extractedDir into all locations
 // where they are currently installed or expected.
 //
-// Strategy (matches npm install.js installSkillsToHomes):
+// Strategy:
+//   - First, scan $HOME for any */skills/ directories (active discovery)
+//   - Merge discovered dirs with knownSkillDirs (fallback) for full coverage
 //   - ~/.agents/skills/dws/ is ALWAYS updated (primary install location)
-//   - Other agent dirs (claude, cursor, ...) are updated only when the parent
-//     directory exists (e.g. ~/.claude/ exists => user has Claude)
-//   - ~/.real/ and other blacklisted paths are NEVER touched
+//   - Other agent dirs are updated only when the parent directory exists
+//   - Blacklisted paths (e.g. ~/.real/) are NEVER touched
+//   - Symlink destinations are handled safely (link removed, not target)
 //   - If no location was updated at all, fall back to ~/.agents/skills/dws/
 func UpgradeSkillLocations(extractedDir string) (*SkillUpgradeResult, error) {
 	homeDir, err := os.UserHomeDir()
@@ -105,7 +195,13 @@ func UpgradeSkillLocations(extractedDir string) (*SkillUpgradeResult, error) {
 
 	result := &SkillUpgradeResult{}
 
-	for i, agentDir := range knownSkillDirs {
+	// Phase 1: Active discovery — scan $HOME for any */skills/ directories
+	discovered := DiscoverSkillDirs(homeDir)
+
+	// Phase 2: Merge with known list for full coverage
+	allDirs := mergeSkillDirs(discovered, knownSkillDirs)
+
+	for i, agentDir := range allDirs {
 		destDir := filepath.Join(homeDir, agentDir, "dws")
 
 		if isBlacklisted(agentDir) {
@@ -113,6 +209,8 @@ func UpgradeSkillLocations(extractedDir string) (*SkillUpgradeResult, error) {
 			continue
 		}
 
+		// Primary location (.agents/skills) is always updated;
+		// others require the parent directory to exist
 		if i > 0 {
 			parentGate := filepath.Dir(filepath.Join(homeDir, agentDir))
 			if _, err := os.Stat(parentGate); os.IsNotExist(err) {
@@ -121,7 +219,7 @@ func UpgradeSkillLocations(extractedDir string) (*SkillUpgradeResult, error) {
 			}
 		}
 
-		os.RemoveAll(destDir)
+		removeAllSafe(destDir)
 		if err := copyDir(extractedDir, destDir); err != nil {
 			result.Results = append(result.Results, SkillDirResult{Dir: destDir, Status: SkillDirFailed, Err: err})
 			continue

--- a/internal/upgrade/paths_test.go
+++ b/internal/upgrade/paths_test.go
@@ -6,6 +6,8 @@ package upgrade
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -245,8 +247,211 @@ func TestKnownSkillDirsNotEmpty(t *testing.T) {
 	if len(knownSkillDirs) == 0 {
 		t.Error("knownSkillDirs is empty")
 	}
-	// First entry should be the primary location
 	if knownSkillDirs[0] != ".agents/skills" {
 		t.Errorf("first knownSkillDir = %q, want .agents/skills", knownSkillDirs[0])
 	}
+}
+
+func TestDiscoverSkillDirs(t *testing.T) {
+	home := t.TempDir()
+	os.MkdirAll(filepath.Join(home, ".claude", "skills"), 0755)
+	os.MkdirAll(filepath.Join(home, ".cursor", "skills"), 0755)
+	os.MkdirAll(filepath.Join(home, ".hermes", "skills"), 0755)
+	os.MkdirAll(filepath.Join(home, "downloads"), 0755)
+
+	got := DiscoverSkillDirs(home)
+	want := map[string]bool{
+		".claude/skills": true,
+		".cursor/skills": true,
+		".hermes/skills": true,
+	}
+	if len(got) != len(want) {
+		t.Errorf("DiscoverSkillDirs() len = %d, want %d: %v", len(got), len(want), got)
+	}
+	for _, d := range got {
+		if !want[d] {
+			t.Errorf("unexpected dir %q", d)
+		}
+	}
+}
+
+func TestDiscoverSkillDirs_SkipsBlacklisted(t *testing.T) {
+	home := t.TempDir()
+	os.MkdirAll(filepath.Join(home, ".real", "skills"), 0755)
+	os.MkdirAll(filepath.Join(home, ".claude", "skills"), 0755)
+
+	got := DiscoverSkillDirs(home)
+	for _, d := range got {
+		if strings.HasPrefix(d, ".real") {
+			t.Errorf("blacklisted .real/skills should not appear, got %q", d)
+		}
+	}
+	found := false
+	for _, d := range got {
+		if d == ".claude/skills" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected .claude/skills to be discovered")
+	}
+}
+
+func TestDiscoverSkillDirs_SkipsNonSkillDirs(t *testing.T) {
+	home := t.TempDir()
+	os.MkdirAll(filepath.Join(home, "Documents"), 0755)
+	os.WriteFile(filepath.Join(home, "notes.txt"), []byte("notes"), 0644)
+
+	got := DiscoverSkillDirs(home)
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestDiscoverSkillDirs_EmptyHome(t *testing.T) {
+	home := t.TempDir()
+	if got := DiscoverSkillDirs(home); len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestDiscoverSkillDirs_InvalidHome(t *testing.T) {
+	got := DiscoverSkillDirs("/nonexistent/path/xyz123")
+	if len(got) != 0 {
+		t.Errorf("expected empty for invalid home, got %v", got)
+	}
+}
+
+func TestMergeSkillDirs(t *testing.T) {
+	discovered := []string{".cursor/skills", ".claude/skills"}
+	known := []string{".agents/skills", ".claude/skills", ".gemini/skills"}
+
+	got := mergeSkillDirs(discovered, known)
+
+	if got[0] != ".agents/skills" {
+		t.Errorf("primary = %q, want .agents/skills", got[0])
+	}
+
+	seen := make(map[string]int)
+	for _, d := range got {
+		seen[d]++
+	}
+	for d, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate dir %q", d)
+		}
+	}
+
+	for _, want := range []string{".agents/skills", ".claude/skills", ".cursor/skills", ".gemini/skills"} {
+		if seen[want] != 1 {
+			t.Errorf("missing %q", want)
+		}
+	}
+
+	if len(got) > 2 {
+		for i := 2; i < len(got); i++ {
+			if got[i] < got[i-1] {
+				t.Errorf("not sorted: %q before %q", got[i-1], got[i])
+			}
+		}
+	}
+}
+
+func TestMergeSkillDirs_PrimaryAlwaysFirst(t *testing.T) {
+	got := mergeSkillDirs([]string{".cursor/skills"}, []string{".claude/skills"})
+	if got[0] != ".agents/skills" {
+		t.Errorf("primary not injected first, got %v", got)
+	}
+}
+
+func TestMergeSkillDirs_EmptyInputs(t *testing.T) {
+	got := mergeSkillDirs(nil, nil)
+	if len(got) != 1 || got[0] != ".agents/skills" {
+		t.Errorf("expected [.agents/skills], got %v", got)
+	}
+}
+
+func TestRemoveAllSafe_RegularDir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "remove-me")
+	os.MkdirAll(sub, 0755)
+	os.WriteFile(filepath.Join(sub, "file.txt"), []byte("data"), 0644)
+
+	if err := removeAllSafe(sub); err != nil {
+		t.Fatalf("removeAllSafe failed: %v", err)
+	}
+	if _, err := os.Stat(sub); !os.IsNotExist(err) {
+		t.Error("expected subdir to be removed")
+	}
+}
+
+func TestRemoveAllSafe_NonExistent(t *testing.T) {
+	if err := removeAllSafe("/nonexistent/path/xyz123"); err != nil {
+		t.Errorf("expected nil error for nonexistent path, got %v", err)
+	}
+}
+
+func TestRemoveAllSafe_Symlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests skipped on Windows")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	os.MkdirAll(target, 0755)
+	os.WriteFile(filepath.Join(target, "file.txt"), []byte("data"), 0644)
+
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("cannot create symlink: %v", err)
+	}
+
+	if err := removeAllSafe(link); err != nil {
+		t.Fatalf("removeAllSafe failed: %v", err)
+	}
+	if _, err := os.Lstat(link); !os.IsNotExist(err) {
+		t.Error("expected symlink to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(target, "file.txt")); os.IsNotExist(err) {
+		t.Error("target should still exist after symlink removal")
+	}
+}
+
+func TestUpgradeSkillLocations_WithDiscovery(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot get home dir")
+	}
+
+	// Create a new agent dir that is NOT in knownSkillDirs
+	hermesSkillDir := filepath.Join(homeDir, ".hermes", "skills")
+	os.MkdirAll(hermesSkillDir, 0755)
+	defer os.RemoveAll(filepath.Join(homeDir, ".hermes"))
+
+	skillSrc := t.TempDir()
+	os.WriteFile(filepath.Join(skillSrc, "SKILL.md"), []byte("# discovered skill"), 0644)
+
+	result, err := UpgradeSkillLocations(skillSrc)
+	if err != nil {
+		t.Fatalf("UpgradeSkillLocations() error = %v", err)
+	}
+
+	// Verify .hermes/skills/dws was discovered and installed
+	hermesDest := filepath.Join(hermesSkillDir, "dws")
+	found := false
+	for _, d := range result.Succeeded() {
+		if d.Dir == hermesDest {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf(".hermes/skills/dws not installed; succeeded dirs: %v", result.Succeeded())
+	}
+	if _, err := os.Stat(filepath.Join(hermesDest, "SKILL.md")); os.IsNotExist(err) {
+		t.Error("SKILL.md not found at discovered .hermes destination")
+	}
+
+	// Cleanup
+	os.RemoveAll(hermesDest)
 }


### PR DESCRIPTION
## Summary

`dws upgrade` and `SyncSkills` now dynamically scan `$HOME` for any `*/skills/` directories instead of relying solely on a hardcoded list. New AI agents are automatically covered without code changes.

## Changed files

- `internal/upgrade/paths.go` — Add `DiscoverSkillDirs`, `mergeSkillDirs`, `removeAllSafe`; refactor `UpgradeSkillLocations`
- `internal/upgrade/paths_test.go` — 12 new tests covering all new functions
- `internal/plugin/loader.go` — `SyncSkills` uses `upgrade.DiscoverSkillDirs()` instead of hardcoded list
- `CHANGELOG.md` — Record behavior change

## Verification

- `go build ./...` — PASS
- `go vet ./...` — PASS
- `gofmt -l` — no unformatted files
- `staticcheck ./...` — PASS
- `git diff --check` — no whitespace errors
- `go test ./internal/upgrade/... ./internal/plugin/... -skip TestCopyFile` — PASS