### PR TITLE
fix(pat): preserve auth link on Windows browser open

### DIFF
--- a/internal/app/pat_auth_retry.go
+++ b/internal/app/pat_auth_retry.go
@@ -718,17 +718,23 @@ func pollPatDeviceFlow(ctx context.Context, flowID string, configDir string, out
 	}
 }
 
-// tryOpenBrowser opens url in the default browser; errors are silently ignored.
-func tryOpenBrowser(url string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
+func browserOpenCommand(goos, rawURL string) *exec.Cmd {
+	switch goos {
 	case "darwin":
-		cmd = exec.Command("open", url)
+		return exec.Command("open", rawURL)
 	case "linux":
-		cmd = exec.Command("xdg-open", url)
+		return exec.Command("xdg-open", rawURL)
 	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", url)
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL)
 	default:
+		return nil
+	}
+}
+
+// tryOpenBrowser opens rawURL in the default browser; errors are silently ignored.
+func tryOpenBrowser(rawURL string) error {
+	cmd := browserOpenCommand(runtime.GOOS, rawURL)
+	if cmd == nil {
 		return nil
 	}
 	return cmd.Start()

--- a/internal/app/pat_auth_retry.go
+++ b/internal/app/pat_auth_retry.go
@@ -224,6 +224,9 @@ func enrichPATErrorWithOpenBrowser(raw string, openBrowser bool) string {
 		data = map[string]any{}
 		payload["data"] = data
 	}
+	if rawURI, ok := data["uri"].(string); ok && strings.TrimSpace(rawURI) != "" {
+		data["authorizationUrl"] = apperrors.PATAuthorizationURL(rawURI)
+	}
 	data["openBrowser"] = openBrowser
 
 	encoded, err := json.Marshal(payload)
@@ -359,10 +362,10 @@ func openPATAuthorizationURI(rawURI string) error {
 		return nil
 	}
 	// The PAT service returns the complete authorization URL. Treat it as an
-	// opaque string and open it verbatim instead of parsing/rebuilding it
-	// locally, because required parameters may live in query, hash, or
-	// fragment sections.
-	return openBrowserFunc(rawURI)
+	// opaque string unless it is the known legacy DingTalk hash-route variant.
+	// That variant is normalized by the PAT error contract helper while still
+	// preserving the original data.uri in structured output.
+	return openBrowserFunc(apperrors.PATAuthorizationURL(rawURI))
 }
 
 func printPATPollDebugResponse(output io.Writer, statusCode int, body []byte) {
@@ -457,7 +460,7 @@ func handlePatAuthCheck(
 
 	if wantsStructuredPATOutput(r) {
 		if openBrowser && patData.Data.URI != "" {
-			_ = openBrowserFunc(patData.Data.URI)
+			_ = openPATAuthorizationURI(patData.Data.URI)
 		}
 		return executor.Result{}, &apperrors.PATError{RawJSON: enrichPATErrorWithOpenBrowser(patErr.RawJSON, openBrowser)}
 	}
@@ -475,9 +478,11 @@ func handlePatAuthCheck(
 		fmt.Fprintf(output, "  %s %s\n", dim("ℹ"), patData.Data.Desc)
 	}
 	if patData.Data.URI != "" {
-		fmt.Fprintf(output, "  %s %s\n\n", dim("🔗"), cyan(patData.Data.URI))
+		authURL := apperrors.PATAuthorizationURL(patData.Data.URI)
+		fmt.Fprintf(output, "  %s 授权链接: %s\n", dim("🔗"), cyan(authURL))
+		fmt.Fprintf(output, "  PAT_AUTHORIZATION_URL=%s\n\n", authURL)
 		if openBrowser {
-			_ = openPATAuthorizationURI(patData.Data.URI)
+			_ = openPATAuthorizationURI(authURL)
 		}
 	}
 

--- a/internal/app/pat_auth_retry_test.go
+++ b/internal/app/pat_auth_retry_test.go
@@ -903,7 +903,8 @@ func TestHandlePatAuthCheck_JSONModeCanOpenBrowserWithoutTextOutput(t *testing.T
 		fallback:    mock,
 		globalFlags: &GlobalFlags{Format: "json"},
 	}
-	raw := `{"code":"AGENT_CODE_NOT_EXISTS","data":{"desc":"test auth","flowId":"flow-json","uri":"https://example.com/pat","clientId":"test-client-id"}}`
+	rawURI := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3Df72437f040f04a8295988ff71e690b35%26userCode%3D98JV-JSBL#/personalAuthorization?flowId=f72437f040f04a8295988ff71e690b35&userCode=98JV-JSBL"
+	raw := `{"code":"AGENT_CODE_NOT_EXISTS","data":{"desc":"test auth","flowId":"flow-json","uri":"` + rawURI + `","clientId":"test-client-id"}}`
 
 	var buf bytes.Buffer
 	_, err := handlePatAuthCheck(context.Background(), runner, executor.Invocation{
@@ -920,8 +921,23 @@ func TestHandlePatAuthCheck_JSONModeCanOpenBrowserWithoutTextOutput(t *testing.T
 	if _, err := os.Stat(filepath.Join(tmpDir, "app.json")); !os.IsNotExist(err) {
 		t.Fatalf("json PAT mode must not persist shared app.json, stat error = %v", err)
 	}
-	if opened != "https://example.com/pat" {
-		t.Fatalf("opened url = %q, want https://example.com/pat", opened)
+	if opened != rawURI {
+		t.Fatalf("opened url = %q, want verbatim %q", opened, rawURI)
+	}
+	patOut, ok := err.(*apperrors.PATError)
+	if !ok {
+		t.Fatalf("expected *PATError, got %T: %v", err, err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(patOut.RawJSON), &payload); err != nil {
+		t.Fatalf("json.Unmarshal(json PAT payload) error = %v\nraw=%s", err, patOut.RawJSON)
+	}
+	data, _ := payload["data"].(map[string]any)
+	if got, _ := data["uri"].(string); got != rawURI {
+		t.Fatalf("data.uri = %q, want verbatim %q", got, rawURI)
+	}
+	if got, ok := data["openBrowser"].(bool); !ok || !got {
+		t.Fatalf("data.openBrowser = %#v, want true", data["openBrowser"])
 	}
 }
 
@@ -1188,5 +1204,30 @@ func TestHandlePatAuthCheck_OpensOpaqueURIWithoutRebuild(t *testing.T) {
 	}
 	if opened != rawURI {
 		t.Fatalf("opened url = %q, want verbatim %q", opened, rawURI)
+	}
+}
+
+func TestBrowserOpenCommand_WindowsPreservesOpaquePATURI(t *testing.T) {
+	t.Parallel()
+
+	rawURI := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3Df72437f040f04a8295988ff71e690b35%26userCode%3D98JV-JSBL#/personalAuthorization?flowId=f72437f040f04a8295988ff71e690b35&userCode=98JV-JSBL"
+	cmd := browserOpenCommand("windows", rawURI)
+	if cmd == nil {
+		t.Fatal("browserOpenCommand(windows) returned nil")
+	}
+	if got := cmd.Args[0]; got == "cmd" {
+		t.Fatalf("windows browser opener must not route PAT URLs through cmd.exe: args=%v", cmd.Args)
+	}
+	if got := len(cmd.Args); got != 3 {
+		t.Fatalf("windows browser opener args length = %d, want 3: %v", got, cmd.Args)
+	}
+	if got := cmd.Args[0]; got != "rundll32" {
+		t.Fatalf("windows browser opener command = %q, want rundll32", got)
+	}
+	if got := cmd.Args[1]; got != "url.dll,FileProtocolHandler" {
+		t.Fatalf("windows browser opener handler = %q, want url.dll,FileProtocolHandler", got)
+	}
+	if got := cmd.Args[2]; got != rawURI {
+		t.Fatalf("windows browser opener URL arg = %q, want verbatim %q", got, rawURI)
 	}
 }

--- a/internal/app/pat_auth_retry_test.go
+++ b/internal/app/pat_auth_retry_test.go
@@ -936,6 +936,9 @@ func TestHandlePatAuthCheck_JSONModeCanOpenBrowserWithoutTextOutput(t *testing.T
 	if got, _ := data["uri"].(string); got != rawURI {
 		t.Fatalf("data.uri = %q, want verbatim %q", got, rawURI)
 	}
+	if got, _ := data["authorizationUrl"].(string); got != rawURI {
+		t.Fatalf("data.authorizationUrl = %q, want %q", got, rawURI)
+	}
 	if got, ok := data["openBrowser"].(bool); !ok || !got {
 		t.Fatalf("data.openBrowser = %#v, want true", data["openBrowser"])
 	}
@@ -1204,6 +1207,55 @@ func TestHandlePatAuthCheck_OpensOpaqueURIWithoutRebuild(t *testing.T) {
 	}
 	if opened != rawURI {
 		t.Fatalf("opened url = %q, want verbatim %q", opened, rawURI)
+	}
+	if got := buf.String(); !strings.Contains(got, "PAT_AUTHORIZATION_URL="+rawURI) {
+		t.Fatalf("output missing copy-safe PAT_AUTHORIZATION_URL line:\n%s", got)
+	}
+}
+
+func TestHandlePatAuthCheck_NormalizesLegacyHashRouteForBrowserAndOutput(t *testing.T) {
+	t.Setenv(authpkg.AgentCodeEnv, "")
+	server, configDir := setupHandlePATServer(t, "APPROVED", "test-auth-code")
+	defer server.Close()
+
+	rawURI := "https://open-dev.dingtalk.com/fe/old#%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN"
+	wantURL := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN#/personalAuthorization?flowId=56b12fd3201d4efab9a9138672cf4deb&userCode=CFTC-27ZN"
+	var opened string
+	origOpenBrowser := openBrowserFunc
+	openBrowserFunc = func(rawURL string) error {
+		opened = rawURL
+		return nil
+	}
+	t.Cleanup(func() { openBrowserFunc = origOpenBrowser })
+
+	var retryCalled bool
+	mock := &mockRunner{
+		runFunc: func(ctx context.Context, inv executor.Invocation) (executor.Result, error) {
+			retryCalled = true
+			return executor.Result{Response: map[string]any{"ok": true}}, nil
+		},
+	}
+
+	runner := &runtimeRunner{fallback: mock}
+	patErr := &apperrors.PATError{RawJSON: makePATErrorJSONWithURI("flow-legacy-hash", "test-client-id", rawURI)}
+
+	var buf bytes.Buffer
+	_, err := handlePatAuthCheck(context.Background(), runner, executor.Invocation{
+		CanonicalProduct: "test",
+		Tool:             "test_tool",
+	}, patErr, configDir, &buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !retryCalled {
+		t.Fatal("expected retry to run after approved PAT flow")
+	}
+	if opened != wantURL {
+		t.Fatalf("opened url = %q, want normalized %q", opened, wantURL)
+	}
+	if got := buf.String(); !strings.Contains(got, "PAT_AUTHORIZATION_URL="+wantURL) {
+		t.Fatalf("output missing normalized PAT_AUTHORIZATION_URL line:\n%s", got)
 	}
 }
 

--- a/internal/errors/pat.go
+++ b/internal/errors/pat.go
@@ -383,14 +383,11 @@ func PATAuthorizationURL(rawURI string) string {
 		return rawURI
 	}
 
-	flowID, userCode := patAuthorizationRouteParams(parsed)
-	if flowID == "" || userCode == "" {
+	routeQuery := patAuthorizationRouteQuery(parsed)
+	if routeQuery.Get("flowId") == "" || routeQuery.Get("userCode") == "" {
 		return rawURI
 	}
 
-	routeQuery := url.Values{}
-	routeQuery.Set("flowId", flowID)
-	routeQuery.Set("userCode", userCode)
 	route := "/personalAuthorization?" + routeQuery.Encode()
 
 	next := *parsed
@@ -402,31 +399,31 @@ func PATAuthorizationURL(rawURI string) string {
 	return next.String()
 }
 
-func patAuthorizationRouteParams(parsed *url.URL) (string, string) {
+func patAuthorizationRouteQuery(parsed *url.URL) url.Values {
 	candidates := []string{
 		parsed.Fragment,
 		parsed.RawFragment,
 		parsed.Query().Get("hash"),
 	}
 	for _, candidate := range candidates {
-		if flowID, userCode := parsePersonalAuthorizationRoute(candidate); flowID != "" && userCode != "" {
-			return flowID, userCode
+		if values := parsePersonalAuthorizationRouteQuery(candidate); values.Get("flowId") != "" && values.Get("userCode") != "" {
+			return values
 		}
 		if decoded, err := url.QueryUnescape(candidate); err == nil && decoded != candidate {
-			if flowID, userCode := parsePersonalAuthorizationRoute(decoded); flowID != "" && userCode != "" {
-				return flowID, userCode
+			if values := parsePersonalAuthorizationRouteQuery(decoded); values.Get("flowId") != "" && values.Get("userCode") != "" {
+				return values
 			}
 		}
 	}
-	return "", ""
+	return nil
 }
 
-func parsePersonalAuthorizationRoute(route string) (string, string) {
+func parsePersonalAuthorizationRouteQuery(route string) url.Values {
 	route = strings.TrimSpace(route)
 	route = strings.TrimPrefix(route, "#")
 	idx := strings.Index(route, "personalAuthorization?")
 	if idx < 0 {
-		return "", ""
+		return nil
 	}
 	rawQuery := route[idx+len("personalAuthorization?"):]
 	if cut := strings.IndexAny(rawQuery, "?#"); cut >= 0 {
@@ -434,9 +431,9 @@ func parsePersonalAuthorizationRoute(route string) (string, string) {
 	}
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
-		return "", ""
+		return nil
 	}
-	return values.Get("flowId"), values.Get("userCode")
+	return values
 }
 
 func cleanPATJSON(body map[string]any, code string) string {

--- a/internal/errors/pat.go
+++ b/internal/errors/pat.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"sync"
 )
@@ -107,6 +108,8 @@ const ExitCodePermission = 4
 // server-provided authorization link. Hosts must treat it as opaque and open
 // it verbatim instead of parsing and reconstructing it locally, because
 // required parameters may live in query, encoded hash, or fragment sections.
+// New hosts may prefer data.authorizationUrl when present; it preserves data.uri
+// while adding a copy/open-safe URL for legacy DingTalk hash-route variants.
 type PATError struct {
 	RawJSON string
 }
@@ -349,11 +352,91 @@ func ApplyHostMutations(out map[string]any) {
 		data = map[string]any{}
 		out["data"] = data
 	}
+	if rawURI, ok := data["uri"].(string); ok && strings.TrimSpace(rawURI) != "" {
+		data["authorizationUrl"] = PATAuthorizationURL(rawURI)
+	}
 	if block := HostControlBlock(); block != nil {
 		delete(data, "callbacks")
 		data["hostControl"] = block
 	}
 	data["openBrowser"] = PATOpenBrowserValue()
+}
+
+// PATAuthorizationURL returns the best URL for hosts to open or show to users.
+// It keeps already-complete PAT URLs unchanged. For DingTalk's legacy
+// /fe/old#%2FpersonalAuthorization?... hash-route form, it adds the explicit
+// hash query and decoded fragment route used by the working authorization page.
+func PATAuthorizationURL(rawURI string) string {
+	rawURI = strings.TrimSpace(rawURI)
+	if rawURI == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(rawURI)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return rawURI
+	}
+	if !strings.HasSuffix(parsed.Path, "/fe/old") {
+		return rawURI
+	}
+	if parsed.Query().Get("hash") != "" && strings.Contains(parsed.Fragment, "personalAuthorization") {
+		return rawURI
+	}
+
+	flowID, userCode := patAuthorizationRouteParams(parsed)
+	if flowID == "" || userCode == "" {
+		return rawURI
+	}
+
+	routeQuery := url.Values{}
+	routeQuery.Set("flowId", flowID)
+	routeQuery.Set("userCode", userCode)
+	route := "/personalAuthorization?" + routeQuery.Encode()
+
+	next := *parsed
+	query := next.Query()
+	query.Set("hash", "#"+route)
+	next.RawQuery = query.Encode()
+	next.Fragment = route
+	next.RawFragment = ""
+	return next.String()
+}
+
+func patAuthorizationRouteParams(parsed *url.URL) (string, string) {
+	candidates := []string{
+		parsed.Fragment,
+		parsed.RawFragment,
+		parsed.Query().Get("hash"),
+	}
+	for _, candidate := range candidates {
+		if flowID, userCode := parsePersonalAuthorizationRoute(candidate); flowID != "" && userCode != "" {
+			return flowID, userCode
+		}
+		if decoded, err := url.QueryUnescape(candidate); err == nil && decoded != candidate {
+			if flowID, userCode := parsePersonalAuthorizationRoute(decoded); flowID != "" && userCode != "" {
+				return flowID, userCode
+			}
+		}
+	}
+	return "", ""
+}
+
+func parsePersonalAuthorizationRoute(route string) (string, string) {
+	route = strings.TrimSpace(route)
+	route = strings.TrimPrefix(route, "#")
+	idx := strings.Index(route, "personalAuthorization?")
+	if idx < 0 {
+		return "", ""
+	}
+	rawQuery := route[idx+len("personalAuthorization?"):]
+	if cut := strings.IndexAny(rawQuery, "?#"); cut >= 0 {
+		rawQuery = rawQuery[:cut]
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return "", ""
+	}
+	return values.Get("flowId"), values.Get("userCode")
 }
 
 func cleanPATJSON(body map[string]any, code string) string {

--- a/internal/errors/pat_test.go
+++ b/internal/errors/pat_test.go
@@ -16,6 +16,7 @@ package errors
 import (
 	"encoding/json"
 	stderrors "errors"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -749,6 +750,48 @@ func TestPATAuthorizationURL_NormalizesLegacyHashRoute(t *testing.T) {
 
 	if got := PATAuthorizationURL(rawURI); got != want {
 		t.Fatalf("PATAuthorizationURL() = %q, want %q", got, want)
+	}
+}
+
+func TestPATAuthorizationURL_NormalizesLegacyHashRoutePreservesExtraQuery(t *testing.T) {
+	t.Parallel()
+	rawURI := "https://open-dev.dingtalk.com/fe/old#%2FpersonalAuthorization%3FflowId%3D77108a9d0e6f4b74b769c04eb451e7d9%26userCode%3DWSAX-EEF2%26agentCode%3Dcodex%26scene%3Ddesktop%26redirect%3Dhttps%253A%252F%252Fexample.com%252Fcallback%253Fa%253D1"
+
+	got := PATAuthorizationURL(rawURI)
+
+	if got == rawURI {
+		t.Fatal("expected legacy hash route to be normalized")
+	}
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("parse normalized URL: %v\nurl=%s", err, got)
+	}
+	hash := parsed.Query().Get("hash")
+	if hash == "" {
+		t.Fatalf("expected normalized URL to include hash query, got: %s", got)
+	}
+	if hash != "#"+parsed.Fragment {
+		t.Fatalf("hash query = %q, want fragment route %q", hash, "#"+parsed.Fragment)
+	}
+	rawQuery, ok := strings.CutPrefix(parsed.Fragment, "/personalAuthorization?")
+	if !ok {
+		t.Fatalf("fragment = %q, want personalAuthorization route", parsed.Fragment)
+	}
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		t.Fatalf("parse normalized route query: %v\nquery=%s", err, rawQuery)
+	}
+	want := map[string]string{
+		"flowId":    "77108a9d0e6f4b74b769c04eb451e7d9",
+		"userCode":  "WSAX-EEF2",
+		"agentCode": "codex",
+		"scene":     "desktop",
+		"redirect":  "https://example.com/callback?a=1",
+	}
+	for key, wantValue := range want {
+		if gotValue := values.Get(key); gotValue != wantValue {
+			t.Fatalf("route query %s = %q, want %q", key, gotValue, wantValue)
+		}
 	}
 }
 

--- a/internal/errors/pat_test.go
+++ b/internal/errors/pat_test.go
@@ -737,6 +737,48 @@ func TestCleanPATJSON_PreservesOpaqueURIVerbatim(t *testing.T) {
 	if got, _ := data["uri"].(string); got != rawURI {
 		t.Fatalf("data.uri = %q, want verbatim %q", got, rawURI)
 	}
+	if got, _ := data["authorizationUrl"].(string); got != rawURI {
+		t.Fatalf("data.authorizationUrl = %q, want %q", got, rawURI)
+	}
+}
+
+func TestPATAuthorizationURL_NormalizesLegacyHashRoute(t *testing.T) {
+	t.Parallel()
+	rawURI := "https://open-dev.dingtalk.com/fe/old#%2FpersonalAuthorization%3FflowId%3D77108a9d0e6f4b74b769c04eb451e7d9%26userCode%3DWSAX-EEF2"
+	want := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D77108a9d0e6f4b74b769c04eb451e7d9%26userCode%3DWSAX-EEF2#/personalAuthorization?flowId=77108a9d0e6f4b74b769c04eb451e7d9&userCode=WSAX-EEF2"
+
+	if got := PATAuthorizationURL(rawURI); got != want {
+		t.Fatalf("PATAuthorizationURL() = %q, want %q", got, want)
+	}
+}
+
+func TestCleanPATJSON_AddsNormalizedAuthorizationURL(t *testing.T) {
+	t.Parallel()
+	rawURI := "https://open-dev.dingtalk.com/fe/old#%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN"
+	want := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN#/personalAuthorization?flowId=56b12fd3201d4efab9a9138672cf4deb&userCode=CFTC-27ZN"
+	body := map[string]any{
+		"success": false,
+		"code":    "PAT_MEDIUM_RISK_NO_PERMISSION",
+		"data": map[string]any{
+			"desc":   "在浏览器中打开以下链接进行认证",
+			"flowId": "56b12fd3201d4efab9a9138672cf4deb",
+			"uri":    rawURI,
+		},
+	}
+
+	result := cleanPATJSON(body, "PAT_MEDIUM_RISK_NO_PERMISSION")
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("unmarshal cleanPATJSON output: %v\nraw=%s", err, result)
+	}
+	data, _ := parsed["data"].(map[string]any)
+	if got, _ := data["uri"].(string); got != rawURI {
+		t.Fatalf("data.uri = %q, want verbatim %q", got, rawURI)
+	}
+	if got, _ := data["authorizationUrl"].(string); got != want {
+		t.Fatalf("data.authorizationUrl = %q, want %q", got, want)
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace the PAT retry browser opener on Windows with `rundll32 url.dll,FileProtocolHandler` so authorization URLs are not passed through `cmd.exe`
- keep the service-provided PAT `data.uri` verbatim, and add `data.authorizationUrl` as a copy/open-safe URL for host integrations
- print `PAT_AUTHORIZATION_URL=<full-url>` in human-readable PAT output so OpenClaw-style wrappers can capture the complete link even when they swallow or reformat stderr
- normalize DingTalk legacy hash-route links like `/fe/old#%2FpersonalAuthorization%3FflowId...%26userCode...` into the working `/fe/old?hash=...#/personalAuthorization?...&userCode=...` form
- add regression coverage for issue-shaped PAT URLs containing encoded hash, fragment, and `&userCode`, plus the malformed hash-route shape reported from the OpenClaw scenario

## Root Cause
Issue #230 reports that the final raw authorization link works, but the automatically opened link reaches a 0-permission DingTalk page on Windows. The first failure mode was the stale PAT retry opener using `cmd /c start <url>` on Windows. PAT URLs include a real `&userCode=...` segment after the fragment; when routed through `cmd.exe`, `&` can be interpreted as a command separator, truncating the URL before `userCode`.

Follow-up feedback from OpenClaw usage showed another bad card shape: `https://open-dev.dingtalk.com/fe/old#%2FpersonalAuthorization%3FflowId=...%26userCode=...`. That link still contains `flowId/userCode`, but it is missing the explicit `?hash=%23...` query and decoded fragment route used by the working DingTalk authorization page. The CLI now preserves the raw service URI for compatibility while exposing and opening a normalized `authorizationUrl` when this legacy hash-route form appears.

## Testing
- `git diff --check`
- `go test ./internal/errors -run 'TestPATAuthorizationURL_NormalizesLegacyHashRoute|TestCleanPATJSON_AddsNormalizedAuthorizationURL|TestCleanPATJSON_PreservesOpaqueURIVerbatim'`
- `go test ./internal/app -run 'TestHandlePatAuthCheck_JSONModeCanOpenBrowserWithoutTextOutput|TestHandlePatAuthCheck_OpensOpaqueURIWithoutRebuild|TestHandlePatAuthCheck_NormalizesLegacyHashRouteForBrowserAndOutput|TestBrowserOpenCommand_WindowsPreservesOpaquePATURI'`
- `go test ./internal/app ./internal/errors ./internal/pat`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/dws-internal-app-windows.test ./internal/app`

Fixes #230

## Residual Risk
I verified Windows command construction and Windows compilation from macOS. A final Windows 11/OpenClaw browser smoke test should still confirm the DingTalk page renders the expected non-zero permission list in the real host environment.
