### PR TITLE
ci(release): add workflow_dispatch trigger as fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch:` to `.github/workflows/release.yml` so the release job can be triggered manually from any tag/branch ref.
- No change to the existing `push: tags: v*` trigger.

## 背景
本次 `v1.0.24` tag 推上去后，push event 没有触发 release workflow（三次删-推都没起来）。GitHub Actions 偶发会吞 tag push 事件，目前没有"重放"机制，唯一兜底是改 workflow 本身。

加 `workflow_dispatch` 后，遇到同类问题可以直接：
```
gh workflow run release.yml --ref v1.0.24
```
立即在指定 tag 上跑发布流程（`github.ref_name` 仍会是 `v1.0.24`，下游所有 step 不用改）。

## Test plan
- [ ] PR 合入 main
- [ ] `gh workflow run release.yml --ref v1.0.24` 触发一次，确认 release 产物（7 个平台二进制 + dws-skills.zip + npm publish）齐全
- [ ] 后续正常 tag push 路径不受影响（下次发版验证）