### PR TITLE
docs(chat): 补充从聊天记录下载资源的分流策略（按链接 host 三层，closes #375）

### DIFF
--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -921,16 +921,18 @@ Flags:
   - --output 如果指定目录，文件名会从下载 URL 中自动推断
 ```
 
-#### 资源链接形态分流 — 按 content 里的链接形态选下载方式
+#### 资源链接形态分流 — 按 content 里的链接 host 选下载方式
 
-`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接形态决定，按下表三类分流：
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式**由链接的 host 决定、不由文件扩展名决定**，按下表三类分流、不要混用：
 
 | `content` 里的形态 | 资源性质 | 下载方式 |
 |---|---|---|
-| 消息含 `mediaId`（图片 / 视频 / 语音等） | 钉钉消息媒体资源 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`） |
-| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘文件 | `dws drive download --node <fileId> --output <路径>` |
-| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / 视频等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+| `mediaId=https://down.dingtalk.com/media/...`（图片 / 视频 / 语音，扩展名任意） | 公开 CDN 直链 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`）；该链接为公开 CDN，**直接 `curl -sL -o` 也能下**，无需鉴权 |
+| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘临时签名链接 | `dws drive download --node <fileId> --output <路径>`（裸 curl 不通用，需签名头） |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
 
+> - media 直链与扩展名无关：图片(png/jpg/gif)、pdf、docx、xlsx、html 实测 `curl` 均 HTTP 200。部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载，下载后用 `file <文件>` 判断真实类型。
+> - 图片消息还会附带 AI 识别的内容描述（`<imageContent>...</imageContent>`），不下载也能理解图意。
 > - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
 > - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。
 

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -923,15 +923,15 @@ Flags:
 
 #### 资源链接形态分流 — 按 content 里的链接 host 选下载方式
 
-`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式**由链接的 host 决定、不由文件扩展名决定**，按下表三类分流、不要混用：
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接的 host 决定、不由文件扩展名决定；**首选对应 dws 命令**，裸 curl 仅对明确的公开直链有效。按下表分流、不要混用：
 
 | `content` 里的形态 | 资源性质 | 下载方式 |
 |---|---|---|
-| `mediaId=https://down.dingtalk.com/media/...`（图片 / 视频 / 语音，扩展名任意） | 公开 CDN 直链 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`）；该链接为公开 CDN，**直接 `curl -sL -o` 也能下**，无需鉴权 |
+| `mediaId=...`（图片 / 视频 / 语音，扩展名任意） | 钉钉消息媒体；**host 不唯一**：`down.dingtalk.com/media`（公开直链）或 `*.trans.dingtalk.com/...?Expires=&Signature=`（签名 + 会过期） | **首选 `dws chat message download-media`**（内部取最新下载 URL，不受过期影响，需 `--message-id` + `--open-conversation-id`）。仅当链接是 `down.dingtalk.com/media` 公开直链时，可 `curl -sL -o` 快捷下载；**签名/过期链（`trans.dingtalk.com`、带 `Signature`/`Expires`）不要裸 curl，过期会 403** |
 | `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘临时签名链接 | `dws drive download --node <fileId> --output <路径>`（裸 curl 不通用，需签名头） |
-| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download`（裸 curl 只得 HTML 预览页） |
 
-> - media 直链与扩展名无关：图片(png/jpg/gif)、pdf、docx、xlsx、html 实测 `curl` 均 HTTP 200。部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载，下载后用 `file <文件>` 判断真实类型。
+> - 下载到本地后用 `file <文件>` 判断真实类型：部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载。
 > - 图片消息还会附带 AI 识别的内容描述（`<imageContent>...</imageContent>`），不下载也能理解图意。
 > - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
 > - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -921,16 +921,18 @@ Flags:
   - --output 如果指定目录，文件名会从下载 URL 中自动推断
 ```
 
-#### 资源链接形态分流 — 按 content 里的链接形态选下载方式
+#### 资源链接形态分流 — 按 content 里的链接 host 选下载方式
 
-`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接形态决定，按下表三类分流：
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式**由链接的 host 决定、不由文件扩展名决定**，按下表三类分流、不要混用：
 
 | `content` 里的形态 | 资源性质 | 下载方式 |
 |---|---|---|
-| 消息含 `mediaId`（图片 / 视频 / 语音等） | 钉钉消息媒体资源 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`） |
-| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘文件 | `dws drive download --node <fileId> --output <路径>` |
-| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / 视频等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+| `mediaId=https://down.dingtalk.com/media/...`（图片 / 视频 / 语音，扩展名任意） | 公开 CDN 直链 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`）；该链接为公开 CDN，**直接 `curl -sL -o` 也能下**，无需鉴权 |
+| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘临时签名链接 | `dws drive download --node <fileId> --output <路径>`（裸 curl 不通用，需签名头） |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
 
