### PR TITLE
docs: document PAT product-line batch authorization

### DIFF
--- a/internal/pat/chmod.go
+++ b/internal/pat/chmod.go
@@ -189,7 +189,12 @@ scope 格式: <product>.<entity>:<permission>
 grantType 规则:
   once       一次性，执行一次后自动失效
   session    当前会话有效（默认），需要 --session-id
-  permanent  永久有效`,
+  permanent  永久有效
+
+批量授权:
+  产品线批量授权推荐使用 --recommend --product <productCode[,productCode]>。
+  --products / --domain / --domains 保持兼容；裸 --recommend 保持可用，
+  但会按推荐集合规划，可能跨产品。`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			productCodes := collectChmodProductCodes(productFlags, productsFlag, domainFlags, domainsFlag)
 			if len(args) > 0 || recommend || len(productCodes) > 0 {
@@ -200,6 +205,7 @@ grantType 规则:
 		Example: `  dws pat chmod aitable.record:read --grant-type session --session-id session-xxx
   dws pat chmod chat.message:list --grant-type once
   dws pat chmod aitable.record:read aitable.record:write --grant-type permanent
+  dws pat chmod --recommend --product minutes --grant-type permanent --dry-run
   dws pat chmod --products calendar,aitable --grant-type session --session-id session-xxx
   dws pat chmod --recommend --grant-type session --session-id session-xxx`,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Background

This PR documents the intended PAT product-line batch authorization usage in `dws pat chmod --help`. The code path already supports explicit scopes, product filters, and recommendation planning; this change makes the recommended product-line form clearer for users while keeping the existing compatible forms documented.

## Changes

**Edited**
- `internal/pat/chmod.go`: add a `批量授权` help section recommending `--recommend --product <productCode[,productCode]>`.
- Add a dry-run example for product-line batch authorization:
  `dws pat chmod --recommend --product minutes --grant-type permanent --dry-run`.
- Preserve existing explicit-scope, `--products`, and bare `--recommend` examples.

## Scope

Help/docs text only.

Current PR head: `9029773`  
Current diff: single file, `internal/pat/chmod.go`, `+7 / -1`.

## Verification

Passed:
- `git diff --check upstream/main...HEAD` ✅
- `go run ./cmd/main.go pat chmod --help --format json` ✅
- `go test ./internal/pat ./test/contract` ✅

The help output now includes the new `批量授权` section and the `--recommend --product minutes --grant-type permanent --dry-run` example.