### PR TITLE
fix(keychain): add StorageDir for Windows to unblock v1.0.33 release

### DIFF
--- a/internal/keychain/keychain_windows.go
+++ b/internal/keychain/keychain_windows.go
@@ -18,6 +18,8 @@ package keychain
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"unsafe"
@@ -31,6 +33,28 @@ import (
 // ---------------------------------------------------------------------------
 
 const regRootPath = `Software\DwsCli\keychain`
+
+// StorageDir returns the storage directory for a given service name on Windows.
+// The Windows keychain backend keeps secrets in DPAPI-protected HKCU registry
+// values rather than on disk, so this path is used only by the portable
+// auth-bundle export/import (internal/auth) to colocate config. When the
+// DWS_KEYCHAIN_DIR environment variable is set (used by tests for isolation),
+// the storage root is taken from that env var instead; otherwise it defaults
+// to %LocalAppData%\<service>.
+func StorageDir(service string) string {
+	if override := os.Getenv(StorageDirEnv); override != "" {
+		return filepath.Join(override, service)
+	}
+	if local := os.Getenv("LocalAppData"); local != "" {
+		return filepath.Join(local, service)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		fmt.Fprintf(os.Stderr, "warning: unable to determine home directory: %v\n", err)
+		return filepath.Join(".dws", "keychain", service)
+	}
+	return filepath.Join(home, "AppData", "Local", service)
+}
 
 func registryPathForService(service string) string {
 	return regRootPath + `\` + safeRegistryComponent(service)

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -921,16 +921,18 @@ Flags:
   - --output 如果指定目录，文件名会从下载 URL 中自动推断
 ```
 
-#### 资源链接形态分流 — 按 content 里的链接形态选下载方式
+#### 资源链接形态分流 — 按 content 里的链接 host 选下载方式
 
-`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接形态决定，按下表三类分流：
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式**由链接的 host 决定、不由文件扩展名决定**，按下表三类分流、不要混用：
 
 | `content` 里的形态 | 资源性质 | 下载方式 |
 |---|---|---|
-| 消息含 `mediaId`（图片 / 视频 / 语音等） | 钉钉消息媒体资源 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`） |
-| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘文件 | `dws drive download --node <fileId> --output <路径>` |
-| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / 视频等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+| `mediaId=https://down.dingtalk.com/media/...`（图片 / 视频 / 语音，扩展名任意） | 公开 CDN 直链 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`）；该链接为公开 CDN，**直接 `curl -sL -o` 也能下**，无需鉴权 |
+| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘临时签名链接 | `dws drive download --node <fileId> --output <路径>`（裸 curl 不通用，需签名头） |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
 
+> - media 直链与扩展名无关：图片(png/jpg/gif)、pdf、docx、xlsx、html 实测 `curl` 均 HTTP 200。部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载，下载后用 `file <文件>` 判断真实类型。
+> - 图片消息还会附带 AI 识别的内容描述（`<imageContent>...</imageContent>`），不下载也能理解图意。
 > - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
 > - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。
 

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -923,15 +923,15 @@ Flags:
 
 #### 资源链接形态分流 — 按 content 里的链接 host 选下载方式
 
-`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式**由链接的 host 决定、不由文件扩展名决定**，按下表三类分流、不要混用：
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接的 host 决定、不由文件扩展名决定；**首选对应 dws 命令**，裸 curl 仅对明确的公开直链有效。按下表分流、不要混用：
 
 | `content` 里的形态 | 资源性质 | 下载方式 |
 |---|---|---|
-| `mediaId=https://down.dingtalk.com/media/...`（图片 / 视频 / 语音，扩展名任意） | 公开 CDN 直链 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`）；该链接为公开 CDN，**直接 `curl -sL -o` 也能下**，无需鉴权 |
+| `mediaId=...`（图片 / 视频 / 语音，扩展名任意） | 钉钉消息媒体；**host 不唯一**：`down.dingtalk.com/media`（公开直链）或 `*.trans.dingtalk.com/...?Expires=&Signature=`（签名 + 会过期） | **首选 `dws chat message download-media`**（内部取最新下载 URL，不受过期影响，需 `--message-id` + `--open-conversation-id`）。仅当链接是 `down.dingtalk.com/media` 公开直链时，可 `curl -sL -o` 快捷下载；**签名/过期链（`trans.dingtalk.com`、带 `Signature`/`Expires`）不要裸 curl，过期会 403** |
 | `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘临时签名链接 | `dws drive download --node <fileId> --output <路径>`（裸 curl 不通用，需签名头） |
-| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download`（裸 curl 只得 HTML 预览页） |
 
-> - media 直链与扩展名无关：图片(png/jpg/gif)、pdf、docx、xlsx、html 实测 `curl` 均 HTTP 200。部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载，下载后用 `file <文件>` 判断真实类型。
+> - 下载到本地后用 `file <文件>` 判断真实类型：部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载。
 > - 图片消息还会附带 AI 识别的内容描述（`<imageContent>...</imageContent>`），不下载也能理解图意。
 > - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
 > - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -921,16 +921,18 @@ Flags:
   - --output 如果指定目录，文件名会从下载 URL 中自动推断
 ```
 
-#### 资源链接形态分流 — 按 content 里的链接形态选下载方式
+#### 资源链接形态分流 — 按 content 里的链接 host 选下载方式
 
-`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接形态决定，按下表三类分流：
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式**由链接的 host 决定、不由文件扩展名决定**，按下表三类分流、不要混用：
 
 | `content` 里的形态 | 资源性质 | 下载方式 |
 |---|---|---|
-| 消息含 `mediaId`（图片 / 视频 / 语音等） | 钉钉消息媒体资源 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`） |
-| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘文件 | `dws drive download --node <fileId> --output <路径>` |
-| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / 视频等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+| `mediaId=https://down.dingtalk.com/media/...`（图片 / 视频 / 语音，扩展名任意） | 公开 CDN 直链 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`）；该链接为公开 CDN，**直接 `curl -sL -o` 也能下**，无需鉴权 |
+| `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘临时签名链接 | `dws drive download --node <fileId> --output <路径>`（裸 curl 不通用，需签名头） |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
 
+> - media 直链与扩展名无关：图片(png/jpg/gif)、pdf、docx、xlsx、html 实测 `curl` 均 HTTP 200。部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载，下载后用 `file <文件>` 判断真实类型。
+> - 图片消息还会附带 AI 识别的内容描述（`<imageContent>...</imageContent>`），不下载也能理解图意。
 > - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
 > - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。
 

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -923,15 +923,15 @@ Flags:
 
 #### 资源链接形态分流 — 按 content 里的链接 host 选下载方式
 
-`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式**由链接的 host 决定、不由文件扩展名决定**，按下表三类分流、不要混用：
+`message list` / `message list-all` 拉到的消息，`content` 里的资源**不一定都是 mediaId**，下载方式由链接的 host 决定、不由文件扩展名决定；**首选对应 dws 命令**，裸 curl 仅对明确的公开直链有效。按下表分流、不要混用：
 
 | `content` 里的形态 | 资源性质 | 下载方式 |
 |---|---|---|
-| `mediaId=https://down.dingtalk.com/media/...`（图片 / 视频 / 语音，扩展名任意） | 公开 CDN 直链 | **`dws chat message download-media`**（见上一节，需 `--message-id` + `--open-conversation-id`）；该链接为公开 CDN，**直接 `curl -sL -o` 也能下**，无需鉴权 |
+| `mediaId=...`（图片 / 视频 / 语音，扩展名任意） | 钉钉消息媒体；**host 不唯一**：`down.dingtalk.com/media`（公开直链）或 `*.trans.dingtalk.com/...?Expires=&Signature=`（签名 + 会过期） | **首选 `dws chat message download-media`**（内部取最新下载 URL，不受过期影响，需 `--message-id` + `--open-conversation-id`）。仅当链接是 `down.dingtalk.com/media` 公开直链时，可 `curl -sL -o` 快捷下载；**签名/过期链（`trans.dingtalk.com`、带 `Signature`/`Expires`）不要裸 curl，过期会 403** |
 | `[文件] xxx fileId: <fileId>`（钉盘文件） | 钉盘临时签名链接 | `dws drive download --node <fileId> --output <路径>`（裸 curl 不通用，需签名头） |
-| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download` |
+| `https://alidocs.dingtalk.com/i/nodes/<nodeId>`（钉钉文档 / .adoc / 视频 .mov 等节点） | 文档 / 钉盘节点 | 读内容用 `dws doc`，下文件用 `dws drive download`（裸 curl 只得 HTML 预览页） |
 
-> - media 直链与扩展名无关：图片(png/jpg/gif)、pdf、docx、xlsx、html 实测 `curl` 均 HTTP 200。部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载，下载后用 `file <文件>` 判断真实类型。
+> - 下载到本地后用 `file <文件>` 判断真实类型：部分链接扩展名是 `.unknown`、服务端按 `application/octet-stream` 返回，仍可正常下载。
 > - 图片消息还会附带 AI 识别的内容描述（`<imageContent>...</imageContent>`），不下载也能理解图意。
 > - 钉盘文件在 `content` 里给的是 `fileId`、不是 mediaId，必须走 `dws drive download`（下载链接是带签名头的临时链接，裸 curl 不通用）。
 > - alidocs 节点裸 curl 只会拿到 HTML 预览页、不是文件本体，需走 `dws doc`（读内容）或 `dws drive download`（下文件）。


### PR DESCRIPTION
## 问题

`v1.0.33` 的 release workflow 失败（[run 26827906675](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/26827906675)）：GoReleaser 交叉编译 **windows/amd64 + windows/arm64** 时报

```
internal/auth/portable_store.go:58:36: undefined: keychain.StorageDir
（67 / 95 / 148 行同）
```

## 根因

#357 的 `internal/auth/portable_store.go` 在**所有平台**引用 `keychain.StorageDir`，但该函数只在 `keychain_darwin.go` / `keychain_linux.go` 定义了。Windows 后端（DPAPI + HKCU 注册表）的 `keychain_windows.go` **漏了 `StorageDir`**。

- 本地 darwin `go build` 和 CI 的 linux 构建都能过 → 一直没暴露
- 只有 GoReleaser 跨平台编 windows 时才挂 → 卡住 release

## 修复

给 `keychain_windows.go` 补 `StorageDir`，逻辑对齐 linux/darwin：`DWS_KEYCHAIN_DIR` override → 默认 `%LocalAppData%\<service>`。不动现有 DPAPI/注册表逻辑。

## 验证

```
go build ./...  →  windows/darwin/linux × amd64/arm64 全部通过
go vet ./internal/keychain ./internal/auth (GOOS=windows)  →  通过
```