### PR TITLE
fix: 修复跨产品同名 tool 路由冲突导致 dws drive mkdir 请求发错服务器 (#219)

### DIFF
--- a/internal/app/direct_runtime.go
+++ b/internal/app/direct_runtime.go
@@ -227,14 +227,11 @@ func directRuntimeEndpoint(productID, toolName string) (string, bool) {
 	te := dynamicToolEndpoints
 	dynamicMu.RUnlock()
 
-	// Priority 1: tool-level endpoint (resolves multi-endpoint products).
-	if tool := strings.TrimSpace(toolName); tool != "" && te != nil {
-		if endpoint, ok := te[tool]; ok {
-			return endpoint, true
-		}
-	}
-
-	// Priority 2: product-level endpoint.
+	// Priority 1: product-level endpoint.
+	// When the caller already knows the productID (e.g. "drive"), the product
+	// endpoint is authoritative. This prevents cross-product tool name
+	// collisions (e.g. both "drive" and "doc" register "create_folder") from
+	// routing the request to the wrong MCP server. See issue #219.
 	for _, candidate := range []string{strings.TrimSpace(productID), normalized} {
 		if candidate == "" {
 			continue
@@ -243,6 +240,16 @@ func directRuntimeEndpoint(productID, toolName string) (string, bool) {
 			if endpoint, ok := de[candidate]; ok {
 				return endpoint, true
 			}
+		}
+	}
+
+	// Priority 2: tool-level endpoint (fallback for unknown productID).
+	// This path is used when the caller does not know the productID but has a
+	// tool name, e.g. in helper invocations or plugin routes where only the
+	// tool name is available.
+	if tool := strings.TrimSpace(toolName); tool != "" && te != nil {
+		if endpoint, ok := te[tool]; ok {
+			return endpoint, true
 		}
 	}
 

--- a/internal/app/direct_runtime_override_test.go
+++ b/internal/app/direct_runtime_override_test.go
@@ -181,3 +181,114 @@ func TestAppendDynamicServer_ServerOverrideDoesNotHijackToolEndpoint(t *testing.
 		})
 	}
 }
+
+// --- Issue #219 regression tests: cross-product tool name collision ---
+//
+// When two different products register tools with the same name (e.g. drive
+// and doc both have "create_folder"), the product-level endpoint must win
+// when the caller already knows the productID. Otherwise the tool-level map
+// (last-writer-wins) routes the invocation to the wrong MCP server.
+
+const (
+	testDriveEndpoint = "https://mcp-gw.dingtalk.com/server/drive-hash"
+	testDocEndpoint   = "https://mcp-gw.dingtalk.com/server/doc-hash"
+)
+
+func driveDescriptor() market.ServerDescriptor {
+	return market.ServerDescriptor{
+		Endpoint: testDriveEndpoint,
+		CLI: market.CLIOverlay{
+			ID:      "drive",
+			Command: "drive",
+			ToolOverrides: map[string]market.CLIToolOverride{
+				"create_folder":   {CLIName: "mkdir"},
+				"list_files":      {CLIName: "list"},
+				"download_file":   {CLIName: "download"},
+				"get_upload_info": {CLIName: "upload-info"},
+			},
+		},
+	}
+}
+
+func docDescriptor() market.ServerDescriptor {
+	return market.ServerDescriptor{
+		Endpoint: testDocEndpoint,
+		CLI: market.CLIOverlay{
+			ID:      "doc",
+			Command: "doc",
+			ToolOverrides: map[string]market.CLIToolOverride{
+				"create_folder":    {CLIName: "create", Group: "folder"},
+				"download_file":    {CLIName: "download"},
+				"search_documents": {CLIName: "search"},
+				"list_nodes":       {CLIName: "list"},
+			},
+		},
+	}
+}
+
+// TestDirectRuntimeEndpoint_ProductLevelWinsOverConflictingToolLevel verifies
+// that when productID is known and has a registered endpoint, the product-level
+// endpoint is used even if the tool-level map points to a different server
+// (due to same-name tool collision). This is the core fix for issue #219.
+func TestDirectRuntimeEndpoint_ProductLevelWinsOverConflictingToolLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		servers []market.ServerDescriptor
+	}{
+		{
+			name:    "drive first, doc second",
+			servers: []market.ServerDescriptor{driveDescriptor(), docDescriptor()},
+		},
+		{
+			name:    "doc first, drive second",
+			servers: []market.ServerDescriptor{docDescriptor(), driveDescriptor()},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withCleanDynamicRegistry(t)
+			SetDynamicServers(tc.servers)
+
+			// Drive tools must always route to drive's endpoint regardless of
+			// registration order — productID "drive" is known.
+			assertEndpoint(t, "drive", "create_folder", testDriveEndpoint)
+			assertEndpoint(t, "drive", "download_file", testDriveEndpoint)
+			assertEndpoint(t, "drive", "list_files", testDriveEndpoint)
+			assertEndpoint(t, "drive", "get_upload_info", testDriveEndpoint)
+
+			// Doc tools must always route to doc's endpoint.
+			assertEndpoint(t, "doc", "create_folder", testDocEndpoint)
+			assertEndpoint(t, "doc", "download_file", testDocEndpoint)
+			assertEndpoint(t, "doc", "search_documents", testDocEndpoint)
+			assertEndpoint(t, "doc", "list_nodes", testDocEndpoint)
+
+			// Product-level fallback (no tool name) still works.
+			assertEndpoint(t, "drive", "", testDriveEndpoint)
+			assertEndpoint(t, "doc", "", testDocEndpoint)
+		})
+	}
+}
+
+// TestDirectRuntimeEndpoint_ToolLevelFallbackWhenProductUnknown verifies that
+// tool-level routing still works as a fallback when productID is empty or has
+// no registered endpoint (the original design intent for tool-level Priority 1).
+func TestDirectRuntimeEndpoint_ToolLevelFallbackWhenProductUnknown(t *testing.T) {
+	withCleanDynamicRegistry(t)
+	SetDynamicServers([]market.ServerDescriptor{driveDescriptor(), docDescriptor()})
+
+	// When productID is empty, tool-level endpoint is the only option.
+	// The actual endpoint depends on registration order (last-writer-wins),
+	// but the lookup must succeed.
+	endpoint, ok := directRuntimeEndpoint("", "create_folder")
+	if !ok {
+		t.Fatal("directRuntimeEndpoint(\"\", \"create_folder\") returned ok=false, want ok=true")
+	}
+	if endpoint != testDriveEndpoint && endpoint != testDocEndpoint {
+		t.Fatalf("directRuntimeEndpoint(\"\", \"create_folder\") = %q, want one of drive/doc endpoints", endpoint)
+	}
+
+	// Unique tools (no collision) still resolve via tool-level.
+	assertEndpoint(t, "", "search_documents", testDocEndpoint)
+	assertEndpoint(t, "", "get_upload_info", testDriveEndpoint)
+}


