### PR TITLE
docs(auth): correct login help to reflect actual default + SSH guidance (#226)

### DIFF
--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -68,16 +68,21 @@ func newAuthLoginCommand() *cobra.Command {
 		Long: `登录钉钉并获取认证凭证。
 
 支持的登录方式:
-  - OAuth 设备流 (默认): 通过钉钉扫码授权登录
-  - 直接提供 Token: 通过 --token 参数传入已有 token
+  - OAuth Loopback 流 (默认): 本机自动起 127.0.0.1 监听接收回调，浏览器授权后自动完成
+  - OAuth 设备流 (--device): 显示 user_code + 短 URL，适合 SSH 远程 / 容器 / 无头环境
+  - 直接提供 Token (--token): 跳过授权，使用已有 token
 
 不支持的登录方式:
   - 邮箱/密码登录
   - 手机号/验证码登录
   - 应用凭证 (AppKey/AppSecret) 直接登录
 
+⚠️  SSH 远程或无头环境（无本地浏览器可访问远端的 127.0.0.1）请使用 --device，
+    否则 OAuth 回调会跳到本机不可达的 127.0.0.1 链接，授权完成后无法回写 token。
+
 示例:
-  dws auth login              # 扫码登录
+  dws auth login              # 本机扫码登录 (loopback 流)
+  dws auth login --device     # SSH 远程 / 无头环境登录 (设备流)
   dws auth login --force      # 强制重新登录 (忽略缓存 token)
   dws auth login --token xxx  # 使用指定 token`,
 		DisableAutoGenTag: true,

--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -77,8 +77,8 @@ func newAuthLoginCommand() *cobra.Command {
   - 手机号/验证码登录
   - 应用凭证 (AppKey/AppSecret) 直接登录
 
-⚠️  SSH 远程或无头环境（无本地浏览器可访问远端的 127.0.0.1）请使用 --device，
-    否则 OAuth 回调会跳到本机不可达的 127.0.0.1 链接，授权完成后无法回写 token。
+注意: SSH 远程或无头环境（无本地浏览器可访问远端的 127.0.0.1）请使用 --device，
+      否则 OAuth 回调会跳到本机不可达的 127.0.0.1 链接，授权完成后无法回写 token。
 
 示例:
   dws auth login              # 本机扫码登录 (loopback 流)

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -120,8 +120,8 @@ func flagErrorWithSuggestions(cmd *cobra.Command, err error) error {
 	// Common flag aliases and suggestions
 	suggestions := map[string]string{
 		"--json":        "提示: 请使用 --format json 或 -f json 来输出 JSON 格式",
-		"--method":      "提示: dws auth login 默认使用 OAuth 设备流登录，无需指定 --method",
-		"--device-flow": "提示: dws auth login 默认已使用设备流，无需 --device-flow 参数",
+		"--method":      "提示: dws auth login 默认使用 OAuth loopback 流；SSH/无头环境请加 --device 走设备流",
+		"--device-flow": "提示: 设备流的标志名是 --device（不是 --device-flow），SSH/无头环境登录请用 dws auth login --device",
 		"--email":       "提示: dws 不支持邮箱/密码登录，请使用 dws auth login 进行扫码登录",
 		"--code":        "提示: dws 不支持验证码登录，请使用 dws auth login 进行扫码登录",
 		"--corp-id":     "提示: corp-id 会在登录时自动获取，无需手动指定",


### PR DESCRIPTION
## Summary

修复 #226：SSH 远程登录用户被 `dws auth login --help` 文档误导。

文档原文写"OAuth 设备流 (默认)"，但实际代码默认起 `127.0.0.1:0` loopback 监听（`internal/auth/oauth_provider.go:131-136`），`--device` 才走真正的设备流。SSH 进无头 Linux 的用户照文档跑默认 `dws auth login`，授权回调跳到远端 `127.0.0.1` 本地浏览器连不上，登录无法完成。

## 改动

- `internal/app/auth_command.go`：`Long` 描述按实际行为重写
  - OAuth Loopback 流（默认）：本机自动起 127.0.0.1 监听
  - OAuth 设备流（`--device`）：显示 user_code + 短 URL，适合 SSH/容器/无头
  - 直接提供 Token（`--token`）
  - 加一段 ⚠️ 警示：SSH 远程或无头环境必须用 `--device`
  - 示例里加 `dws auth login --device`
- `internal/app/root.go`：两条 typo-suggestion 字符串 (`--method` / `--device-flow`) 跟着改，把"默认使用设备流"的错误说法改成"默认 loopback / SSH 加 --device"

## 不改的

- 默认登录行为：保持 loopback（issue 里 P2 提的"默认改设备流"风险大、影响所有现有用户，需要单独评估）
- 自动检测 SSH 环境降级（issue 里 P1）：本 PR 不做，后续可独立 issue

## Test plan
- [x] `go build ./...` 通过
- [x] `go test ./internal/app/` 通过
- [x] 本地 `dws auth login --help` 渲染正确，文案准确
- [x] 无行为变更，所有现有 unit/integration 测试无需修改