### PR TITLE
fix(chat): require --title for group messages, completing #250's symmetric fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and this project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`dws chat message send` 群聊缺 `--title` 时前置校验** — 完成 #250 的对称修复。`send_message_as_user`（群聊）的 schema 同样把 `title` 列为 `required`，缺失时 API 返回与单聊一致的误导性 `发群服务窗会话消息失败`（实测：`dws chat message send --group <cid> --text "1"` 失败；带上 `--title` 后成功）。CLI 现在在 `buildChatMessageSendInvocation` 把缺 title 的校验扩展到 `--group` 分支，分别返回 `--title is required for group messages (--group)` 和原有的 `--title is required for direct messages (--user / --open-dingtalk-id)`；同时把 `Long` help、`--title` flag 描述、Example、`skills/references/products/chat.md` 全部对齐为「群聊与单聊都必填」。`internal/helpers/chat_test.go` 新增 `group-without-title` 断言，并把既有 `group` / `positional-text` 用例补上 `--title`，群聊 API 行为不变。
+
 ## [1.0.27] - 2026-05-14
 
 Two user-visible fixes plus the schema primitive they're built on. `dws doc update` now reads Markdown from a file or stdin, so long / multi-line / table-heavy content no longer gets mangled by shell escaping; `dws sheet find --query` stops returning `unknown flag` on the open-source build, restoring copy-paste from internal wukong docs. Underneath, schema/discovery envelopes get a generic `file_read` transform and a `CLIFlagOverride.MapsTo` field that lets two sibling CLI flags route into the same MCP parameter slot. Also suppresses a noisy WARN on normal stdio-plugin shutdown.

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -93,11 +93,11 @@ func newChatMessageSendCommand(runner executor.Runner) *cobra.Command {
 三者只能选其一，不能同时指定。
 
 消息内容通过 --text 传入，也可作为位置参数；支持 Markdown。
-单聊消息（--user / --open-dingtalk-id）必须提供 --title 作为消息标题；群聊可选。
+--title 是消息标题，群聊与单聊都必填（API 强制要求；缺失时返回误导性的 "发群服务窗会话消息失败"）。
 
 群聊场景下可用 --at-all / --at-users / --at-mobiles 进行 @ 提醒（仅 --group 时生效）。
 注意 --text 中需包含对应的 <@userId> / <@all> 占位符才能在客户端渲染出 @ 效果。`,
-		Example: `  dws chat message send --group <openconversation_id> --text "hello"
+		Example: `  dws chat message send --group <openconversation_id> --title "周报" --text "请提交本周日报"
   dws chat message send --user <userId> --title "提醒" --text "请查收"
   dws chat message send --open-dingtalk-id <openDingTalkId> --title "提醒" --text "请确认"
   dws chat message send --group <openconversation_id> --title "拉群通知" --text "<@uid> 你被 @ 了" --at-users uid`,
@@ -128,7 +128,7 @@ func newChatMessageSendCommand(runner executor.Runner) *cobra.Command {
 	cmd.Flags().String("user", "", "接收人 userId (单聊三选一)")
 	cmd.Flags().String("open-dingtalk-id", "", "接收人 openDingTalkId (单聊三选一)")
 	cmd.Flags().String("text", "", "消息内容，支持 Markdown (也可作位置参数)")
-	cmd.Flags().String("title", "", "消息标题 (单聊必填，群聊可选)")
+	cmd.Flags().String("title", "", "消息标题 (必填，群聊与单聊都必填)")
 	cmd.Flags().Bool("at-all", false, "@所有人 (仅 --group 群聊生效)")
 	cmd.Flags().String("at-users", "", "按 userId @ 指定成员，逗号分隔 (仅 --group 群聊生效)")
 	cmd.Flags().String("at-mobiles", "", "按手机号 @ 指定成员，逗号分隔 (仅 --group 群聊生效)")
@@ -196,10 +196,14 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 	if !hasGroup && (atAll || hasAtUsers || hasAtMobiles) {
 		return nil, "", apperrors.NewValidation("--at-all / --at-users / --at-mobiles only apply when --group is set")
 	}
-	// Direct-message tools (send_direct_message_as_user) reject an empty title at
-	// the API level with a misleading "发群服务窗会话消息失败" error, so fail loudly
-	// here instead. Group messages do not require a title.
-	if (hasUser || hasOpenID) && strings.TrimSpace(title) == "" {
+	// Both send_message_as_user (group) and send_direct_message_as_user (direct)
+	// reject an empty title at the API level with a misleading
+	// "发群服务窗会话消息失败" error, so fail loudly here instead. The schema
+	// declares title as a required parameter on both tools.
+	if strings.TrimSpace(title) == "" {
+		if hasGroup {
+			return nil, "", apperrors.NewValidation("--title is required for group messages (--group)")
+		}
 		return nil, "", apperrors.NewValidation("--title is required for direct messages (--user / --open-dingtalk-id)")
 	}
 

--- a/internal/helpers/chat_test.go
+++ b/internal/helpers/chat_test.go
@@ -60,7 +60,7 @@ func TestChatMessageSendRoutesByDestination(t *testing.T) {
 	}{
 		{
 			name:      "group",
-			args:      []string{"--group", "cid-xyz", "--text", "hello"},
+			args:      []string{"--group", "cid-xyz", "--title", "t", "--text", "hello"},
 			wantTool:  "send_message_as_user",
 			wantKey:   "openConversation_id",
 			wantValue: "cid-xyz",
@@ -81,7 +81,7 @@ func TestChatMessageSendRoutesByDestination(t *testing.T) {
 		},
 		{
 			name:      "positional-text",
-			args:      []string{"--group", "cid-xyz", "hello from positional"},
+			args:      []string{"--group", "cid-xyz", "--title", "t", "hello from positional"},
 			wantTool:  "send_message_as_user",
 			wantKey:   "text",
 			wantValue: "hello from positional",
@@ -131,6 +131,11 @@ func TestChatMessageSendRejectsInvalidDestination(t *testing.T) {
 			name:    "empty-text",
 			args:    []string{"--group", "cid-x"},
 			wantErr: "--text (or positional argument) is required",
+		},
+		{
+			name:    "group-without-title",
+			args:    []string{"--group", "cid-x", "--text", "hi"},
+			wantErr: "--title is required for group messages",
 		},
 		{
 			name:    "direct-user-without-title",

--- a/skills/references/products/chat.md
+++ b/skills/references/products/chat.md
@@ -183,7 +183,7 @@ Flags:
 
 ## message send — 以当前用户身份发消息
 
---group 指定群聊 ID 发群消息；--user 指定用户 userId 发单聊；--open-dingtalk-id 指定用户 openDingTalkId 发单聊。三者只能选其一，不能同时指定。消息内容为位置参数（恰好 1 个），支持 Markdown。单聊消息（--user / --open-dingtalk-id）必须提供 --title 作为消息标题；群聊可选。
+--group 指定群聊 ID 发群消息；--user 指定用户 userId 发单聊；--open-dingtalk-id 指定用户 openDingTalkId 发单聊。三者只能选其一，不能同时指定。消息内容为位置参数（恰好 1 个），支持 Markdown。`--title` 是消息标题，**群聊与单聊都必填**（API 强制要求；缺失时服务端返回误导性的 "发群服务窗会话消息失败"，CLI 现在前置校验直接报错）。
 --群聊时可选 --at-all @所有人，或 --at-users 指定成员（仅群聊时生效）。
 --发送图片消息：指定 --media-id（通过 dt_media_upload 工具上传获得），自动设置 msgType=image，此时不需要传文本内容。
 
@@ -191,15 +191,15 @@ Flags:
 Usage:
   dws chat message send [flags] [<text>]
 Example:
-  dws chat message send --group <openconversation_id> --text "hello"
+  dws chat message send --group <openconversation_id> --title "周报" --text "请提交本周日报"
   dws chat message send --user <userId> --title "提醒" --text "请查收"
   dws chat message send --open-dingtalk-id <openDingTalkId> --title "提醒" --text "请查收"
-  dws chat message send --group <openconversation_id> "hello"
+  dws chat message send --group <openconversation_id> --title "通知" "hello"
   dws chat message send --group <openconversation_id> --title "周报提醒" --text "请大家本周五前提交周报"
-  dws chat message send --group <openconversation_id> --at-all "<@all> 请大家注意"
-  dws chat message send --group <openconversation_id> --at-users userId1,userId2 "<@userId1> <@userId2> 请查收"
-  dws chat message send --group <openconversation_id> --media-id <mediaId>
-  dws chat message send --open-dingtalk-id <openDingTalkId> --media-id <mediaId>
+  dws chat message send --group <openconversation_id> --title "通知" --at-all "<@all> 请大家注意"
+  dws chat message send --group <openconversation_id> --title "通知" --at-users userId1,userId2 "<@userId1> <@userId2> 请查收"
+  dws chat message send --group <openconversation_id> --title "图片" --media-id <mediaId>
+  dws chat message send --open-dingtalk-id <openDingTalkId> --title "图片" --media-id <mediaId>
 Flags:
       --text string              消息内容（推荐使用，也可用位置参数）
       --group string             群聊 openconversation_id（群聊时必填）
@@ -219,6 +219,7 @@ Flags:
 
 注意:
   - --text 和位置参数二选一，--text 优先
+  - --title 必填（群聊与单聊都必填，API 强制要求）
   - --group、--user、--open-dingtalk-id 三者互斥，只需指定其一：群聊用 --group，单聊用 --user 或 --open-dingtalk-id
   - --group 的别名: --id, --chat, --conversation-id (均可替代 --group)
   - --at-all / --at-users / --at-mobiles 仅在 --group 群聊时生效；当设置--at-all时，消息内容中一定要包含对应的占位符<@all>；当设置--at-users userId1,userId2时，消息内容中一定要包含对应格式的占位符<@userId1> <@userId2>
@@ -722,7 +723,7 @@ dws drive download --file-id <dentryUuid> --format json
 
 # Step 5: 用 Markdown 图片语法发送
 dws chat message send --group <openconversation_id> \
-  --text "![截图](下载链接)" --format json
+  --title "截图" --text "![截图](下载链接)" --format json
 ```
 
 ## 上下文传递表


### PR DESCRIPTION
## Summary

- `dws chat message send --group <cid> --text "1"` (no `--title`) failed at the API with the same misleading `发群服务窗会话消息失败` that #250 already fixed for direct messages — because `send_message_as_user`'s schema also marks `title` as **required**, but `buildChatMessageSendInvocation` only had the pre-validation on the `--user` / `--open-dingtalk-id` branches.
- Completes #250 symmetrically: group sends without title now fail fast with `--title is required for group messages (--group)`; direct sends keep `--title is required for direct messages (--user / --open-dingtalk-id)`.
- Realigns Long help, the `--title` flag description, the first `Example`, and `skills/references/products/chat.md` (including the deeper drive→chat workflow example) to **"群聊与单聊都必填"** — the doc previously contradicted itself (the prose said "群聊可选" while the flag-listing said "（必填）").
- `internal/helpers/chat_test.go` adds a `group-without-title` rejection case; the existing `group` / `positional-text` success cases now pass `--title`.

### How it was discovered

```text
$ dws chat message send --group cidVlNfWzpM89yEZ0SL8mtEgw== --text "1"
{ "message": "发群服务窗会话消息失败", ... }

$ dws schema "chat message send" --jq '.tool.required'
[ "openConversation_id", "text", "title" ]

$ dws chat message send --group cidVlNfWzpM89yEZ0SL8mtEgw== --title "test" --text "1"
{ "errcode": 0, "errorMsg": "ok", "result": { "open_taskId": "..." } }
```

No API request shape change — server already required `title`; CLI now matches.

## Verification

- [x] `make build`
- [x] `make lint`
- [x] `make test` — `./internal/helpers/...` passes; pre-existing failures in `./test/cli_compat/...` (missing `testdata/empty_catalog.json` fixture) and `./test/unit` (`open_source_policy_test.go` flagging the existing `upgrade_embedded_guard_test.go`) reproduce on `origin/main` and are unrelated to this change.
- [x] `make policy`
- [x] `./scripts/policy/check-generated-drift.sh`
- [x] `./scripts/policy/check-command-surface.sh --strict` (command surface unchanged — only flag description text changed)

## Notes

- No behaviour change for callers who were already passing `--title` (which the underlying API has always required).
- Existing callers who were relying on the misleading server error to discover the missing flag will now get a deterministic CLI validation error with exit code 2 (same as the direct-message branch).
- Considered surfacing the underlying schema `required` list at runtime instead of hardcoding the check, but kept the same shape as #250 to stay minimal-diff. If a broader "auto-validate required fields from schema" pass lands, this check can be removed at that point.