### PR TITLE
fix(compat): json-parse object/array-of-object schema flags (#222)

### DIFF
--- a/internal/compat/dynamic_commands.go
+++ b/internal/compat/dynamic_commands.go
@@ -275,11 +275,19 @@ type toolRequestSchema struct {
 }
 
 type toolRequestProp struct {
-	Type        string `json:"type"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Default     string `json:"default,omitempty"`
+	Type        string           `json:"type"`
+	Title       string           `json:"title"`
+	Description string           `json:"description"`
+	Default     string           `json:"default,omitempty"`
+	Items       *toolRequestProp `json:"items,omitempty"`
 }
+
+// schemaJSONParseAnnotation marks a schema-derived flag whose CLI string value
+// should be parsed into a structured object/array (via transformJSONParse) before
+// being forwarded as an MCP tool param. Set when the JSON Schema declares
+// `type: object` or `type: array` of object items — the upstream tool expects
+// a nested value, not a serialized JSON string.
+const schemaJSONParseAnnotation = "dws-schema-json-parse"
 
 // buildFlagsFromDetailSchema adds properly-typed cobra flags to cmd based on
 // the MCP toolRequest JSON Schema. The flagOverrides map (from CLIToolOverride.Flags)
@@ -357,8 +365,25 @@ func buildFlagsFromDetailSchema(cmd *cobra.Command, schemaJSON string, flagOverr
 		case "boolean":
 			cmd.Flags().Bool(flagName, false, help)
 		case "array":
-			cmd.Flags().StringSlice(flagName, nil, help+" (comma-separated)")
-		default: // "string", "object", or unknown → string
+			// Comma-separated StringSlice works for primitive items, but
+			// arrays of objects need full JSON input (e.g. table create
+			// --fields '[{...}]'). Register a String flag and tag it for
+			// json_parse so the structured payload survives the trip.
+			if prop.Items != nil && (prop.Items.Type == "object" || prop.Items.Type == "array") {
+				cmd.Flags().String(flagName, "", help+" (JSON array)")
+				_ = cmd.Flags().SetAnnotation(flagName, schemaJSONParseAnnotation, []string{"true"})
+			} else {
+				cmd.Flags().StringSlice(flagName, nil, help+" (comma-separated)")
+			}
+		case "object":
+			// Nested-object payloads (chart config, layout, etc.) must be
+			// parsed into a Go map before reaching the MCP transport.
+			// Otherwise upstream sees a raw JSON string and best-effort
+			// re-parses it (yaml.safe_load → str()), which mangles bool
+			// fields into "True"/"False" — see issue #222.
+			cmd.Flags().String(flagName, prop.Default, help+" (JSON object)")
+			_ = cmd.Flags().SetAnnotation(flagName, schemaJSONParseAnnotation, []string{"true"})
+		default: // "string" or unknown → string
 			defaultVal := prop.Default
 			cmd.Flags().String(flagName, defaultVal, help)
 		}

--- a/internal/compat/dynamic_commands_test.go
+++ b/internal/compat/dynamic_commands_test.go
@@ -744,6 +744,116 @@ func TestBuildDynamicCommands_OverlayFlagWinsOverDetailSchema(t *testing.T) {
 	}
 }
 
+// TestBuildDynamicCommands_ObjectSchemaPreservesTypes is the regression test
+// for issue #222: when the Detail API schema declares a field as `type:
+// object`, the user's --flag JSON string must reach the MCP as a structured
+// map with original types, not as a serialized string. Otherwise upstream
+// best-effort re-parses it and bool/number fields get mangled (e.g. true →
+// "True"). Same constraint applies to arrays of object items.
+func TestBuildDynamicCommands_ObjectSchemaPreservesTypes(t *testing.T) {
+	t.Parallel()
+
+	runner := &captureRunner{}
+	servers := []market.ServerDescriptor{
+		{
+			Endpoint: "https://endpoint-aitable",
+			CLI: market.CLIOverlay{
+				ID:      "aitable",
+				Command: "aitable",
+				ToolOverrides: map[string]market.CLIToolOverride{
+					"create_chart": {CLIName: "chart-create"},
+				},
+			},
+		},
+	}
+	details := map[string][]market.DetailTool{
+		"aitable": {
+			{
+				ToolName: "create_chart",
+				ToolRequest: `{"properties":{` +
+					`"baseId":{"type":"string"},` +
+					`"config":{"type":"object","description":"Chart config"},` +
+					`"layout":{"type":"object","description":"Chart layout"},` +
+					`"rows":{"type":"array","items":{"type":"object"},"description":"Object rows"}` +
+					`}}`,
+			},
+		},
+	}
+
+	cmds := BuildDynamicCommands(servers, runner, details)
+	leaf := findChild(cmds[0], "chart-create")
+	if leaf == nil {
+		t.Fatal("chart-create leaf not found")
+	}
+
+	configFlag := leaf.Flags().Lookup("config")
+	if configFlag == nil {
+		t.Fatal("--config flag missing")
+	}
+	if configFlag.Value.Type() != "string" {
+		t.Errorf("--config Value.Type() = %q, want string (object types stay as JSON-string flag)", configFlag.Value.Type())
+	}
+	if !needsSchemaJSONParse(configFlag) {
+		t.Errorf("--config should carry schemaJSONParseAnnotation, annotations=%v", configFlag.Annotations)
+	}
+
+	layoutFlag := leaf.Flags().Lookup("layout")
+	if !needsSchemaJSONParse(layoutFlag) {
+		t.Errorf("--layout should carry schemaJSONParseAnnotation, annotations=%v", layoutFlag.Annotations)
+	}
+
+	rowsFlag := leaf.Flags().Lookup("rows")
+	if rowsFlag == nil {
+		t.Fatal("--rows flag missing")
+	}
+	if rowsFlag.Value.Type() != "string" {
+		t.Errorf("--rows (array of object) Value.Type() = %q, want string", rowsFlag.Value.Type())
+	}
+	if !needsSchemaJSONParse(rowsFlag) {
+		t.Errorf("--rows should carry schemaJSONParseAnnotation, annotations=%v", rowsFlag.Annotations)
+	}
+
+	cmds[0].SetArgs([]string{
+		"chart-create",
+		"--base-id", "BASE_ID",
+		"--config", `{"chartType":"SUMMARY","numberFormat":{"digits":0,"thousandSeparator":true}}`,
+		"--layout", `{"x":0,"y":0,"w":3,"h":3}`,
+		"--rows", `[{"fieldName":"name","type":"text"}]`,
+	})
+	cmds[0].SilenceErrors = true
+	cmds[0].SilenceUsage = true
+	if err := cmds[0].Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if runner.lastTool != "create_chart" {
+		t.Fatalf("captured tool = %q, want create_chart", runner.lastTool)
+	}
+
+	cfg, ok := runner.lastParams["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("config param = %T (%v), want map[string]any (proves issue #222 fix)", runner.lastParams["config"], runner.lastParams["config"])
+	}
+	nf, ok := cfg["numberFormat"].(map[string]any)
+	if !ok {
+		t.Fatalf("numberFormat = %T, want map[string]any", cfg["numberFormat"])
+	}
+	if got := nf["thousandSeparator"]; got != true {
+		t.Errorf("thousandSeparator = %v (%T), want true (bool) — regression of issue #222", got, got)
+	}
+
+	if _, ok := runner.lastParams["layout"].(map[string]any); !ok {
+		t.Fatalf("layout param = %T, want map[string]any", runner.lastParams["layout"])
+	}
+	rows, ok := runner.lastParams["rows"].([]any)
+	if !ok {
+		t.Fatalf("rows param = %T, want []any (array)", runner.lastParams["rows"])
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows len = %d, want 1", len(rows))
+	}
+}
+
 // Phase 5 P2 schema extensions ----------------------------------------------
 
 // TestBuildDynamicCommands_BodyWrapper verifies that bodyWrapper wraps all

--- a/internal/compat/registry.go
+++ b/internal/compat/registry.go
@@ -246,7 +246,9 @@ func NewDirectCommand(route Route, runner executor.Runner) *cobra.Command {
 
 			// Collect schema-derived flags (from buildFlagsFromDetailSchema)
 			// that are not covered by explicit bindings.
-			collectSchemaFlags(cmd, route.Bindings, params)
+			if err := collectSchemaFlags(cmd, route.Bindings, params); err != nil {
+				return err
+			}
 
 			// Required-presence check for positional bindings — must run after
 			// both flag (CollectBindings) and positional (collectPositionalBindings)
@@ -617,7 +619,13 @@ func validateRequiredPositionalBindings(cmd *cobra.Command, bindings []FlagBindi
 // collectSchemaFlags picks up flags created by buildFlagsFromDetailSchema that
 // have no explicit FlagBinding. This bridges the gap for plugin-defined tools
 // whose parameters come from the MCP inputSchema rather than CLIToolOverride.Flags.
-func collectSchemaFlags(cmd *cobra.Command, bindings []FlagBinding, params map[string]any) {
+//
+// Flags marked with the schemaJSONParseAnnotation (i.e. JSON Schema declared
+// `type: object` or `type: array` of object items) have their string value
+// parsed via ApplyTransform("json_parse", ...) before being stored. Without
+// this step, the upstream MCP would receive a serialized JSON string in a
+// field declared as object — see issue #222 for the symptoms.
+func collectSchemaFlags(cmd *cobra.Command, bindings []FlagBinding, params map[string]any) error {
 	// Build a set of flag names already covered by bindings.
 	bound := make(map[string]bool, len(bindings)*2)
 	for _, b := range bindings {
@@ -643,7 +651,11 @@ func collectSchemaFlags(cmd *cobra.Command, bindings []FlagBinding, params map[s
 		"client-id": true, "client-secret": true,
 	}
 
+	var visitErr error
 	cmd.Flags().Visit(func(f *pflag.Flag) {
+		if visitErr != nil {
+			return
+		}
 		if bound[f.Name] || skip[f.Name] {
 			return
 		}
@@ -669,11 +681,36 @@ func collectSchemaFlags(cmd *cobra.Command, bindings []FlagBinding, params map[s
 				params[paramName] = v
 			}
 		default:
-			if v, err := cmd.Flags().GetString(f.Name); err == nil {
-				params[paramName] = v
+			v, err := cmd.Flags().GetString(f.Name)
+			if err != nil {
+				return
 			}
+			if needsSchemaJSONParse(f) && strings.TrimSpace(v) != "" {
+				parsed, perr := ApplyTransform(v, "json_parse", nil)
+				if perr != nil {
+					visitErr = fmt.Errorf("--%s: %w", f.Name, perr)
+					return
+				}
+				params[paramName] = parsed
+				return
+			}
+			params[paramName] = v
 		}
 	})
+	return visitErr
+}
+
+// needsSchemaJSONParse reports whether a schema-derived flag was tagged for
+// JSON parsing because its declared type is object or array-of-object.
+func needsSchemaJSONParse(f *pflag.Flag) bool {
+	if f == nil || f.Annotations == nil {
+		return false
+	}
+	values, ok := f.Annotations[schemaJSONParseAnnotation]
+	if !ok || len(values) == 0 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(values[0]), "true")
 }
 
 // toOriginalParamName converts a kebab-case flag name back to the original

--- a/internal/compat/registry_test.go
+++ b/internal/compat/registry_test.go
@@ -230,7 +230,9 @@ func TestCollectSchemaFlagsPicksUpUnboundFlags(t *testing.T) {
 	_ = cmd.Flags().Set("loud", "true")
 
 	params := make(map[string]any)
-	collectSchemaFlags(cmd, nil, params)
+	if err := collectSchemaFlags(cmd, nil, params); err != nil {
+		t.Fatalf("collectSchemaFlags: %v", err)
+	}
 
 	if params["name"] != "Alice" {
 		t.Errorf("name = %v, want Alice", params["name"])
@@ -267,7 +269,9 @@ func TestCollectSchemaFlagsSkipsBoundFlags(t *testing.T) {
 	_ = cmd.Flags().Set("title", "Hello")
 
 	params := make(map[string]any)
-	collectSchemaFlags(cmd, bindings, params)
+	if err := collectSchemaFlags(cmd, bindings, params); err != nil {
+		t.Fatalf("collectSchemaFlags: %v", err)
+	}
 
 	// dept-id is bound, should NOT be collected by collectSchemaFlags
 	if _, exists := params["dept_id"]; exists {
@@ -276,6 +280,104 @@ func TestCollectSchemaFlagsSkipsBoundFlags(t *testing.T) {
 	// title is unbound, should be collected
 	if params["title"] != "Hello" {
 		t.Errorf("title = %v, want Hello", params["title"])
+	}
+}
+
+// TestCollectSchemaFlagsParsesObjectAndArrayJSON guards the fix for issue
+// #222: when a JSON Schema declares `type: object` (or array of object items),
+// the user-supplied --flag string must be parsed into a structured value
+// before being forwarded to the MCP. Otherwise upstream sees a serialized JSON
+// string and best-effort re-parses it, which mangles bool/number fields.
+func TestCollectSchemaFlagsParsesObjectAndArrayJSON(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("config", "", "Chart config (JSON object)")
+	if err := cmd.Flags().SetAnnotation("config", schemaJSONParseAnnotation, []string{"true"}); err != nil {
+		t.Fatalf("SetAnnotation config: %v", err)
+	}
+	cmd.Flags().String("layout", "", "Chart layout (JSON object)")
+	if err := cmd.Flags().SetAnnotation("layout", schemaJSONParseAnnotation, []string{"true"}); err != nil {
+		t.Fatalf("SetAnnotation layout: %v", err)
+	}
+	// Use "rows" not "fields" — the latter collides with the reserved
+	// global flag name (collectSchemaFlags skip list).
+	cmd.Flags().String("rows", "", "Rows (JSON array)")
+	if err := cmd.Flags().SetAnnotation("rows", schemaJSONParseAnnotation, []string{"true"}); err != nil {
+		t.Fatalf("SetAnnotation rows: %v", err)
+	}
+	cmd.Flags().String("name", "", "Plain string flag")
+
+	_ = cmd.Flags().Set("config", `{"chartType":"SUMMARY","numberFormat":{"digits":0,"thousandSeparator":true}}`)
+	_ = cmd.Flags().Set("layout", `{"x":0,"y":0,"w":3,"h":3}`)
+	_ = cmd.Flags().Set("rows", `[{"fieldName":"name","type":"text"}]`)
+	_ = cmd.Flags().Set("name", "测试")
+
+	params := make(map[string]any)
+	if err := collectSchemaFlags(cmd, nil, params); err != nil {
+		t.Fatalf("collectSchemaFlags: %v", err)
+	}
+
+	cfg, ok := params["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("config should be parsed object, got %T (%v)", params["config"], params["config"])
+	}
+	nf, ok := cfg["numberFormat"].(map[string]any)
+	if !ok {
+		t.Fatalf("numberFormat should be parsed object, got %T", cfg["numberFormat"])
+	}
+	if got := nf["thousandSeparator"]; got != true {
+		t.Errorf("thousandSeparator = %v (%T), want true (bool)", got, got)
+	}
+	if got, ok := nf["digits"].(float64); !ok || got != 0 {
+		t.Errorf("digits = %v (%T), want 0 (number)", nf["digits"], nf["digits"])
+	}
+
+	layout, ok := params["layout"].(map[string]any)
+	if !ok {
+		t.Fatalf("layout should be parsed object, got %T", params["layout"])
+	}
+	if got, ok := layout["w"].(float64); !ok || got != 3 {
+		t.Errorf("layout.w = %v (%T), want 3 (number)", layout["w"], layout["w"])
+	}
+
+	rows, ok := params["rows"].([]any)
+	if !ok {
+		t.Fatalf("rows should be parsed array, got %T", params["rows"])
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows len = %d, want 1", len(rows))
+	}
+	first, ok := rows[0].(map[string]any)
+	if !ok {
+		t.Fatalf("rows[0] should be object, got %T", rows[0])
+	}
+	if first["type"] != "text" {
+		t.Errorf("rows[0].type = %v, want text", first["type"])
+	}
+
+	if params["name"] != "测试" {
+		t.Errorf("name = %v, want 测试 (plain string flag should not be parsed)", params["name"])
+	}
+}
+
+// TestCollectSchemaFlagsReportsBadJSON ensures the fix for #222 doesn't
+// silently swallow malformed input — invalid JSON for an object-typed flag
+// should surface as a validation error to the caller.
+func TestCollectSchemaFlagsReportsBadJSON(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("config", "", "Chart config")
+	if err := cmd.Flags().SetAnnotation("config", schemaJSONParseAnnotation, []string{"true"}); err != nil {
+		t.Fatalf("SetAnnotation: %v", err)
+	}
+	_ = cmd.Flags().Set("config", "not-json-not-yaml: }{")
+
+	params := make(map[string]any)
+	err := collectSchemaFlags(cmd, nil, params)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
 	}
 }
 
@@ -298,7 +400,9 @@ func TestCollectSchemaFlagsSkipsGlobalFlags(t *testing.T) {
 	_ = cmd.Flags().Set("format", "table")
 
 	params := make(map[string]any)
-	collectSchemaFlags(cmd, nil, params)
+	if err := collectSchemaFlags(cmd, nil, params); err != nil {
+		t.Fatalf("collectSchemaFlags: %v", err)
+	}
 
 	if params["name"] != "Bob" {
 		t.Errorf("name = %v, want Bob", params["name"])


### PR DESCRIPTION
## Summary

- 修复 issue #222：`dws aitable chart create --config '{...}'` 把 JSON 里的 number/bool 序列化成字符串（`true → "True"`, `0 → "0"`），且 `chart update` 整体 silent no-op。
- 根因：`internal/compat/dynamic_commands.go` 的 schema-to-flag 映射没有 `case "object"` 分支，object 类型字段被注册为普通 string flag，原始 JSON 字符串透传给上游 MCP；上游用 `yaml.safe_load` + `str()` 兜底解析 → bool 字段变成 Python `"True"`。
- 修复：在 schema 派生的 object / array-of-object flag 上打 `dws-schema-json-parse` 注解，`collectSchemaFlags` 读取该注解时调用 `transformJSONParse` 把字符串反序列化成结构化 map / 数组后再塞进 invocation params。

## Test plan
- [x] `go test ./internal/compat/... -run "TestCollectSchemaFlags|TestBuildDynamicCommands_ObjectSchema" -v` 全绿
- [x] `go test ./internal/compat/...` 全绿（不破坏既有测试）
- [x] 新增 unit test `TestCollectSchemaFlagsParsesObjectAndArrayJSON`：直接驱动 `collectSchemaFlags`，验证 object / array-of-object / plain-string 三类 flag 行为
- [x] 新增 unit test `TestCollectSchemaFlagsReportsBadJSON`：恶意 JSON 输入要返回 error，不能静默吞掉
- [x] 新增 end-to-end test `TestBuildDynamicCommands_ObjectSchemaPreservesTypes`：模拟 issue #222 报告的 chart create 路径，captureRunner 拦截最终 invocation params，断言 `config.numberFormat.thousandSeparator` 是 Go `bool(true)` 而不是字符串
- [ ] 等 reporter (@RandallLu) 在 issue #222 复现命令验证 Bug 1 已修
- [ ] Bug 2 (`chart update` silent no-op) 跟踪：本 PR 修完 Bug 1 后请 reporter 重跑 update 复现，如仍 silent no-op 需联系上游 aitable MCP server 团队

## 设计选择

- **覆盖面控制**：注解只挂在 schema 派生的、且没有显式 overlay binding/transform 的 flag 上。已经声明 `transform: json_parse` 的 overlay 不受影响。
- **错误透传**：`collectSchemaFlags` 改成返回 `error`，恶意 JSON 输入不再被静默丢弃。调用点 `compat/registry.go` 已 plumb 通。
- **array 区分**：`array` 字段保持 StringSlice 行为；只有 `items.type == object/array` 的复合数组才走 String + json_parse。

## 关联

- 修复 #222
- 不影响：`internal/helpers/aitable_commands.go` 里手写的 `--fields` parse（走自己的 `parseAitableFieldsJSON`，不经过 `collectSchemaFlags`）