### PR TITLE
docs(help): mark required flags for chat send-by-bot and document contents.key=field_name (#106 #107)

### DIFF
--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -252,9 +252,9 @@ func newChatMessageSendByBotCommand(runner executor.Runner) *cobra.Command {
 	preferLegacyLeaf(cmd)
 
 	cmd.Flags().String("group", "", "群会话 openConversationId (群聊必填)")
-	cmd.Flags().String("robot-code", "", "机器人 Code")
-	cmd.Flags().String("text", "", "消息内容 (Markdown)")
-	cmd.Flags().String("title", "", "消息标题")
+	cmd.Flags().String("robot-code", "", "机器人 Code (必填)")
+	cmd.Flags().String("text", "", "消息内容 Markdown (必填)")
+	cmd.Flags().String("title", "", "消息标题 (必填)")
 	cmd.Flags().String("users", "", "接收者 userId 列表，逗号分隔，最多 20 个 (单聊必填)")
 	return cmd
 }

--- a/internal/helpers/report.go
+++ b/internal/helpers/report.go
@@ -204,8 +204,18 @@ func newReportCreateCommand(runner executor.Runner) *cobra.Command {
 		Use:   "create",
 		Short: "创建日志",
 		Long: `按模版创建一条日志。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，
-与远程 create_report 一致；可先通过 report template list / template detail 取得 templateId 与控件定义。`,
-		Example: `  dws report create --template-id TPL_ID --contents '[{"content":"完成开发","sort":"0","key":"今日完成","contentType":"markdown","type":"1"}]'
+与远程 create_report 一致；可先通过 report template list / template detail 取得 templateId 与控件定义。
+
+注意：每个 contents 项的 key 必须精确等于模板的 field_name（中文/英文逐字匹配，不是控件 ID 或别名）。
+key 与 field_name 不一致时钉钉 API 会返回 SYSTEM_ERROR (success=false)，CLI 层不会预先拦截。
+请先用 report template detail 查到 report_template_fields[].field_name 后再填。`,
+		Example: `  # Step 1：查模板，取 report_template_fields[].field_name 当作 contents[].key
+  dws report template detail --name "周报"
+
+  # Step 2：用上一步拿到的 field_name 作为 key 创建日志
+  dws report create --template-id TPL_ID --contents '[{"key":"<field_name>","sort":"0","content":"完成开发","contentType":"markdown","type":"1"}]'
+
+  # 同时通知到接收人单聊
   dws report create --template-id TPL_ID --contents '[...]' --to-chat --to-user-ids userId1,userId2`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
@@ -251,7 +261,7 @@ func newReportCreateCommand(runner executor.Runner) *cobra.Command {
 		},
 	}
 	cmd.Flags().String("template-id", "", "日志模版 ID (必填)")
-	cmd.Flags().String("contents", "", "日志内容 JSON 数组 (必填)，每项含 key/sort/content/contentType/type")
+	cmd.Flags().String("contents", "", "日志内容 JSON 数组 (必填)，每项含 key/sort/content/contentType/type；key 必须精确等于模板 field_name (用 report template detail --name <模板名> 查询)")
 	cmd.Flags().String("dd-from", "dws", "创建来源标识")
 	cmd.Flags().Bool("to-chat", false, "是否发送到日志接收人单聊")
 	cmd.Flags().String("to-user-ids", "", "接收人 userId，逗号分隔 (可选)")


### PR DESCRIPTION
## Summary

Both #106 and #107 stem from incomplete `--help` text contracts that downstream MCP wrappers / agents read to auto-generate tool schemas. This PR is a 16-line, 2-file string-only change — no logic moves.

## Issues closed

### #106 — `dws report create --contents.key` must equal the template `field_name`

`RunE` already enforces `--contents` as required, but the description only said "each item contains key/sort/content/contentType/type" without naming the hidden contract: `key` must literally match the template's `field_name` (Chinese-character-for-Chinese-character). A wrong key gets bounced by the DingTalk API as `PARAM_ERROR`, never pre-caught by the CLI, so an LLM agent fails on the first call.

**Fix:**
- `--contents` description appends "key must exactly equal the template field_name (look it up via `report template detail --name <template-name>`)"
- `Long` adds a note about the API behavior on key mismatch (SYSTEM_ERROR / no CLI pre-validation)
- `Example` becomes a two-step pipeline (Step 1: `template detail` to fetch field_name → Step 2: use field_name as `contents[].key` to create)

### #107 — `dws chat message send-by-bot --robot-code/--title/--text` missing `(必填)`

`RunE` already enforces all three as required, but the help description never marked them as such, so wrappers parsing `--help` produced schemas with required fields missing.

**Fix:** append ` (必填)` to each of the three flag descriptions, matching the existing `--group/--users` style ("(群聊必填)" / "(单聊必填)").

## Verification

```bash
$ go build ./... && go test ./internal/helpers/ -run "Chat|Report"
PASS

# #106
$ dws report create --help | grep contents
--contents string  日志内容 JSON 数组 (必填)，每项含 key/sort/content/contentType/type；
                   key 必须精确等于模板 field_name (用 report template detail --name <模板名> 查询)

# #107
$ dws chat message send-by-bot --help | grep -E 'robot-code|text|title'
--robot-code string  机器人 Code (必填)
--text string        消息内容 Markdown (必填)
--title string       消息标题 (必填)

# Behavior unchanged — RunE still rejects empty values
$ dws chat message send-by-bot --users U --text hi
{ "error": { "message": "--robot-code is required" } }
```

## Also validated on the pre-release branch

The pre-release branch (`test/pre-mcp-discovery`) was merged with main + this helper change, and all three issues verified end-to-end against the pre-release MCP gateway:
- `chat message send-by-bot` reachable, all 4 flags marked (必填), cobra rejects missing values
- `oa approval list-initiated` shows process-code/start as (必填), end as optional (API doesn't enforce — empirically verified), defaults rendered for next-token/max-results
- `report create` description carries the key=field_name contract, Examples show the two-step pipeline

Closes #106
Closes #107
