### PR TITLE
chore: 移除 test-only 的 pre_mcp_discovery.json gitignore 规则

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,3 @@ _docs
 dws.zip
 *.code-workspace
 /dingtalk-workspace.zip
-
-pre_mcp_discovery.json


### PR DESCRIPTION
## 改动

把 `.gitignore` 末尾的 test-only 规则（`pre_mcp_discovery.json`）和它前面的空行删掉，让本 PR 合到 main 后 `.gitignore` 跟 main 当前状态完全一致。

```diff
-
-pre_mcp_discovery.json
-\ No newline at end of file
+\ EOF newline restored
```

## 为什么

- `pre_mcp_discovery.json` 是 test 分支验证期间手工拼装 Diamond/mcp-gw envelope 草稿用的本地文件，**仓库里从不存在该文件**
- 原 commit [`104421b`](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/commit/104421b) 的 commit message 明确写着 "must never be tracked by git (test branch only — **not relevant to main**)"
- 但这条规则正随 PR #314 一起 merge 进 main，跟原作者本意冲突，所以在合 main 前先剔除
- 顺手修了原 commit 留下的 "No newline at end of file" 瑕疵

## 验证

```bash
$ diff <(git show origin/main:.gitignore) .gitignore
$ echo $?
0   # 与 main 上的 .gitignore 完全一致
```

## 工作流

跟 #315 一样：独立分支 → PR 到 `test/pre-mcp-discovery` → squash merge → 触发 #314 重新 CI。