### PR TITLE
fix(drive): unblock OSS upload + improve AI-agent discoverability

### DIFF
--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -267,6 +267,7 @@ func NewRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine) 
 	root := &cobra.Command{
 		Use:               "dws",
 		Short:             "DWS CLI",
+		Long:              `提示: 如果遇到能力缺失、命令报错、新功能未注册、或无法完成任务, 请先用 'dws upgrade' 升级到最新版本后再试. 钉钉 OpenAPI 和 dws CLI 持续迭代, 新能力和 bugfix 会先在新版本上线.`,
 		Args:              cobra.NoArgs,
 		SilenceErrors:     true,
 		SilenceUsage:      true,

--- a/internal/app/root_help.go
+++ b/internal/app/root_help.go
@@ -82,6 +82,16 @@ func renderRootHelp(root *cobra.Command) {
 		_, _ = fmt.Fprintln(w)
 	}
 	_, _ = fmt.Fprintln(w, `Use "dws <service> --help" for more information about a discovered MCP service or "dws <command> --help" for utility commands.`)
+
+	// Render root.Long after the command list so agents see the upgrade
+	// hint (or any other root-level guidance) after browsing all available
+	// commands and concluding none of them fit. Cobra's default help template
+	// would render Long automatically; the custom SetHelpFunc above replaces
+	// it and dropped this, so we restore it explicitly here.
+	if long := strings.TrimSpace(root.Long); long != "" {
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w, long)
+	}
 }
 
 // resolveVisibleProducts returns the set of top-level product IDs that should

--- a/internal/app/visibility_test.go
+++ b/internal/app/visibility_test.go
@@ -14,6 +14,8 @@
 package app
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
@@ -122,4 +124,28 @@ func commandNames(cmds []*cobra.Command) []string {
 		names = append(names, c.Name())
 	}
 	return names
+}
+
+// TestRenderRootHelpIncludesLong guards that renderRootHelp surfaces the
+// root command's Long description in `dws --help` output. The custom
+// SetHelpFunc in root_help.go replaces cobra's default help template, which
+// previously caused root.Long to be silently dropped. The production
+// root.Long carries the "use 'dws upgrade' if a command is missing or
+// failing" hint that AI agents rely on when they cannot find a suitable
+// command — if this test fails after a help-rendering change, agents will
+// silently lose that guidance.
+func TestRenderRootHelpIncludesLong(t *testing.T) {
+	const sentinel = "SENTINEL-LONG-MUST-APPEAR-IN-HELP"
+	root := &cobra.Command{
+		Use:  "dws",
+		Long: sentinel,
+	}
+	var out bytes.Buffer
+	root.SetOut(&out)
+
+	renderRootHelp(root)
+
+	if !strings.Contains(out.String(), sentinel) {
+		t.Fatalf("renderRootHelp must render root.Long verbatim in --help output; got:\n%s", out.String())
+	}
 }

