### PR TITLE
style(im): gofmt newChatMessageReplyCommand 字段对齐

### DIFF
--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -647,10 +647,10 @@ func newChatMessageSendByWebhookCommand(runner executor.Runner) *cobra.Command {
 
 func newChatMessageReplyCommand(runner executor.Runner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "reply",
-		Short: "引用回复消息（支持单聊/群聊）",
-		Long:  "以当前用户身份引用某条消息并回复。需 --conversation-id 会话 ID、--ref-msg-id 被引用消息 ID、--ref-sender 原发送者 openDingTalkId、--text 回复内容。",
-		Example: `  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "收到，马上处理"`,
+		Use:               "reply",
+		Short:             "引用回复消息（支持单聊/群聊）",
+		Long:              "以当前用户身份引用某条消息并回复。需 --conversation-id 会话 ID、--ref-msg-id 被引用消息 ID、--ref-sender 原发送者 openDingTalkId、--text 回复内容。",
+		Example:           `  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "收到，马上处理"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## 改动

PR #314 的 Lint 步骤挂在 gofmt 检查上，根因是 `0630e5be`（fix(im): align CLI to wukong IM envelope）里的 `newChatMessageReplyCommand` cobra.Command 结构体字段对齐没过 `gofmt -l`。

应用 `gofmt -w internal/helpers/chat.go` 修复：

```
diff
-		Use:   "reply",
-		Short: "引用回复消息（支持单聊/群聊）",
-		Long:  "以当前用户身份引用某条消息并回复。...",
-		Example: `  dws chat message reply --conversation-id ...`,
+		Use:               "reply",
+		Short:             "引用回复消息（支持单聊/群聊）",
+		Long:              "以当前用户身份引用某条消息并回复。...",
+		Example:           `  dws chat message reply --conversation-id ...`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
```

纯空格对齐，无逻辑变化。

## 为什么用独立分支 PR 到 test/pre-mcp-discovery

跟之前 #169/#170/#180 的工作流一致：每一笔独立修复走独立分支，PR 到基线分支 `test/pre-mcp-discovery`，再由 #314 整体合到 main。

## 验证

- `gofmt -l internal/helpers/chat.go` 返回空 ✓
- `make build` 通过 ✓