### PR TITLE
feat(compat): bridge wukong↔opensource flag naming for dws sheet find (--query alias)

### DIFF
--- a/internal/compat/cross_edition_aliases.go
+++ b/internal/compat/cross_edition_aliases.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compat
+
+import "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
+
+// crossEditionFlagAliases bridges flag-name differences between the
+// open-source `dws` build and the closed-source DingTalk in-house build
+// ("wukong"). The same underlying MCP parameter can be exposed as
+// different CLI flag names across editions — when that happens, users
+// who follow wukong-flavoured docs or copy-paste wukong commands get a
+// confusing `unknown flag: --foo` error on open-source binaries.
+//
+// Each entry: canonical tool name (`<productID>.<rpcName>`) → MCP
+// parameter name → list of *additional* hidden CLI flag aliases to
+// accept. These do **not** override the primary CLI flag name advertised
+// by the server-side overlay; they're registered as silent fallbacks so
+// either spelling works.
+//
+// Adding entries:
+//   - Use the canonical path printed by `dws schema "<group> <name>"`.
+//   - Inspect the server overlay's `flag_overlay.<param>.alias` to find
+//     the open-source primary name. Add only the *other* edition's name
+//     as alias, not the primary.
+//   - Keep entries minimal — alias registration is hidden in help, but
+//     each one is a maintenance liability if the upstream renames again.
+//
+// Verified divergences (as of 2026-05):
+//
+//   sheet.find_cells | text → primary: --find (opensource), alias: --query (wukong)
+//
+// (Confirmed via `dws sheet find --help` showing `--find` on opensource
+// v1.0.26 and `--query` on wukong v0.2.67, where wukong's help description
+// explicitly states "别名: --find".)
+var crossEditionFlagAliases = map[string]map[string][]string{
+	"sheet.find_cells": {
+		"text": {"query"},
+	},
+}
+
+// applyCrossEditionAliases mutates `override.Flags` to add hidden CLI
+// aliases declared in `crossEditionFlagAliases` for the given canonical
+// tool path. No-op when the canonical path is unknown. Existing aliases
+// (whether from the server overlay or already injected) are preserved
+// and de-duplicated.
+func applyCrossEditionAliases(override *market.CLIToolOverride, canonicalPath string) {
+	if override == nil {
+		return
+	}
+	extras, ok := crossEditionFlagAliases[canonicalPath]
+	if !ok || len(extras) == 0 {
+		return
+	}
+	if override.Flags == nil {
+		override.Flags = make(map[string]market.CLIFlagOverride, len(extras))
+	}
+	for paramName, aliasesToAdd := range extras {
+		flag := override.Flags[paramName]
+		// Dedup against the primary alias + existing alias list.
+		existing := map[string]bool{}
+		if flag.Alias != "" {
+			existing[flag.Alias] = true
+		}
+		for _, a := range flag.Aliases {
+			existing[a] = true
+		}
+		added := false
+		for _, a := range aliasesToAdd {
+			if a == "" || existing[a] {
+				continue
+			}
+			flag.Aliases = append(flag.Aliases, a)
+			existing[a] = true
+			added = true
+		}
+		if added {
+			override.Flags[paramName] = flag
+		}
+	}
+}

--- a/internal/compat/cross_edition_aliases.go
+++ b/internal/compat/cross_edition_aliases.go
@@ -38,7 +38,7 @@ import "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
 //
 // Verified divergences (as of 2026-05):
 //
-//   sheet.find_cells | text → primary: --find (opensource), alias: --query (wukong)
+//	sheet.find_cells | text → primary: --find (opensource), alias: --query (wukong)
 //
 // (Confirmed via `dws sheet find --help` showing `--find` on opensource
 // v1.0.26 and `--query` on wukong v0.2.67, where wukong's help description

