### PR TITLE
fix(compat): relax envelope leaf cmd Args from NoArgs to ArbitraryArgs

### DIFF
--- a/internal/compat/registry.go
+++ b/internal/compat/registry.go
@@ -169,10 +169,10 @@ func NewDirectCommand(route Route, runner executor.Runner) *cobra.Command {
 			strictMin = b.PositionalIndex + 1
 		}
 	}
-	var argsValidator cobra.PositionalArgs = cobra.NoArgs
+	var argsValidator cobra.PositionalArgs = cobra.ArbitraryArgs
 	switch {
 	case totalMax == 0:
-		argsValidator = cobra.NoArgs
+		argsValidator = cobra.ArbitraryArgs
 	case strictMin > 0 && strictMin == totalMax:
 		argsValidator = cobra.MinimumNArgs(strictMin)
 	case strictMin > 0:


### PR DESCRIPTION
## Summary

`NewDirectCommand` in `internal/compat/registry.go` was hard-coding `cobra.NoArgs` for envelope-generated leaf commands without positional bindings. This is **stricter than cobra's own default** — cobra's `legacyArgs` (args.go:30-32) treats a leaf (`!cmd.HasSubCommands()`) as accepting arbitrary args.

The over-strict default surfaces as `unknown command \"<word>\" for \"<leaf>\"` whenever an AI agent passes trailing positional words after a leaf, e.g.

\`\`\`
dws aisearch person search --keyword \"张\"
dws aisearch person user search --keyword \"张\"
\`\`\`

Switching the `totalMax == 0` branch from `cobra.NoArgs` to `cobra.ArbitraryArgs` restores cobra's natural leaf behavior. Trailing positional args are silently ignored, which is the expected model-tolerance contract per the F-class regression tests in `dws-wukong/auto-test/cli_to_mcp/testcases/aisearch/test_90_aisearch_param_regression.py` (classes A/B/C/D/E/F).

Existing positional-binding paths (`MinimumNArgs` / `RangeArgs` / `MaximumNArgs`) are unchanged — only the no-positional-bindings case is relaxed.

## Test plan

- [x] Build clean with `make build`
- [x] aiapp / live / aisearch product tests under `dws-wukong/auto-test/cli_to_mcp/`: **50/50 pass** (was 48/50 before this patch — the 2 remaining failures were the F-class \"extra positional args tolerance\" cases this patch closes)
- [x] No regression on smoke test: `dws aisearch person --keyword \"张\"` returns real results; `dws aisearch person search --keyword \"张\"` also returns real results with the trailing \`search\` silently dropped
- [ ] Reviewer to confirm no other product relies on `NoArgs` as a typo-guard for leaves (we now match cobra's default)

## Context

This came up while wiring the `aisearch` product via envelope (no hard-coded cobra commands). Adding `cliAliases` + flag `aliases` + `shorthand` to the envelope fixed 5/7 regression tests; the remaining 2 (F class) required this Args validator change because no envelope field maps onto `cobra.PositionalArgs`.