### PR TITLE
feat(auth): scaffold `dws auth scopes` / `dws auth check <scope>` (#253)

### DIFF
--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -57,6 +57,9 @@ func buildAuthCommand() *cobra.Command {
 		newAuthStatusCommand(),
 		newAuthExchangeCommand(),
 		newAuthResetCommand(),
+		// TODO(#253): scopes / check are skeletons — see auth_scopes_command.go.
+		newAuthScopesCommand(),
+		newAuthCheckCommand(),
 	)
 	return cmd
 }

--- a/internal/app/auth_scopes_command.go
+++ b/internal/app/auth_scopes_command.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/spf13/cobra"
+)
+
+// issue253URL points at the tracking issue so the stub error messages are
+// actionable. Remove the references once the commands are implemented.
+const issue253URL = "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/issues/253"
+
+// newAuthScopesCommand is the SKELETON for `dws auth scopes` (#253).
+//
+// Goal: list the OAuth scopes granted to the currently-logged-in identity, so
+// users and agents can answer "why am I getting a permission error?" without
+// guessing.
+//
+// TODO(#253): implement.
+//   - Source of truth for granted scopes: the stored token. Look at
+//     internal/auth (TokenData / identity.go) — the OAuth token response, or a
+//     JWT-style access token, carries the granted scope set; surface it here.
+//     If the encrypted MCP-default token doesn't expose scopes, say so clearly
+//     and point at `dws auth login` with `--client-id/--client-secret`.
+//   - Cross-reference with internal/auth/auth_registry.go for the catalogue of
+//     scopes the CLI knows about (human-readable names / which products need
+//     them), so the output can mark "granted" vs "available but not granted".
+//   - Honour the global -f flag via output.WriteCommandPayload; default JSON
+//     shape: {"granted":[...],"identity":{...}}.
+//   - Optional: a --check <scope> shortcut here, but `dws auth check` (below)
+//     is the dedicated entry point.
+func newAuthScopesCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "scopes",
+		Short:             "列出当前登录身份已授予的 OAuth scope",
+		Long:              "列出当前登录身份已授予的 OAuth scope，便于排查权限不足问题。\n\n[未实现 — 见 " + issue253URL + "]",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(#253): replace with the real implementation described above.
+			return apperrors.NewInternal(fmt.Sprintf("`dws auth scopes` is not implemented yet — see %s", issue253URL))
+		},
+	}
+}
+
+// newAuthCheckCommand is the SKELETON for `dws auth check <scope>` (#253).
+//
+// Goal: exit 0 if <scope> is granted to the current identity, non-zero with a
+// "how to request it" hint otherwise — so scripts/agents can gate on it.
+//
+// TODO(#253): implement.
+//   - Reuse whatever `dws auth scopes` ends up using to read the granted set.
+//   - Match <scope> case-insensitively against the granted set; print a short
+//     OK/NOT-GRANTED line (and JSON under -f json: {"scope":..,"granted":bool}).
+//   - On NOT-GRANTED return a non-zero exit (apperrors with a non-zero code so
+//     CI/scripts can branch) and include the admin-approval / re-login hint
+//     that `dws auth login` already shows when a scope is missing.
+//   - Optional `--for <command>`: resolve the command's required scope(s) via
+//     the same metadata `dws schema` reads, then check each — pairs naturally
+//     with #251.
+func newAuthCheckCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "check <scope>",
+		Short:             "检查指定 OAuth scope 是否已授权 (未授权时退出码非 0)",
+		Long:              "检查指定 OAuth scope 是否已授予当前登录身份；未授权时退出码非 0 并给出申请引导。\n\n[未实现 — 见 " + issue253URL + "]",
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO(#253): replace with the real implementation described above.
+			return apperrors.NewInternal(fmt.Sprintf("`dws auth check` is not implemented yet — see %s", issue253URL))
+		},
+	}
+}

--- a/internal/app/auth_scopes_command_test.go
+++ b/internal/app/auth_scopes_command_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestAuthScopesAndCheckRegistered guards that the skeleton subcommands stay
+// wired into `dws auth`. Once #253 is implemented, replace the not-implemented
+// assertions below with real behaviour coverage.
+func TestAuthScopesAndCheckRegistered(t *testing.T) {
+	auth := buildAuthCommand()
+	for _, name := range []string{"scopes", "check"} {
+		sub, _, err := auth.Find([]string{name})
+		if err != nil || sub == nil || sub.Name() != name {
+			t.Fatalf("expected `dws auth %s` to be registered; err=%v sub=%v", name, err, sub)
+		}
+	}
+}
+
+// TODO(#253): replace with real coverage once `dws auth scopes` / `dws auth
+// check` are implemented (granted-scope listing, exit-code behaviour, --for).
+func TestAuthScopesNotImplementedYet(t *testing.T) {
+	cmd := newAuthScopesCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(nil)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected `dws auth scopes` to return a not-implemented error; got nil — implementing #253? update this test")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error = %q, want it to mention 'not implemented'", err)
+	}
+}
+
+func TestAuthCheckNotImplementedYet(t *testing.T) {
+	cmd := newAuthCheckCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"Calendar.Events.Write"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected `dws auth check` to return a not-implemented error; got nil — implementing #253? update this test")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error = %q, want it to mention 'not implemented'", err)
+	}
+}


### PR DESCRIPTION
Skeleton PR for #253. Closes #253 once implemented.

## Why

`larksuite/cli` exposes `auth scopes` / `auth check`. dws's `dws auth` only has `login / logout / status / exchange / reset`, so when a command fails with a permission error there's no way to ask "what scopes does this token have?" or "what does this command need?". This wires the two commands in as stubs so the implementation has a home.

## What's here

- **`internal/app/auth_scopes_command.go`** — `newAuthScopesCommand()` (`dws auth scopes`) and `newAuthCheckCommand()` (`dws auth check <scope>`). Both currently return a clear `not implemented (#253)` error. Each has a TODO block spelling out the plan:
  - granted scopes → read from the stored token (`internal/auth`, `identity.go` / `TokenData`); if the encrypted MCP-default token doesn't expose scopes, say so and point at `dws auth login --client-id/--client-secret`.
  - cross-reference `internal/auth/auth_registry.go` for the known-scope catalogue → mark "granted" vs "available but not granted".
  - `dws auth check <scope>` → exit non-zero + admin-approval / re-login hint when not granted (so scripts/CI can gate).
  - optional `dws auth check --for <command>` → resolve required scope(s) from the same metadata `dws schema` reads (pairs with #251).
  - honour the global `-f` flag via `output.WriteCommandPayload`.
- **`internal/app/auth_command.go`** — registers both under `dws auth`.
- **`internal/app/auth_scopes_command_test.go`** — pins that both subcommands stay registered and the current not-implemented contract; TODOs to replace with real coverage.

No behaviour change to existing `dws auth` subcommands. `go build ./...` + `go test ./internal/app/ -run 'TestAuthScopes|TestAuthCheck'` green.

## How to pick this up

Implement the two `RunE`s per the TODOs, replace the not-implemented tests with real coverage (granted-scope listing, `check` exit-code behaviour, `--for`), update `docs/command-index.md`'s `dws auth` section, drop `[draft]`.

