### PR TITLE
fix(pat): emit safe device-flow authorization URL

### DIFF
--- a/internal/app/pat_auth_retry.go
+++ b/internal/app/pat_auth_retry.go
@@ -224,9 +224,7 @@ func enrichPATErrorWithOpenBrowser(raw string, openBrowser bool) string {
 		data = map[string]any{}
 		payload["data"] = data
 	}
-	if rawURI, ok := data["uri"].(string); ok && strings.TrimSpace(rawURI) != "" {
-		data["authorizationUrl"] = apperrors.PATAuthorizationURL(rawURI)
-	}
+	apperrors.ApplyPATAuthorizationFields(data)
 	data["openBrowser"] = openBrowser
 
 	encoded, err := json.Marshal(payload)

--- a/internal/app/pat_auth_retry_test.go
+++ b/internal/app/pat_auth_retry_test.go
@@ -904,6 +904,7 @@ func TestHandlePatAuthCheck_JSONModeCanOpenBrowserWithoutTextOutput(t *testing.T
 		globalFlags: &GlobalFlags{Format: "json"},
 	}
 	rawURI := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3Df72437f040f04a8295988ff71e690b35%26userCode%3D98JV-JSBL#/personalAuthorization?flowId=f72437f040f04a8295988ff71e690b35&userCode=98JV-JSBL"
+	wantURL := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3Df72437f040f04a8295988ff71e690b35%26userCode%3D98JV-JSBL"
 	raw := `{"code":"AGENT_CODE_NOT_EXISTS","data":{"desc":"test auth","flowId":"flow-json","uri":"` + rawURI + `","clientId":"test-client-id"}}`
 
 	var buf bytes.Buffer
