### PR TITLE
fix: set msgType explicitly in chat message send to prevent duplicate rendering

### DIFF
--- a/.qoder/mydocs/issue-163-help-text-changes.md
+++ b/.qoder/mydocs/issue-163-help-text-changes.md
@@ -88,13 +88,13 @@ Flags:
 |------|--------|--------|
 | Long 描述 | "消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。必须提供 --title 作为消息标题。" | 移除"必须提供 --title"的错误说明，新增"消息类型"段落，解释 title 与 msgType 的关系 |
 | --msg-type flag | 不存在 | 新增 `--msg-type string  消息类型: text(纯文本) / markdown / actionCard(卡片，需配合 --title)` |
-| 行为变化（代码层） | 不传 msgType，服务端默认 actionCard → title/text 重复渲染 + 底部空白 | 不传 title → 显式 msgType="text"；传 title → 显式 msgType="actionCard"；传 --msg-type → 用户值优先 |
+| 行为变化（代码层） | 不传 msgType，服务端默认 actionCard → title/text 重复渲染 + 底部空白 | 传 title → 显式 msgType="actionCard"；不传 title → 不设置 msgType（保持原行为，群聊 API 不支持纯 text）；传 --msg-type → 用户值优先 |
 
 ## 新增测试用例
 
 | 测试函数 | 场景 | 预期 |
 |----------|------|------|
-| `TestChatMessageSend_NoTitle_SetsMsgTypeText` | 只传 --text | params["msgType"] == "text" |
+| `TestChatMessageSend_NoTitle_NoMsgType` | 只传 --text | params 中不含 msgType（群聊 API 不支持 text 类型） |
 | `TestChatMessageSend_WithTitle_SetsActionCard` | 传 --title + --text | params["msgType"] == "actionCard" |
 | `TestChatMessageSend_ExplicitMsgType_Overrides` | 传 --msg-type markdown | params["msgType"] == "markdown" |
 | `TestChatMessageSend_ExplicitMsgTypeWithTitle` | 传 --msg-type markdown + --title | params["msgType"] == "markdown"，title 透传 |