--- a/internal/compat/cross_edition_aliases_test.go
+++ b/internal/compat/cross_edition_aliases_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compat
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
+)
+
+func TestApplyCrossEditionAliases_NilOverride(t *testing.T) {
+	// Nil override must not panic.
+	applyCrossEditionAliases(nil, "sheet.find_cells")
+}
+
+func TestApplyCrossEditionAliases_UnknownCanonicalPath(t *testing.T) {
+	override := &market.CLIToolOverride{
+		Flags: map[string]market.CLIFlagOverride{
+			"text": {Alias: "find"},
+		},
+	}
+	applyCrossEditionAliases(override, "unknown.tool")
+	flag := override.Flags["text"]
+	if len(flag.Aliases) != 0 {
+		t.Fatalf("unexpected aliases injected for unknown path: %v", flag.Aliases)
+	}
+}
+
+func TestApplyCrossEditionAliases_SheetFindCells_AddsQuery(t *testing.T) {
+	override := &market.CLIToolOverride{
+		Flags: map[string]market.CLIFlagOverride{
+			"text": {Alias: "find"},
+		},
+	}
+	applyCrossEditionAliases(override, "sheet.find_cells")
+	flag := override.Flags["text"]
+	if flag.Alias != "find" {
+		t.Errorf("primary alias must not be overwritten, got %q", flag.Alias)
+	}
+	if !reflect.DeepEqual(flag.Aliases, []string{"query"}) {
+		t.Errorf("expected hidden alias [query], got %v", flag.Aliases)
+	}
+}
+
+func TestApplyCrossEditionAliases_DedupesAgainstExisting(t *testing.T) {
+	// If server overlay already declared --query as an alias (shouldn't
+	// happen today, but future-proofing), we must not duplicate it.
+	override := &market.CLIToolOverride{
+		Flags: map[string]market.CLIFlagOverride{
+			"text": {Alias: "find", Aliases: []string{"query"}},
+		},
+	}
+	applyCrossEditionAliases(override, "sheet.find_cells")
+	flag := override.Flags["text"]
+	if !reflect.DeepEqual(flag.Aliases, []string{"query"}) {
+		t.Errorf("alias should be deduped, got %v", flag.Aliases)
+	}
+}
+
+func TestApplyCrossEditionAliases_DedupesAgainstPrimary(t *testing.T) {
+	// If the primary alias already happens to be "query" (e.g. hypothetical
+	// inverse rename), we must not add it again as a hidden alias.
+	override := &market.CLIToolOverride{
+		Flags: map[string]market.CLIFlagOverride{
+			"text": {Alias: "query"},
+		},
+	}
+	applyCrossEditionAliases(override, "sheet.find_cells")
+	flag := override.Flags["text"]
+	if len(flag.Aliases) != 0 {
+		t.Errorf("must not duplicate primary as alias, got %v", flag.Aliases)
+	}
+}
+
+func TestApplyCrossEditionAliases_NilFlagsMap(t *testing.T) {
+	// Override without any Flags map yet — function must initialize it.
+	override := &market.CLIToolOverride{}
+	applyCrossEditionAliases(override, "sheet.find_cells")
+	if override.Flags == nil {
+		// Map auto-initialized for the param.
+		t.Fatalf("Flags map should have been initialized")
+	}
+	flag := override.Flags["text"]
+	if !reflect.DeepEqual(flag.Aliases, []string{"query"}) {
+		t.Errorf("expected [query] when injecting into empty Flags, got %v", flag.Aliases)
+	}
+}
+
+func TestCrossEditionRegistry_NoEmptyAliases(t *testing.T) {
+	// Lint: registry entries must not declare empty strings as aliases —
+	// they'd be silently dropped by applyCrossEditionAliases and clutter
+	// the table.
+	for canonical, params := range crossEditionFlagAliases {
+		for paramName, aliases := range params {
+			for _, a := range aliases {
+				if a == "" {
+					t.Errorf("empty alias in %s.%s", canonical, paramName)
+				}
+			}
+			// Ensure each alias list is unique within itself.
+			seen := map[string]bool{}
+			for _, a := range aliases {
+				if seen[a] {
+					t.Errorf("duplicate alias %q in %s.%s", a, canonical, paramName)
+				}
+				seen[a] = true
+			}
+			// Sortedness is not required but make sure deterministic
+			// iteration order downstream isn't accidentally relied on.
+			_ = sort.StringsAreSorted(aliases)
+		}
+	}
+}

