### PR TITLE
fix(plugin): silence stdio discovery handshake failures (Warn → Debug)

### DIFF
--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -1495,22 +1495,38 @@ func registerStdioServer(p *plugin.Plugin, sc plugin.StdioServerClient, runner e
 }
 
 // discoverStdioTools performs the blocking Initialize + ListTools handshake
-// on a stdio MCP subprocess. Returns nil on any error (logged at Warn level).
+// on a stdio MCP subprocess. Returns nil on any error (logged at Debug level).
 // The default 2s budget comfortably accommodates Python/Node runtimes whose
 // interpreter + dependency load dominates the first response. Operators with
 // heavier startup chains can relax further via DWS_PLUGIN_COLD_TIMEOUT.
+//
+// A handshake failure here is an EXPECTED, benign outcome for an optional local
+// plugin: e.g. the conference plugin reports "本地服务未就绪" whenever the
+// DingTalk desktop client isn't running, which is the common case for anyone
+// not actively recording a meeting. Discovery simply yields no tools and the
+// run proceeds — commands that ship toolOverrides still register up-front via
+// registerStdioServerFromOverlay (Phase A), so availability is unaffected.
+//
+// These run during command-tree construction (NewRootCommandWithEngine), which
+// happens BEFORE PersistentPreRunE applies --debug/--verbose via
+// configureLogLevel. So a Warn here printed to stderr on EVERY invocation
+// regardless of flags, polluting output and misleading callers into treating it
+// as the cause of an unrelated command error (e.g. an auth or PARAM_ERROR from a
+// completely different server). Logging at Debug keeps the discovery miss out of
+// normal output; surfacing it would require configuring the log level before the
+// tree is built, which we deliberately avoid this close to release.
 func discoverStdioTools(p *plugin.Plugin, sc plugin.StdioServerClient, timeouts pluginColdTimeouts) []transport.ToolDescriptor {
 	ctx, cancel := context.WithTimeout(context.Background(), timeouts.stdio)
 	defer cancel()
 
 	if _, err := sc.Client.Initialize(ctx); err != nil {
-		slog.Warn("plugin: stdio initialize failed",
+		slog.Debug("plugin: stdio initialize failed",
 			"plugin", p.Manifest.Name, "server", sc.Key, "error", err)
 		return nil
 	}
 	toolsResult, err := sc.Client.ListTools(ctx)
 	if err != nil {
-		slog.Warn("plugin: stdio ListTools failed",
+		slog.Debug("plugin: stdio ListTools failed",
 			"plugin", p.Manifest.Name, "server", sc.Key, "error", err)
 		return nil
 	}


### PR DESCRIPTION
## 问题

`dws <任意命令>` 在钉钉桌面客户端未运行时，顶部会冒出一条 WARN：

```
WARN plugin: stdio initialize failed plugin=conference server=conference-local error="stdio: RPC error -32000: 钉钉会议本地服务未就绪，请确认已登录钉钉客户端（版本 ≥ 8.3.20）"
```

这条 WARN 跟实际执行的命令、命令报什么错**完全无关**，纯粹是启动期 conference-local stdio 插件发现握手失败的噪声。它会把真正的错误（如未登录 / 某 server 的 PARAM_ERROR）挤到下面，**误导用户和大模型**把它当成失败原因。

## 根因

stdio 插件发现（Initialize + ListTools）在 `NewRootCommandWithEngine` 构建命令树阶段执行，**早于** `PersistentPreRunE → configureLogLevel` 应用 `--debug/--verbose`。所以发现期日志走的是配置前的默认 handler：`Warn` 不论加不加 flag 都会打到 stderr（这也是为什么用户加了 `--verbose` 还是看到）。

## 修复

把 `discoverStdioTools` 里两条发现握手失败日志从 `Warn` 降到 `Debug`。这是可选本地插件的**预期、良性**结果——带 toolOverrides 的命令仍由 `registerStdioServerFromOverlay`（Phase A）提前注册，命令可用性不受影响，只是少了一次实时工具列表刷新。

## 验证

强制握手超时（`DWS_PLUGIN_COLD_TIMEOUT=1ns`）复现失败路径，统计 `stdio initialize failed` 出现次数：

| 场景 | 次数 |
|---|---|
| 修复前 默认 | 1（复现噪声）|
| 修复后 默认 | 0 |
| 修复后 `--verbose` | 0 |
| 修复后 `--debug` | 0 |

`go build` / `go vet ./internal/app/` 通过；`go test ./internal/app/`（Stdio/Overlay/Visibility/Plugin）通过。