### PR TITLE
fix: honour HTTP_PROXY/HTTPS_PROXY in custom HTTP transports (#236)

### DIFF
--- a/internal/apiclient/client.go
+++ b/internal/apiclient/client.go
@@ -210,6 +210,8 @@ func NormalisePath(path, baseURL string) string {
 // defaultTransport returns a tuned http.Transport matching the project conventions.
 func defaultTransport() *http.Transport {
 	return &http.Transport{
+		// Honour HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars (#236).
+		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   3 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/internal/apiclient/proxy_env_test.go
+++ b/internal/apiclient/proxy_env_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiclient
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+// TestDefaultTransportHonoursHTTPProxyEnv is the regression guard for #236
+// on the apiclient transport. Same rationale as transport/proxy_env_test.go:
+// a custom Transport without an explicit Proxy field silently bypasses
+// HTTP_PROXY/HTTPS_PROXY.
+//
+// We pointer-compare against http.ProxyFromEnvironment instead of invoking
+// it, because http.ProxyFromEnvironment memoises the env on first call;
+// other tests that read proxy env early would make a value-based assertion
+// flaky.
+func TestDefaultTransportHonoursHTTPProxyEnv(t *testing.T) {
+	t.Parallel()
+
+	tr := defaultTransport()
+	if tr.Proxy == nil {
+		t.Fatal("defaultTransport().Proxy is nil — HTTP_PROXY env will be ignored (regression of #236)")
+	}
+	wantPC := reflect.ValueOf(http.ProxyFromEnvironment).Pointer()
+	gotPC := reflect.ValueOf(tr.Proxy).Pointer()
+	if gotPC != wantPC {
+		t.Errorf("defaultTransport().Proxy is not http.ProxyFromEnvironment — env-var proxy may not be honoured (regression of #236)")
+	}
+}

--- a/internal/app/legacy.go
+++ b/internal/app/legacy.go
@@ -464,6 +464,8 @@ func ipv4HTTPClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Timeout: timeout,
 		Transport: &http.Transport{
+			// Honour HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars (#236).
+			Proxy: http.ProxyFromEnvironment,
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 				return dialer.DialContext(ctx, "tcp4", addr)
 			},

--- a/internal/app/proxy_env_test.go
+++ b/internal/app/proxy_env_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// TestIPv4HTTPClientHonoursHTTPProxyEnv guards the fix for #236 on the
+// IPv4-forcing client used by the legacy registry / discovery path. The
+// custom Transport overrides DialContext to force IPv4 — without an
+// explicit Proxy field it would also drop env-var proxy support.
+//
+// We can't reliably invoke tr.Proxy(req) here because http.ProxyFromEnvironment
+// memoises the env vars on first call (Go's envProxyOnce); ordering with other
+// tests that read proxy env early would make this flaky. Asserting that the
+// Transport's Proxy func points at http.ProxyFromEnvironment is sufficient to
+// catch the regression — the runtime takes care of reading HTTP_PROXY/HTTPS_PROXY
+// at process boot.
+func TestIPv4HTTPClientHonoursHTTPProxyEnv(t *testing.T) {
+	t.Parallel()
+
+	client := ipv4HTTPClient(5 * time.Second)
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("ipv4HTTPClient transport is %T, want *http.Transport", client.Transport)
+	}
+	if tr.Proxy == nil {
+		t.Fatal("ipv4HTTPClient transport.Proxy is nil — HTTP_PROXY env will be ignored (regression of #236)")
+	}
+	wantPC := reflect.ValueOf(http.ProxyFromEnvironment).Pointer()
+	gotPC := reflect.ValueOf(tr.Proxy).Pointer()
+	if gotPC != wantPC {
+		t.Errorf("ipv4HTTPClient transport.Proxy is not http.ProxyFromEnvironment — env-var proxy may not be honoured (regression of #236)")
+	}
+}

--- a/internal/transport/client.go
+++ b/internal/transport/client.go
@@ -211,6 +211,11 @@ func (r *ToolCallResult) UnmarshalJSON(data []byte) error {
 // "accepted but never responded" servers faster, and explicit TLS/dial timeouts.
 func defaultTransport() *http.Transport {
 	return &http.Transport{
+		// Honour HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars; a custom
+		// Transport without an explicit Proxy field would otherwise bypass
+		// proxies entirely, which breaks sandboxed/air-gapped deployments
+		// that rely on an outbound proxy (#236).
+		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   3 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/internal/transport/proxy_env_test.go
+++ b/internal/transport/proxy_env_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+// TestDefaultTransportHonoursHTTPProxyEnv guards the fix for issue #236:
+// the MCP HTTP transport must honour HTTP_PROXY / HTTPS_PROXY env vars.
+// A custom Transport built without an explicit Proxy field defaults to
+// "no proxy" — sandboxed deployments behind an outbound proxy would then
+// silently bypass the proxy and fail.
+//
+// We assert tr.Proxy points at http.ProxyFromEnvironment rather than invoking
+// it, because http.ProxyFromEnvironment memoises env on first call (Go's
+// envProxyOnce). Test ordering with anything else that reads proxy env early
+// would make a value-based assertion flaky. The runtime reads env at process
+// boot — pointing at the stdlib resolver is the contract we need.
+func TestDefaultTransportHonoursHTTPProxyEnv(t *testing.T) {
+	t.Parallel()
+
+	tr := defaultTransport()
+	if tr.Proxy == nil {
+		t.Fatal("defaultTransport().Proxy is nil — HTTP_PROXY/HTTPS_PROXY env will be ignored (regression of #236)")
+	}
+	wantPC := reflect.ValueOf(http.ProxyFromEnvironment).Pointer()
+	gotPC := reflect.ValueOf(tr.Proxy).Pointer()
+	if gotPC != wantPC {
+		t.Errorf("defaultTransport().Proxy is not http.ProxyFromEnvironment — env-var proxy may not be honoured (regression of #236)")
+	}
+}


### PR DESCRIPTION
## Summary

修复 issue #236：DWS CLI 自定义的 HTTP transport 漏写 `Proxy` 字段，按 Go `net/http` 的契约这等于"永远不走代理"，沙盒/隔离环境用户配了 `HTTP_PROXY` / `HTTPS_PROXY` 也不生效。

涉及三处 transport，全部补上 `Proxy: http.ProxyFromEnvironment`：

| 位置 | 用途 |
|------|------|
| `internal/transport/client.go` 的 `defaultTransport()` | MCP JSON-RPC 主链路 |
| `internal/apiclient/client.go` 的 `defaultTransport()` | `dws api` 直连 DingTalk OpenAPI |
| `internal/app/legacy.go` 的 `ipv4HTTPClient()` | 强制 IPv4 的服务发现/registry 客户端 |

## Test plan
- [x] 每个 transport 加一个 regression test，pointer-compare `tr.Proxy` 与 `http.ProxyFromEnvironment`（不直接调用，避开 Go `envProxyOnce` 的全局 memoise 带来的测试间相互污染）
- [x] 在 main HEAD（无 fix）跑这三个 test，全部 FAIL 并打印 `Proxy is nil — HTTP_PROXY env will be ignored (regression of #236)`
- [x] 应用 fix 后三个 test 全部 PASS
- [x] `go test ./internal/transport/ ./internal/apiclient/ ./internal/app/` 整包绿
- [x] 不改公共行为：未配置 proxy env 的用户无感，配置了的用户走代理

## 注意

`http.ProxyFromEnvironment` 内部使用 `envProxyOnce.Do` 缓存第一次读到的 env 值，因此 PR 修复的是"创建 transport 时绑定到 env 解析器"，不是"每次请求重读 env"——后者也不是 Go 标准做法。这与社区主流网络库（gRPC、CockroachDB、Kubernetes 等）保持一致。