+> - media 直链与扩展名无关：图片(png/jpg/gif)、pdf、docx、xlsx、html 实测 `curl` 均 HTTP 200。部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载，下载后用 `file <文件>` 判断真实类型。
+> - 图片消息还会附带 AI 识别的内容描述（`<imageContent>...</imageContent>`），不下载也能理解图意。
 > - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
 > - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。
 

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -923,15 +923,15 @@ Flags:
 
 #### 资源链接形态分流 — 按 content 里的链接 host 选下载方式
 
-`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式**由链接的 host 决定、不由文件扩展名决定**，按下表三类分流、不要混用：
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接的 host 决定、不由文件扩展名决定；**首选对应 dws 命令**，裸 curl 仅对明确的公开直链有效。按下表分流、不要混用：
 
 | `content` 里的形态 | 资源性质 | 下载方式 |
 |---|---|---|
-| `mediaId=https://down.dingtalk.com/media/...`（图片 / 视频 / 语音，扩展名任意） | 公开 CDN 直链 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`）；该链接为公开 CDN，**直接 `curl -sL -o` 也能下**，无需鉴权 |
+| `mediaId=...`（图片 / 视频 / 语音，扩展名任意） | 钉钉消息媒体；**host 不唯一**：`down.dingtalk.com/media`（公开直链）或 `*.trans.dingtalk.com/...?Expires=&Signature=`（签名 + 会过期） | **首选 `dws chat message download-media`**（内部取最新下载 URL，不受过期影响，需 `--message-id` + `--open-conversation-id`）。仅当链接是 `down.dingtalk.com/media` 公开直链时，可 `curl -sL -o` 快捷下载；**签名/过期链（`trans.dingtalk.com`、带 `Signature`/`Expires`）不要裸 curl，过期会 403** |
 | `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘临时签名链接 | `dws drive download --node <fileId> --output <路径>`（裸 curl 不通用，需签名头） |
-| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download`（裸 curl 只得 HTML 预览页） |
 
-> - media 直链与扩展名无关：图片(png/jpg/gif)、pdf、docx、xlsx、html 实测 `curl` 均 HTTP 200。部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载，下载后用 `file <文件>` 判断真实类型。
+> - 下载到本地后用 `file <文件>` 判断真实类型：部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载。
 > - 图片消息还会附带 AI 识别的内容描述（`<imageContent>...</imageContent>`），不下载也能理解图意。
 > - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
 > - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。


### PR DESCRIPTION
## What

为 `references/products/chat.md`（**mono 与 multi 两份同步**）补充一节「**从聊天记录下载资源（图片/GIF/文件/视频/文档）**」，放在 `message list` 翻页说明之后、`message list-all` 之前。

## Why

`dws chat message list` 能拉到带资源的消息，但 skill 文档只讲了「发图片」，没讲拿到链接后如何**下载/展示**资源。详见 #375。

## 核心结论：下载方式由链接 host 决定，不由文件类型决定

| `content` 里的链接形态 | 资源性质 | 下载方式 |
|---|---|---|
| `down.dingtalk.com/media/...`（任意类型） | 公开 CDN 直链 | **curl 直接下**，无需鉴权 |
| `[文件] xxx fileId: <fileId>` | 钉盘临时签名链接 | `dws drive download --node <fileId>` |
| `alidocs.dingtalk.com/i/nodes/<nodeId>` | 文档/钉盘节点 | `dws doc` / `dws drive download`（裸 curl 仅得 HTML 预览页） |

## 实测证据（覆盖图片与非图片）

```
# media 直链 —— 与文件类型无关，全部裸 curl HTTP 200：
png / jpg / gif → 图片         pdf → application/pdf
docx → Microsoft Word          xlsx → Microsoft Excel          html
# 扩展名 .unknown 时按 application/octet-stream 返回，仍可下载，file 判真实类型为 docx/xlsx/html
# alidocs 节点 —— 裸 curl 只拿到 ~6KB HTML 预览页（非文件本体）
# 钉盘文件 —— drive download --node <fileId> 可下；--help 写明需「下载 URL + 签名请求头」，裸 curl 不通用
```

dws 无 media 下载命令（`dws schema | grep media` 为空），media 直链只能 HTTP GET。

> 文档示例均使用脱敏占位符，不含任何真实链接或 ID。

Closes #375
