### PR TITLE
fix(todo): 修正 todo task get 工具名 query_todo_detail → get_todo_detail

### DIFF
--- a/internal/helpers/todo.go
+++ b/internal/helpers/todo.go
@@ -379,7 +379,7 @@ func newTodoTaskGetCommand(runner executor.Runner) *cobra.Command {
 			invocation := executor.NewHelperInvocation(
 				cobracmd.LegacyCommandPath(cmd),
 				"todo",
-				"query_todo_detail",
+				"get_todo_detail",
 				params,
 			)
 			invocation.DryRun = commandDryRun(cmd)

--- a/test/cli_compat/todo_test.go
+++ b/test/cli_compat/todo_test.go
@@ -258,7 +258,7 @@ func TestTodoTaskGet_should_call_query_todo_detail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	assertToolName(t, cap, "query_todo_detail")
+	assertToolName(t, cap, "get_todo_detail")
 }
 
 func TestTodoTaskGet_should_pass_taskId(t *testing.T) {


### PR DESCRIPTION
## 概述

修复 `todo task get` 命令返回空结果 `result: {}` 的问题，原因是硬编码的 MCP 工具名写错了。

## 问题现象

执行 `todo task get --task-id <id>` 始终返回空结果：
```json
{"result": {}}
```

## 根因分析

`internal/helpers/todo.go` 中 helper 调用使用了 `query_todo_detail` 作为 MCP 工具名，但 `discovery.json` 中定义的正确工具名是 `get_todo_detail`。远端 MCP 服务同时暴露了这两个工具，但只有 `get_todo_detail` 能返回正确数据。

## 改动内容

- `internal/helpers/todo.go`：将工具名从 `query_todo_detail` 改为 `get_todo_detail`
- `test/cli_compat/todo_test.go`：同步更新测试断言

## 验证

- `go build ./...` — 编译通过，零错误
- `go vet ./...` — 零警告
- `go test ./internal/... ./pkg/... ./test/unit/...` — 全量测试通过
- 端到端手动测试：list / get / update / done / delete 均正常工作
- 测试 todo
<img width="576" height="374" alt="image" src="https://github.com/user-attachments/assets/69e6b159-0ae1-446c-b73e-ea8dd2a7642d" />
<img width="625" height="375" alt="image" src="https://github.com/user-attachments/assets/98b7cda7-2130-4755-941b-52be69995396" />


Fixes #201