### PR TITLE
feat(schema): add CLIAliases tool override + json_parse_strict transform

### DIFF
--- a/internal/compat/dynamic_commands.go
+++ b/internal/compat/dynamic_commands.go
@@ -163,9 +163,12 @@ func BuildDynamicCommands(servers []market.ServerDescriptor, runner executor.Run
 			}
 
 			route := Route{
-				Use:   cliName,
-				Short: short,
-				Long:  long,
+				Use: cliName,
+				// CLIAliases register additional cobra command aliases for the
+				// same MCP tool. Empty / nil means no extra names.
+				Aliases: append([]string(nil), override.CLIAliases...),
+				Short:   short,
+				Long:    long,
 				// Preserve left-side indentation: cobra's Examples template
 				// renders {{.Example}} verbatim, and hardcoded helper commands
 				// rely on a 2-space prefix to look indented under "Examples:".

--- a/internal/compat/transform.go
+++ b/internal/compat/transform.go
@@ -26,7 +26,8 @@ import (
 )
 
 // ApplyTransform applies a named transform rule to a value.
-// Supported transforms: iso8601_to_millis, csv_to_array, json_parse, enum_map.
+// Supported transforms: iso8601_to_millis, csv_to_array, json_parse,
+// json_parse_strict, enum_map.
 func ApplyTransform(value any, transform string, args map[string]any) (any, error) {
 	switch strings.TrimSpace(transform) {
 	case "":
@@ -37,6 +38,8 @@ func ApplyTransform(value any, transform string, args map[string]any) (any, erro
 		return transformCSVToArray(value)
 	case "json_parse":
 		return transformJSONParse(value)
+	case "json_parse_strict":
+		return transformJSONParseStrict(value)
 	case "enum_map":
 		return transformEnumMap(value, args)
 	default:
@@ -149,6 +152,30 @@ func transformJSONParse(value any) (any, error) {
 			"quote the whole value and use `[{key: value, ...}]` for ad-hoc input, " +
 			"or pass `@path/to/file.json` to read from a file",
 	)
+}
+
+// transformJSONParseStrict is the strict variant of json_parse: only accepts
+// well-formed JSON, rejecting input that the YAML fallback would otherwise
+// silently coerce to a scalar string. Use when the upstream tool requires a
+// structured array/object value and "garbage in → empty out" is unacceptable.
+func transformJSONParseStrict(value any) (any, error) {
+	s, ok := toString(value)
+	if !ok {
+		return value, nil
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return value, nil
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return nil, apperrors.NewValidation(
+			"json_parse_strict: input is not valid JSON; " +
+				"this transform rejects YAML-style ad-hoc input — quote the whole value " +
+				"as strict JSON (e.g. '[{\"key\":\"value\"}]') or use `json_parse` for YAML-tolerant parsing",
+		)
+	}
+	return parsed, nil
 }
 
 func transformEnumMap(value any, args map[string]any) (any, error) {

--- a/internal/market/registry.go
+++ b/internal/market/registry.go
@@ -173,8 +173,16 @@ type CLIOutputFormat struct {
 
 // CLIToolOverride maps an MCP tool to a CLI command with flag aliases and transforms.
 type CLIToolOverride struct {
-	CLIName     string `json:"cliName"`
-	Description string `json:"description,omitempty"`
+	CLIName string `json:"cliName"`
+	// CLIAliases registers additional cobra command aliases for the same MCP
+	// tool, so the leaf command can be invoked under multiple names without
+	// duplicating the override. Mirrors cobra.Command.Aliases. Each alias is
+	// added to the cobra Aliases slice; conflicts with existing siblings are
+	// silently ignored by cobra. Use for command-name normalisation (e.g.
+	// `range read` accepts `range get` as an alias) or hardcoded-command
+	// migration paths. Empty / nil means no extra aliases.
+	CLIAliases  []string `json:"cliAliases,omitempty"`
+	Description string   `json:"description,omitempty"`
 	// Example, when non-empty, is wired to cobra.Command.Example to render
 	// the "Examples:" section in --help. Mirrors hardcoded helper commands'
 	// Example field (e.g. wukong/products/oa.go list-forms). Empty value


### PR DESCRIPTION
## Summary

Two generic CLI envelope schema enhancements that close gaps surfaced by the `cli_to_mcp` regression suite — without resorting to product-specific helpers in open core.

### 1. `CLIToolOverride.CLIAliases` (`registry.go` + `dynamic_commands.go`)

Lets a single MCP tool register additional cobra command aliases via envelope JSON. Plumbs through the existing `Route.Aliases → cobra.Command.Aliases` path; conflicts with siblings are silently skipped by cobra.

**Envelope usage**:
```json
"get_range": {
  "cliName": "read",
  "cliAliases": ["get"],
  "group": "range",
  ...
}
```
After this, both `dws sheet range read` and `dws sheet range get` resolve to the same `get_range` MCP tool.

### 2. `json_parse_strict` transform (`transform.go`)

Strict JSON variant of `json_parse` that does **not** fall back to YAML. Use when the upstream tool requires a structured array/object value and silently coercing malformed input to a scalar string would mask a real user error.

**Bug it fixes**: `dws sheet filter-view create --criteria 'NOT_VALID_JSON'` was being accepted by `json_parse` (YAML happily parsed the input as a scalar string), and the request reached the server with `criteria: "NOT_VALID_JSON"`, which the API silently dropped to `criteria: {}`. Result: filter view was created with empty criteria and no error returned. With `json_parse_strict`, the CLI rejects malformed JSON before sending.

## Why these are schema enhancements, not product hardcode

- `CLIAliases` works for any product / any tool — sheet, wiki, aitable, chat, anyone wanting command-name aliases benefits.
- `json_parse_strict` is a generic transform option, not tied to filter-view.
- No product-specific code; the actual "sheet range get == sheet range read" declaration lives in the envelope JSON, not in Go.

## Test plan

- [x] `go test ./internal/compat/...` — existing transform + dynamic_commands tests still pass
- [x] Smoke test `dws sheet range get --node X --sheet-id Y` returns the same payload as `dws sheet range read --node X --sheet-id Y`
- [x] Smoke test `dws wiki member ls --space X` returns the same payload as `dws wiki member list --space X`
- [x] Smoke test `dws sheet filter-view create --criteria 'NOT_VALID_JSON' ...` now exits non-zero with a clear validation error (was previously silently accepted)
- [ ] Add unit tests for `CLIAliases` rendering to a `cobra.Command` (suggested follow-up)
- [ ] Add unit tests for `transformJSONParseStrict` (suggested follow-up)

## Backward compatibility

- `cliAliases` is `omitempty` — envelopes without it deserialize unchanged
- `json_parse_strict` is a new transform name — existing `json_parse` users are unaffected
- No breaking changes to existing CLI commands / behavior