### PR DESCRIPTION
## 问题

`dws drive mkdir` 和 `dws drive download` 被静默路由到了 **钉钉文档** MCP 服务器，而非 **钉盘** MCP 服务器。

根因：钉盘（drive）和钉钉文档（doc）都注册了同名 tool `create_folder` 和 `download_file`。`directRuntimeEndpoint` 函数中 tool-level 查找（Priority 1）优先于 product-level 查找（Priority 2），而 `toolEndpoints` map 是 last-writer-wins，导致后注册的 doc 覆盖了 drive 的 tool 路由。

### 根因分析

`internal/app/direct_runtime.go` 的 `directRuntimeEndpoint()` 原先的优先级：
1. **Priority 1: tool-level**（`toolEndpoints[toolName]`）— 可能指向错误的服务器
2. **Priority 2: product-level**（`dynamicEndpoints[productID]`）— 始终正确

当两个产品有同名 tool 时，tool-level map 是不可靠的，但 product-level map 是权威的。

### 通过 `--dry-run` 验证

| 命令 | tool | 修复前（错误） | 修复后（正确） |
|------|------|--------------|--------------|
| `dws drive mkdir` | `create_folder` | `91e17caf...`（doc） | `536f3b32...`（drive） |
| `dws drive download` | `download_file` | `91e17caf...`（doc） | `536f3b32...`（drive） |
| `dws drive list` | `list_files` | `536f3b32...`（drive）✅ | `536f3b32...`（drive）✅ |

### 修复后实测截图

修复后 `dws drive mkdir` 成功在钉盘创建了文件夹（返回了真实的 `spaceId` 和 `fileId`）：

![修复验证](https://aone-copilot.oss-cn-shanghai.aliyuncs.com/images/1777958367130.png)

## 修复方案

交换 `directRuntimeEndpoint` 中 Priority 1 和 Priority 2 的顺序：当调用方已知 `productID` 时，优先使用 product-level endpoint。tool-level 查找保留为 `productID` 为空时的 fallback。

## 测试

- `TestDirectRuntimeEndpoint_ProductLevelWinsOverConflictingToolLevel` — 验证 drive/doc 冲突在任意注册顺序下均能正确路由
- `TestDirectRuntimeEndpoint_ToolLevelFallbackWhenProductUnknown` — 验证 productID 为空时 tool-level fallback 仍然生效
- 所有已有测试通过（含 `ServerOverrideDoesNotHijackToolEndpoint`）
- 竞态检测通过

Closes #219