### PR TITLE
fix(compat): relax envelope leaf cmd Args from NoArgs to ArbitraryArgs (pre)

### DIFF
--- a/internal/compat/registry.go
+++ b/internal/compat/registry.go
@@ -169,10 +169,10 @@ func NewDirectCommand(route Route, runner executor.Runner) *cobra.Command {
 			strictMin = b.PositionalIndex + 1
 		}
 	}
-	var argsValidator cobra.PositionalArgs = cobra.NoArgs
+	var argsValidator cobra.PositionalArgs = cobra.ArbitraryArgs
 	switch {
 	case totalMax == 0:
-		argsValidator = cobra.NoArgs
+		argsValidator = cobra.ArbitraryArgs
 	case strictMin > 0 && strictMin == totalMax:
 		argsValidator = cobra.MinimumNArgs(strictMin)
 	case strictMin > 0:


### PR DESCRIPTION
## Summary

Cherry-pick of #306 onto `test/pre-mcp-discovery` so the predeployment test build picks up the fix without waiting for the main → pre merge cycle.

Single-file change in `internal/compat/registry.go` (2 lines):

\`\`\`diff
-var argsValidator cobra.PositionalArgs = cobra.NoArgs
+var argsValidator cobra.PositionalArgs = cobra.ArbitraryArgs
 switch {
 case totalMax == 0:
-    argsValidator = cobra.NoArgs
+    argsValidator = cobra.ArbitraryArgs
\`\`\`

`NewDirectCommand` was hard-coding `cobra.NoArgs` for envelope-generated leaf commands without positional bindings. cobra's own `legacyArgs` default for a leaf (`!cmd.HasSubCommands()`) is to accept arbitrary args — the existing behavior was stricter than cobra's baseline. The over-strict default surfaced as `unknown command \"<word>\" for \"<leaf>\"` whenever a model passed trailing positional words after a leaf, e.g. `dws aisearch person search --keyword \"张\"`.

## Test plan

Verified on this exact branch (cherry-picked + clean rebuild + real pre-Diamond envelope, no local hacks):

- [x] `make build` clean
- [x] `dws cache refresh` succeeds (21 services from pre-mcp.dingtalk.com)
- [x] `pytest aiapp/ live/ aisearch/` against `dws-wukong/auto-test/cli_to_mcp/testcases`: **50/50 pass**
  - aiapp 9/9 — 100%
  - live 3/3 — 100%
  - aisearch 38/38 — 100% (was 36/38 before this patch; the 2 F-class extra-positional-args tolerance cases now pass)
- [x] No regression on other products (smoke: `dws aitable base list -f json` still works as expected)

## Relationship to #306

Same patch, different target. #306 targets `main`. This PR targets `test/pre-mcp-discovery` so QA can validate the envelope-only deployment path on pre. Once both land, merging main → test/pre-mcp-discovery later will be a clean no-op for this hunk.