### PR TITLE
feat: align CLI to wukong IM envelope + schema pipeline / transform / market enhancements

### DIFF
--- a/internal/app/direct_runtime.go
+++ b/internal/app/direct_runtime.go
@@ -210,6 +210,25 @@ func shouldUseDirectRuntime(invocation executor.Invocation) bool {
 	}
 }
 
+// directRuntimeToolEndpoint returns the MCP endpoint owned by the server
+// whose toolOverrides registered this tool name. Used to correct catalog
+// lookups when two envelope servers share the same cli.command and the
+// per-product endpoint map collides (see runner.go cross-check).
+func directRuntimeToolEndpoint(toolName string) (string, bool) {
+	toolName = strings.TrimSpace(toolName)
+	if toolName == "" {
+		return "", false
+	}
+	dynamicMu.RLock()
+	te := dynamicToolEndpoints
+	dynamicMu.RUnlock()
+	if te == nil {
+		return "", false
+	}
+	endpoint, ok := te[toolName]
+	return endpoint, ok && strings.TrimSpace(endpoint) != ""
+}
+
 func directRuntimeEndpoint(productID, toolName string) (string, bool) {
 	// Priority 0: env-var override always wins (DINGTALK_<PRODUCT>_MCP_URL).
 	normalized := normalizeDirectRuntimeProductID(productID)

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -219,6 +219,19 @@ func (r *runtimeRunner) Run(ctx context.Context, invocation executor.Invocation)
 	if override, ok := productEndpointOverride(invocation.CanonicalProduct); ok {
 		endpoint = override
 	}
+	// Multi-server tool-name authority correction.
+	//
+	// When two envelope servers share the same cli.command (e.g. group-chat
+	// and im both publish `dws chat ...`), the endpoints[cmd] map in
+	// registerDynamicServer is the second-writer wins, and catalog FindProduct
+	// may pick the wrong product's Endpoint for a tool whose real owner is
+	// a different server. Cross-check the canonical tool→endpoint map: when
+	// the per-tool endpoint exists and differs from the per-product endpoint
+	// catalog returned, trust the tool-owner endpoint (the server that
+	// actually declares this tool in its toolOverrides).
+	if toolEndpoint, ok := directRuntimeToolEndpoint(invocation.Tool); ok && toolEndpoint != "" && toolEndpoint != endpoint {
+		endpoint = toolEndpoint
+	}
 	return r.executeInvocation(ctx, endpoint, invocation)
 }
 

--- a/internal/cli/stdin.go
+++ b/internal/cli/stdin.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"unicode"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 )
@@ -122,19 +123,51 @@ func readStdinBounded() (string, error) {
 	return string(data), nil
 }
 
+// looksLikeFilePath returns true when value should be interpreted as the
+// `@<path>` file-injection syntax. Heuristic: value must start with '@', and
+// the character right after '@' must be ASCII (letter, digit, or one of the
+// common path-prefix characters: . / ~ _ -). This rules out mistaken matches
+// for natural-language messages that happen to start with '@' followed by
+// non-ASCII text — e.g. "@所有人" should be a chat mention, not a file path.
+func looksLikeFilePath(value string) bool {
+	if !strings.HasPrefix(value, "@") || len(value) < 2 {
+		return false
+	}
+	rest := value[1:]
+	if rest == "-" {
+		return true // @- = stdin
+	}
+	first := rune(rest[0])
+	if first > unicode.MaxASCII {
+		// First byte is part of a multi-byte rune (e.g. Chinese) — not a path.
+		return false
+	}
+	switch {
+	case first >= 'A' && first <= 'Z',
+		first >= 'a' && first <= 'z',
+		first >= '0' && first <= '9',
+		first == '.', first == '/', first == '~', first == '_', first == '-':
+		return true
+	}
+	return false
+}
+
 // ReadFileArg reads the contents of a file referenced by the @filename syntax.
