### PR TITLE
docs(help): document --contents.key=field_name and surface required markers (#106 #107)

### DIFF
--- a/internal/compat/dynamic_commands.go
+++ b/internal/compat/dynamic_commands.go
@@ -337,7 +337,7 @@ func buildFlagsFromDetailSchema(cmd *cobra.Command, schemaJSON string, flagOverr
 					help = strings.TrimSpace(prop.Title)
 				}
 				if help != "" {
-					f.Usage = help
+					f.Usage = appendRequiredMarker(help, requiredSet[key])
 				}
 			}
 			continue
@@ -350,6 +350,11 @@ func buildFlagsFromDetailSchema(cmd *cobra.Command, schemaJSON string, flagOverr
 		if help == "" {
 			help = key
 		}
+		// Append `(必填)` so the rendered --help line carries the contract that
+		// schema.required already encodes. cobra.MarkFlagRequired only enforces
+		// at runtime; without this suffix downstream MCP wrappers / agents can't
+		// see the required flags from `dws --help` text alone (issue #107).
+		help = appendRequiredMarker(help, requiredSet[key])
 
 		switch prop.Type {
 		case "integer", "number":
@@ -367,6 +372,23 @@ func buildFlagsFromDetailSchema(cmd *cobra.Command, schemaJSON string, flagOverr
 			_ = cmd.MarkFlagRequired(flagName)
 		}
 	}
+}
+
+// appendRequiredMarker conditionally appends ` (必填)` to a flag's help text
+// when the underlying MCP schema marks the property as required. The marker
+// is skipped if the upstream description already contains an equivalent
+// (`(必填)` or `(required)`), so localized / pre-marked descriptions are not
+// double-tagged. See issue #107 for the motivation: cobra.MarkFlagRequired
+// enforces at runtime but doesn't surface the contract in --help text.
+func appendRequiredMarker(help string, required bool) string {
+	if !required {
+		return help
+	}
+	if strings.Contains(help, "(必填)") || strings.Contains(help, "（必填）") ||
+		strings.Contains(strings.ToLower(help), "(required)") {
+		return help
+	}
+	return help + " (必填)"
 }
 
 // toKebabCase converts camelCase or snake_case identifiers to kebab-case.

