### PR TITLE
docs(chat): 聊天资源按链接形态分流下载指引（适配 #376 到 test/pre-mcp-discovery）

### DIFF
--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -921,6 +921,19 @@ Flags:
   - --output 如果指定目录，文件名会从下载 URL 中自动推断
 ```
 
+#### 资源链接形态分流 — 按 content 里的链接形态选下载方式
+
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接形态决定，按下表三类分流：
+
+| `content` 里的形态 | 资源性质 | 下载方式 |
+|---|---|---|
+| 消息含 `mediaId`（图片 / 视频 / 语音等） | 钉钉消息媒体资源 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`） |
+| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘文件 | `dws drive download --node <fileId> --output <路径>` |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / 视频等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+
+> - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
+> - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。
+
 ### search-common (搜索共同群)
 
 #### 搜索共同群 — 查询指定人共同所在的群聊

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -921,6 +921,19 @@ Flags:
   - --output 如果指定目录，文件名会从下载 URL 中自动推断
 ```
 
+#### 资源链接形态分流 — 按 content 里的链接形态选下载方式
+
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接形态决定，按下表三类分流：
+
+| `content` 里的形态 | 资源性质 | 下载方式 |
+|---|---|---|
+| 消息含 `mediaId`（图片 / 视频 / 语音等） | 钉钉消息媒体资源 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`） |
+| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘文件 | `dws drive download --node <fileId> --output <路径>` |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / 视频等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+
+> - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
+> - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。
+
 ### search-common (搜索共同群)
 
 #### 搜索共同群 — 查询指定人共同所在的群聊


### PR DESCRIPTION
## 背景
把 #376（base=main）的「从聊天记录下载资源」指引落到 `test/pre-mcp-discovery`。

## 为什么不是直接 cherry-pick #376
#376 基于 `main` 写，核心论断是「dws 没有按 mediaId 下载的命令，media 直链只能 curl」。但 **`test/pre-mcp-discovery` 上已有 `dws chat message download-media` 命令**（chat.md `### download-media` 一节）。直接并入会与现有内容**重复 + 自相矛盾**，并在本分支引入**过时/错误**指引。

## 本 PR 的适配
- media 资源 → 指向已有的 **`dws chat message download-media`** 命令（而非 curl）
- 保留 #376 真正有价值的分流：`fileId` → `dws drive download`；`alidocs.../i/nodes/...` → `dws doc` / `dws drive download`
- 删除「无下载命令、只能 curl」的过时论断
- mono / multi 两份 chat.md 同步，纯新增（+26/-0），插在 `download-media` 节之后

## 验证
- 无冲突标记，diff 纯新增，新段每文件仅一次
- 与现有 `download-media` 段互补、不矛盾

关联 #376 / closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)