### PR TITLE
fix(transport): suppress noisy WARN on stdio client shutdown

### DIFF
--- a/internal/transport/stdio.go
+++ b/internal/transport/stdio.go
@@ -106,6 +106,7 @@ func (s *StdioClient) Start(ctx context.Context) error {
 }
 
 // Stop kills the subprocess and waits for it to exit.
+// A non-zero exit code after Kill is expected and not treated as an error.
 func (s *StdioClient) Stop() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -116,11 +117,18 @@ func (s *StdioClient) Stop() error {
 
 	s.stdin.Close()
 
+	killed := false
 	if s.cmd.Process != nil {
 		_ = s.cmd.Process.Kill()
+		killed = true
 	}
 	err := s.cmd.Wait()
 	s.started = false
+	// A killed process always exits with a non-zero status; suppress that
+	// expected error to avoid noisy warnings on normal shutdown.
+	if killed {
+		return nil
+	}
 	return err
 }
 

--- a/internal/transport/stdio.go
+++ b/internal/transport/stdio.go
@@ -117,18 +117,14 @@ func (s *StdioClient) Stop() error {
 
 	s.stdin.Close()
 
-	killed := false
 	if s.cmd.Process != nil {
 		_ = s.cmd.Process.Kill()
-		killed = true
+		_ = s.cmd.Wait()
+		s.started = false
+		return nil
 	}
 	err := s.cmd.Wait()
 	s.started = false
-	// A killed process always exits with a non-zero status; suppress that
-	// expected error to avoid noisy warnings on normal shutdown.
-	if killed {
-		return nil
-	}
 	return err
 }
 

--- a/internal/transport/stdio_integration_test.go
+++ b/internal/transport/stdio_integration_test.go
@@ -97,10 +97,9 @@ func TestStdioClientEndToEnd(t *testing.T) {
 		t.Error("CallTool with unknown tool should return error")
 	}
 
-	// Stop
+	// Stop — after kill, Stop should return nil (non-zero exit is suppressed)
 	if err := client.Stop(); err != nil {
-		// Process killed, expected to return an error
-		_ = err
+		t.Errorf("Stop after kill should return nil, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Suppress noisy WARN log "failed to stop stdio client: exit status 1" on normal shutdown.

When `Stop()` explicitly kills the subprocess, the non-zero exit code is expected.
After kill, `Stop()` now returns nil instead of propagating the exit error.

## Changes

- `internal/transport/stdio.go`: Simplify Stop() — Kill+Wait+return nil inline, no separate flag
- `internal/transport/stdio_integration_test.go`: Assert Stop() returns nil after kill