-// Returns the original value unchanged if it does not start with "@".
+// Returns the original value unchanged if it does not start with "@" or is
+// otherwise not a file-path-shaped value (e.g. "@所有人" is treated as plain
+// text, not a path).
 // Returns an error if the file cannot be read or exceeds the size limit.
 //
 // Note: @- (stdin) is NOT handled here; use ResolveInputSource instead.
 func ReadFileArg(value string) (string, bool, error) {
-	if !strings.HasPrefix(value, "@") {
+	// Preserve the historical bare-"@" behaviour (empty filename → error).
+	if value == "@" {
+		return "", false, apperrors.NewValidation("@file: filename must not be empty")
+	}
+	if !looksLikeFilePath(value) {
 		return value, false, nil
 	}
 	path := value[1:]
-	if path == "" {
-		return "", false, apperrors.NewValidation("@file: filename must not be empty")
-	}
 	// @- is stdin, not a file — callers should use ResolveInputSource.
 	if path == "-" {
 		return value, false, nil
@@ -156,14 +189,17 @@ func ReadFileArg(value string) (string, bool, error) {
 //
 // The flagName parameter is used only for error messages and StdinGuard tracking.
 func ResolveInputSource(value string, flagName string, guard *StdinGuard) (string, error) {
-	if !strings.HasPrefix(value, "@") {
+	// Preserve the historical bare-"@" behaviour (empty filename → error).
+	if value == "@" {
+		return "", apperrors.NewValidation(fmt.Sprintf("--%s: @file filename must not be empty", flagName))
+	}
+	if !looksLikeFilePath(value) {
+		// Pass through natural-language strings that happen to start with
+		// '@' (e.g. "@所有人 早上好") so they reach the MCP payload intact.
 		return value, nil
 	}
 
 	path := value[1:]
-	if path == "" {
-		return "", apperrors.NewValidation(fmt.Sprintf("--%s: @file filename must not be empty", flagName))
-	}
 
 	// @- reads from stdin.
 	if path == "-" {

--- a/internal/cli/stdin_test.go
+++ b/internal/cli/stdin_test.go
@@ -47,6 +47,38 @@ func TestReadFileArgPlainValue(t *testing.T) {
 	}
 }
 
+// TestReadFileArgChineseAtMention guards the @所有人-style mentions that the
+// chat bot Webhook tests rely on: an '@' followed by non-ASCII text must be
+// treated as a literal message, not as the @file injection syntax.
+func TestReadFileArgChineseAtMention(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"@所有人 这是 @ 所有人 的消息",
+		"@张三",
+		"@A 但接下来都是中文@测试",
+	}
+	for _, in := range cases {
+		val, isFile, err := ReadFileArg(in)
+		if in == "@A 但接下来都是中文@测试" {
+			// '@A' starts with ASCII, treated as path → expect file error
+			if err == nil {
+				t.Errorf("@A... should attempt file lookup; got val=%q isFile=%v", val, isFile)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%q: unexpected error %v", in, err)
+			continue
+		}
+		if isFile {
+			t.Errorf("%q: should be plain text, got isFile=true", in)
+		}
+		if val != in {
+			t.Errorf("%q: got %q", in, val)
+		}
+	}
+}
+
 func TestReadFileArgReadsFile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compat/dynamic_commands.go
+++ b/internal/compat/dynamic_commands.go
@@ -236,10 +236,18 @@ func BuildDynamicCommands(servers []market.ServerDescriptor, runner executor.Run
 	for _, b := range built {
 		if b.parent == "" {
 			name := b.cmd.Name()
-			if _, exists := topLevel[name]; !exists {
+			if existing, exists := topLevel[name]; exists {
+				// Multiple servers contribute the same top-level command
+				// (e.g. group-chat and im both register `dws chat`). Move
+				// the incoming command's *children* into the existing top-
+				// level command instead of attaching the whole command (which
+				// would create `dws chat chat` because attachOrMerge would
+				// AddCommand(b.cmd) when no same-named sub exists).
+				mergeSubcommandsInto(existing, b.cmd)
+			} else {
 				topOrder = append(topOrder, name)
+				topLevel[name] = b.cmd
 			}
-			topLevel[name] = b.cmd
 		} else {
 			children = append(children, b)
 		}
@@ -248,12 +256,16 @@ func BuildDynamicCommands(servers []market.ServerDescriptor, runner executor.Run
 		if parent, ok := topLevel[child.parent]; ok {
 			attachOrMerge(parent, child.cmd)
 		} else {
-			// Parent not found among dynamic commands; emit as top-level.
+			// Parent not found among dynamic commands; emit as top-level,
+			// merging into an existing same-named top-level command if one
+			// is already registered (same reasoning as the loop above).
 			name := child.cmd.Name()
-			if _, exists := topLevel[name]; !exists {
+			if existing, exists := topLevel[name]; exists {
+				mergeSubcommandsInto(existing, child.cmd)
+			} else {
 				topOrder = append(topOrder, name)
+				topLevel[name] = child.cmd
 			}
-			topLevel[name] = child.cmd
 		}
 	}
 
@@ -489,6 +501,24 @@ func resolveNestedGroup(root *cobra.Command, groupPath string, registry map[stri
 	}
 	// Auto-create if not defined in groups
 	return ensureNestedGroup(root, groupPath, groupPath, registry)
+}
+
+// mergeSubcommandsInto moves all sub-commands of src into dst, using
+// attachOrMerge so subtree merges happen recursively. src itself is left
+// empty after the call. Used when two envelope entries register the same
+// top-level command (e.g. group-chat and im both `cli.command="chat"`):
+// we want their *children* to coexist under one chat root, not have one
+// nested inside the other.
+func mergeSubcommandsInto(dst, src *cobra.Command) {
+	if dst == nil || src == nil {
+		return
+	}
+	subs := make([]*cobra.Command, len(src.Commands()))
+	copy(subs, src.Commands())
+	for _, sub := range subs {
+		src.RemoveCommand(sub)
+		attachOrMerge(dst, sub)
+	}
 }
 
 // attachOrMerge adds child as a sub-command of parent. If parent already has a

--- a/internal/compat/pipeline.go
+++ b/internal/compat/pipeline.go
@@ -149,12 +149,12 @@ func executePipelineCall(
 		if result.Response == nil {
 			return map[string]any{}, nil
 		}
-		// Fail-fast on MCP business errors. Pre-execution validation (e.g.
-		// cobra MarkFlagRequired) only checks that the flag was set, not
-		// that the value is non-empty — so a `--required-flag ""` reaches
-		// here and the upstream tool rejects with errorCode. Without this
-		// check the pipeline would happily proceed to poll/download and
-		// either spin until PollTimeout or burn through retries.
+		// Fail-fast on MCP business errors. Pre-execution validation (cobra
+		// MarkFlagRequired) only checks that the flag was set, not that
+		// the value is non-empty — so a `--required-flag ""` reaches here
+		// and the upstream tool rejects with errorCode. Without this check
+		// the pipeline proceeds to poll/download and either spins until
+		// PollTimeout or burns through retries.
 		if errCode := getDotPath(result.Response, "content.errorCode"); errCode != nil && fmt.Sprint(errCode) != "" {
 			msg := getDotPath(result.Response, "content.errorMessage")
 			return nil, apperrors.NewValidation(fmt.Sprintf(

--- a/internal/compat/transform.go
+++ b/internal/compat/transform.go
@@ -30,7 +30,7 @@ import (
 
 // ApplyTransform applies a named transform rule to a value.
 // Supported transforms: iso8601_to_millis, csv_to_array, json_parse,
-// json_parse_strict, enum_map, file_read.
+// json_parse_strict, enum_map, file_read, invert_bool.
 func ApplyTransform(value any, transform string, args map[string]any) (any, error) {
 	switch strings.TrimSpace(transform) {
 	case "":
@@ -47,6 +47,31 @@ func ApplyTransform(value any, transform string, args map[string]any) (any, erro
 		return transformEnumMap(value, args)
 	case "file_read":
 		return transformFileRead(value)
+	case "invert_bool":
+		return transformInvertBool(value)
+	default:
+		return value, nil
+	}
+}
+
+// transformInvertBool flips a boolean: true → false, false → true. Strings
+// "true"/"false" (any case) are accepted. Used by envelope flags whose CLI
+// surface and MCP body have opposite semantics — e.g. `--off` (CLI) maps to
+// `mute=true` (MCP) for "mute is enabled", so the flag override declares
+// `transform: invert_bool` and the framework flips at send time.
+func transformInvertBool(value any) (any, error) {
+	switch v := value.(type) {
+	case bool:
+		return !v, nil
+	case string:
+		s := strings.ToLower(strings.TrimSpace(v))
+		switch s {
+		case "true", "1", "yes", "on":
+			return false, nil
+		case "false", "0", "no", "off", "":
+			return true, nil
+		}
+		return value, nil
 	default:
 		return value, nil
 	}

--- a/internal/compat/transform_test.go
+++ b/internal/compat/transform_test.go
@@ -259,3 +259,29 @@ func TestFileRead_UnknownTransformPassThrough(t *testing.T) {
 		t.Errorf("expected pass-through, got %v", got)
 	}
 }
+
+func TestInvertBoolTransform(t *testing.T) {
+	cases := []struct {
+		in   any
+		want any
+	}{
+		{true, false},
+		{false, true},
+		{"true", false},
+		{"false", true},
+		{"True", false},
+		{"FALSE", true},
+		{"on", false},
+		{"off", true},
+		{"", true},
+	}
+	for _, c := range cases {
+		got, err := ApplyTransform(c.in, "invert_bool", nil)
+		if err != nil {
+			t.Errorf("ApplyTransform(%v, invert_bool) err=%v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("ApplyTransform(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -15,6 +15,7 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
@@ -30,6 +31,12 @@ func init() {
 	})
 }
 
+// chatHandler retains only the chat commands that carry real business logic
+// (intelligent tool routing, current-user resolution, response normalization,
+// or stdin/@file input support that dynamic commands do not yet provide).
+// Thin wrappers — search, group rename, group members list/add/remove/add-bot,
+// bot search — are now produced by the dynamic service-discovery envelope
+// (envelope/pre-discovery.json) so the helper does not have to duplicate them.
 type chatHandler struct{}
 
 func (chatHandler) Name() string {
@@ -40,7 +47,7 @@ func (chatHandler) Command(runner executor.Runner) *cobra.Command {
 	root := &cobra.Command{
 		Use:               "chat",
 		Short:             "群聊 / 消息 / 机器人",
-		Long:              "管理钉钉会话与群聊：创建群、搜索群、查看群成员、添加机器人到群、修改群名称、拉取会话消息、发送群消息、机器人消息与 Webhook。",
+		Long:              "钉钉会话与群聊：发送消息（用户/机器人/Webhook）、撤回机器人消息、创建群。其余命令由服务发现 envelope 提供。",
 		Args:              cobra.NoArgs,
 		TraverseChildren:  true,
 		DisableAutoGenTag: true,
@@ -64,11 +71,12 @@ func (chatHandler) Command(runner executor.Runner) *cobra.Command {
 		newChatMessageSendByBotCommand(runner),
 		newChatMessageRecallByBotCommand(runner),
 		newChatMessageSendByWebhookCommand(runner),
+		newChatMessageReplyCommand(runner),
 	)
 
-	bot := &cobra.Command{
-		Use:               "bot",
-		Short:             "机器人管理",
+	group := &cobra.Command{
+		Use:               "group",
+		Short:             "群组管理",
 		Args:              cobra.NoArgs,
 		TraverseChildren:  true,
 		DisableAutoGenTag: true,
@@ -76,9 +84,9 @@ func (chatHandler) Command(runner executor.Runner) *cobra.Command {
 			return cmd.Help()
 		},
 	}
-	bot.AddCommand(newChatBotSearchCommand(runner))
+	group.AddCommand(newChatGroupCreateCommand(runner))
 
-	root.AddCommand(message, newChatSearchCommand(runner), newChatGroupCommand(runner), bot)
+	root.AddCommand(message, group)
 	return root
 }
 
@@ -268,94 +276,6 @@ func newChatMessageSendByBotCommand(runner executor.Runner) *cobra.Command {
 	cmd.Flags().String("title", "", "消息标题 (必填)")
 	cmd.Flags().String("users", "", "接收者 userId 列表，逗号分隔，最多 20 个 (单聊必填)")
 	return cmd
-}
-
-func newChatSearchCommand(runner executor.Runner) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:               "search",
-		Short:             "根据名称搜索会话列表",
-		Example:           `  dws chat search --query "项目冲刺"`,
-		Args:              cobra.NoArgs,
-		DisableAutoGenTag: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			query, err := cmd.Flags().GetString("query")
-			if err != nil {
-				return apperrors.NewInternal("failed to read --query")
-			}
-			query = strings.TrimSpace(query)
-			if query == "" {
-				return apperrors.NewValidation("--query is required")
-			}
-
-			searchReq := map[string]any{"query": query}
-			cursor, err := cmd.Flags().GetString("cursor")
-			if err != nil {
-				return apperrors.NewInternal("failed to read --cursor")
-			}
-			if strings.TrimSpace(cursor) != "" {
-				searchReq["cursor"] = cursor
-			}
-
-			result, err := runner.Run(cmd.Context(), executor.NewHelperInvocation(
-				cobracmd.LegacyCommandPath(cmd),
-				"chat",
-				"search_groups_by_keyword",
-				map[string]any{"OpenSearchRequest": searchReq},
-			))
-			if err != nil {
-				return err
-			}
-			return writeCommandPayload(cmd, result)
-		},
-	}
-	preferLegacyLeaf(cmd)
-
-	cmd.Flags().String("query", "", "搜索关键词 (必填)")
-	cmd.Flags().String("cursor", "", "分页游标 (首页留空)")
-	return cmd
-}
-
-func newChatGroupCommand(runner executor.Runner) *cobra.Command {
-	root := &cobra.Command{
-		Use:               "group",
-		Short:             "群组管理",
-		Args:              cobra.NoArgs,
-		TraverseChildren:  true,
-		DisableAutoGenTag: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		},
-	}
-
-	members := &cobra.Command{
-		Use:               "members",
-		Short:             "群成员管理",
-		Args:              cobra.NoArgs,
-		TraverseChildren:  true,
-		DisableAutoGenTag: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmd.Help()
-		},
-	}
-	// Keeps the helper-restructured group winning over the dynamic envelope's
-	// `members` leaf (which only exposes `get_group_members`); without this
-	// the merge layer treats the shape mismatch as "envelope is authority"
-	// and drops the entire helper subtree (issue #164).
-	preferLegacyLeaf(members)
-
-	members.AddCommand(
-		newChatGroupMembersListCommand(runner),
-		newChatGroupMemberAddCommand(runner),
-		newChatGroupMemberRemoveCommand(runner),
-		newChatGroupMembersAddBotCommand(runner),
-	)
-
-	root.AddCommand(
-		newChatGroupCreateCommand(runner),
-		members,
-		newChatGroupRenameCommand(runner),
-	)
-	return root
 }
 
 func newChatGroupCreateCommand(runner executor.Runner) *cobra.Command {
@@ -647,6 +567,10 @@ func newChatMessageRecallByBotCommand(runner executor.Runner) *cobra.Command {
 }
 
 // ── message send-by-webhook ────────────────────────────────
+//
+// Kept as a helper (rather than delegating to the dynamic envelope) because
+// it needs --text @file / stdin pipe support via resolveStringFlag, which the
+// dynamic-command layer does not yet provide.
 
 func newChatMessageSendByWebhookCommand(runner executor.Runner) *cobra.Command {
 	cmd := &cobra.Command{
@@ -713,65 +637,63 @@ func newChatMessageSendByWebhookCommand(runner executor.Runner) *cobra.Command {
 	return cmd
 }
 
-// ── group members list ─────────────────────────────────────
+// ── message reply ────────────────────────────────────────
+//
+// Kept as a helper because the underlying MCP tool send_personal_message
+// requires the reply payload to be a JSON-encoded string assembled from
+// --ref-msg-id / --ref-sender / --text. Envelope toolOverride does flat
+// flag→param mapping only and cannot construct nested JSON, so this
+// orchestration must live in CLI code.
 
-func newChatGroupMembersListCommand(runner executor.Runner) *cobra.Command {
+func newChatMessageReplyCommand(runner executor.Runner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "list",
-		Short:             "查询群成员列表",
-		Example:           `  dws chat group members list --id <openconversation_id>`,
+		Use:               "reply",
+		Short:             "引用回复消息（支持单聊/群聊）",
+		Long:              "以当前用户身份引用某条消息并回复。需 --conversation-id 会话 ID、--ref-msg-id 被引用消息 ID、--ref-sender 原发送者 openDingTalkId、--text 回复内容。",
+		Example:           `  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "收到，马上处理"`,
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			groupID, _ := cmd.Flags().GetString("id")
-			if strings.TrimSpace(groupID) == "" {
-				return apperrors.NewValidation("--id is required")
+			convID, _ := cmd.Flags().GetString("conversation-id")
+			refMsgID, _ := cmd.Flags().GetString("ref-msg-id")
+			refSender, _ := cmd.Flags().GetString("ref-sender")
+			text, _ := cmd.Flags().GetString("text")
+			if strings.TrimSpace(convID) == "" {
+				return apperrors.NewValidation("--conversation-id is required")
 			}
-			params := map[string]any{
-				"openconversation_id": groupID,
+			if strings.TrimSpace(refMsgID) == "" {
+				return apperrors.NewValidation("--ref-msg-id is required")
 			}
-			if v, _ := cmd.Flags().GetString("cursor"); v != "" {
-				params["cursor"] = v
+			if strings.TrimSpace(refSender) == "" {
+				return apperrors.NewValidation("--ref-sender is required")
 			}
-			result, err := runner.Run(cmd.Context(), executor.NewHelperInvocation(
-				cobracmd.LegacyCommandPath(cmd), "chat", "get_group_members", params,
-			))
+			if strings.TrimSpace(text) == "" {
+				return apperrors.NewValidation("--text is required")
+			}
+			replyContent := map[string]any{
+				"referenceOpenMessageId":   refMsgID,
+				"srcMsgSendOpenDingTalkId": refSender,
+				"replyMsgType":             "text",
+				"content":                  text,
+			}
+			contentJSON, err := jsonMarshal(replyContent)
 			if err != nil {
-				return err
-			}
-			return writeCommandPayload(cmd, result)
-		},
-	}
-	preferLegacyLeaf(cmd)
-	cmd.Flags().String("id", "", "群 ID / openconversation_id (必填)")
-	cmd.Flags().String("cursor", "", "分页游标 (首页留空)")
-	return cmd
-}
-
-// ── group rename ───────────────────────────────────────────
-
-func newChatGroupRenameCommand(runner executor.Runner) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:               "rename",
-		Short:             "更新群名称",
-		Example:           `  dws chat group rename --id <openconversation_id> --name "新群名"`,
-		Args:              cobra.NoArgs,
-		DisableAutoGenTag: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			groupID, _ := cmd.Flags().GetString("id")
-			name, _ := cmd.Flags().GetString("name")
-			if strings.TrimSpace(groupID) == "" {
-				return apperrors.NewValidation("--id is required")
-			}
-			if strings.TrimSpace(name) == "" {
-				return apperrors.NewValidation("--name is required")
+				return apperrors.NewInternal("marshal reply content: " + err.Error())
 			}
 			params := map[string]any{
-				"openconversation_id": groupID,
-				"group_name":          name,
+				"openConversationId": convID,
+				"msgType":            "reply",
+				"content":            contentJSON,
+				"clawType":           "wukong",
+			}
+			if uuid, _ := cmd.Flags().GetString("uuid"); strings.TrimSpace(uuid) != "" {
+				params["uuid"] = uuid
 			}
 			inv := executor.NewHelperInvocation(
-				cobracmd.LegacyCommandPath(cmd), "chat", "update_group_name", params,
+				cobracmd.LegacyCommandPath(cmd),
+				"group-chat",
+				"send_personal_message",
+				params,
 			)
 			inv.DryRun = commandDryRun(cmd)
 			result, err := runner.Run(cmd.Context(), inv)
@@ -782,160 +704,18 @@ func newChatGroupRenameCommand(runner executor.Runner) *cobra.Command {
 		},
 	}
 	preferLegacyLeaf(cmd)
-	cmd.Flags().String("id", "", "群 ID / openconversation_id (必填)")
-	cmd.Flags().String("name", "", "新群名称 (必填)")
+	cmd.Flags().String("conversation-id", "", "会话 openConversationId (必填，支持单聊/群聊)")
+	cmd.Flags().String("ref-msg-id", "", "被引用的消息 openMessageId (必填)")
+	cmd.Flags().String("ref-sender", "", "被引用消息发送者 openDingTalkId (必填)")
+	cmd.Flags().String("text", "", "回复正文 (必填)")
+	cmd.Flags().String("uuid", "", "可选 uuid（幂等标识）")
 	return cmd
 }
 
-// ── group members add ──────────────────────────────────────
-
-func newChatGroupMemberAddCommand(runner executor.Runner) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:               "add",
-		Short:             "添加群成员",
-		Example:           `  dws chat group members add --id <openconversation_id> --users userId1,userId2`,
-		Args:              cobra.NoArgs,
-		DisableAutoGenTag: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			groupID, _ := cmd.Flags().GetString("id")
-			usersStr, _ := cmd.Flags().GetString("users")
-			if strings.TrimSpace(groupID) == "" {
-				return apperrors.NewValidation("--id is required")
-			}
-			if strings.TrimSpace(usersStr) == "" {
-				return apperrors.NewValidation("--users is required")
-			}
-			params := map[string]any{
-				"openconversation_id": groupID,
-				"userId":              splitCSV(usersStr),
-			}
-			inv := executor.NewHelperInvocation(
-				cobracmd.LegacyCommandPath(cmd), "chat", "add_group_member", params,
-			)
-			inv.DryRun = commandDryRun(cmd)
-			result, err := runner.Run(cmd.Context(), inv)
-			if err != nil {
-				return err
-			}
-			return writeCommandPayload(cmd, result)
-		},
+func jsonMarshal(v any) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
 	}
-	preferLegacyLeaf(cmd)
-	cmd.Flags().String("id", "", "群 ID / openconversation_id (必填)")
-	cmd.Flags().String("users", "", "要添加的 userId 列表，逗号分隔 (必填)")
-	return cmd
-}
-
-// ── group members remove ───────────────────────────────────
-
-func newChatGroupMemberRemoveCommand(runner executor.Runner) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:               "remove",
-		Short:             "移除群成员",
-		Example:           `  dws chat group members remove --id <openconversation_id> --users userId1,userId2`,
-		Args:              cobra.NoArgs,
-		DisableAutoGenTag: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			groupID, _ := cmd.Flags().GetString("id")
-			usersStr, _ := cmd.Flags().GetString("users")
-			if strings.TrimSpace(groupID) == "" {
-				return apperrors.NewValidation("--id is required")
-			}
-			if strings.TrimSpace(usersStr) == "" {
-				return apperrors.NewValidation("--users is required")
-			}
-			params := map[string]any{
-				"openconversationId": groupID,
-				"userIdList":         splitCSV(usersStr),
-			}
-			inv := executor.NewHelperInvocation(
-				cobracmd.LegacyCommandPath(cmd), "chat", "remove_group_member", params,
-			)
-			inv.DryRun = commandDryRun(cmd)
-			result, err := runner.Run(cmd.Context(), inv)
-			if err != nil {
-				return err
-			}
-			return writeCommandPayload(cmd, result)
-		},
-	}
-	preferLegacyLeaf(cmd)
-	cmd.Flags().String("id", "", "Group ID / openconversation_id (required)")
-	cmd.Flags().String("users", "", "Comma-separated userId list to remove (required)")
-	return cmd
-}
-
-// ── group members add-bot ──────────────────────────────────
-
-func newChatGroupMembersAddBotCommand(runner executor.Runner) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:               "add-bot",
-		Short:             "Add bot to group",
-		Example:           `  dws chat group members add-bot --robot-code <robot-code> --id <openconversation_id>`,
-		Args:              cobra.NoArgs,
-		DisableAutoGenTag: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			robotCode, _ := cmd.Flags().GetString("robot-code")
-			groupID, _ := cmd.Flags().GetString("id")
-			if strings.TrimSpace(robotCode) == "" {
-				return apperrors.NewValidation("--robot-code is required")
-			}
-			if strings.TrimSpace(groupID) == "" {
-				return apperrors.NewValidation("--id is required")
-			}
-			params := map[string]any{
-				"robotCode":          robotCode,
-				"openConversationId": groupID,
-			}
-			inv := executor.NewHelperInvocation(
-				cobracmd.LegacyCommandPath(cmd), "bot", "add_robot_to_group", params,
-			)
-			inv.DryRun = commandDryRun(cmd)
-			result, err := runner.Run(cmd.Context(), inv)
-			if err != nil {
-				return err
-			}
-			return writeCommandPayload(cmd, result)
-		},
-	}
-	preferLegacyLeaf(cmd)
-	cmd.Flags().String("robot-code", "", "Bot code (required)")
-	cmd.Flags().String("id", "", "Group openConversationId (required)")
-	return cmd
-}
-
-// ── bot search ─────────────────────────────────────────────
-
-func newChatBotSearchCommand(runner executor.Runner) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:               "search",
-		Short:             "Search my bots",
-		Example:           "  dws chat bot search --page 1\n  dws chat bot search --page 1 --size 10 --name \"日报\"",
-		Args:              cobra.NoArgs,
-		DisableAutoGenTag: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			page, _ := cmd.Flags().GetInt("page")
-			params := map[string]any{
-				"currentPage": page,
-			}
-			if v, _ := cmd.Flags().GetInt("size"); v > 0 {
-				params["pageSize"] = v
-			}
-			if v, _ := cmd.Flags().GetString("name"); v != "" {
-				params["robotName"] = v
-			}
-			result, err := runner.Run(cmd.Context(), executor.NewHelperInvocation(
-				cobracmd.LegacyCommandPath(cmd), "bot", "search_my_robots", params,
-			))
-			if err != nil {
-				return err
-			}
-			return writeCommandPayload(cmd, result)
-		},
-	}
-	preferLegacyLeaf(cmd)
-	cmd.Flags().Int("page", 1, "Page number, starting from 1")
-	cmd.Flags().Int("size", 0, "Items per page (default 50)")
-	cmd.Flags().String("name", "", "Search by name")
-	return cmd
+	return string(b), nil
 }

--- a/internal/helpers/chat_test.go
+++ b/internal/helpers/chat_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
-	"github.com/spf13/cobra"
 )
 
 type captureRunner struct {
@@ -304,76 +303,6 @@ func equalAny(a, b any) bool {
 		return true
 	default:
 		return a == b
-	}
-}
-
-// TestChatGroupMembersListSubcommand pins the explicit `list` subcommand
-// added for issue #164: previously the bare `chat group members --id` was
-// the list path, but it shape-mismatched the dynamic envelope's `members`
-// leaf and got eaten by the merge layer. Now `dws chat group members list
-// --id <cid>` is a proper leaf siblings of add/remove/add-bot.
-func TestChatGroupMembersListSubcommand(t *testing.T) {
-	runner := &captureRunner{}
-	groupCmd := newChatGroupCommand(runner)
-	var members *cobra.Command
-	for _, sub := range groupCmd.Commands() {
-		if sub.Name() == "members" {
-			members = sub
-			break
-		}
-	}
-	if members == nil {
-		t.Fatalf("members subcommand missing under chat group")
-	}
-
-	want := map[string]bool{"list": false, "add": false, "remove": false, "add-bot": false}
-	for _, leaf := range members.Commands() {
-		if _, ok := want[leaf.Name()]; ok {
-			want[leaf.Name()] = true
-		}
-	}
-	for name, seen := range want {
-		if !seen {
-			t.Errorf("expected `chat group members %s` subcommand, missing", name)
-		}
-	}
-
-	if members.Flags().Lookup("id") != nil {
-		t.Errorf("members container should not declare --id (moved to `list` subcommand to avoid shape-mismatch with dynamic envelope)")
-	}
-
-	var listCmd *cobra.Command
-	for _, leaf := range members.Commands() {
-		if leaf.Name() == "list" {
-			listCmd = leaf
-			break
-		}
-	}
-	if listCmd == nil {
-		t.Fatalf("`list` subcommand not found")
-	}
-	if listCmd.Flags().Lookup("id") == nil {
-		t.Errorf("`list` subcommand must declare --id")
-	}
-	if listCmd.Flags().Lookup("cursor") == nil {
-		t.Errorf("`list` subcommand must declare --cursor")
-	}
-
-	// Drive execution via the group root so cobra resolves the subcommand
-	// path properly (calling Execute() on a child directly would re-enter
-	// the root help branch).
-	var out bytes.Buffer
-	groupCmd.SetOut(&out)
-	groupCmd.SetErr(&out)
-	groupCmd.SetArgs([]string{"members", "list", "--id", "cid-xyz"})
-	if err := groupCmd.Execute(); err != nil {
-		t.Fatalf("members list Execute error = %v\noutput: %s", err, out.String())
-	}
-	if got := runner.last.Tool; got != "get_group_members" {
-		t.Fatalf("Tool = %q, want get_group_members", got)
-	}
-	if got := runner.last.Params["openconversation_id"]; got != "cid-xyz" {
-		t.Fatalf("openconversation_id = %#v, want cid-xyz", got)
 	}
 }
 

--- a/internal/market/registry.go
+++ b/internal/market/registry.go
@@ -647,18 +647,24 @@ func NormalizeServers(response ListResponse, source string) []ServerDescriptor {
 			descriptor.UpdatedAt = updatedAt
 		}
 
-		existing, exists := bestByEndpoint[descriptor.Key]
+		// Dedup key includes cli.id when present so that envelopes
+		// intentionally splitting one MCP endpoint into multiple CLI command
+		// trees (e.g. bot-root / bot-message / bot-group all serving
+		// .../server/4717... but exposing different command roots) are not
+		// collapsed by endpoint-only dedup. Without cli.id the key falls
+		// back to descriptor.Key (= endpoint) for backwards compatibility.
+		endpointKey := dedupKeyForEndpoint(descriptor)
+		existing, exists := bestByEndpoint[endpointKey]
 		if !exists || descriptorIsNewer(descriptor, existing) {
-			bestByEndpoint[descriptor.Key] = descriptor
+			bestByEndpoint[endpointKey] = descriptor
 		}
 	}
 
 	bestByName := make(map[string]ServerDescriptor)
 	for _, descriptor := range bestByEndpoint {
-		nameKey := normalizeDisplayNameKey(descriptor.DisplayName)
-		if nameKey == "" {
-			nameKey = descriptor.Key
-		}
+		// Same reasoning as endpoint dedup: append cli.id so three bot-*
+		// entries with displayName "机器人消息" don't collapse into one.
+		nameKey := dedupKeyForName(descriptor)
 		existing, exists := bestByName[nameKey]
 		if !exists || descriptorIsNewer(descriptor, existing) {
 			bestByName[nameKey] = descriptor
@@ -702,6 +708,33 @@ func descriptorIsNewer(current, existing ServerDescriptor) bool {
 
 func normalizeDisplayNameKey(displayName string) string {
 	return strings.ToLower(strings.TrimSpace(displayName))
+}
+
+// dedupKeyForEndpoint returns the dedup key used when collapsing multiple
+// envelope entries that share an MCP endpoint. cli.id is appended so an
+// endpoint intentionally fronting multiple CLI command roots (bot-root /
+// bot-message / bot-group all served by the same MCP server) stays as
+// distinct descriptors. When cli.id is empty (or absent), the key is the
+// endpoint alone to preserve historical dedup behaviour.
+func dedupKeyForEndpoint(descriptor ServerDescriptor) string {
+	if cliID := strings.TrimSpace(descriptor.CLI.ID); cliID != "" {
+		return descriptor.Key + "#" + cliID
+	}
+	return descriptor.Key
+}
+
+// dedupKeyForName mirrors dedupKeyForEndpoint for the second-pass name-based
+// dedup so two envelopes with the same displayName but distinct cli.id (the
+// bot-* trio shares displayName "机器人消息") remain separate.
+func dedupKeyForName(descriptor ServerDescriptor) string {
+	nameKey := normalizeDisplayNameKey(descriptor.DisplayName)
+	if nameKey == "" {
+		nameKey = descriptor.Key
+	}
+	if cliID := strings.TrimSpace(descriptor.CLI.ID); cliID != "" {
+		return nameKey + "#" + cliID
+	}
+	return nameKey
 }
 
 func markDeprecatedCandidate(displayName string, lifecycle LifecycleInfo) LifecycleInfo {

--- a/internal/market/registry_test.go
+++ b/internal/market/registry_test.go
@@ -101,6 +101,65 @@ func TestNormalizeServersDeduplicatesSameNameAcrossEndpoints(t *testing.T) {
 	}
 }
 
+// TestNormalizeServersPreservesDistinctCLIIDsOnSharedEndpoint guards the
+// bot-root / bot-message / bot-group split (issue: chat bot subtree vanished
+// from the CLI after NormalizeServers collapsed three envelopes that share a
+// single MCP endpoint and displayName but expose different cli.id values).
+func TestNormalizeServersPreservesDistinctCLIIDsOnSharedEndpoint(t *testing.T) {
+	t.Parallel()
+
+	sharedURL := "https://example.com/server/4717"
+	sharedName := "机器人消息"
+	response := ListResponse{
+		Servers: []ServerEnvelope{
+			{
+				Server: RegistryServer{
+					Name:    sharedName,
+					Remotes: []RegistryRemote{{Type: "streamable-http", URL: sharedURL}},
+				},
+				Meta: EnvelopeMeta{
+					Registry: RegistryMetadata{Status: "active", UpdatedAt: "2026-03-29T00:00:00Z"},
+					CLI:      CLIOverlay{ID: "bot-root", Command: "bot"},
+				},
+			},
+			{
+				Server: RegistryServer{
+					Name:    sharedName,
+					Remotes: []RegistryRemote{{Type: "streamable-http", URL: sharedURL}},
+				},
+				Meta: EnvelopeMeta{
+					Registry: RegistryMetadata{Status: "active", UpdatedAt: "2026-03-29T00:00:00Z"},
+					CLI:      CLIOverlay{ID: "bot-message", Command: "message"},
+				},
+			},
+			{
+				Server: RegistryServer{
+					Name:    sharedName,
+					Remotes: []RegistryRemote{{Type: "streamable-http", URL: sharedURL}},
+				},
+				Meta: EnvelopeMeta{
+					Registry: RegistryMetadata{Status: "active", UpdatedAt: "2026-03-29T00:00:00Z"},
+					CLI:      CLIOverlay{ID: "bot-group", Command: "group"},
+				},
+			},
+		},
+	}
+
+	servers := NormalizeServers(response, "live_market")
+	if len(servers) != 3 {
+		t.Fatalf("NormalizeServers() len = %d, want 3 (one per cli.id)", len(servers))
+	}
+	seen := map[string]bool{}
+	for _, s := range servers {
+		seen[s.CLI.ID] = true
+	}
+	for _, want := range []string{"bot-root", "bot-message", "bot-group"} {
+		if !seen[want] {
+			t.Errorf("NormalizeServers() missing descriptor with cli.id %q", want)
+		}
+	}
+}
+
 func TestNormalizeServersMarksLegacyNameAsDeprecatedCandidate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- 把 `test/pre-mcp-discovery` 上累积稳定的改动整理成一个干净 commit 合入 main
- 已剔除 test-only 的预发环境硬编码（源分支已 revert）和中间 merge/revert 噪音
- 最终 net diff: 12 个文件，+369 / -387

## Scope
- **`internal/helpers/chat.go` + 测试** — 重写 chat.go 对齐 wukong IM envelope，拆分共享 `chat` 命令，删减历史测试桩
- **`internal/compat/`** — Pipeline tool override + executor、CLIAliases override、json_parse_strict、file_read transform，envelope leaf cmd Args 从 NoArgs 放宽到 ArbitraryArgs
- **`internal/cli/stdin.go` + 测试** — stdin 处理增强，覆盖更多 `--content` / `--content-file` 路径
- **`internal/app/`** — direct_runtime / runner 适配嫁接硬编码 helper 到动态命令树
- **`internal/market/`** — registry 强化 + 单元测试

## Test plan
- [x] `go build ./...` 通过
- [ ] `go test ./internal/...`
- [ ] 手动跑 `chat message send` / `chat message reply`
- [ ] 跑一遍 schema pipeline 用例（file_read transform、CLIAliases）

## Notes
- 等价性验证：`git diff feat/im-wukong-and-schema..test/pre-mcp-discovery` 为空，与源分支 net diff 完全一致
- 源分支 `test/pre-mcp-discovery` 保留不删，便于回溯