### PR TITLE
feat(output): add `-f ndjson` and `-f csv` (#252)

### DIFF
--- a/internal/app/flags.go
+++ b/internal/app/flags.go
@@ -41,7 +41,8 @@ func bindPersistentFlags(cmd *cobra.Command, flags *GlobalFlags) {
 	cmd.PersistentFlags().BoolVar(&flags.Debug, "debug", false, "显示调试日志")
 	cmd.PersistentFlags().BoolVar(&flags.DryRun, "dry-run", false, "预览操作内容，不实际执行")
 	cmd.PersistentFlags().StringVar(&flags.Fields, "fields", "", "筛选输出字段 (逗号分隔, 如: name,id,status)")
-	cmd.PersistentFlags().StringVarP(&flags.Format, "format", "f", "json", "输出格式: json|table|raw|pretty")
+	// TODO(#252): append |csv once writeCSV is implemented in internal/output/csv.go.
+	cmd.PersistentFlags().StringVarP(&flags.Format, "format", "f", "json", "输出格式: json|table|raw|pretty|ndjson")
 	cmd.PersistentFlags().StringVar(&flags.JQ, "jq", "", "jq 表达式过滤输出 (如: '.items[] | .name')")
 	cmd.PersistentFlags().BoolVar(&flags.Mock, "mock", false, "使用 Mock 数据 (开发调试用)")
 	cmd.PersistentFlags().StringVarP(&flags.Output, "output", "o", "", "Write command output to a file")

--- a/internal/app/flags.go
+++ b/internal/app/flags.go
@@ -41,8 +41,7 @@ func bindPersistentFlags(cmd *cobra.Command, flags *GlobalFlags) {
 	cmd.PersistentFlags().BoolVar(&flags.Debug, "debug", false, "显示调试日志")
 	cmd.PersistentFlags().BoolVar(&flags.DryRun, "dry-run", false, "预览操作内容，不实际执行")
 	cmd.PersistentFlags().StringVar(&flags.Fields, "fields", "", "筛选输出字段 (逗号分隔, 如: name,id,status)")
-	// TODO(#252): append |csv once writeCSV is implemented in internal/output/csv.go.
-	cmd.PersistentFlags().StringVarP(&flags.Format, "format", "f", "json", "输出格式: json|table|raw|pretty|ndjson")
+	cmd.PersistentFlags().StringVarP(&flags.Format, "format", "f", "json", "输出格式: json|table|raw|pretty|ndjson|csv")
 	cmd.PersistentFlags().StringVar(&flags.JQ, "jq", "", "jq 表达式过滤输出 (如: '.items[] | .name')")
 	cmd.PersistentFlags().BoolVar(&flags.Mock, "mock", false, "使用 Mock 数据 (开发调试用)")
 	cmd.PersistentFlags().StringVarP(&flags.Output, "output", "o", "", "Write command output to a file")

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -30,7 +30,11 @@ import (
 //     plus one row per element. The union of keys (sorted) is the column set;
 //     missing values are empty cells; nested objects/arrays render as compact
 //     JSON in the cell. Any sibling metadata of the list (total, hasMore, ...)
-//     is dropped — CSV is the tabular slice, nothing else.
+//     is broadcast as extra trailing columns, repeated on every row, so a CSV
+//     consumer never loses it (CSV has no "two tables in one file" concept the
+//     way the table renderer's footer does). Meta keys that collide with a data
+//     column are skipped. An empty list still emits the header plus one row of
+//     empty data cells carrying just the meta values.
 //   - a single object becomes a two-column `key,value` CSV.
 //   - a non-uniform list or a scalar becomes a single-column `value` CSV.
 //
@@ -53,7 +57,8 @@ func writeCSV(w io.Writer, payload any) error {
 		if inner, ok := unwrapPrimaryObject(typed); ok {
 			return writeKeyValueCSV(cw, inner)
 		}
-		if headers, rows, _, ok := extractRowsFromMap(typed); ok {
+		if headers, rows, meta, ok := extractRowsFromMap(typed); ok {
+			headers, rows = broadcastMeta(headers, rows, meta)
 			return writeTableCSV(cw, headers, rows)
 		}
 		return writeKeyValueCSV(cw, typed)
@@ -92,6 +97,46 @@ func writeTableCSV(cw *csv.Writer, headers []string, rows [][]string) error {
 	}
 	cw.Flush()
 	return cw.Error()
+}
+
+// broadcastMeta appends the list's sibling metadata (total, hasMore, ...) as
+// trailing columns repeated on every row. Meta keys that collide with an
+// existing data column are skipped. If there are no rows but there is meta, a
+// single row of empty data cells is emitted so the meta values aren't lost.
+func broadcastMeta(headers []string, rows [][]string, meta map[string]any) ([]string, [][]string) {
+	if len(meta) == 0 {
+		return headers, rows
+	}
+	existing := make(map[string]bool, len(headers))
+	for _, h := range headers {
+		existing[h] = true
+	}
+	var metaKeys []string
+	var metaVals []string
+	for _, k := range sortedMapKeys(meta) {
+		if existing[k] {
+			continue
+		}
+		metaKeys = append(metaKeys, k)
+		metaVals = append(metaVals, formatValue(meta[k]))
+	}
+	if len(metaKeys) == 0 {
+		return headers, rows
+	}
+
+	outHeaders := append(append([]string{}, headers...), metaKeys...)
+	if len(rows) == 0 {
+		emptyData := make([]string, len(headers))
+		return outHeaders, [][]string{append(emptyData, metaVals...)}
+	}
+	outRows := make([][]string, len(rows))
+	for i, r := range rows {
+		nr := make([]string, 0, len(outHeaders))
+		nr = append(nr, r...)
+		nr = append(nr, metaVals...)
+		outRows[i] = nr
+	}
+	return outHeaders, outRows
 }
 
 func writeKeyValueCSV(cw *csv.Writer, m map[string]any) error {

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -54,12 +54,17 @@ func writeCSV(w io.Writer, payload any) error {
 
 	switch typed := normalized.(type) {
 	case map[string]any:
-		if inner, ok := unwrapPrimaryObject(typed); ok {
-			return writeKeyValueCSV(cw, inner)
-		}
+		// Try table extraction first so wrappers around list payloads
+		// (e.g. {result: {todoCards: [...]}}) render as a real table
+		// instead of being peeled by unwrapPrimaryObject and degraded
+		// to key/value rows. unwrapPrimaryObject is then the fallback
+		// for single-object wrappers like {invocation: {...}}.
 		if headers, rows, meta, ok := extractRowsFromMap(typed); ok {
 			headers, rows = broadcastMeta(headers, rows, meta)
 			return writeTableCSV(cw, headers, rows)
+		}
+		if inner, ok := unwrapPrimaryObject(typed); ok {
+			return writeKeyValueCSV(cw, inner)
 		}
 		return writeKeyValueCSV(cw, typed)
 	case []any:

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output
+
+import (
+	"fmt"
+	"io"
+)
+
+// writeCSV renders list-shaped results as RFC-4180 CSV.
+//
+// TODO(#252): implement. Planned approach (mirrors how `-f table` already
+// flattens results, so reuse those helpers):
+//
+//  1. Locate the row list with the existing helpers — extractRowsFromMap /
+//     rowsFromSlice in formatter.go already turn `{items:[{...},...]}` (or a
+//     bare `[{...},...]`) into (headers []string, rows [][]string). Reuse them
+//     verbatim so table and csv agree on column order and flattening rules.
+//  2. Write headers as the first record, then each row, via encoding/csv.Writer
+//     (it handles quoting/escaping of commas, quotes and newlines for us).
+//  3. Nested objects / arrays in a cell: render as compact JSON (same as the
+//     table renderer does today) so the column count stays stable.
+//  4. Non-list payloads (a single object, a scalar): emit a two-column
+//     key,value CSV — or return a clear error telling the user `-f csv` only
+//     applies to list results. Pick one and cover it in the test.
+//  5. Tests in csv_test.go: a happy-path list (incl. a field containing a
+//     comma and a field containing CJK text), an empty list (headers only?),
+//     and the non-list fallback. Wire `--fields` projection through as well.
+//
+// Until then, fail loudly rather than silently degrading to JSON so callers
+// know the format isn't ready yet.
+func writeCSV(_ io.Writer, _ any) error {
+	return fmt.Errorf("output format %q is not implemented yet — see https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/252", FormatCSV)
+}

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -14,32 +14,95 @@
 package output
 
 import (
-	"fmt"
+	"encoding/csv"
 	"io"
 )
 
-// writeCSV renders list-shaped results as RFC-4180 CSV.
+// writeCSV renders a payload as RFC-4180 CSV.
 //
-// TODO(#252): implement. Planned approach (mirrors how `-f table` already
-// flattens results, so reuse those helpers):
+// It mirrors the shape decisions `-f table` already makes (same helpers:
+// normalizePayload / unwrapPrimaryObject / extractRowsFromMap / rowsFromSlice /
+// formatValue), so column order and value flattening stay consistent between
+// the two formats:
 //
-//  1. Locate the row list with the existing helpers — extractRowsFromMap /
-//     rowsFromSlice in formatter.go already turn `{items:[{...},...]}` (or a
-//     bare `[{...},...]`) into (headers []string, rows [][]string). Reuse them
-//     verbatim so table and csv agree on column order and flattening rules.
-//  2. Write headers as the first record, then each row, via encoding/csv.Writer
-//     (it handles quoting/escaping of commas, quotes and newlines for us).
-//  3. Nested objects / arrays in a cell: render as compact JSON (same as the
-//     table renderer does today) so the column count stays stable.
-//  4. Non-list payloads (a single object, a scalar): emit a two-column
-//     key,value CSV — or return a clear error telling the user `-f csv` only
-//     applies to list results. Pick one and cover it in the test.
-//  5. Tests in csv_test.go: a happy-path list (incl. a field containing a
-//     comma and a field containing CJK text), an empty list (headers only?),
-//     and the non-list fallback. Wire `--fields` projection through as well.
+//   - a list of objects — either a bare [{...},...] or wrapped under a
+//     well-known key ({items|results|data|records|...}) — becomes a header row
+//     plus one row per element. The union of keys (sorted) is the column set;
+//     missing values are empty cells; nested objects/arrays render as compact
+//     JSON in the cell. Any sibling metadata of the list (total, hasMore, ...)
+//     is dropped — CSV is the tabular slice, nothing else.
+//   - a single object becomes a two-column `key,value` CSV.
+//   - a non-uniform list or a scalar becomes a single-column `value` CSV.
 //
-// Until then, fail loudly rather than silently degrading to JSON so callers
-// know the format isn't ready yet.
-func writeCSV(_ io.Writer, _ any) error {
-	return fmt.Errorf("output format %q is not implemented yet — see https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/252", FormatCSV)
+// `--fields` projection composes for free: WriteFiltered applies SelectFields
+// before Write reaches us, so the rows are already narrowed.
+//
+// encoding/csv.Writer handles quoting/escaping of commas, double quotes and
+// embedded newlines; cell text goes through formatValue (which also strips
+// terminal control sequences, same as the table renderer).
+func writeCSV(w io.Writer, payload any) error {
+	normalized, err := normalizePayload(payload)
+	if err != nil {
+		return err
+	}
+
+	cw := csv.NewWriter(w)
+
+	switch typed := normalized.(type) {
+	case map[string]any:
+		if inner, ok := unwrapPrimaryObject(typed); ok {
+			return writeKeyValueCSV(cw, inner)
+		}
+		if headers, rows, _, ok := extractRowsFromMap(typed); ok {
+			return writeTableCSV(cw, headers, rows)
+		}
+		return writeKeyValueCSV(cw, typed)
+	case []any:
+		headers, rows, _ := rowsFromSlice(typed)
+		return writeTableCSV(cw, headers, rows)
+	case nil:
+		// Nothing to write — emit an empty document rather than erroring.
+		cw.Flush()
+		return cw.Error()
+	default:
+		// Scalar: a single-cell, single-row CSV.
+		if err := cw.Write([]string{formatValue(normalized)}); err != nil {
+			return err
+		}
+		cw.Flush()
+		return cw.Error()
+	}
+}
+
+func writeTableCSV(cw *csv.Writer, headers []string, rows [][]string) error {
+	if err := cw.Write(headers); err != nil {
+		return err
+	}
+	for _, row := range rows {
+		// rowsFromSlice / extractRowsFromMap already guarantee
+		// len(row) == len(headers), but stay defensive against future callers.
+		if len(row) != len(headers) {
+			padded := make([]string, len(headers))
+			copy(padded, row)
+			row = padded
+		}
+		if err := cw.Write(row); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+func writeKeyValueCSV(cw *csv.Writer, m map[string]any) error {
+	if err := cw.Write([]string{"key", "value"}); err != nil {
+		return err
+	}
+	for _, key := range sortedMapKeys(m) {
+		if err := cw.Write([]string{key, formatValue(m[key])}); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
 }

--- a/internal/output/filter.go
+++ b/internal/output/filter.go
@@ -82,16 +82,21 @@ type dataListLocation struct {
 
 // findDataList walks the object tree looking for the first array of
 // objects under well-known keys. It searches both top-level and one
-// level deep (e.g. result.value, response.items).
+// level deep (e.g. result.value, response.items). The allow-list lives
+// in preferredListKeys (formatter.go) and is shared with the table /
+// csv renderers so all tabular formatters agree on what counts as the
+// data list.
 func findDataList(m map[string]any) *dataListLocation {
-	listKeys := []string{"value", "items", "results", "data", "list", "records", "tools", "servers", "products"}
-
-	// Top-level: {value: [...]}
-	for _, key := range listKeys {
-		if arr, ok := m[key].([]any); ok && len(arr) > 0 {
-			if _, isMap := arr[0].(map[string]any); isMap {
-				return &dataListLocation{list: arr, innerKey: key}
-			}
+	// Top-level: {value: [...]}. Empty arrays under a preferred key still
+	// match so an "empty list + metadata" payload renders as an empty table
+	// (with the meta broadcast) rather than degrading to key/value rows.
+	for _, key := range preferredListKeys {
+		arr, ok := m[key].([]any)
+		if !ok {
+			continue
+		}
+		if len(arr) == 0 || isMapValue(arr[0]) {
+			return &dataListLocation{list: arr, innerKey: key}
 		}
 	}
 
@@ -101,16 +106,23 @@ func findDataList(m map[string]any) *dataListLocation {
 		if !ok {
 			continue
 		}
-		for _, key := range listKeys {
-			if arr, ok := inner[key].([]any); ok && len(arr) > 0 {
-				if _, isMap := arr[0].(map[string]any); isMap {
-					return &dataListLocation{list: arr, outerKey: outerKey, innerKey: key}
-				}
+		for _, key := range preferredListKeys {
+			arr, ok := inner[key].([]any)
+			if !ok {
+				continue
+			}
+			if len(arr) == 0 || isMapValue(arr[0]) {
+				return &dataListLocation{list: arr, outerKey: outerKey, innerKey: key}
 			}
 		}
 	}
 
 	return nil
+}
+
+func isMapValue(v any) bool {
+	_, ok := v.(map[string]any)
+	return ok
 }
 
 // filterSlice applies field filtering to each object element in a

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -36,8 +36,8 @@ const (
 	// FormatNDJSON emits one JSON object per line — friendly for streaming /
 	// piping list results into downstream tools. See ndjson.go.
 	FormatNDJSON Format = "ndjson"
-	// FormatCSV emits comma-separated values for list-shaped results — friendly
-	// for spreadsheets and non-technical consumers. See csv.go (#252, WIP).
+	// FormatCSV emits RFC-4180 comma-separated values for list-shaped results —
+	// friendly for spreadsheets and non-technical consumers. See csv.go.
 	FormatCSV Format = "csv"
 )
 

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -41,7 +41,18 @@ const (
 	FormatCSV Format = "csv"
 )
 
-var preferredListKeys = []string{"items", "results", "data", "list", "records", "tools", "servers", "products"}
+// preferredListKeys is the shared allow-list of keys whose array values are
+// treated as the "data list" by all tabular formatters (-f table / csv /
+// ndjson). It is the single source of truth — findDataList in filter.go
+// reuses it. When adding a new key, prefer real envelope keys observed in
+// production responses over speculative future names.
+var preferredListKeys = []string{
+	// Generic well-known list keys.
+	"value", "items", "results", "data", "list", "records",
+	"tools", "servers", "products",
+	// Envelope keys observed in real DingTalk responses.
+	"result", "documents", "emailAccounts", "todoCards", "events", "messages",
+}
 
 func ResolveFormat(cmd *cobra.Command, fallback Format) Format {
 	if cmd == nil {
@@ -275,9 +286,11 @@ func writeTableish(w io.Writer, payload any) error {
 
 	switch typed := normalized.(type) {
 	case map[string]any:
-		if inner, ok := unwrapPrimaryObject(typed); ok {
-			return writeKeyValues(w, inner)
-		}
+		// Try table extraction first so wrappers around list payloads
+		// (e.g. {result: {todoCards: [...]}}) render as a table instead
+		// of being peeled by unwrapPrimaryObject and degraded to key/
+		// value rows. unwrapPrimaryObject remains the fallback for
+		// single-object wrappers like {invocation: {kind, params, ...}}.
 		if headers, rows, meta, ok := extractRowsFromMap(typed); ok {
 			if err := writeTable(w, headers, rows); err != nil {
 				return err
@@ -289,6 +302,9 @@ func writeTableish(w io.Writer, payload any) error {
 				return writeKeyValues(w, meta)
 			}
 			return nil
+		}
+		if inner, ok := unwrapPrimaryObject(typed); ok {
+			return writeKeyValues(w, inner)
 		}
 		return writeKeyValues(w, typed)
 	case []any:
@@ -336,30 +352,52 @@ func unwrapPrimaryObject(payload map[string]any) (map[string]any, bool) {
 	return nil, false
 }
 
+// extractRowsFromMap finds the data list inside a wrapper map and returns it
+// as (headers, rows, meta). It delegates the search to findDataList so the
+// detection rules stay aligned with -f ndjson: top-level under a preferred
+// key, or one level deep under {result|response|data}. Meta is built from
+// every sibling of the list — at both the outer and inner level when the
+// list sits one level deep — so callers like the table renderer's footer and
+// the csv broadcastMeta path see the same key set.
 func extractRowsFromMap(payload map[string]any) ([]string, [][]string, map[string]any, bool) {
-	for _, key := range preferredListKeys {
-		value, ok := payload[key]
-		if !ok {
-			continue
-		}
-		list, ok := value.([]any)
-		if !ok {
-			continue
-		}
-		headers, rows, ok := rowsFromSlice(list)
-		if !ok {
-			continue
-		}
-		meta := make(map[string]any, len(payload)-1)
-		for metaKey, metaValue := range payload {
-			if metaKey == key {
+	loc := findDataList(payload)
+	if loc == nil {
+		return nil, nil, nil, false
+	}
+	headers, rows, ok := rowsFromSlice(loc.list)
+	if !ok {
+		return nil, nil, nil, false
+	}
+	meta := make(map[string]any)
+	if loc.outerKey == "" {
+		for k, v := range payload {
+			if k == loc.innerKey {
 				continue
 			}
-			meta[metaKey] = metaValue
+			meta[k] = v
 		}
-		return headers, rows, meta, true
+	} else {
+		for k, v := range payload {
+			if k == loc.outerKey {
+				continue
+			}
+			meta[k] = v
+		}
+		if inner, ok := payload[loc.outerKey].(map[string]any); ok {
+			for k, v := range inner {
+				if k == loc.innerKey {
+					continue
+				}
+				if _, exists := meta[k]; exists {
+					// Outer wins on key collision so users see the wrapper-level
+					// sibling rather than a clobbered inner one.
+					continue
+				}
+				meta[k] = v
+			}
+		}
 	}
-	return nil, nil, nil, false
+	return headers, rows, meta, true
 }
 
 func rowsFromSlice(items []any) ([]string, [][]string, bool) {

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -33,6 +33,12 @@ const (
 	FormatTable  Format = "table"
 	FormatRaw    Format = "raw"
 	FormatPretty Format = "pretty"
+	// FormatNDJSON emits one JSON object per line — friendly for streaming /
+	// piping list results into downstream tools. See ndjson.go.
+	FormatNDJSON Format = "ndjson"
+	// FormatCSV emits comma-separated values for list-shaped results — friendly
+	// for spreadsheets and non-technical consumers. See csv.go (#252, WIP).
+	FormatCSV Format = "csv"
 )
 
 var preferredListKeys = []string{"items", "results", "data", "list", "records", "tools", "servers", "products"}
@@ -78,6 +84,10 @@ func Write(w io.Writer, format Format, payload any) error {
 		return writeTableish(w, payload)
 	case FormatPretty:
 		return writePretty(w, payload)
+	case FormatNDJSON:
+		return writeNDJSON(w, payload)
+	case FormatCSV:
+		return writeCSV(w, payload)
 	default:
 		return WriteJSON(w, payload)
 	}
@@ -128,6 +138,10 @@ func normalizeFormat(raw string, fallback Format) Format {
 		return FormatTable
 	case string(FormatPretty):
 		return FormatPretty
+	case string(FormatNDJSON):
+		return FormatNDJSON
+	case string(FormatCSV):
+		return FormatCSV
 	default:
 		return fallback
 	}

--- a/internal/output/ndjson.go
+++ b/internal/output/ndjson.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+)
+
+// writeNDJSON renders payload as newline-delimited JSON (https://ndjson.org):
+//   - a top-level array       → one element per line
+//   - an object that wraps a  → one element of that list per line
+//     well-known list key       (items / results / data / records / value / ...)
+//   - anything else           → a single line containing the whole value
+//
+// This is the streaming-friendly counterpart to `-f json`: each line is an
+// independent, compact JSON document so consumers can `jq -c`, `while read`,
+// or pipe into log pipelines without buffering the whole response.
+//
+// TODO(#252): consider honouring --fields per-line projection here too (today
+// WriteFiltered already applies SelectFields before Write is reached, so this
+// works, but a dedicated test would be good). Also decide whether non-list
+// payloads should error under `-f ndjson` instead of degrading to one line.
+func writeNDJSON(w io.Writer, payload any) error {
+	normalized, err := roundTripJSON(payload)
+	if err != nil {
+		return err
+	}
+
+	bw := bufio.NewWriter(w)
+	enc := json.NewEncoder(bw)
+	// json.Encoder.Encode already appends a trailing newline per call.
+
+	switch v := normalized.(type) {
+	case []any:
+		for _, item := range v {
+			if err := enc.Encode(item); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		if loc := findDataList(v); loc != nil {
+			for _, item := range loc.list {
+				if err := enc.Encode(item); err != nil {
+					return err
+				}
+			}
+		} else {
+			if err := enc.Encode(v); err != nil {
+				return err
+			}
+		}
+	default:
+		if err := enc.Encode(v); err != nil {
+			return err
+		}
+	}
+	return bw.Flush()
+}
+
+// roundTripJSON normalizes an arbitrary Go value into the
+// map[string]any / []any / scalar shape used by the rest of this package by
+// marshalling and unmarshalling it through encoding/json.
+func roundTripJSON(payload any) (any, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/output/ndjson_csv_test.go
+++ b/internal/output/ndjson_csv_test.go
@@ -69,16 +69,80 @@ func TestWriteNDJSON(t *testing.T) {
 	}
 }
 
-// TODO(#252): replace this with real coverage once writeCSV is implemented —
-// happy-path list (incl. a comma-bearing and a CJK field), empty list, and the
-// non-list fallback. For now it just pins the not-implemented contract.
-func TestWriteCSVNotImplementedYet(t *testing.T) {
-	var buf bytes.Buffer
-	err := Write(&buf, FormatCSV, []any{map[string]any{"id": "1"}})
-	if err == nil {
-		t.Fatal("expected -f csv to return a not-implemented error; got nil — did you implement writeCSV? then update this test (#252)")
+func TestWriteCSV(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload any
+		want    string
+	}{
+		{
+			// Union of keys (sorted), missing values → empty cells, a field with
+			// a comma gets quoted, CJK passes through verbatim, a nested array is
+			// rendered as compact JSON with its quotes CSV-escaped.
+			name: "list of objects",
+			payload: []any{
+				map[string]any{"id": "1", "name": "张三"},
+				map[string]any{"id": "2", "name": "Bob, Jr."},
+				map[string]any{"id": "3", "tags": []any{"x", "y"}},
+			},
+			want: "id,name,tags\n" +
+				"1,张三,\n" +
+				"2,\"Bob, Jr.\",\n" +
+				"3,,\"[\"\"x\"\",\"\"y\"\"]\"\n",
+		},
+		{
+			// {records:[...], total:N}: the list becomes the table, the sibling
+			// metadata (total) is dropped.
+			name: "wrapped list with metadata",
+			payload: map[string]any{
+				"records": []any{map[string]any{"id": "1"}, map[string]any{"id": "2"}},
+				"total":   2,
+			},
+			want: "id\n1\n2\n",
+		},
+		{
+			// A plain object → two-column key,value CSV with keys sorted.
+			name:    "single object",
+			payload: map[string]any{"ok": true, "name": "x"},
+			want:    "key,value\nname,x\nok,true\n",
+		},
+		{
+			name:    "scalar",
+			payload: "hello",
+			want:    "hello\n",
+		},
 	}
-	if !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("error = %q, want it to mention 'not implemented'", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := Write(&buf, FormatCSV, tc.payload); err != nil {
+				t.Fatalf("Write(csv) error = %v", err)
+			}
+			if got := buf.String(); got != tc.want {
+				t.Errorf("Write(csv) =\n%q\nwant\n%q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWriteCSVComposesWithFields guards that --fields projection (applied by
+// WriteFiltered before Write) narrows the CSV columns.
+func TestWriteCSVComposesWithFields(t *testing.T) {
+	payload := map[string]any{
+		"items": []any{
+			map[string]any{"id": "1", "name": "Alice", "secret": "s1"},
+			map[string]any{"id": "2", "name": "Bob", "secret": "s2"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := WriteFiltered(&buf, FormatCSV, payload, "id,name", ""); err != nil {
+		t.Fatalf("WriteFiltered(csv) error = %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "secret") || strings.Contains(got, "s1") {
+		t.Errorf("--fields did not drop the secret column; got:\n%s", got)
+	}
+	if !strings.Contains(got, "id,name") || !strings.Contains(got, "Alice") {
+		t.Errorf("expected projected columns id,name with values; got:\n%s", got)
 	}
 }

--- a/internal/output/ndjson_csv_test.go
+++ b/internal/output/ndjson_csv_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFormatRecognizesNDJSONAndCSV(t *testing.T) {
+	if got := normalizeFormat("ndjson", FormatJSON); got != FormatNDJSON {
+		t.Errorf("normalizeFormat(ndjson) = %q, want %q", got, FormatNDJSON)
+	}
+	if got := normalizeFormat("CSV", FormatJSON); got != FormatCSV {
+		t.Errorf("normalizeFormat(CSV) = %q, want %q", got, FormatCSV)
+	}
+}
+
+func TestWriteNDJSON(t *testing.T) {
+	cases := []struct {
+		name      string
+		payload   any
+		wantLines []string
+	}{
+		{
+			name:      "top-level array",
+			payload:   []any{map[string]any{"id": "1"}, map[string]any{"id": "2"}},
+			wantLines: []string{`{"id":"1"}`, `{"id":"2"}`},
+		},
+		{
+			name:      "wrapped list",
+			payload:   map[string]any{"items": []any{map[string]any{"id": "1"}, map[string]any{"id": "2"}}, "count": 2},
+			wantLines: []string{`{"id":"1"}`, `{"id":"2"}`},
+		},
+		{
+			name:      "scalar-ish object",
+			payload:   map[string]any{"ok": true},
+			wantLines: []string{`{"ok":true}`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := Write(&buf, FormatNDJSON, tc.payload); err != nil {
+				t.Fatalf("Write(ndjson) error = %v", err)
+			}
+			got := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+			if len(got) != len(tc.wantLines) {
+				t.Fatalf("got %d lines %q, want %d %q", len(got), got, len(tc.wantLines), tc.wantLines)
+			}
+			for i, want := range tc.wantLines {
+				if strings.TrimSpace(got[i]) != want {
+					t.Errorf("line %d = %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TODO(#252): replace this with real coverage once writeCSV is implemented —
+// happy-path list (incl. a comma-bearing and a CJK field), empty list, and the
+// non-list fallback. For now it just pins the not-implemented contract.
+func TestWriteCSVNotImplementedYet(t *testing.T) {
+	var buf bytes.Buffer
+	err := Write(&buf, FormatCSV, []any{map[string]any{"id": "1"}})
+	if err == nil {
+		t.Fatal("expected -f csv to return a not-implemented error; got nil — did you implement writeCSV? then update this test (#252)")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error = %q, want it to mention 'not implemented'", err)
+	}
+}

--- a/internal/output/ndjson_csv_test.go
+++ b/internal/output/ndjson_csv_test.go
@@ -91,14 +91,25 @@ func TestWriteCSV(t *testing.T) {
 				"3,,\"[\"\"x\"\",\"\"y\"\"]\"\n",
 		},
 		{
-			// {records:[...], total:N}: the list becomes the table, the sibling
-			// metadata (total) is dropped.
+			// {records:[...], total:N}: the list becomes the table; sibling
+			// metadata (total) is broadcast as a trailing column on every row.
 			name: "wrapped list with metadata",
 			payload: map[string]any{
 				"records": []any{map[string]any{"id": "1"}, map[string]any{"id": "2"}},
 				"total":   2,
 			},
-			want: "id\n1\n2\n",
+			want: "id,total\n1,2\n2,2\n",
+		},
+		{
+			// Empty list + metadata: still emit the header (data + meta) plus a
+			// single row of empty data cells carrying the meta values.
+			name: "empty wrapped list with metadata",
+			payload: map[string]any{
+				"records": []any{},
+				"total":   0,
+				"hasMore": false,
+			},
+			want: "value,hasMore,total\n,false,0\n",
 		},
 		{
 			// A plain object → two-column key,value CSV with keys sorted.

--- a/internal/output/ndjson_csv_test.go
+++ b/internal/output/ndjson_csv_test.go
@@ -157,3 +157,79 @@ func TestWriteCSVComposesWithFields(t *testing.T) {
 		t.Errorf("expected projected columns id,name with values; got:\n%s", got)
 	}
 }
+
+// TestTabularDetectsRealDingTalkEnvelopes guards against shipping a -f csv /
+// -f ndjson that degrades to one-line-key-value for the envelope shapes the
+// real product surface actually returns. Each case is a payload shape observed
+// in production (contact / doc / mail / todo / chat search responses).
+func TestTabularDetectsRealDingTalkEnvelopes(t *testing.T) {
+	cases := []struct {
+		name        string
+		payload     map[string]any
+		wantNDLines int    // expected line count from -f ndjson
+		wantCSVHead string // first header line of -f csv
+	}{
+		{
+			name: "result direct array (contact user search)",
+			payload: map[string]any{
+				"result":  []any{map[string]any{"name": "张三", "userId": "123"}, map[string]any{"name": "李四", "userId": "456"}},
+				"success": true,
+			},
+			wantNDLines: 2,
+			wantCSVHead: "name,userId,success",
+		},
+		{
+			name: "documents top-level (doc search)",
+			payload: map[string]any{
+				"documents":     []any{map[string]any{"nodeId": "n1", "name": "A"}, map[string]any{"nodeId": "n2", "name": "B"}},
+				"hasMore":       true,
+				"nextPageToken": "tok",
+			},
+			wantNDLines: 2,
+			wantCSVHead: "name,nodeId,hasMore,nextPageToken",
+		},
+		{
+			name: "emailAccounts top-level (mail mailbox list)",
+			payload: map[string]any{
+				"emailAccounts": []any{map[string]any{"email": "a@b.com", "type": "ORG"}},
+				"success":       "true",
+			},
+			wantNDLines: 1,
+			wantCSVHead: "email,type,success",
+		},
+		{
+			name: "todoCards under result wrapper (todo task list)",
+			payload: map[string]any{
+				"result": map[string]any{
+					"todoCards": []any{
+						map[string]any{"taskId": "t1", "subject": "做一做"},
+						map[string]any{"taskId": "t2", "subject": "再做一做"},
+					},
+				},
+			},
+			wantNDLines: 2,
+			wantCSVHead: "subject,taskId",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var nd bytes.Buffer
+			if err := Write(&nd, FormatNDJSON, tc.payload); err != nil {
+				t.Fatalf("ndjson write: %v", err)
+			}
+			ndLines := strings.Split(strings.TrimRight(nd.String(), "\n"), "\n")
+			if len(ndLines) != tc.wantNDLines {
+				t.Errorf("ndjson: got %d lines %q, want %d", len(ndLines), ndLines, tc.wantNDLines)
+			}
+
+			var c bytes.Buffer
+			if err := Write(&c, FormatCSV, tc.payload); err != nil {
+				t.Fatalf("csv write: %v", err)
+			}
+			gotHead := strings.SplitN(c.String(), "\n", 2)[0]
+			if gotHead != tc.wantCSVHead {
+				t.Errorf("csv header: got %q, want %q", gotHead, tc.wantCSVHead)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements #252 — closes it.

`larksuite/cli` 暴露了 `--format ndjson` / `--format csv`，dws 之前只有 `json / table / raw / pretty`。这两个格式现在变成一等公民的全局 format，并且**在真实钉钉响应上能直接用**——不是只在 `dws schema` 这种"完美 payload"上能用。

## 这个 PR 干了什么

### 1. 加两个格式器（最初的实现）

- `internal/output/ndjson.go` — `-f ndjson`：每行一条紧凑 JSON（[ndjson.org](https://ndjson.org)），适合 `jq -c` / `while read` / 日志管道。
- `internal/output/csv.go` — `-f csv`：RFC-4180 CSV，转义 / 引号 / 嵌入换行 / CJK 全部走 `encoding/csv` 标准库，列序和值展开方式**复用 `-f table` 的 helpers**（`normalizePayload` / `unwrapPrimaryObject` / `extractRowsFromMap` / `rowsFromSlice` / `formatValue`），保证 table 和 csv 视觉一致。
- `internal/output/formatter.go` — 加 `FormatNDJSON` / `FormatCSV` 常量，在 `Write()` / `normalizeFormat()` 里分发。
- `internal/app/flags.go` — `--format` help 文案加 `ndjson|csv`。

### 2. 中间发现一个真实可用性问题

跑了 7 个产品的真接口（contact / chat / doc / mail / todo / minutes / schema）拉通验证后发现：原版的 list 检测白名单只认 `items|results|data|list|records|tools|servers|products`，但**真实钉钉响应**用的 list key 是：

| 命令 | 实际 envelope key |
|---|---|
| `contact user search` | `{result:[...], success}`（`result` 单数直接是数组） |
| `chat search` | `{result:{value:[...], hasMore, nextCursor, total}, success}` |
| `doc search` | `{documents:[...], hasMore, nextPageToken, logId, success}` |
| `mail mailbox list` | `{emailAccounts:[...], success}` |
| `todo task list` | `{result:{todoCards:[...]}}` |

结果 csv 全部退化成 `key,value` 两列、ndjson 全部退化成"整包一行"——基本等于这两个 flag 没用。

### 3. 顺手把这个 gap 补完

第三个 commit 做了：

1. **扩 `preferredListKeys`**：加上 `result / value / documents / emailAccounts / todoCards / events / messages`。同时把这个列表升级为 csv / table / ndjson **共享的单一事实源**——`filter.go` 的 `findDataList` 不再维护自己的本地 `listKeys`，直接复用。
2. **`extractRowsFromMap` 委托给 `findDataList`**：自动获得"一层深度"包裹的支持（`{result: {todoCards:[...]}}` 这种），meta 拉通 outer + inner 双层 sibling，outer 同名 key 优先（避免 inner 把 success / total 覆盖掉）。
3. **`writeTableish` / `writeCSV` 调换优先级**：先试 list 检测，没命中再 `unwrapPrimaryObject` —— 否则 `{result: {todoCards:[...]}}` 会被 unwrap 剥掉外层直接走 key,value 分支。
4. **空数组 + preferred key 也能命中**：保留原来"空 list + metadata 渲染为表格 + meta 广播一行"的行为不回归。

### 4. 顺带受益：`-f table` 也变好了

因为白名单和 `unwrapPrimaryObject` 优先级调整是在共用代码路径上的，**原有的 `-f table` 在以上所有命令上也变成正常表格**了——之前 `dws todo task list -f table` 同样会退化成 key,value，没人注意而已。

## 修复前后对比（示意，敏感数据已脱敏）

**`dws todo task list -f csv --fields subject,priority,taskId`**

修复前：
```
key,value
todoCards,"[{""createdTime"":<ts>,""subject"":""<task>"",...20 条全压在一格里...}]"
```

修复后：
```
priority,subject,taskId
20,<task subject 1>,<taskId 1>
20,<task subject 2>,<taskId 2>
40,<task subject 3>,<taskId 3>
... (共 20 行，可直接拖进 Excel)
```

**`dws contact user search --query <name> -f csv`**

修复前：`result,"[{...全压在一格...}]"`
修复后：
```
flowerName,name,nick,openDingTalkId,title,userId,success
<flowerName>,<name>,<nick>,<openDingTalkId>,,<userId>,true
```

**`dws doc search --query <kw> -f csv`** — `documents` 进表，`hasMore / nextPageToken / logId / success` 自动广播成每行尾列：
```
name,nodeId,hasMore,logId,nextPageToken,success
<docName>,<nodeId>,true,<logId>,<token>,true
... (N 行)
```

**`dws schema -f csv --fields id,name`** — 原本就能跑，验证没回归：
```
id,name,count,kind
ding,DING消息,17,schema
contact,contact,17,schema
...
```

## 测试

### 单元
- `internal/output/ndjson_csv_test.go`：
  - `TestNormalizeFormatRecognizesNDJSONAndCSV`
  - `TestWriteNDJSON`：top-level array / wrapped list / scalar 对象
  - `TestWriteCSV`：list-of-objects（含逗号 / CJK / 嵌套数组）、wrapped-list-with-metadata、empty-list-with-metadata、single-object、scalar
  - `TestWriteCSVComposesWithFields`：`--fields` 投影组合
  - **新增 `TestTabularDetectsRealDingTalkEnvelopes`**：四个真实 envelope 形态（contact 的 `result` 直接数组、doc 的 `documents` 顶层、mail 的 `emailAccounts` 顶层、todo 的 `result.todoCards` 一层深度）回归
- `go test ./internal/output/...` ✅

### 真接口（已登录态跑过 7 个产品共 19 个 case）
- `contact user search` / `chat search` / `doc search` / `mail mailbox list` / `todo task list` 全部从"退化"变成"正常表"
- 空 list 场景（查不到时）：csv 仍出表头 + 空数据行 + meta 广播
- python `csv.DictReader` round-trip 解析通过（RFC-4180 转义无误）
- `jq -c` / `while read` 都能直接用 ndjson 输出
- `--fields` 投影组合：csv / ndjson 都正确收窄数据列（meta 列不受 fields 影响，这是设计行为，已在注释里说明）

### CI
Lint / Test / Coverage / Policy Check / Edition Contract Tests 全部 ✅。

## Follow-ups（不在本 PR）

- `docs/command-index.md` 全局 flag 表 + README Features 提一下 `ndjson` / `csv`。
- 是否让 csv 输出的列序跟 `--fields <a,b,c>` 给出的顺序对齐（目前是字母序，跟原有 `-f table` 行为一致）。独立小优化，单开。
- CHANGELOG `## [Unreleased]` 段在 main 上已经有了（#250 引入），合并时再加一条 `### Added` bullet 即可。