@@ -921,8 +922,8 @@ func TestHandlePatAuthCheck_JSONModeCanOpenBrowserWithoutTextOutput(t *testing.T
 	if _, err := os.Stat(filepath.Join(tmpDir, "app.json")); !os.IsNotExist(err) {
 		t.Fatalf("json PAT mode must not persist shared app.json, stat error = %v", err)
 	}
-	if opened != rawURI {
-		t.Fatalf("opened url = %q, want verbatim %q", opened, rawURI)
+	if opened != wantURL {
+		t.Fatalf("opened url = %q, want canonical %q", opened, wantURL)
 	}
 	patOut, ok := err.(*apperrors.PATError)
 	if !ok {
@@ -936,8 +937,11 @@ func TestHandlePatAuthCheck_JSONModeCanOpenBrowserWithoutTextOutput(t *testing.T
 	if got, _ := data["uri"].(string); got != rawURI {
 		t.Fatalf("data.uri = %q, want verbatim %q", got, rawURI)
 	}
-	if got, _ := data["authorizationUrl"].(string); got != rawURI {
-		t.Fatalf("data.authorizationUrl = %q, want %q", got, rawURI)
+	if got, _ := data["authorizationUrl"].(string); got != wantURL {
+		t.Fatalf("data.authorizationUrl = %q, want %q", got, wantURL)
+	}
+	if got, _ := data["userCode"].(string); got != "98JV-JSBL" {
+		t.Fatalf("data.userCode = %q, want 98JV-JSBL", got)
 	}
 	if got, ok := data["openBrowser"].(bool); !ok || !got {
 		t.Fatalf("data.openBrowser = %#v, want true", data["openBrowser"])
@@ -1168,12 +1172,13 @@ func TestRetryWithPatAuthRetry_HostControlledReturnsJSON(t *testing.T) {
 	}
 }
 
-func TestHandlePatAuthCheck_OpensOpaqueURIWithoutRebuild(t *testing.T) {
+func TestHandlePatAuthCheck_OpensCanonicalAuthorizationURL(t *testing.T) {
 	t.Setenv(authpkg.AgentCodeEnv, "")
 	server, configDir := setupHandlePATServer(t, "APPROVED", "test-auth-code")
 	defer server.Close()
 
 	rawURI := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D50dff7654b7444e88ced7489b07cce8d%26userCode%3DQ8RY-X6E9#/personalAuthorization?flowId=50dff7654b7444e88ced7489b07cce8d&userCode=Q8RY-X6E9"
+	wantURL := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D50dff7654b7444e88ced7489b07cce8d%26userCode%3DQ8RY-X6E9"
 	var opened string
 	origOpenBrowser := openBrowserFunc
 	openBrowserFunc = func(rawURL string) error {
@@ -1205,10 +1210,10 @@ func TestHandlePatAuthCheck_OpensOpaqueURIWithoutRebuild(t *testing.T) {
 	if !retryCalled {
 		t.Fatal("expected retry to run after approved PAT flow")
 	}
-	if opened != rawURI {
-		t.Fatalf("opened url = %q, want verbatim %q", opened, rawURI)
+	if opened != wantURL {
+		t.Fatalf("opened url = %q, want canonical %q", opened, wantURL)
 	}
-	if got := buf.String(); !strings.Contains(got, "PAT_AUTHORIZATION_URL="+rawURI) {
+	if got := buf.String(); !strings.Contains(got, "PAT_AUTHORIZATION_URL="+wantURL) {
 		t.Fatalf("output missing copy-safe PAT_AUTHORIZATION_URL line:\n%s", got)
 	}
 }
@@ -1219,7 +1224,7 @@ func TestHandlePatAuthCheck_NormalizesLegacyHashRouteForBrowserAndOutput(t *test
 	defer server.Close()
 
 	rawURI := "https://open-dev.dingtalk.com/fe/old#%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN"
-	wantURL := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN#/personalAuthorization?flowId=56b12fd3201d4efab9a9138672cf4deb&userCode=CFTC-27ZN"
+	wantURL := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN"
 	var opened string
 	origOpenBrowser := openBrowserFunc
 	openBrowserFunc = func(rawURL string) error {

--- a/internal/app/runner_test.go
+++ b/internal/app/runner_test.go
@@ -458,6 +458,7 @@ func TestDocDownloadPreflightPATAuthorizationUsesExistingHandler(t *testing.T) {
 	t.Cleanup(func() { openBrowserFunc = originalOpenBrowser })
 
 	const authURI = "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3Dflow-1%26userCode%3DCODE#/personalAuthorization?flowId=flow-1&userCode=CODE"
+	const authURL = "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3Dflow-1%26userCode%3DCODE"
 	var calls []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req map[string]any
@@ -500,8 +501,8 @@ func TestDocDownloadPreflightPATAuthorizationUsesExistingHandler(t *testing.T) {
 	if !errors.As(err, &patErr) {
 		t.Fatalf("executeInvocation() error = %T, want *errors.PATError", err)
 	}
-	if openedURI != authURI {
-		t.Fatalf("opened URI = %q, want %q", openedURI, authURI)
+	if openedURI != authURL {
+		t.Fatalf("opened URI = %q, want %q", openedURI, authURL)
 	}
 	if got := strings.Join(calls, ","); got != docGetDocumentInfoTool {
 		t.Fatalf("tool calls = %q, want only %s before PAT authorization", got, docGetDocumentInfoTool)

--- a/internal/errors/pat.go
+++ b/internal/errors/pat.go
@@ -108,8 +108,8 @@ const ExitCodePermission = 4
 // server-provided authorization link. Hosts must treat it as opaque and open
 // it verbatim instead of parsing and reconstructing it locally, because
 // required parameters may live in query, encoded hash, or fragment sections.
-// New hosts may prefer data.authorizationUrl when present; it preserves data.uri
-// while adding a copy/open-safe URL for legacy DingTalk hash-route variants.
+// New hosts may prefer data.authorizationUrl when present; it keeps data.uri
+// untouched while adding a copy/open-safe URL for DingTalk hash-route variants.
 type PATError struct {
 	RawJSON string
 }
@@ -334,6 +334,8 @@ var patTopLevelStrip = map[string]bool{
 
 // ApplyHostMutations writes the two stderr-JSON fields the host integration
 // contract requires onto out["data"]:
+//   - data.authorizationUrl / data.userCode: derived from data.uri when the
+//     service returned a Device Code Flow PAT link.
 //   - data.hostControl: present iff the CLI is in host-owned mode (i.e.
 //     HostControlBlock returns non-nil); legacy data.callbacks is stripped
 //     in the same pass so passive classifier and active retry paths stay
@@ -352,9 +354,7 @@ func ApplyHostMutations(out map[string]any) {
 		data = map[string]any{}
 		out["data"] = data
 	}
-	if rawURI, ok := data["uri"].(string); ok && strings.TrimSpace(rawURI) != "" {
-		data["authorizationUrl"] = PATAuthorizationURL(rawURI)
-	}
+	ApplyPATAuthorizationFields(data)
 	if block := HostControlBlock(); block != nil {
 		delete(data, "callbacks")
 		data["hostControl"] = block
@@ -362,10 +362,35 @@ func ApplyHostMutations(out map[string]any) {
 	data["openBrowser"] = PATOpenBrowserValue()
 }
 
+// ApplyPATAuthorizationFields enriches PAT data with fields that host-owned
+// clients need for Device Code Flow without forcing them to parse the browser
+// URL themselves. data.uri is intentionally preserved verbatim by callers.
+func ApplyPATAuthorizationFields(data map[string]any) {
+	rawURI, ok := data["uri"].(string)
+	if !ok || strings.TrimSpace(rawURI) == "" {
+		return
+	}
+
+	data["authorizationUrl"] = PATAuthorizationURL(rawURI)
+	routeQuery := PATAuthorizationRouteValues(rawURI)
+	if routeQuery.Get("flowId") != "" && stringField(data, "flowId") == "" {
+		data["flowId"] = routeQuery.Get("flowId")
+	}
+	if routeQuery.Get("userCode") != "" && stringField(data, "userCode") == "" {
+		data["userCode"] = routeQuery.Get("userCode")
+	}
+}
+
+func stringField(data map[string]any, key string) string {
+	value, _ := data[key].(string)
+	return strings.TrimSpace(value)
+}
+
 // PATAuthorizationURL returns the best URL for hosts to open or show to users.
-// It keeps already-complete PAT URLs unchanged. For DingTalk's legacy
-// /fe/old#%2FpersonalAuthorization?... hash-route form, it adds the explicit
-// hash query and decoded fragment route used by the working authorization page.
+// It keeps non-PAT URLs unchanged. For DingTalk's /fe/old Device Code Flow
+// route, it returns a canonical hash-query URL and strips the duplicate decoded
+// fragment so hosts do not lose userCode when launching through shell-like
+// openers that split on a naked '&' in the fragment.
 func PATAuthorizationURL(rawURI string) string {
 	rawURI = strings.TrimSpace(rawURI)
 	if rawURI == "" {
@@ -377,9 +402,6 @@ func PATAuthorizationURL(rawURI string) string {
 		return rawURI
 	}
 	if !strings.HasSuffix(parsed.Path, "/fe/old") {
-		return rawURI
-	}
-	if parsed.Query().Get("hash") != "" && strings.Contains(parsed.Fragment, "personalAuthorization") {
 		return rawURI
 	}
 
@@ -394,9 +416,23 @@ func PATAuthorizationURL(rawURI string) string {
 	query := next.Query()
 	query.Set("hash", "#"+route)
 	next.RawQuery = query.Encode()
-	next.Fragment = route
+	next.Fragment = ""
 	next.RawFragment = ""
 	return next.String()
+}
+
+// PATAuthorizationRouteValues extracts the flow route parameters from supported
+// PAT Device Code Flow URLs.
+func PATAuthorizationRouteValues(rawURI string) url.Values {
+	rawURI = strings.TrimSpace(rawURI)
+	if rawURI == "" {
+		return nil
+	}
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		return nil
+	}
+	return patAuthorizationRouteQuery(parsed)
 }
 
 func patAuthorizationRouteQuery(parsed *url.URL) url.Values {

--- a/internal/errors/pat_test.go
+++ b/internal/errors/pat_test.go
@@ -718,6 +718,7 @@ func TestCleanPATJSON_SingleLineOutput(t *testing.T) {
 func TestCleanPATJSON_PreservesOpaqueURIVerbatim(t *testing.T) {
 	t.Parallel()
 	rawURI := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D50dff7654b7444e88ced7489b07cce8d%26userCode%3DQ8RY-X6E9#/personalAuthorization?flowId=50dff7654b7444e88ced7489b07cce8d&userCode=Q8RY-X6E9"
+	wantURL := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D50dff7654b7444e88ced7489b07cce8d%26userCode%3DQ8RY-X6E9"
 	body := map[string]any{
 		"success": false,
 		"code":    "PAT_MEDIUM_RISK_NO_PERMISSION",
@@ -738,15 +739,69 @@ func TestCleanPATJSON_PreservesOpaqueURIVerbatim(t *testing.T) {
 	if got, _ := data["uri"].(string); got != rawURI {
 		t.Fatalf("data.uri = %q, want verbatim %q", got, rawURI)
 	}
-	if got, _ := data["authorizationUrl"].(string); got != rawURI {
-		t.Fatalf("data.authorizationUrl = %q, want %q", got, rawURI)
+	if got, _ := data["authorizationUrl"].(string); got != wantURL {
+		t.Fatalf("data.authorizationUrl = %q, want %q", got, wantURL)
+	}
+	if got, _ := data["userCode"].(string); got != "Q8RY-X6E9" {
+		t.Fatalf("data.userCode = %q, want Q8RY-X6E9", got)
+	}
+}
+
+func TestClassifyPatAuthCheck_HostOwnedDeviceFlowAddsUserCodeAndSafeURL(t *testing.T) {
+	SetHostControlProvider(func() string { return "openClaw" })
+	SetPATOpenBrowserProvider(func() bool { return true })
+	t.Cleanup(func() {
+		SetHostControlProvider(nil)
+		SetPATOpenBrowserProvider(nil)
+	})
+
+	rawURI := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D8bfc1e2b8f954e53a27ed5ad6ca44eac%26userCode%3D4CTX-HVXJ#/personalAuthorization?flowId=8bfc1e2b8f954e53a27ed5ad6ca44eac&userCode=4CTX-HVXJ"
+	wantURL := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D8bfc1e2b8f954e53a27ed5ad6ca44eac%26userCode%3D4CTX-HVXJ"
+	patErr := ClassifyPatAuthCheck(map[string]any{
+		"success": false,
+		"code":    "PAT_MEDIUM_RISK_NO_PERMISSION",
+		"data": map[string]any{
+			"authRequestId": nil,
+			"desc":          "open browser",
+			"flowId":        "8bfc1e2b8f954e53a27ed5ad6ca44eac",
+			"grantOptions":  []any{"once", "permanent"},
+			"requiredScopes": []any{
+				map[string]any{"scope": "mail.message:search"},
+			},
+			"uri": rawURI,
+		},
+	})
+	if patErr == nil {
+		t.Fatal("ClassifyPatAuthCheck returned nil, want PATError")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(patErr.RawJSON), &payload); err != nil {
+		t.Fatalf("unmarshal PAT payload: %v\nraw=%s", err, patErr.RawJSON)
+	}
+	data, _ := payload["data"].(map[string]any)
+	if got, _ := data["uri"].(string); got != rawURI {
+		t.Fatalf("data.uri = %q, want verbatim %q", got, rawURI)
+	}
+	if got, _ := data["authorizationUrl"].(string); got != wantURL {
+		t.Fatalf("data.authorizationUrl = %q, want %q", got, wantURL)
+	}
+	if got, _ := data["userCode"].(string); got != "4CTX-HVXJ" {
+		t.Fatalf("data.userCode = %q, want 4CTX-HVXJ", got)
+	}
+	hostControl, _ := data["hostControl"].(map[string]any)
+	if got, _ := hostControl["clawType"].(string); got != "openClaw" {
+		t.Fatalf("hostControl.clawType = %q, want openClaw", got)
+	}
+	if got, ok := data["openBrowser"].(bool); !ok || !got {
+		t.Fatalf("data.openBrowser = %#v, want true", data["openBrowser"])
 	}
 }
 
 func TestPATAuthorizationURL_NormalizesLegacyHashRoute(t *testing.T) {
 	t.Parallel()
 	rawURI := "https://open-dev.dingtalk.com/fe/old#%2FpersonalAuthorization%3FflowId%3D77108a9d0e6f4b74b769c04eb451e7d9%26userCode%3DWSAX-EEF2"
-	want := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D77108a9d0e6f4b74b769c04eb451e7d9%26userCode%3DWSAX-EEF2#/personalAuthorization?flowId=77108a9d0e6f4b74b769c04eb451e7d9&userCode=WSAX-EEF2"
+	want := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D77108a9d0e6f4b74b769c04eb451e7d9%26userCode%3DWSAX-EEF2"
 
 	if got := PATAuthorizationURL(rawURI); got != want {
 		t.Fatalf("PATAuthorizationURL() = %q, want %q", got, want)
@@ -770,12 +825,12 @@ func TestPATAuthorizationURL_NormalizesLegacyHashRoutePreservesExtraQuery(t *tes
 	if hash == "" {
 		t.Fatalf("expected normalized URL to include hash query, got: %s", got)
 	}
-	if hash != "#"+parsed.Fragment {
-		t.Fatalf("hash query = %q, want fragment route %q", hash, "#"+parsed.Fragment)
+	if parsed.Fragment != "" {
+		t.Fatalf("fragment = %q, want empty canonical authorizationUrl", parsed.Fragment)
 	}
-	rawQuery, ok := strings.CutPrefix(parsed.Fragment, "/personalAuthorization?")
+	rawQuery, ok := strings.CutPrefix(hash, "#/personalAuthorization?")
 	if !ok {
-		t.Fatalf("fragment = %q, want personalAuthorization route", parsed.Fragment)
+		t.Fatalf("hash query = %q, want personalAuthorization route", hash)
 	}
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
@@ -798,7 +853,7 @@ func TestPATAuthorizationURL_NormalizesLegacyHashRoutePreservesExtraQuery(t *tes
 func TestCleanPATJSON_AddsNormalizedAuthorizationURL(t *testing.T) {
 	t.Parallel()
 	rawURI := "https://open-dev.dingtalk.com/fe/old#%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN"
-	want := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN#/personalAuthorization?flowId=56b12fd3201d4efab9a9138672cf4deb&userCode=CFTC-27ZN"
+	want := "https://open-dev.dingtalk.com/fe/old?hash=%23%2FpersonalAuthorization%3FflowId%3D56b12fd3201d4efab9a9138672cf4deb%26userCode%3DCFTC-27ZN"
 	body := map[string]any{
 		"success": false,
 		"code":    "PAT_MEDIUM_RISK_NO_PERMISSION",
@@ -821,6 +876,9 @@ func TestCleanPATJSON_AddsNormalizedAuthorizationURL(t *testing.T) {
 	}
 	if got, _ := data["authorizationUrl"].(string); got != want {
 		t.Fatalf("data.authorizationUrl = %q, want %q", got, want)
+	}
+	if got, _ := data["userCode"].(string); got != "CFTC-27ZN" {
+		t.Fatalf("data.userCode = %q, want CFTC-27ZN", got)
 	}
 }
 


### PR DESCRIPTION
## Root Cause

`lippi-pat-core` creates PAT Device Code Flow with both `flowId` and `userCode`: `DeviceCodeFlowService.CreateFlowResult` carries both, and `queryFlowDetail` / `handleFlowAction` consume `flowId + userCode`. The open-source CLI only forwarded `flowId` plus the raw `uri`.

For host-owned PAT JSON, that left two sharp edges: hosts had no structured `data.userCode`, and `data.authorizationUrl` could still contain the duplicate decoded fragment route with a naked `&userCode`. Shell-like or host launchers can lose that fragment parameter and land on a blank/empty PAT authorization page.

## Changes

- Keep `data.uri` verbatim as the service-provided opaque URL.
- Derive `data.userCode` from the Device Code Flow URL for host/native consumers.
- Canonicalize `data.authorizationUrl` to the hash-query URL without the duplicate decoded fragment.
- Reuse the same enrichment in active PAT retry JSON.
- Add regression coverage for the `PAT_MEDIUM_RISK_NO_PERMISSION` host-owned shape matching the reported payload.

## Validation

- `go test ./internal/errors ./internal/app ./internal/pat`
- `go test ./test/unit -run 'PAT|Pat|pat'`
- `git diff --check`

Note: full `go test ./test/unit` still fails on the pre-existing `TestOpenSourceTreeOmitsEmbeddedHostMarkers` marker check for `internal/app/upgrade_embedded_guard_test.go: EmbeddedMode`, unrelated to this PAT change.