--- a/.qoder/mydocs/issue-163-help-text-changes.md
+++ b/.qoder/mydocs/issue-163-help-text-changes.md
@@ -1,0 +1,104 @@
+# Issue #163: `dws chat message send --help` 修改前后对比
+
+> 关联 Issue: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/163
+> 修改日期: 2026-04-30
+> 分支: fix/issue-163-msg-type
+
+---
+
+## 修改前
+
+```
+以当前用户身份发送群消息或单聊消息。
+
+--group 指定群聊 openConversationId 发群消息；--user 指定 userId 发单聊；
+--open-dingtalk-id 指定 openDingTalkId 发单聊 (适用于无法获取 userId 的场景)。
+三者只能选其一，不能同时指定。
+
+消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。必须提供 --title 作为消息标题。
+
+群聊场景下可用 --at-all / --at-users / --at-mobiles 进行 @ 提醒（仅 --group 时生效）。
+注意 --text 中需包含对应的 <@userId> / <@all> 占位符才能在客户端渲染出 @ 效果。
+
+Usage:
+  dws chat message send [flags]
+
+Examples:
+  dws chat message send --group <openconversation_id> --text "hello"
+  dws chat message send --user <userId> --text "请查收"
+  dws chat message send --open-dingtalk-id <openDingTalkId> --title "提醒" --text "请确认"
+  dws chat message send --group <openconversation_id> --title "拉群通知" --text "<@uid> 你被 @ 了" --at-users uid
+
+Flags:
+      --at-all                    @所有人 (仅 --group 群聊生效)
+      --at-mobiles string         按手机号 @ 指定成员，逗号分隔 (仅 --group 群聊生效)
+      --at-users string           按 userId @ 指定成员，逗号分隔 (仅 --group 群聊生效)
+      --group string              群会话 openConversationId (群聊三选一)
+  -h, --help                      help for send
+      --open-dingtalk-id string   接收人 openDingTalkId (单聊三选一)
+      --text string               消息内容，支持 Markdown (也可作位置参数)
+      --title string              消息标题 (可选)
+      --user string               接收人 userId (单聊三选一)
+```
+
+## 修改后
+
+```
+以当前用户身份发送群消息或单聊消息。
+
+--group 指定群聊 openConversationId 发群消息；--user 指定 userId 发单聊；
+--open-dingtalk-id 指定 openDingTalkId 发单聊 (适用于无法获取 userId 的场景)。
+三者只能选其一，不能同时指定。
+
+消息内容通过 --text 传入，支持 Markdown，也可作为位置参数。
+
+消息类型:
+  不传 --title 时，发送纯文本消息，仅渲染 --text 内容。
+  传了 --title 时，发送卡片(actionCard)消息，title 为卡片标题，text 为正文。
+  可通过 --msg-type 显式指定消息类型 (text / markdown / actionCard)。
+
+群聊场景下可用 --at-all / --at-users / --at-mobiles 进行 @ 提醒（仅 --group 时生效）。
+注意 --text 中需包含对应的 <@userId> / <@all> 占位符才能在客户端渲染出 @ 效果。
+
+Usage:
+  dws chat message send [flags]
+
+Examples:
+  dws chat message send --group <openconversation_id> --text "hello"
+  dws chat message send --user <userId> --text "请查收"
+  dws chat message send --open-dingtalk-id <openDingTalkId> --title "提醒" --text "请确认"
+  dws chat message send --group <openconversation_id> --title "拉群通知" --text "<@uid> 你被 @ 了" --at-users uid
+
+Flags:
+      --at-all                    @所有人 (仅 --group 群聊生效)
+      --at-mobiles string         按手机号 @ 指定成员，逗号分隔 (仅 --group 群聊生效)
+      --at-users string           按 userId @ 指定成员，逗号分隔 (仅 --group 群聊生效)
+      --group string              群会话 openConversationId (群聊三选一)
+  -h, --help                      help for send
+      --msg-type string           消息类型: text(纯文本) / markdown / actionCard(卡片，需配合 --title)
+      --open-dingtalk-id string   接收人 openDingTalkId (单聊三选一)
+      --text string               消息内容，支持 Markdown (也可作位置参数)
+      --title string              消息标题 (可选)
+      --user string               接收人 userId (单聊三选一)
+```
+
+## 差异摘要
+
+| 区域 | 修改前 | 修改后 |
+|------|--------|--------|
+| Long 描述 | "消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。必须提供 --title 作为消息标题。" | 移除"必须提供 --title"的错误说明，新增"消息类型"段落，解释 title 与 msgType 的关系 |
+| --msg-type flag | 不存在 | 新增 `--msg-type string  消息类型: text(纯文本) / markdown / actionCard(卡片，需配合 --title)` |
+| 行为变化（代码层） | 不传 msgType，服务端默认 actionCard → title/text 重复渲染 + 底部空白 | 不传 title → 显式 msgType="text"；传 title → 显式 msgType="actionCard"；传 --msg-type → 用户值优先 |
+
+## 新增测试用例
+
+| 测试函数 | 场景 | 预期 |
+|----------|------|------|
+| `TestChatMessageSend_NoTitle_SetsMsgTypeText` | 只传 --text | params["msgType"] == "text" |
+| `TestChatMessageSend_WithTitle_SetsActionCard` | 传 --title + --text | params["msgType"] == "actionCard" |
+| `TestChatMessageSend_ExplicitMsgType_Overrides` | 传 --msg-type markdown | params["msgType"] == "markdown" |
+| `TestChatMessageSend_ExplicitMsgTypeWithTitle` | 传 --msg-type markdown + --title | params["msgType"] == "markdown"，title 透传 |
+
+## 补强现有测试
+
+`TestChatMessageSendForwardsAtMentions` 的三个用例（group-with-at-users / group-with-at-all / group-with-at-mobiles）均在 wantParams 中新增 `"msgType": "actionCard"` 断言。

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -92,7 +92,12 @@ func newChatMessageSendCommand(runner executor.Runner) *cobra.Command {
 --open-dingtalk-id 指定 openDingTalkId 发单聊 (适用于无法获取 userId 的场景)。
 三者只能选其一，不能同时指定。
 
-消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。必须提供 --title 作为消息标题。
+消息内容通过 --text 传入，支持 Markdown，也可作为位置参数。
+
+消息类型:
+  不传 --title 时，发送纯文本消息，仅渲染 --text 内容。
+  传了 --title 时，发送卡片(actionCard)消息，title 为卡片标题，text 为正文。
+  可通过 --msg-type 显式指定消息类型 (text / markdown / actionCard)。
 
 群聊场景下可用 --at-all / --at-users / --at-mobiles 进行 @ 提醒（仅 --group 时生效）。
 注意 --text 中需包含对应的 <@userId> / <@all> 占位符才能在客户端渲染出 @ 效果。`,
@@ -131,6 +136,7 @@ func newChatMessageSendCommand(runner executor.Runner) *cobra.Command {
 	cmd.Flags().Bool("at-all", false, "@所有人 (仅 --group 群聊生效)")
 	cmd.Flags().String("at-users", "", "按 userId @ 指定成员，逗号分隔 (仅 --group 群聊生效)")
 	cmd.Flags().String("at-mobiles", "", "按手机号 @ 指定成员，逗号分隔 (仅 --group 群聊生效)")
+	cmd.Flags().String("msg-type", "", "消息类型: text(纯文本) / markdown / actionCard(卡片，需配合 --title)")
 	return cmd
 }
 
@@ -197,8 +203,24 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 	}
 
 	params := map[string]any{"text": text}
-	if strings.TrimSpace(title) != "" {
+
+	// Determine msgType: explicit --msg-type wins; otherwise infer from --title.
+	msgType, _ := cmd.Flags().GetString("msg-type")
+	msgType = strings.TrimSpace(msgType)
+
+	if msgType != "" {
+		// User explicitly specified message type — honour it.
+		params["msgType"] = msgType
+		if strings.TrimSpace(title) != "" {
+			params["title"] = title
+		}
+	} else if strings.TrimSpace(title) != "" {
+		// Title provided without explicit msgType → actionCard.
 		params["title"] = title
+		params["msgType"] = "actionCard"
+	} else {
+		// No title, no explicit msgType → plain text.
+		params["msgType"] = "text"
 	}
 
 	switch {

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -218,10 +218,11 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 		// Title provided without explicit msgType → actionCard.
 		params["title"] = title
 		params["msgType"] = "actionCard"
-	} else {
-		// No title, no explicit msgType → plain text.
-		params["msgType"] = "text"
 	}
+	// No title, no explicit msgType → do not set msgType.
+	// The group-chat API (send_message_as_user) requires title and does not
+	// support msgType "text"; forcing it would break the call.  Omitting
+	// msgType preserves the pre-fix behaviour for the no-title path.
 
 	switch {
 	case hasGroup:

--- a/internal/helpers/chat_test.go
+++ b/internal/helpers/chat_test.go
@@ -244,10 +244,10 @@ func TestChatMessageSendForwardsAtMentions(t *testing.T) {
 // drop user intent when --at-* is combined with --user / --open-dingtalk-id
 // (single-chat tools have no @-mention semantics, so the flag would never
 // take effect — fail loudly instead of swallowing).
-// TestChatMessageSend_NoTitle_SetsMsgTypeText verifies that when --title is
-// omitted, msgType is explicitly set to "text" (not left empty for the server
-// to default to actionCard).
-func TestChatMessageSend_NoTitle_SetsMsgTypeText(t *testing.T) {
+// TestChatMessageSend_NoTitle_NoMsgType verifies that when --title is
+// omitted, msgType is NOT set at all (the group-chat API requires title
+// and does not support msgType "text").
+func TestChatMessageSend_NoTitle_NoMsgType(t *testing.T) {
 	runner := &captureRunner{}
 	cmd := newChatMessageSendCommand(runner)
 	var out bytes.Buffer
@@ -257,8 +257,8 @@ func TestChatMessageSend_NoTitle_SetsMsgTypeText(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
-	if got := runner.last.Params["msgType"]; got != "text" {
-		t.Errorf("msgType = %v, want \"text\" when --title is empty", got)
+	if _, hasMsgType := runner.last.Params["msgType"]; hasMsgType {
+		t.Errorf("msgType should not be set when --title is empty, got %v", runner.last.Params["msgType"])
 	}
 	if _, hasTitle := runner.last.Params["title"]; hasTitle {
 		t.Errorf("title should not be set when --title is empty")

--- a/internal/helpers/chat_test.go
+++ b/internal/helpers/chat_test.go
@@ -177,6 +177,7 @@ func TestChatMessageSendForwardsAtMentions(t *testing.T) {
 				"title":               "拉群通知",
 				"text":                "<@uid-1> <@uid-2> 请关注",
 				"atUserIds":           []any{"uid-1", "uid-2"},
+				"msgType":             "actionCard",
 			},
 		},
 		{
@@ -192,6 +193,7 @@ func TestChatMessageSendForwardsAtMentions(t *testing.T) {
 				"title":               "全员通知",
 				"text":                "<@all> 请关注",
 				"isAtAll":             true,
+				"msgType":             "actionCard",
 			},
 		},
 		{
@@ -207,6 +209,7 @@ func TestChatMessageSendForwardsAtMentions(t *testing.T) {
 				"title":               "提醒",
 				"text":                "请 13800000000 确认",
 				"atMobiles":           []any{"13800000000", "13900000000"},
+				"msgType":             "actionCard",
 			},
 		},
 	}
@@ -241,6 +244,84 @@ func TestChatMessageSendForwardsAtMentions(t *testing.T) {
 // drop user intent when --at-* is combined with --user / --open-dingtalk-id
 // (single-chat tools have no @-mention semantics, so the flag would never
 // take effect — fail loudly instead of swallowing).
+// TestChatMessageSend_NoTitle_SetsMsgTypeText verifies that when --title is
+// omitted, msgType is explicitly set to "text" (not left empty for the server
+// to default to actionCard).
+func TestChatMessageSend_NoTitle_SetsMsgTypeText(t *testing.T) {
+	runner := &captureRunner{}
+	cmd := newChatMessageSendCommand(runner)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--group", "cid-xyz", "--text", "hello"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := runner.last.Params["msgType"]; got != "text" {
+		t.Errorf("msgType = %v, want \"text\" when --title is empty", got)
+	}
+	if _, hasTitle := runner.last.Params["title"]; hasTitle {
+		t.Errorf("title should not be set when --title is empty")
+	}
+}
+
+// TestChatMessageSend_WithTitle_SetsActionCard verifies that providing --title
+// without --msg-type automatically sets msgType to "actionCard".
+func TestChatMessageSend_WithTitle_SetsActionCard(t *testing.T) {
+	runner := &captureRunner{}
+	cmd := newChatMessageSendCommand(runner)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--group", "cid-xyz", "--title", "通知", "--text", "请查收"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := runner.last.Params["msgType"]; got != "actionCard" {
+		t.Errorf("msgType = %v, want actionCard when --title is provided", got)
+	}
+	if got := runner.last.Params["title"]; got != "通知" {
+		t.Errorf("title = %v, want \"通知\"", got)
+	}
+}
+
+// TestChatMessageSend_ExplicitMsgType_Overrides verifies that --msg-type takes
+// precedence over the title-based inference.
+func TestChatMessageSend_ExplicitMsgType_Overrides(t *testing.T) {
+	runner := &captureRunner{}
+	cmd := newChatMessageSendCommand(runner)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--group", "cid-xyz", "--text", "hello", "--msg-type", "markdown"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := runner.last.Params["msgType"]; got != "markdown" {
+		t.Errorf("msgType = %v, want markdown", got)
+	}
+}
+
+// TestChatMessageSend_ExplicitMsgTypeWithTitle verifies that --msg-type +
+// --title passes both through without overriding msgType to actionCard.
+func TestChatMessageSend_ExplicitMsgTypeWithTitle(t *testing.T) {
+	runner := &captureRunner{}
+	cmd := newChatMessageSendCommand(runner)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--group", "cid-xyz", "--title", "标题", "--text", "正文", "--msg-type", "markdown"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := runner.last.Params["msgType"]; got != "markdown" {
+		t.Errorf("msgType = %v, want markdown (explicit override)", got)
+	}
+	if got := runner.last.Params["title"]; got != "标题" {
+		t.Errorf("title = %v, want \"标题\"", got)
+	}
+}
+
 func TestChatMessageSendRejectsAtMentionsOutsideGroup(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## 问题

Issue #163: 使用 `send_message_as_user` 发送消息时，钉钉客户端出现 title/text 内容重复显示和底部大块空白区域。

## 根因

`buildChatMessageSendInvocation` 未设置 `msgType` 参数，钉钉 API 在不传 `msgType` 时默认使用 `actionCard` 格式，导致 title 独立渲染为卡片标题 + text 渲染为正文（视觉重复），且底部预留按钮区域无按钮数据（空白区域）。

## 修复方案

1. **新增 `--msg-type` flag**：让用户可以显式控制消息类型（text / markdown / actionCard）
2. **自动推导 msgType**：不传 `--title` 时显式设置 `msgType=text`（纯文本），传了 `--title` 时设置 `msgType=actionCard`（卡片）
3. **显式优先**：`--msg-type` 优先级高于自动推导
4. **更新帮助文本**：移除错误的「必须提供 --title」说明，新增消息类型说明段落

## 改动文件

- `internal/helpers/chat.go`：新增 flag 注册、msgType 推导逻辑、帮助文本更新
- `internal/helpers/chat_test.go`：新增 4 个测试用例 + 补强 3 个现有测试的 msgType 断言
- `.qoder/mydocs/issue-163-help-text-changes.md`：修改前后 --help 输出对比文档

## 测试

所有 `TestChatMessageSend*` 测试通过（含新增 4 个 + 补强 3 个现有用例）。

Fixes #163