### PR TITLE
fix(keychain): add DWS_DISABLE_KEYCHAIN fallback for macOS sandbox

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -10,6 +10,7 @@
 | `DWS_CLIENT_SECRET` | OAuth client secret (DingTalk AppSecret) |
 | `DWS_TRUSTED_DOMAINS` | Comma-separated trusted domains for bearer token (default: `*.dingtalk.com`). `*` for dev only / Bearer token 允许发送的域名白名单，默认 `*.dingtalk.com`，仅开发环境可设为 `*` |
 | `DWS_ALLOW_HTTP_ENDPOINTS` | Set `1` to allow HTTP for loopback during dev / 设为 `1` 允许回环地址 HTTP，仅用于开发调试 |
+| `DWS_DISABLE_KEYCHAIN` | macOS only. Set `1` to skip system Keychain for the encryption key and use file-based storage (same scheme as Linux). For sandboxed runtimes (e.g. Codex App) that block Keychain APIs. Weakens at-rest protection — DEK and ciphertext live in the same directory. / 仅 macOS。设为 `1` 时跳过系统 Keychain，密钥以文件形式存储（与 Linux 一致）。用于 Keychain API 被拦截的沙盒环境（如 Codex App）。代价是 DEK 与密文同目录，保护强度低于默认方案 |
 
 ## Exit Codes / 退出码
 

--- a/internal/keychain/file_dek.go
+++ b/internal/keychain/file_dek.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin || linux
+
+package keychain
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+)
+
+// fileDEK retrieves or generates a Data Encryption Key stored as a plain
+// file under the platform storage directory. Shared by Linux (default) and
+// the macOS sandbox fallback path (DWS_DISABLE_KEYCHAIN=1).
+func fileDEK(service string) ([]byte, error) {
+	dir := StorageDir(service)
+	keyPath := filepath.Join(dir, "dek")
+
+	key, err := os.ReadFile(keyPath)
+	if err == nil && len(key) == dekBytes {
+		return key, nil
+	}
+
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create keychain dir: %w", err)
+	}
+
+	key = make([]byte, dekBytes)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generate dek: %w", err)
+	}
+
+	tmpKeyPath := filepath.Join(dir, "dek."+uuid.New().String()+".tmp")
+	defer os.Remove(tmpKeyPath)
+
+	if err := os.WriteFile(tmpKeyPath, key, 0600); err != nil {
+		return nil, fmt.Errorf("write dek: %w", err)
+	}
+
+	if err := os.Rename(tmpKeyPath, keyPath); err != nil {
+		// If rename fails, another process might have created it. Try reading again.
+		existingKey, readErr := os.ReadFile(keyPath)
+		if readErr == nil && len(existingKey) == dekBytes {
+			return existingKey, nil
+		}
+		return nil, fmt.Errorf("save dek: %w", err)
+	}
+
+	return key, nil
+}

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -30,6 +30,14 @@ const (
 	// real user environment and from sibling test packages running in
 	// parallel. When empty, the platform default applies.
 	StorageDirEnv = "DWS_KEYCHAIN_DIR"
+
+	// DisableKeychainEnv opts the macOS implementation out of system
+	// Keychain access for the DEK, falling back to a file-based DEK
+	// (same scheme as Linux). Intended for sandboxed runtimes where
+	// Keychain APIs are blocked (e.g. Codex App). This weakens the
+	// at-rest protection — DEK and ciphertext live in the same
+	// directory — and is therefore opt-in.
+	DisableKeychainEnv = "DWS_DISABLE_KEYCHAIN"
 )
 
 // KeychainAccess abstracts keychain Get/Set/Remove for dependency injection.

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -59,8 +59,16 @@ func safeFileName(account string) string {
 	return safeFileNameRe.ReplaceAllString(account, "_") + ".enc"
 }
 
-// getDEK retrieves or generates the Data Encryption Key from system Keychain.
+// getDEK retrieves or generates the Data Encryption Key.
+// When DWS_DISABLE_KEYCHAIN=1 (set in sandboxed runtimes like Codex App
+// where Keychain APIs are blocked), falls back to a file-based DEK
+// identical to the Linux scheme. See DisableKeychainEnv docs for the
+// security tradeoff.
 func getDEK(service string) ([]byte, error) {
+	if os.Getenv(DisableKeychainEnv) != "" {
+		return fileDEK(service)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), keychainTimeout)
 	defer cancel()
 

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin
+
+package keychain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDisableKeychainFallback verifies that setting DWS_DISABLE_KEYCHAIN
+// routes the DEK to a local file (same scheme as Linux) and the full
+// Set/Get/Remove cycle works without touching the system Keychain.
+// This is the support path for sandboxed runtimes such as Codex App.
+func TestDisableKeychainFallback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(StorageDirEnv, tmp)
+	t.Setenv(DisableKeychainEnv, "1")
+
+	service := "test-disable-keychain"
+	account := "auth-token"
+	payload := `{"access_token":"abc","refresh_token":"def"}`
+
+	if err := Set(service, account, payload); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	// File DEK must materialize on disk.
+	dekPath := filepath.Join(tmp, service, "dek")
+	info, err := os.Stat(dekPath)
+	if err != nil {
+		t.Fatalf("file DEK not created at %s: %v", dekPath, err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Fatalf("DEK file perm = %o, want 0600", mode)
+	}
+
+	got, err := Get(service, account)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got != payload {
+		t.Fatalf("Get() = %q, want %q", got, payload)
+	}
+
+	// A second Get must reuse the same DEK (no regeneration).
+	dek1, err := os.ReadFile(dekPath)
+	if err != nil {
+		t.Fatalf("ReadFile(dek) error = %v", err)
+	}
+	if _, err := Get(service, account); err != nil {
+		t.Fatalf("second Get() error = %v", err)
+	}
+	dek2, err := os.ReadFile(dekPath)
+	if err != nil {
+		t.Fatalf("ReadFile(dek) second error = %v", err)
+	}
+	if string(dek1) != string(dek2) {
+		t.Fatal("DEK rotated between calls; want stable")
+	}
+
+	if err := Remove(service, account); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if Exists(service, account) {
+		t.Fatal("Exists() = true after Remove(), want false")
+	}
+}
+
+// TestDisableKeychainOverwrite verifies the fallback path supports
+// overwriting an existing token entry.
+func TestDisableKeychainOverwrite(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(StorageDirEnv, tmp)
+	t.Setenv(DisableKeychainEnv, "1")
+
+	service := "test-disable-keychain-overwrite"
+	account := "auth-token"
+
+	if err := Set(service, account, "initial"); err != nil {
+		t.Fatalf("Set() initial error = %v", err)
+	}
+	if err := Set(service, account, "overwritten"); err != nil {
+		t.Fatalf("Set() overwrite error = %v", err)
+	}
+
+	got, err := Get(service, account)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got != "overwritten" {
+		t.Fatalf("Get() = %q, want %q", got, "overwritten")
+	}
+}

