### PR TITLE
fix(chat): require --title for direct messages, fix misleading help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and this project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`dws chat message send` 单聊缺 `--title` 时前置校验** (#250) — 单聊（`--user` / `--open-dingtalk-id`）的底层工具 `send_direct_message_as_user` 在 API 层强制要求 title，缺失时返回误导性的 `发群服务窗会话消息失败`。CLI 现在在 `buildChatMessageSendInvocation` 里前置校验，直接返回 `--title is required for direct messages (--user / --open-dingtalk-id)`；同时把 `Long` help、`--title` flag 描述、Example 和 `skills/references/products/chat.md` 全部对齐为「单聊必填，群聊可选」。群聊行为不变。
+
 ## [1.0.25] - 2026-05-11
 
 Two generic envelope-schema enhancements that close gaps the `cli_to_mcp` test suite kept surfacing — both product-agnostic, no hardcoded helper commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and this project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`dws chat message send` to a single chat failed with a misleading "发群服务窗会话消息失败" when `--title` was omitted** — the `send_direct_message_as_user` tool requires a title at the business layer, but the `--title` flag was documented as "可选" (optional) and one of the help examples sent a direct message without it, so callers (humans and agents alike) hit a cryptic API error instead of a clear validation message. The CLI now validates `--title` up front for `--user` / `--open-dingtalk-id` sends (`--title is required for direct messages`), and the long help, flag description, examples, and `skills/references/products/chat.md` now state that the title is required for direct messages and optional for group messages.
+
 ## [1.0.23] - 2026-05-08
 
 A single fix for HTTP proxy support across the CLI's custom HTTP transports. No behaviour changes elsewhere.

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -92,12 +92,13 @@ func newChatMessageSendCommand(runner executor.Runner) *cobra.Command {
 --open-dingtalk-id 指定 openDingTalkId 发单聊 (适用于无法获取 userId 的场景)。
 三者只能选其一，不能同时指定。
 
-消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。必须提供 --title 作为消息标题。
+消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。
+单聊消息（--user / --open-dingtalk-id）必须提供 --title 作为消息标题；群聊可选。
 
 群聊场景下可用 --at-all / --at-users / --at-mobiles 进行 @ 提醒（仅 --group 时生效）。
 注意 --text 中需包含对应的 <@userId> / <@all> 占位符才能在客户端渲染出 @ 效果。`,
 		Example: `  dws chat message send --group <openconversation_id> --text "hello"
-  dws chat message send --user <userId> --text "请查收"
+  dws chat message send --user <userId> --title "提醒" --text "请查收"
   dws chat message send --open-dingtalk-id <openDingTalkId> --title "提醒" --text "请确认"
   dws chat message send --group <openconversation_id> --title "拉群通知" --text "<@uid> 你被 @ 了" --at-users uid`,
 		Args:              cobra.MaximumNArgs(1),
@@ -127,7 +128,7 @@ func newChatMessageSendCommand(runner executor.Runner) *cobra.Command {
 	cmd.Flags().String("user", "", "接收人 userId (单聊三选一)")
 	cmd.Flags().String("open-dingtalk-id", "", "接收人 openDingTalkId (单聊三选一)")
 	cmd.Flags().String("text", "", "消息内容，支持 Markdown (也可作位置参数)")
-	cmd.Flags().String("title", "", "消息标题 (可选)")
+	cmd.Flags().String("title", "", "消息标题 (单聊必填，群聊可选)")
 	cmd.Flags().Bool("at-all", false, "@所有人 (仅 --group 群聊生效)")
 	cmd.Flags().String("at-users", "", "按 userId @ 指定成员，逗号分隔 (仅 --group 群聊生效)")
 	cmd.Flags().String("at-mobiles", "", "按手机号 @ 指定成员，逗号分隔 (仅 --group 群聊生效)")
@@ -194,6 +195,12 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 	hasAtMobiles := strings.TrimSpace(atMobiles) != ""
 	if !hasGroup && (atAll || hasAtUsers || hasAtMobiles) {
 		return nil, "", apperrors.NewValidation("--at-all / --at-users / --at-mobiles only apply when --group is set")
+	}
+	// Direct-message tools (send_direct_message_as_user) reject an empty title at
+	// the API level with a misleading "发群服务窗会话消息失败" error, so fail loudly
+	// here instead. Group messages do not require a title.
+	if (hasUser || hasOpenID) && strings.TrimSpace(title) == "" {
+		return nil, "", apperrors.NewValidation("--title is required for direct messages (--user / --open-dingtalk-id)")
 	}
 
 	params := map[string]any{"text": text}

--- a/internal/helpers/chat_test.go
+++ b/internal/helpers/chat_test.go
@@ -67,14 +67,14 @@ func TestChatMessageSendRoutesByDestination(t *testing.T) {
 		},
 		{
 			name:      "user-direct",
-			args:      []string{"--user", "034766", "--text", "hi"},
+			args:      []string{"--user", "034766", "--title", "t", "--text", "hi"},
 			wantTool:  "send_direct_message_as_user",
 			wantKey:   "receiverUserId",
 			wantValue: "034766",
 		},
 		{
 			name:      "open-dingtalk-id-direct",
-			args:      []string{"--open-dingtalk-id", "OP123", "--text", "hi"},
+			args:      []string{"--open-dingtalk-id", "OP123", "--title", "t", "--text", "hi"},
 			wantTool:  "send_direct_message_as_user",
 			wantKey:   "receiverOpenDingTalkId",
 			wantValue: "OP123",
@@ -131,6 +131,16 @@ func TestChatMessageSendRejectsInvalidDestination(t *testing.T) {
 			name:    "empty-text",
 			args:    []string{"--group", "cid-x"},
 			wantErr: "--text (or positional argument) is required",
+		},
+		{
+			name:    "direct-user-without-title",
+			args:    []string{"--user", "034766", "--text", "hi"},
+			wantErr: "--title is required for direct messages",
+		},
+		{
+			name:    "direct-open-dingtalk-id-without-title",
+			args:    []string{"--open-dingtalk-id", "OP123", "--text", "hi"},
+			wantErr: "--title is required for direct messages",
 		},
 	}
 	for _, tc := range cases {

--- a/skills/references/products/chat.md
+++ b/skills/references/products/chat.md
@@ -183,7 +183,7 @@ Flags:
 
 ## message send — 以当前用户身份发消息
 
---group 指定群聊 ID 发群消息；--user 指定用户 userId 发单聊；--open-dingtalk-id 指定用户 openDingTalkId 发单聊。三者只能选其一，不能同时指定。消息内容为位置参数（恰好 1 个），支持 Markdown。必须提供 --title 作为消息标题。
+--group 指定群聊 ID 发群消息；--user 指定用户 userId 发单聊；--open-dingtalk-id 指定用户 openDingTalkId 发单聊。三者只能选其一，不能同时指定。消息内容为位置参数（恰好 1 个），支持 Markdown。单聊消息（--user / --open-dingtalk-id）必须提供 --title 作为消息标题；群聊可选。
 --群聊时可选 --at-all @所有人，或 --at-users 指定成员（仅群聊时生效）。
 --发送图片消息：指定 --media-id（通过 dt_media_upload 工具上传获得），自动设置 msgType=image，此时不需要传文本内容。
 
@@ -192,8 +192,8 @@ Usage:
   dws chat message send [flags] [<text>]
 Example:
   dws chat message send --group <openconversation_id> --text "hello"
-  dws chat message send --user <userId> --text "请查收"
-  dws chat message send --open-dingtalk-id <openDingTalkId> --text "请查收"
+  dws chat message send --user <userId> --title "提醒" --text "请查收"
+  dws chat message send --open-dingtalk-id <openDingTalkId> --title "提醒" --text "请查收"
   dws chat message send --group <openconversation_id> "hello"
   dws chat message send --group <openconversation_id> --title "周报提醒" --text "请大家本周五前提交周报"
   dws chat message send --group <openconversation_id> --at-all "<@all> 请大家注意"


### PR DESCRIPTION
## Problem

`dws chat message send --user <userId> --text "你好"` (and the `--open-dingtalk-id` variant) fails at the API layer with the cryptic, wrong-sounding error:

```
"message": "发群服务窗会话消息失败"
```

…even though it is a **single chat**, not a group/service-window. Root cause: the underlying `send_direct_message_as_user` tool requires a **title** at the business layer, but the CLI advertised the opposite:

- the `--title` flag description said `消息标题 (可选)` — "optional";
- one of the help examples — `dws chat message send --user <userId> --text "请查收"` — sends a direct message **without** `--title`;
- only the `Long` help prose said "必须提供 --title"，directly contradicting the flag and the example.

So a caller (human or agent) following the flag help / examples lands on an opaque API error instead of a clear validation message. (This bit me while driving the CLI — I followed the title-less example and got the `发群服务窗会话消息失败` error.)

## Fix

- **Validate `--title` up front** for direct sends (`--user` / `--open-dingtalk-id`): returns `--title is required for direct messages (--user / --open-dingtalk-id)` instead of letting the request reach the API. The check is placed after the destination / `--text` / `--at-*` validations so existing error precedence is preserved.
- **Group messages are unchanged** — `--title` stays optional there (no evidence the group tool requires it; existing tests and the first help example send title-less group messages). If it turns out the group tool also needs a title, the validation can be widened to all destinations.
- Updated the `Long` help, the `--title` flag description (`消息标题 (单聊必填，群聊可选)`), the help examples, and `skills/references/products/chat.md` so docs, flag help, and behaviour all agree.

## Tests

- `TestChatMessageSendRoutesByDestination`: added `--title` to the two direct-message routing cases that now require it.
- `TestChatMessageSendRejectsInvalidDestination`: added rejection cases for `--user` / `--open-dingtalk-id` sends without `--title`.
- `go build ./...`, `go test ./internal/helpers/... ./internal/app/... ./internal/cli/... ./internal/compat/... ./internal/generator/...` all green.

## Changelog

Added an `## [Unreleased]` entry describing the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)