--- a/internal/compat/dynamic_commands.go
+++ b/internal/compat/dynamic_commands.go
@@ -120,6 +120,11 @@ func BuildDynamicCommands(servers []market.ServerDescriptor, runner executor.Run
 		toolNames := sortedToolNames(cli.ToolOverrides)
 		for _, toolName := range toolNames {
 			override := cli.ToolOverrides[toolName]
+			// Cross-edition flag alias injection: bridges naming diffs
+			// between open-source and DingTalk in-house ("wukong") builds.
+			// See cross_edition_aliases.go for the registry and rationale.
+			// Mutates a local copy; the server-side overlay is untouched.
+			applyCrossEditionAliases(&override, strings.TrimSpace(cli.ID)+"."+strings.TrimSpace(toolName))
 			// §1.5: toolOverrides[tool].hidden = true → skip
 			if override.Hidden {
 				continue


### PR DESCRIPTION
## Summary

Adds a small `cross_edition_aliases` registry so the open-source `dws` CLI accepts wukong-flavoured flag spellings as **hidden** compat aliases. First entry: `dws sheet find --query` (wukong primary) is now accepted as an alias of `--find` (open-source primary).

Closes / refs: #280

## Problem

```bash
# v1.0.26 (current)
$ dws sheet find --query "test"
{"error":{"code":5,"message":"unknown flag: --query"}}
```

`dws schema "sheet find"` confirms the underlying MCP param is `text` in both editions; the divergence is purely the CLI-facing flag name (wukong calls it `--query` with `--find` as alias declared in help desc; open-source calls it `--find`). Any user copying wukong-flavoured docs / agent prompts hits this error.

## What changed

| File | Change |
|---|---|
| `internal/compat/cross_edition_aliases.go` *(new, 91 lines)* | Registry: `map[canonical]map[paramName][]aliasNames`. One entry: `sheet.find_cells.text` ← `query`. + `applyCrossEditionAliases` mutator. |
| `internal/compat/dynamic_commands.go` *(+5 lines)* | One-line hook inside `BuildDynamicCommands` §1.3 to apply the registry to each tool's local override copy. Server-side overlay untouched. |
| `internal/compat/cross_edition_aliases_test.go` *(new, 126 lines)* | 7 unit tests: nil guard, unknown path no-op, sheet.find_cells injection, dedup vs existing alias / primary, nil-Flags init, registry lint. |

## Mechanism (re-uses existing infrastructure)

The CLI already plumbs `CLIFlagOverride.Aliases []string` end-to-end (introduced in #272's structured unknown-flag recovery path):

- `internal/market/registry.go` declares the field with doc comment "preserve legacy flag names when migrating from hardcoded commands; all entries registered as hidden flags".
- `internal/compat/dynamic_commands.go` line 595-609 dedupes & registers them on the cobra binding.

This PR just provides a single place to declare known cross-edition naming divergences so they apply automatically per matched tool.

## Verification

After patch (built locally, `go build ./cmd`):

```bash
# --query now accepted (cobra moves past flag parsing to required-flag check)
$ dws-patched sheet find --query "test"
{"error":{"message":"required flag(s) \"node\", \"sheet-id\" not set"}}

# --find still primary, zero regression
$ dws-patched sheet find --find "test"
{"error":{"message":"required flag(s) \"node\", \"sheet-id\" not set"}}

# --help unchanged — --query is hidden
$ dws-patched sheet find --help 2>&1 | grep -E '^\s+--(find|query)'
      --find string         搜索文本 (必填)
```

## Tests

- 7 new tests in `internal/compat/cross_edition_aliases_test.go` all pass
- Full `go test ./internal/...` passes (no regression)
- `go vet ./...` clean

## Trade-offs / decisions

- **Why a hardcoded table and not config?** Cross-edition divergences are rare and require coordination with the wukong team — a code-level registry keeps the surface area visible and reviewable. Easy to convert to config later if entries proliferate.
- **Why hidden aliases instead of advertising both?** `--find` remains the documented primary on open-source builds. The alias is a compat bridge, not a recommendation.
- **Server-side fix?** Yes, the ideal long-term fix is to declare `aliases: ["query"]` in the server-side `flag_overlay` for `sheet.find_cells.text`. This client-side bridge unblocks users today without waiting on server coordination.

## Test plan

- [x] Unit tests added & green
- [x] `go test ./internal/...` no regression
- [x] `go vet ./...` clean
- [x] Manual smoke against built binary (above output)