### PR TITLE
fix(install): add .hermes/skills to AGENT_DIRS (#188)

### DIFF
--- a/build/homebrew.rb.tmpl
+++ b/build/homebrew.rb.tmpl
@@ -53,6 +53,7 @@ __KEG_ONLY_LINE__
       Pathname.new(File.join(Dir.home, ".kiro/skills/dws")),
       Pathname.new(File.join(Dir.home, ".trae/skills/dws")),
       Pathname.new(File.join(Dir.home, ".openclaw/skills/dws")),
+      Pathname.new(File.join(Dir.home, ".hermes/skills/dws")),
     ]
 
     targets.each_with_index do |dest, index|

--- a/build/npm/install.js
+++ b/build/npm/install.js
@@ -22,6 +22,7 @@ const AGENT_DIRS = [
   ".kiro/skills",
   ".trae/skills",
   ".openclaw/skills",
+  ".hermes/skills",
 ];
 
 const PLATFORM_MAP = {

--- a/internal/upgrade/paths.go
+++ b/internal/upgrade/paths.go
@@ -19,7 +19,15 @@ const (
 )
 
 // knownSkillDirs lists all known Agent skill directories (relative to $HOME).
-// Kept in sync with build/npm/install.js AGENT_DIRS.
+// Kept in sync with:
+//   - build/npm/install.js                                  AGENT_DIRS
+//   - scripts/install.sh                                    for-in list
+//   - scripts/install.ps1                                   $AgentDirs
+//   - scripts/install-skills.sh                             for-in list
+//   - build/homebrew.rb.tmpl                                targets
+//   - test/scripts/package_script_test.go                   expectedPackagedSkillTargets
+//   - scripts/release/verify-package-managers.sh            HOME_AGENT_PARENTS / HOME_SKILL_TARGETS
+//
 // The first entry (.agents/skills) is always updated; subsequent entries are
 // only updated when their parent directory already exists.
 var knownSkillDirs = []string{
@@ -36,6 +44,7 @@ var knownSkillDirs = []string{
 	".kiro/skills",
 	".trae/skills",
 	".openclaw/skills",
+	".hermes/skills",
 }
 
 // skillDirBlacklist contains parent directories whose skills are managed by

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -116,7 +116,8 @@ install_skills_to_root() {
     ".amp/skills" \
     ".kiro/skills" \
     ".trae/skills" \
-    ".openclaw/skills"
+    ".openclaw/skills" \
+    ".hermes/skills"
   do
     base_dir="$root/$agent_dir"
     parent_gate="$(dirname "$base_dir")"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -44,7 +44,8 @@ $AgentDirs = @(
     ".amp\skills",
     ".kiro\skills",
     ".trae\skills",
-    ".openclaw\skills"
+    ".openclaw\skills",
+    ".hermes\skills"
 )
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -201,7 +201,8 @@ install_skills_to_homes() {
     ".amp/skills" \
     ".kiro/skills" \
     ".trae/skills" \
-    ".openclaw/skills"
+    ".openclaw/skills" \
+    ".hermes/skills"
   do
     base_dir="$root/$agent_dir"
     parent_gate="$(dirname "$base_dir")"

--- a/scripts/release/verify-package-managers.sh
+++ b/scripts/release/verify-package-managers.sh
@@ -37,6 +37,7 @@ HOME_AGENT_PARENTS="
 .kiro
 .trae
 .openclaw
+.hermes
 "
 HOME_SKILL_TARGETS="
 .agents/skills/dws
@@ -52,6 +53,7 @@ HOME_SKILL_TARGETS="
 .kiro/skills/dws
 .trae/skills/dws
 .openclaw/skills/dws
+.hermes/skills/dws
 "
 cleanup() {
   if command -v brew >/dev/null 2>&1; then

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -23,6 +23,7 @@ var expectedPackagedSkillTargets = []string{
 	".kiro/skills/dws",
 	".trae/skills/dws",
 	".openclaw/skills/dws",
+	".hermes/skills/dws",
 }
 
 // seedDistArtifacts creates fake goreleaser output archives (empty tar.gz/zip


### PR DESCRIPTION
## Summary

Closes #188.

`dws` 安装后没有自动把 skill 复制到 `.hermes/skills/` 目录下，原因是 4 份硬编码的 `AGENT_DIRS` 清单都漏写了 `.hermes/skills` 这一项。本 PR 在 4 处统一补齐，保持顺序与条目一致。

## Changes

| File | Change |
|------|--------|
| `build/npm/install.js` | AGENT_DIRS 末尾追加 `.hermes/skills` |
| `scripts/install.sh` | for-in 列表末尾追加 `.hermes/skills` |
| `scripts/install.ps1` | `$AgentDirs` 数组末尾追加 `.hermes\skills` |
| `scripts/install-skills.sh` | for-in 列表末尾追加 `.hermes/skills` |

## Why this is safe

4 个安装脚本都有同一段 **父目录守卫（parent-directory gate）** 逻辑：除第一个目录外，只有当 `~/.<agent>/` 父目录已存在时才会复制 skill。

```js
const parentGate = path.dirname(baseDir); // ~/.hermes
if (index > 0 && !fs.existsSync(parentGate)) {
  return; // 未安装 Hermes 的用户会被跳过，零副作用
}
```

- ✅ **已安装 Hermes 的用户**：自动获得 `~/.hermes/skills/dws`
- ✅ **未安装 Hermes 的用户**：父目录不存在则跳过，不会创建任何空目录
- ✅ **零回归**：纯增量修改

## Self-test

| File | Command | Result |
|------|---------|--------|
| `scripts/install.sh` | `sh -n` | ✅ |
| `scripts/install-skills.sh` | `sh -n` | ✅ |
| `build/npm/install.js` | `node --check` | ✅ |
| `scripts/install.ps1` | 本机无 `pwsh`，做了 diff 与原数组风格一致性核对 | ✅ |

> 建议 maintainer 在已安装 Hermes 的环境跑一次 `curl … install-skills.sh | sh` 做端到端验证。

## Follow-up（不在本 PR 范围）

Issue 评论区 @skywalker-35 提出了 **"中央目录 + 软链/Junction"** 的方案，可以根本性解决"每加一个 Agent 都要改 4 份脚本"的问题。该方案涉及跨平台符号链接语义、覆盖更新策略、CLI 选项设计等，建议作为独立 issue 跟进，避免本 bug 修复被放大成大重构。