--- a/internal/compat/registry.go
+++ b/internal/compat/registry.go
@@ -399,6 +399,13 @@ func ApplyBindings(cmd *cobra.Command, bindings []FlagBinding) {
 		// see consistent --help text and zero-value behavior.
 		defStr, defInt, defFloat, defBool, defSlice := parseFlagDefault(binding.Kind, binding.Default)
 
+		// Surface the required contract in --help text so MCP wrappers and
+		// agents reading `dws ... --help` can see which flags are mandatory
+		// without having to introspect cobra MarkFlagRequired (issue #107).
+		// Only the primary visible flag carries the marker; hidden alias
+		// rows already render `(alias)` and would clutter with `(必填) (alias)`.
+		usage := appendRequiredMarker(binding.Usage, binding.Required)
+
 		registerHidden := func(name string, suffix string) {
 			if name == "" {
 				return
@@ -422,17 +429,17 @@ func ApplyBindings(cmd *cobra.Command, bindings []FlagBinding) {
 
 		switch binding.Kind {
 		case ValueString:
-			cmd.Flags().StringP(primary, binding.Short, defStr, binding.Usage)
+			cmd.Flags().StringP(primary, binding.Short, defStr, usage)
 		case ValueInt:
-			cmd.Flags().IntP(primary, binding.Short, defInt, binding.Usage)
+			cmd.Flags().IntP(primary, binding.Short, defInt, usage)
 		case ValueFloat:
-			cmd.Flags().Float64P(primary, binding.Short, defFloat, binding.Usage)
+			cmd.Flags().Float64P(primary, binding.Short, defFloat, usage)
 		case ValueBool:
-			cmd.Flags().BoolP(primary, binding.Short, defBool, binding.Usage)
+			cmd.Flags().BoolP(primary, binding.Short, defBool, usage)
 		case ValueStringSlice, ValueIntSlice, ValueFloatSlice, ValueBoolSlice:
-			cmd.Flags().StringSliceP(primary, binding.Short, defSlice, binding.Usage)
+			cmd.Flags().StringSliceP(primary, binding.Short, defSlice, usage)
 		case ValueJSON:
-			cmd.Flags().StringP(primary, binding.Short, defStr, binding.Usage+" (JSON)")
+			cmd.Flags().StringP(primary, binding.Short, defStr, usage+" (JSON)")
 		}
 		registerHidden(alias, " (alias)")
 		for _, extra := range extras {

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -252,9 +252,9 @@ func newChatMessageSendByBotCommand(runner executor.Runner) *cobra.Command {
 	preferLegacyLeaf(cmd)
 
 	cmd.Flags().String("group", "", "群会话 openConversationId (群聊必填)")
-	cmd.Flags().String("robot-code", "", "机器人 Code")
-	cmd.Flags().String("text", "", "消息内容 (Markdown)")
-	cmd.Flags().String("title", "", "消息标题")
+	cmd.Flags().String("robot-code", "", "机器人 Code (必填)")
+	cmd.Flags().String("text", "", "消息内容 Markdown (必填)")
+	cmd.Flags().String("title", "", "消息标题 (必填)")
 	cmd.Flags().String("users", "", "接收者 userId 列表，逗号分隔，最多 20 个 (单聊必填)")
 	return cmd
 }

--- a/internal/helpers/report.go
+++ b/internal/helpers/report.go
@@ -204,8 +204,18 @@ func newReportCreateCommand(runner executor.Runner) *cobra.Command {
 		Use:   "create",
 		Short: "创建日志",
 		Long: `按模版创建一条日志。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，
-与远程 create_report 一致；可先通过 report template list / template detail 取得 templateId 与控件定义。`,
-		Example: `  dws report create --template-id TPL_ID --contents '[{"content":"完成开发","sort":"0","key":"今日完成","contentType":"markdown","type":"1"}]'
+与远程 create_report 一致；可先通过 report template list / template detail 取得 templateId 与控件定义。
+
+注意：每个 contents 项的 key 必须精确等于模板的 field_name（中文/英文逐字匹配，不是控件 ID 或别名）。
+key 与 field_name 不一致时钉钉 API 会返回 SYSTEM_ERROR (success=false)，CLI 层不会预先拦截。
+请先用 report template detail 查到 report_template_fields[].field_name 后再填。`,
+		Example: `  # Step 1：查模板，取 report_template_fields[].field_name 当作 contents[].key
+  dws report template detail --name "周报"
+
+  # Step 2：用上一步拿到的 field_name 作为 key 创建日志
+  dws report create --template-id TPL_ID --contents '[{"key":"<field_name>","sort":"0","content":"完成开发","contentType":"markdown","type":"1"}]'
+
+  # 同时通知到接收人单聊
   dws report create --template-id TPL_ID --contents '[...]' --to-chat --to-user-ids userId1,userId2`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
@@ -251,7 +261,7 @@ func newReportCreateCommand(runner executor.Runner) *cobra.Command {
 		},
 	}
 	cmd.Flags().String("template-id", "", "日志模版 ID (必填)")
-	cmd.Flags().String("contents", "", "日志内容 JSON 数组 (必填)，每项含 key/sort/content/contentType/type")
+	cmd.Flags().String("contents", "", "日志内容 JSON 数组 (必填)，每项含 key/sort/content/contentType/type；key 必须精确等于模板 field_name (用 report template detail --name <模板名> 查询)")
 	cmd.Flags().String("dd-from", "dws", "创建来源标识")
 	cmd.Flags().Bool("to-chat", false, "是否发送到日志接收人单聊")
 	cmd.Flags().String("to-user-ids", "", "接收人 userId，逗号分隔 (可选)")


### PR DESCRIPTION
## 改动一句话
\#106 / \#107 都是 \`--help\` 文本契约不全的问题, 影响下游 MCP wrapper 自动生成的 schema 准确度。本 PR 修两个 helper + 改 dynamic 命令构造器把 \`(必填)\` 渲染对齐。

## Issues

### \#106 — \`dws report create --contents.key\` 必须等于模板 field_name

实测: 用错 key (例 \`\"content\"\` 而非 \`\"本周完成工作\"\`) 直接被钉钉 API 返 \`SYSTEM_ERROR / PARAM_ERROR\`, CLI 层不预拦, --help 也没说这个契约。

修法: \`report create --contents\` 描述追加 \"key 必须精确等于模板 field_name (用 report template detail --name <模板名> 查询)\"; Long + Examples 改成两步流水线 (Step 1: template detail 拿 field_name → Step 2: 用 field_name 当 contents[].key 创建)。

### \#107 — \`dws chat message send-by-bot --robot-code/--title/--text\`

RunE 已校验三者为必填, --help 缺 \`(必填)\`。补三个 \`(必填)\`。

### \#107 — \`dws oa approval list-initiated --process-code\` 等 (本 PR 不直接修, 提供渲染逻辑)

这条命令是动态构建 (从 MCP discovery 配置生成), 本仓没法在 helper 里直接改 \`(必填)\`。本 PR 改了 \`ApplyBindings\` 和 \`buildFlagsFromDetailSchema\`: 任何 binding.Required=true 或 schema.required 命中的 flag, Usage 自动追加 \`(必填)\` (含 dedup, 上游已有不重复加)。

闭环路径: discovery 配置端在 \`list_initiated_instances.flags\` 给 \`processCode\` / \`startTime\` 加 \`\"required\": true\`, 给 \`nextToken\` / \`maxResults\` 加 \`\"default\": \"0\"\` / \`\"20\"\` (实测 \`endTime\` 不必填, API 可省)。该配置 PR 跟本 PR 解耦, 配置发布后开源 dws CLI 自动渲染 \`(必填)\`。

## 实测验证

\`\`\`bash
$ go build ./... && go test ./internal/compat/ ./internal/helpers/
PASS

# #106
$ dws report create --help | grep contents
--contents string  日志内容 JSON 数组 (必填), 每项含 key/sort/content/contentType/type;
                   key 必须精确等于模板 field_name (用 report template detail --name <模板名> 查询)

# #107 (chat)
$ dws chat message send-by-bot --help | grep -E 'robot-code|title|text'
--robot-code string  机器人 Code (必填)
--text string        消息内容 Markdown (必填)
--title string       消息标题 (必填)

$ dws chat message send-by-bot --users U --text hi
{ \"error\": { \"message\": \"--robot-code is required\" } }   # 行为不变, RunE 拦下
\`\`\`

## 未闭环 (留给 follow-up)

- \#107 oa list-initiated --process-code: 等 oa MCP server 的 discovery 配置 PR 合入。本 PR 已提供 CLI 端渲染逻辑, 配置发布即生效, 不再需要 dws CLI 二次修改。

Refs #106 #107