### PR TITLE
fix(upgrade): ad-hoc sign darwin binaries to fix amfid SIGKILL on Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,17 @@ jobs:
       - name: Install archive tooling
         run: sudo apt-get update && sudo apt-get install -y zip unzip
 
+      - name: Install rcodesign (ad-hoc sign darwin binaries from Linux)
+        run: |
+          set -eu
+          RCS_VERSION="0.27.0"
+          curl -fsSL -o /tmp/rcodesign.tar.gz \
+            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCS_VERSION}/apple-codesign-${RCS_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          mkdir -p /tmp/rcodesign
+          tar -xzf /tmp/rcodesign.tar.gz -C /tmp/rcodesign --strip-components=1
+          sudo install -m 0755 /tmp/rcodesign/rcodesign /usr/local/bin/rcodesign
+          rcodesign --version
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/internal/app/upgrade.go
+++ b/internal/app/upgrade.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -580,18 +581,55 @@ func validateNewBinary(binaryPath, expectedVersion string) error {
 		return fmt.Errorf("设置执行权限失败: %w", err)
 	}
 
-	// Try running the binary
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	out, err := exec.CommandContext(ctx, binaryPath, "version").CombinedOutput()
+	out, err := tryExecVersion(binaryPath)
 	if err != nil {
-		return fmt.Errorf("二进制无法执行: %w", err)
+		// Apple Silicon kills unsigned arm64 binaries with SIGKILL via amfid.
+		// Repair the binary in-place (ad-hoc codesign + drop quarantine) and retry once.
+		if runtime.GOOS == "darwin" && isLikelyAMFIKill(err) {
+			if repairErr := repairDarwinBinary(binaryPath); repairErr == nil {
+				out, err = tryExecVersion(binaryPath)
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("二进制无法执行: %w", err)
+		}
 	}
 
 	if !strings.Contains(string(out), expectedVersion) {
 		// Not fatal, version format might differ
 		fmt.Printf("\n  注意: 版本输出中未包含 %s", expectedVersion)
+	}
+	return nil
+}
+
+func tryExecVersion(binaryPath string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, binaryPath, "version").CombinedOutput()
+}
+
+// isLikelyAMFIKill returns true when err looks like macOS amfid SIGKILL'ing an
+// unsigned binary. Go reports this as "signal: killed".
+func isLikelyAMFIKill(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "signal: killed") || strings.Contains(msg, "signal: kill")
+}
+
+// repairDarwinBinary applies an ad-hoc codesign and clears the quarantine xattr.
+// Used as a self-heal step when an unsigned binary is killed by amfid on Apple Silicon.
+func repairDarwinBinary(binaryPath string) error {
+	// Best-effort: strip quarantine. Failure is fine (attribute often absent).
+	_ = exec.Command("xattr", "-d", "com.apple.quarantine", binaryPath).Run()
+
+	if _, err := exec.LookPath("codesign"); err != nil {
+		return fmt.Errorf("codesign 不可用: %w", err)
+	}
+	out, err := exec.Command("codesign", "--force", "--sign", "-", binaryPath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("codesign 失败: %v: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/internal/app/upgrade_test.go
+++ b/internal/app/upgrade_test.go
@@ -7,8 +7,11 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -426,5 +429,82 @@ func TestNewUpgradeCommand_Help(t *testing.T) {
 	}
 	if !strings.Contains(help, "--rollback") {
 		t.Error("help should contain --rollback")
+	}
+}
+
+// --- isLikelyAMFIKill ---
+
+func TestIsLikelyAMFIKill(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"signal killed (real Go format)", errors.New("signal: killed"), true},
+		{"signal kill variant", errors.New("signal: kill"), true},
+		{"unrelated error", errors.New("exit status 1"), false},
+		{"file not found", errors.New("no such file or directory"), false},
+		{"wrapped killed in middle", errors.New("exec: signal: killed: cleanup"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLikelyAMFIKill(tt.err); got != tt.want {
+				t.Errorf("isLikelyAMFIKill(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- validateNewBinary self-heal (darwin only) ---
+//
+// On macOS, an unsigned arm64 binary is SIGKILL'd by amfid. This test verifies
+// validateNewBinary recovers via repairDarwinBinary (ad-hoc codesign) and
+// successfully re-executes the binary. We use go itself as a stand-in for the
+// new dws binary — it's a real signed Mach-O we can strip and re-sign.
+
+func TestValidateNewBinary_RecoversFromUnsignedDarwin(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("amfid SIGKILL only happens on macOS")
+	}
+	if _, err := exec.LookPath("codesign"); err != nil {
+		t.Skip("codesign not available")
+	}
+
+	// Build a fresh dws binary into a temp dir.
+	tmpDir := t.TempDir()
+	bin := filepath.Join(tmpDir, "dws-test")
+
+	// Locate repo root from this test file's location.
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	repoRoot := filepath.Join(wd, "..", "..")
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd")
+	cmd.Dir = repoRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+
+	// Strip signature to reproduce the unsigned state from CI cross-compilation.
+	if out, err := exec.Command("codesign", "--remove-signature", bin).CombinedOutput(); err != nil {
+		t.Fatalf("strip signature: %v\n%s", err, out)
+	}
+
+	// Sanity: confirm direct exec is killed.
+	if _, err := tryExecVersion(bin); err == nil {
+		t.Skip("unsigned binary executed without amfid kill — likely Intel Mac or SIP disabled")
+	}
+
+	// validateNewBinary should self-heal and succeed.
+	if err := validateNewBinary(bin, "dev"); err != nil {
+		t.Fatalf("validateNewBinary did not recover: %v", err)
+	}
+
+	// Verify the binary now has an ad-hoc signature.
+	out, _ := exec.Command("codesign", "-dv", bin).CombinedOutput()
+	if !strings.Contains(string(out), "Signature=adhoc") {
+		t.Errorf("expected adhoc signature, got: %s", out)
 	}
 }

--- a/scripts/release/post-goreleaser.sh
+++ b/scripts/release/post-goreleaser.sh
@@ -174,6 +174,74 @@ create_skills_zip() {
   )
 }
 
+# ---------- darwin ad-hoc signing ----------
+#
+# Unsigned arm64 binaries are SIGKILL'd by amfid on Apple Silicon (macOS 11+).
+# We unpack each dws-darwin-*.tar.gz, ad-hoc sign the dws binary, repack
+# deterministically, and rewrite the corresponding line in checksums.txt.
+
+sign_one_darwin_binary() {
+  bin="$1"
+  if command -v codesign >/dev/null 2>&1; then
+    codesign --force --sign - "$bin"
+    return
+  fi
+  if command -v rcodesign >/dev/null 2>&1; then
+    rcodesign sign "$bin"
+    return
+  fi
+  err "neither codesign nor rcodesign found — install rcodesign (cargo install apple-codesign) to ad-hoc sign darwin builds"
+}
+
+update_checksum_entry() {
+  filename="$1"
+  new_sha="$2"
+  checksum_path="$DIST_DIR/checksums.txt"
+  [ -f "$checksum_path" ] || return 0
+  tmp="$(mktemp)"
+  grep -v "  ${filename}\$" "$checksum_path" > "$tmp" 2>/dev/null || true
+  printf '%s  %s\n' "$new_sha" "$filename" >> "$tmp"
+  mv "$tmp" "$checksum_path"
+}
+
+sign_darwin_archives() {
+  work="$(mktemp -d)"
+  found_any=0
+  for archive in "$DIST_DIR"/dws-darwin-*.tar.gz; do
+    [ -f "$archive" ] || continue
+    found_any=1
+    name="$(basename "$archive")"
+    say "  signing $name"
+
+    stage="$work/${name%.tar.gz}"
+    rm -rf "$stage"
+    mkdir -p "$stage"
+    tar -xzf "$archive" -C "$stage"
+
+    bin="$stage/dws"
+    if [ ! -f "$bin" ]; then
+      err "dws binary not found inside $name after extraction"
+    fi
+    sign_one_darwin_binary "$bin"
+
+    # Repack deterministically: sorted file order, zeroed owner/mtime so
+    # rerunning the script produces byte-identical archives (and sha256s).
+    (
+      cd "$stage" \
+        && tar --sort=name --owner=0 --group=0 --numeric-owner \
+              --mtime='2020-01-01 00:00Z' \
+              -czf "$archive.new" .
+    )
+    mv "$archive.new" "$archive"
+
+    update_checksum_entry "$name" "$(sha256_file "$archive")"
+  done
+  rm -rf "$work"
+  if [ "$found_any" -eq 0 ]; then
+    say "  (no darwin archives found, skipping)"
+  fi
+}
+
 write_checksums() {
   checksum_path="$DIST_DIR/checksums.txt"
   # Append skills zip checksum to goreleaser's checksums file
@@ -185,6 +253,9 @@ write_checksums() {
 # ---------- main ----------
 
 version="$(resolve_version)"
+
+say "==> Ad-hoc signing darwin binaries"
+sign_darwin_archives
 
 say "==> Creating skills zip"
 create_skills_zip


### PR DESCRIPTION
## 问题

Apple Silicon 用户跑 `dws upgrade` 在第 4 步 "解压并验证" 失败：

```
[4/5] 解压并验证...
{
  "error": {
    "category": "internal",
    "code": -1,
    "message": "验证失败: 二进制无法执行: signal: killed"
  }
}
```

## 根因

Release 流程在 `ubuntu-latest` 上用 GoReleaser **交叉编译** darwin/arm64，整条流水线没有任何 codesign 步骤。macOS 11+ 在 Apple Silicon 上强制要求所有 arm64 可执行文件至少要有 ad-hoc 签名，否则 `amfid` 在首次 exec 时直接 SIGKILL。Go 看到的就是 `signal: killed`，被 `validateNewBinary` 中止升级。

复现：未签名 dws 二进制 → `exit 137`（128+9 = SIGKILL）；ad-hoc 签名后 → 正常。

## 方案（双管齐下）

### 1. Release 端 ad-hoc 签名（治本）

- `scripts/release/post-goreleaser.sh` 新增 `sign_darwin_archives`：
  - 解包每个 `dws-darwin-*.tar.gz`
  - 用 `codesign`（本地）/ `rcodesign`（CI）做 ad-hoc 签名
  - 确定性重打包（`--sort=name`、零 owner/mtime）
  - 重写 `checksums.txt` 对应行
- `.github/workflows/release.yml` 在 GoReleaser 之前安装 `rcodesign 0.27.0`（一个纯 Linux 可跑的 Apple codesign 实现）。

### 2. 客户端自愈（兜底）

`validateNewBinary` 在 macOS 上检测到 `signal: killed` 时，自动：
- `xattr -d com.apple.quarantine`（清隔离属性，兜底）
- `codesign --force --sign -`（ad-hoc 签名）
- 重试一次 `dws version`

即便未来 release 端意外漏签，客户端也能自动修复。

## 验证

**端到端实测**（本地）：
- 未签名 dws → exec 直接 exit 137（amfid SIGKILL）
- 跑 `sign_darwin_archives` → 解压后 `Signature=adhoc`，能正常输出 `dws version`
- `checksums.txt`：darwin 行换成新 sha，linux 行不动

**单元测试**：
- `TestIsLikelyAMFIKill`：6 个 case，覆盖 nil/真实 Go 报错格式/无关错误
- `TestValidateNewBinary_RecoversFromUnsignedDarwin`：build 真实二进制 → strip 签名 → 验证 exec 失败 → 走自愈 → 验收 `Signature=adhoc`
- 全包 regression：`internal/app` + `internal/upgrade` 全绿

## 影响范围

- ✅ 解决：Apple Silicon Mac 用户 `dws upgrade` 失败
- ✅ 兼容：Intel Mac（Rosetta 兼容性提升）/ Linux / Windows 路径完全不变
- ✅ Homebrew formula 自动用新 sha（`stage_homebrew_formula` 是签名后才跑）
- ✅ npm 包里的 `assets/dws-darwin-*.tar.gz` 也是签名后的

## 用户当前升级 workaround

1.0.30 还没有客户端自愈，所以现存 1.0.30 用户升 1.0.31 仍会失败。临时绕过：

```bash
cd /tmp && curl -fL -o dws.tar.gz \
  https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.31/dws-darwin-arm64.tar.gz \
  && tar xzf dws.tar.gz \
  && codesign --force --sign - dws \
  && cp dws "$(which dws)"
```

下一个 release（带本 PR）出来后即可正常 `dws upgrade`。