--- a/internal/helpers/aitable.go
+++ b/internal/helpers/aitable.go
@@ -393,13 +393,15 @@ func confirmDeletePrompt(cmd *cobra.Command, resourceType, resourceName string) 
 
 func newAITableUploadFileCommand(runner executor.Runner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "upload-file",
-		Short:  i18n.T("本地文件一键上传到 AITable 附件字段"),
-		Hidden: true,
-		Long: `完整流程 (自动执行 3 步):
-  1. dws aitable attachment upload → 获取 uploadUrl + fileToken
-  2. HTTP PUT 上传文件到 OSS
-  3. 返回 fileToken，可直接用于 record create/update`,
+		Use:   "upload-file",
+		Short: i18n.T("本地文件一键上传到 AITable 附件字段 (3 步自动合一: prepare + PUT + 返回 fileToken)"),
+		Long: `本地文件一键上传到 AITable 附件字段, 一行命令完成 3 步:
+  1. prepare_attachment_upload → 获取 OSS 上传地址 uploadUrl + fileToken
+  2. HTTP PUT 文件二进制 → OSS
+  3. 返回 fileToken (可直接用于 dws aitable record create/update 的 attachment 字段)
+
+推荐 AI Agent 优先使用此命令上传单个附件, 比手动调用 attachment upload (只 prepare)
+之后再自己 PUT 文件二进制要可靠得多.`,
 		Example:           "  dws aitable attachment upload-file --base-id <BASE_ID> --file ./report.pdf",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,

--- a/internal/helpers/aitable_commands.go
+++ b/internal/helpers/aitable_commands.go
@@ -594,8 +594,17 @@ func newAitableTemplateSearchCommand(runner executor.Runner) *cobra.Command {
 
 func newAITableAttachmentUploadCommand(runner executor.Runner) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "upload",
-		Short:             i18n.T("准备附件上传"),
+		Use:   "upload",
+		Short: i18n.T("准备附件上传 (仅返回 uploadUrl + fileToken, 不上传文件)"),
+		Long: i18n.T(`准备附件上传 — 3 步流程的第 1 步.
+
+本命令只调用 prepare_attachment_upload, 返回 OSS 上传地址 uploadUrl 和 fileToken,
+不实际上传文件二进制. 拿到响应后你还需要:
+  2. HTTP PUT 文件二进制 → uploadUrl
+  3. 把 fileToken 填到 record 的 attachment 字段, 格式 [{"fileToken":"ft_xxx"}]
+
+推荐 AI Agent 直接用 'dws aitable attachment upload-file --base-id X --file ./report.pdf'
+一行完成 3 步, 不用自己处理 HTTP PUT 二进制.`),
 		Example:           "  dws aitable attachment upload --base-id BASE_ID --file-name report.pdf --size 1024",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,

--- a/internal/helpers/aitable_upload_file_test.go
+++ b/internal/helpers/aitable_upload_file_test.go
@@ -92,3 +92,18 @@ func TestAITableUploadFileUnwrapsRuntimeContent(t *testing.T) {
 		t.Fatalf("fileToken = %#v, want ft_test_123", got)
 	}
 }
+
+// TestAITableUploadFileCommandIsDiscoverable guards that the upload-file
+// command stays visible via --help. It was previously marked Hidden:true,
+// which caused AI agents (e.g. Lobster) to discover only the prepare-only
+// `attachment upload` command and get stuck after step 1, falling back to
+// "please use the UI to upload". Keeping this command discoverable is the
+// single change that unlocks the end-to-end attachment upload flow for
+// agents that only read --help.
+func TestAITableUploadFileCommandIsDiscoverable(t *testing.T) {
+	runner := &uploadFileRunner{}
+	cmd := newAITableUploadFileCommand(runner)
+	if cmd.Hidden {
+		t.Fatalf("upload-file command must not be Hidden: AI agents discover it via --help; hiding it strands them after step 1 (see commit message for full rationale)")
+	}
+}

--- a/internal/helpers/drive.go
+++ b/internal/helpers/drive.go
@@ -190,7 +190,7 @@ func runDriveUpload(cmd *cobra.Command, runner executor.Runner) error {
 
 	// Step 2: HTTP PUT to OSS
 	fmt.Fprintln(os.Stderr, "[2/3] 上传文件到 OSS...")
-	if err := httpPutDriveFile(cmd.Context(), resourceURL, ossHeaders, absPath, fileSize, mimeType); err != nil {
+	if err := httpPutDriveFile(cmd.Context(), resourceURL, ossHeaders, absPath, fileSize); err != nil {
 		return err
 	}
 
@@ -303,7 +303,26 @@ func parseDriveUploadInfo(resp map[string]any) (resourceURL, uploadID string, he
 	return
 }
 
-func httpPutDriveFile(ctx context.Context, resourceURL string, headers map[string]string, filePath string, fileSize int64, fallbackMIME string) error {
+// httpPutDriveFile uploads the file at filePath to a DingTalk drive OSS presigned URL.
+//
+// PROTOCOL CONTRACT: the headers map is authoritative. It contains the exact
+// and complete set of HTTP headers required for the upload. An empty map means
+// "no client-side headers needed" (this is the normal case for DingTalk drive,
+// where the signature is embedded in the URL query string).
+//
+// DO NOT add Content-Type or any other client-inferred header here. DingTalk
+// drive uses OSS v1 presigned URLs whose StringToSign includes the Content-Type
+// header that the server saw at signing time (typically empty). Any client-side
+// addition of Content-Type makes the signature computed by OSS at PUT time
+// differ from the server's presignature → 403 SignatureDoesNotMatch.
+//
+// If a future OSS endpoint requires header-based signing (Authorization header
+// instead of URL signing), introduce a separate helper rather than reintroducing
+// a fallback here. The aitable attachment upload helper in aitable.go does set
+// Content-Type because its OSS endpoint uses a different signing mode where the
+// server includes the client-declared mime in its signature computation; do not
+// unify the two helpers without re-validating both endpoints.
+func httpPutDriveFile(ctx context.Context, resourceURL string, headers map[string]string, filePath string, fileSize int64) error {
 	f, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("无法打开文件: %w", err)
@@ -315,15 +334,8 @@ func httpPutDriveFile(ctx context.Context, resourceURL string, headers map[strin
 		return fmt.Errorf("构建 OSS 上传请求失败: %w", err)
 	}
 	req.ContentLength = fileSize
-	hasContentType := false
 	for k, v := range headers {
 		req.Header.Set(k, v)
-		if strings.EqualFold(k, "Content-Type") {
-			hasContentType = true
-		}
-	}
-	if !hasContentType && fallbackMIME != "" {
-		req.Header.Set("Content-Type", fallbackMIME)
 	}
 
 	client := &http.Client{Timeout: 10 * time.Minute}

--- a/internal/helpers/drive_test.go
+++ b/internal/helpers/drive_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestHttpPutDriveFile_NoContentTypeWhenServerHeadersEmpty guards the fix for
+// the SignatureDoesNotMatch bug on DingTalk drive presigned OSS uploads.
+//
+// DingTalk drive returns an OSS presigned URL (signature in the URL query
+// string) and signs the upload with Content-Type left empty. Any client-side
+// Content-Type makes the signature OSS computes at PUT time differ from the
+// server presignature → 403 SignatureDoesNotMatch.
+//
+// Previous behavior: httpPutDriveFile fell back to a client-inferred mime when
+// the server's `headers` map was empty, which is the normal case for DingTalk
+// drive (`{"headers": {}}`). That fallback broke every PNG / image / typed-mime
+// upload in production.
+//
+// This test asserts the PUT request body contains no Content-Type header when
+// the server returns an empty headers map. If a future change reintroduces
+// client-side Content-Type fallback this test will fail loudly.
+func TestHttpPutDriveFile_NoContentTypeWhenServerHeadersEmpty(t *testing.T) {
+	var receivedContentType string
+	var receivedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		receivedContentType = r.Header.Get("Content-Type")
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmp := filepath.Join(t.TempDir(), "test.png")
+	wantBody := []byte("fake-png-bytes")
+	if err := os.WriteFile(tmp, wantBody, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	err := httpPutDriveFile(context.Background(), server.URL, map[string]string{}, tmp, int64(len(wantBody)))
+	if err != nil {
+		t.Fatalf("httpPutDriveFile() error = %v", err)
+	}
+	if receivedContentType != "" {
+		t.Fatalf("Content-Type = %q, want empty (presigned URL signing requires no client-inferred headers)", receivedContentType)
+	}
+	if string(receivedBody) != string(wantBody) {
+		t.Fatalf("uploaded body = %q, want %q", string(receivedBody), string(wantBody))
+	}
+}
+
+// TestHttpPutDriveFile_PassthroughServerHeaders verifies that any header the
+// server returns in its prepare response is forwarded verbatim to the PUT
+// request. This is the symmetric guarantee to the test above: clients must
+// neither add nor drop headers — they pass through exactly what the server
+// declared.
+func TestHttpPutDriveFile_PassthroughServerHeaders(t *testing.T) {
+	var receivedHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	tmp := filepath.Join(t.TempDir(), "test.bin")
+	if err := os.WriteFile(tmp, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	headers := map[string]string{
+		"Content-Type":        "application/octet-stream",
+		"x-oss-storage-class": "Standard",
+	}
+	err := httpPutDriveFile(context.Background(), server.URL, headers, tmp, 1)
+	if err != nil {
+		t.Fatalf("httpPutDriveFile() error = %v", err)
+	}
+	if got := receivedHeaders.Get("Content-Type"); got != "application/octet-stream" {
+		t.Fatalf("Content-Type = %q, want application/octet-stream", got)
+	}
+	if got := receivedHeaders.Get("x-oss-storage-class"); got != "Standard" {
+		t.Fatalf("x-oss-storage-class = %q, want Standard", got)
+	}
+}


### PR DESCRIPTION
## Problem

Three related but independent issues block AI agents (and many users) from using DingTalk drive / aitable attachments via `dws`:

1. **`dws drive upload` returns HTTP 403 SignatureDoesNotMatch on every typed file** (PNG / PDF / image / video, basically everything). The drive helper sets a client-side `Content-Type` fallback header when the server's `prepare_upload` response returns an empty `headers` map, but DingTalk drive uses OSS presigned URLs whose StringToSign was computed with empty Content-Type at signing time. Any client-side Content-Type makes the signature OSS recomputes at PUT time differ from the server presignature.

2. **`dws aitable attachment` only exposes a prepare-only `upload` command via `--help`**, while the real one-shot `upload-file` (which does prepare + HTTP PUT + return fileToken automatically) is marked `Hidden:true`. AI agents that discover commands through `--help` only see the prepare-only command, call it, get an `uploadUrl` they have no idea how to consume, and fall back to "please use the UI to upload" messages — which makes `dws` look broken even when the capability is fully implemented. A public 测评 article ([example](https://mp.weixin.qq.com/s/u9wCgFU3bu5F6qEzUlP-GQ)) using Lobster + dws to upload 15 resumes into a Base concluded `dws` cannot upload attachments — the real cause is discoverability, not capability.

3. **`dws --help` provides no hint about `dws upgrade`** when an agent / user cannot find a suitable command. The natural failure mode is to give up or hack around, when often the right action is just to upgrade the binary because new capabilities and bugfixes ship continuously.

## Changes (3 commits)

### `fix(drive): drop client-side Content-Type fallback on presigned OSS PUT`

`internal/helpers/drive.go`:

- Remove the `hasContentType` + `fallbackMIME` path in `httpPutDriveFile`. Trust the server's `headers` map as authoritative — empty means "no client-side headers needed".
- Drop the `fallbackMIME` parameter from `httpPutDriveFile`.
- Explicit comment in the function body documents the protocol contract and explains why `aitable.go` must NOT be unified with this helper (different OSS signing modes).

`internal/helpers/drive_test.go` (new):

- `TestHttpPutDriveFile_NoContentTypeWhenServerHeadersEmpty` — guards that an empty server headers map results in no Content-Type on PUT.
- `TestHttpPutDriveFile_PassthroughServerHeaders` — guards that server-supplied headers (`Content-Type`, `x-oss-*`) are forwarded verbatim.

### `feat(aitable): unhide attachment upload-file + clarify prepare-only command`

`internal/helpers/aitable.go`:

- Remove `Hidden:true` from `newAITableUploadFileCommand` so AI agents discover it via `--help`.
- Tighten Short text to explicitly mention the 3 steps it bundles.
- Long text calls out the prepare-only sibling and recommends `upload-file` as the default for AI agents.

`internal/helpers/aitable_commands.go`:

- Add `Long` description to the prepare-only `newAITableAttachmentUploadCommand` explicitly stating it is step 1 of 3, listing what an agent must do after (HTTP PUT, then `[{\"fileToken\":\"ft_xxx\"}]` in record attachment field), and pointing to `upload-file` as the recommended one-shot alternative.

`internal/helpers/aitable_upload_file_test.go`:

- `TestAITableUploadFileCommandIsDiscoverable` — guards against re-introducing `Hidden:true`.

Note: aitable.go's `Set(\"Content-Type\", mimeType)` is intentionally kept — aitable's OSS endpoint uses a different signing mode (server includes the client-declared mime in its signature). Verified by running `aitable attachment upload-file` across 12 file types (JPEG / PNG with auto-detect / Chinese filename / 60 MB binary / 11 byte text / PDF / MP4 / ZIP / spaces / Chinese + spaces) — all succeed.

### `feat(root): show 'dws upgrade' guidance in dws --help when commands are missing`

`internal/app/root.go`:

- Set `root.Long` to a one-paragraph hint: \"if you hit a missing command, an error, or cannot complete the task, try `dws upgrade` first; both the DingTalk OpenAPI surface and dws CLI evolve continuously.\"

`internal/app/root_help.go`:

- The custom `SetHelpFunc` that renders root help (`renderRootHelp`) replaces cobra's default template and had been silently dropping `root.Long`. Restore rendering by appending `root.Long` (when non-empty) after the command list, separated by a blank line.

`internal/app/visibility_test.go`:

- `TestRenderRootHelpIncludesLong` — uses a sentinel Long and asserts `renderRootHelp` output contains it verbatim. Prevents future help-rendering rewrites from re-dropping Long.

## Verification

Real-world end-to-end test on DingTalk production drive endpoint:

```
# Before fix (system v1.0.31):
$ dws drive upload --file any.png
[1/3] 获取上传凭证 any.png (X 字节, image/png)...
[2/3] 上传文件到 OSS...
→ OSS 上传失败 HTTP 403: SignatureDoesNotMatch

# After fix (this PR):
$ ./dws drive upload --file gaoshan.png
[1/3] / [2/3] / [3/3] passed
→ success: true, fileId: wva2dxOW4kaa9y4Es0AqrLBp8bkz3BRL, docUrl: ...
```

Manual curl verification proving root cause:

```
$ curl -X PUT -H \"Content-Type:\" --data-binary @file <same-presigned-url>
→ HTTP 200  (forcing empty Content-Type with -H \"Content-Type:\" makes the signature match)
```

Aitable regression matrix (12 file types) — all succeed after the change, no behavior regression.

`dws --help` end of output now shows the upgrade hint:

```
Use \"dws <service> --help\" ...

提示: 如果遇到能力缺失、命令报错、新功能未注册、或无法完成任务, 请先用 'dws upgrade' 升级到最新版本后再试. 钉钉 OpenAPI 和 dws CLI 持续迭代, 新能力和 bugfix 会先在新版本上线.
```

New unit tests pass: `go test -race ./internal/helpers/... ./internal/app/...` all green for new tests. Pre-existing failures (todo / report / recovery / goreleaser / open-source-policy / race in TestPrintExecutionErrorUsesJSONWhenFormatIsJSON) reproduce identically on `upstream/main` without these changes — unrelated to this PR.

## Out of scope (potential follow-up PRs)

- Add an end-to-end `dws aitable attachment upload-to-record --base-id X --table-id Y --field-id F --record-id R --file ./xxx` command, bundling upload + write-to-record. Parity with lark-cli's `base +record-upload-attachment`.
- Add an end-to-end `dws chat message send-image --user X --file ./xxx.png` command bundling drive upload + drive download URL + send-direct with markdown image. Currently agents must compose three steps manually; this is the next discoverability win.
- Server-side: extend `drive.download_file` schema to accept `expiresSeconds` parameter (default 7 days, current hardcoded 1 hour), and add a `long_description` field to tool schemas so the in-place workflow guidance reaches all `--help` outputs.
- Long-term: add IM-native `sampleImageMsg` / mediaId capability so image messages are not bound by OSS presigned URL expiry.