--- a/internal/keychain/keychain_linux.go
+++ b/internal/keychain/keychain_linux.go
@@ -27,6 +27,11 @@ import (
 	"github.com/google/uuid"
 )
 
+// getDEK retrieves or generates the Data Encryption Key from local file.
+func getDEK(service string) ([]byte, error) {
+	return fileDEK(service)
+}
+
 const (
 	dekBytes = 32 // DEK = Data Encryption Key (AES-256)
 	ivBytes  = 12
@@ -54,48 +59,6 @@ var safeFileNameRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
 
 func safeFileName(account string) string {
 	return safeFileNameRe.ReplaceAllString(account, "_") + ".enc"
-}
-
-// getDEK retrieves or generates the Data Encryption Key from local file.
-func getDEK(service string) ([]byte, error) {
-	dir := StorageDir(service)
-	keyPath := filepath.Join(dir, "dek")
-
-	// Try to read existing DEK
-	key, err := os.ReadFile(keyPath)
-	if err == nil && len(key) == dekBytes {
-		return key, nil
-	}
-
-	// Create directory if needed
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return nil, fmt.Errorf("create keychain dir: %w", err)
-	}
-
-	// Generate new random DEK
-	key = make([]byte, dekBytes)
-	if _, err := rand.Read(key); err != nil {
-		return nil, fmt.Errorf("generate dek: %w", err)
-	}
-
-	// Atomic write to prevent multi-process initialization collision
-	tmpKeyPath := filepath.Join(dir, "dek."+uuid.New().String()+".tmp")
-	defer os.Remove(tmpKeyPath)
-
-	if err := os.WriteFile(tmpKeyPath, key, 0600); err != nil {
-		return nil, fmt.Errorf("write dek: %w", err)
-	}
-
-	if err := os.Rename(tmpKeyPath, keyPath); err != nil {
-		// If rename fails, another process might have created it. Try reading again.
-		existingKey, readErr := os.ReadFile(keyPath)
-		if readErr == nil && len(existingKey) == dekBytes {
-			return existingKey, nil
-		}
-		return nil, fmt.Errorf("save dek: %w", err)
-	}
-
-	return key, nil
 }
 
 func encryptData(plaintext string, key []byte) ([]byte, error) {


### PR DESCRIPTION
Fixes #214

## Summary
- macOS 实现里每次 token 读写都要从系统 Keychain 取 DEK，在 Codex App 等沙盒里 `security` / Keychain API 被拦截，整条链路就废了。
- 新增 opt-in 环境变量 `DWS_DISABLE_KEYCHAIN=1`，开启后 macOS 切换到与 Linux 相同的文件 DEK 方案，绕过系统 Keychain。
- 默认行为不变，只有显式设置 env 才会走 fallback。

## 改动
- `internal/keychain/keychain.go`: 新增 `DisableKeychainEnv` 常量 + 安全权衡说明
- `internal/keychain/file_dek.go`（新）: `darwin || linux` 共享的文件 DEK 实现
- `internal/keychain/keychain_linux.go`: `getDEK` 改为调用共享 `fileDEK`，去重 ~40 行
- `internal/keychain/keychain_darwin.go`: 检测到 `DWS_DISABLE_KEYCHAIN` 时短路到 `fileDEK`
- `internal/keychain/keychain_darwin_test.go`（新）: 覆盖 fallback 主路径 + 覆盖写场景
- `docs/reference.md`: 新增 `DWS_DISABLE_KEYCHAIN` 文档（中英），明确安全代价

## 安全权衡
开启 fallback 后，DEK 以 `0600` 权限文件落在 `~/Library/Application Support/dws-cli/dek`，与密文同目录，弱于默认的「Keychain 托管 DEK」。所以做成 opt-in，不自动 fallback，让用户在「沙盒能跑」和「Keychain 强保护」之间显式选择。

## Test plan
- [x] `go test ./internal/keychain/... -v` — 7/7 通过（5 旧 + 2 新）
- [x] `go test ./internal/auth/...` — 全过
- [x] `make lint` 通过（go vet + staticcheck）
- [x] `GOOS=linux/darwin/windows go build ./...` 三平台都过
- [ ] 沙盒回归（需要 issue 报告人在 Codex App 实际场景验证）

## 用户使用方式
```bash
export DWS_DISABLE_KEYCHAIN=1
dws auth login --client-id <key> --client-secret <secret>
# 后续命令也走文件 DEK，不再触碰系统 Keychain
```