### PR TITLE
docs(changelog): add 1.0.23 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and this project follows [Semantic Versioning](https://semver.org/).
 
+## [1.0.23] - 2026-05-08
+
+A single fix for HTTP proxy support across the CLI's custom HTTP transports. No behaviour changes elsewhere.
+
+### Fixed
+
+- **`HTTP_PROXY` / `HTTPS_PROXY` environment variables silently ignored by all custom transports** (#237, fixes #236) — the three custom `http.Transport` instances built by the CLI (`internal/transport/client.go` MCP transport, `internal/apiclient/client.go` DingTalk OpenAPI client, `internal/app/legacy.go` IPv4-forcing registry client) all set `DialContext` / `TLSClientConfig` / timeouts but omitted the `Proxy` field. Per Go's `net/http` contract, a non-nil Transport without an explicit `Proxy` means "no proxy" — env vars are silently ignored, breaking sandboxed or air-gapped deployments that route outbound through `HTTP_PROXY` / `HTTPS_PROXY`. All three transports now set `Proxy: http.ProxyFromEnvironment`.
+
+### Tests
+
+- Per-package regression test that pointer-compares the Transport's `Proxy` func against `http.ProxyFromEnvironment`, avoiding flakiness from Go's `envProxyOnce` memoisation when running alongside tests that read proxy env early. (#237)
+
 ## [1.0.22] - 2026-05-07
 
 Two release-blocking bug fixes: `dws attendance summary` now exposes the server-required `--stats-type` flag (without it, every call returned C0002), and the install scripts finally populate `~/.hermes/skills/dws/` for users who already have Hermes.


### PR DESCRIPTION
## Summary

补 v1.0.23 的 CHANGELOG 章节。tag `v1.0.23` 已于 2026-05-08 推送，GoReleaser / npm publish 均已成功，但 CHANGELOG.md 仍停在 1.0.22。本 PR 单独 backfill 一个章节，沿用 #231 的格式。

## Changes

| Version | Date | 内容来源 |
|---------|------|----------|
| 1.0.23 | 2026-05-08 | PR #237（`HTTP_PROXY` / `HTTPS_PROXY` 在 3 处 custom `http.Transport` 静默失效，fixes #236） |

narrative 与 #237 commit message / GitHub Release body 对齐，沿用 1.0.22 的小节顺序（Fixed / Tests）。

## Verification

- 纯文档改动，单文件 +12 行，0 删除
- 1.0.22 及之前章节未动
- 不影响构建 / 测试 / release 流程