### PR TITLE
docs(chat-skill): add host-agnostic DingTalk bot-provisioning recipe

### DIFF
--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -1099,30 +1099,39 @@ search 与 find 选择指南:
 | 额外返回 openDingTalkId | 无 | 有（可用于给机器人发单聊消息） |
 | 触发词 | "我创建的""我的""我自己的" | "搜索机器人""找机器人""查机器人" |
 
-#### 创建【新】机器人 — 通过 OpenClaw 连接器（dws 无原生创建命令）
+#### 创建【新】机器人 — 通过钉钉官方 Connector（dws 无原生创建命令，宿主无关）
 
 范围: `dws chat bot` 只能**搜索**（search / find）和**拉机器人进群**（group members add-bot），**不能创建**机器人。
-要"给我建一个新机器人/给 agent 接入钉钉/接入 OpenClaw"，走官方连接器 `@dingtalk-real-ai/dingtalk-connector`（Hermes / OpenClaw 原生方式），它会免控制台一键建号并以 Stream 模式接入 agent（无需公网 IP / Webhook）。
-典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw""provision a bot"。
+要"给我建一个新机器人 / 给 agent 接入钉钉"，走官方 Connector `@dingtalk-real-ai/dingtalk-connector`。它**分两层**——建号宿主无关，收发按宿主接入，不要把它当成 OpenClaw 专属：
 
-固定路线（前置闸门 → 创建 → 交叉验证，缺一步不算闭环）:
+- **① 建号（host-agnostic）**: `npx -y @dingtalk-real-ai/dingtalk-connector install` 走钉钉 OpenAPI 设备授权（扫码一键建号），**与具体 agent 宿主无关**，任何能跑 Node 的环境都能建号。
+- **② 收→回（按宿主接入）**: 让机器人真正"收消息 → 回消息"需要一个宿主运行时。
+  - **OpenClaw 及其 fork（如 Hermes）**: 开箱即用，Connector 以 Stream 模式接入（无公网 IP / Webhook）。
+  - **其它主流 agent（Claude / Cursor / Codex / …）**: 通过宿主暴露的 **OpenAI Chat Completions endpoint** 接入（Connector 把钉钉消息桥接到该端点）。
+
+典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw / Hermes""provision a bot"。
+
+固定路线（前置闸门 → 建号 → 按宿主接入 → 交叉验证，缺一步不算闭环）:
 
 ```
-# 1. 前置闸门：确认 OpenClaw 已安装且版本达标（< 2026.4.9 直接告知用户先升级，不要硬跑 npx）
-openclaw -v            # 需 OpenClaw CLI ≥ 2026.4.9
+# 1. 前置闸门：确认存在【任一】受支持的宿主运行时，而不是硬卡 openclaw
+#    OpenClaw / Hermes 系（Stream 宿主，≥ 2026.4.9）：openclaw -v
+#    其它 agent：确认有一个 OpenAI Chat Completions endpoint 可桥接
+openclaw -v 2>/dev/null || echo "无 OpenClaw/Hermes 宿主 → 改用 OpenAI-compatible endpoint 接入（见上层②）"
 
-# 2. 创建：连接器在终端渲染钉钉二维码；手机钉钉扫码 → 点「一键创建新机器人」→ 自动建号 + 授权 + Stream 接入
+# 2. 建号（宿主无关）：终端渲染钉钉二维码 → 手机钉钉扫码 → 一键创建新机器人 → 自动建号 + 授权
 npx -y @dingtalk-real-ai/dingtalk-connector install
 
-# 3. 验证 channel 已 running
-openclaw channels status --deep | grep DingTalk
+# 3. 按宿主验证接入：OpenClaw / Hermes 系 → channel 应 running + connected
+openclaw channels status --deep | grep -i dingtalk
 
-# 4. 交叉验证：连接器新建的机器人，dws 应当能搜到（两个独立工具看到同一个 robotCode 才算真创建成功）
+# 4. 交叉验证（宿主无关）：新建机器人 dws 应当能搜到（两个独立工具看到同一 robotCode 才算真成功）
 dws chat bot search --format json
 ```
 
 注意:
-  - 这条 recipe 依赖 dws 之外的前置（OpenClaw 运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
+  - **分层理解**：建号是钉钉 OpenAPI 能力，宿主无关；收→回依赖宿主运行时——今天 OpenClaw 及其 fork（Hermes）开箱即用，其它主流 agent 经 OpenAI-compatible endpoint 接入。**不要因为包名含 openclaw 就以为只支持 OpenClaw**（`peerDependencies.openclaw` 标记为 optional）。
+  - 这条 recipe 依赖 dws 之外的前置（宿主运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
   - 创建成功后，发消息/拉群仍走上面的 `chat message send-by-bot` / `group members add-bot`，用 `dws chat bot search` 返回的 `robotCode`。
   - 安全: 机器人在你的授权范围内以你的身份行事，按个人助理对待，勿用于无人值守的生产部署。
 

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -1099,6 +1099,33 @@ search 与 find 选择指南:
 | 额外返回 openDingTalkId | 无 | 有（可用于给机器人发单聊消息） |
 | 触发词 | "我创建的""我的""我自己的" | "搜索机器人""找机器人""查机器人" |
 
+#### 创建【新】机器人 — 通过 OpenClaw 连接器（dws 无原生创建命令）
+
+范围: `dws chat bot` 只能**搜索**（search / find）和**拉机器人进群**（group members add-bot），**不能创建**机器人。
+要"给我建一个新机器人/给 agent 接入钉钉/接入 OpenClaw"，走官方连接器 `@dingtalk-real-ai/dingtalk-connector`（Hermes / OpenClaw 原生方式），它会免控制台一键建号并以 Stream 模式接入 agent（无需公网 IP / Webhook）。
+典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw""provision a bot"。
+
+固定路线（前置闸门 → 创建 → 交叉验证，缺一步不算闭环）:
+
+```
+# 1. 前置闸门：确认 OpenClaw 已安装且版本达标（< 2026.4.9 直接告知用户先升级，不要硬跑 npx）
+openclaw -v            # 需 OpenClaw CLI ≥ 2026.4.9
+
+# 2. 创建：连接器在终端渲染钉钉二维码；手机钉钉扫码 → 点「一键创建新机器人」→ 自动建号 + 授权 + Stream 接入
+npx -y @dingtalk-real-ai/dingtalk-connector install
+
+# 3. 验证 channel 已 running
+openclaw channels status --deep | grep DingTalk
+
+# 4. 交叉验证：连接器新建的机器人，dws 应当能搜到（两个独立工具看到同一个 robotCode 才算真创建成功）
+dws chat bot search --format json
+```
+
+注意:
+  - 这条 recipe 依赖 dws 之外的前置（OpenClaw 运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
+  - 创建成功后，发消息/拉群仍走上面的 `chat message send-by-bot` / `group members add-bot`，用 `dws chat bot search` 返回的 `robotCode`。
+  - 安全: 机器人在你的授权范围内以你的身份行事，按个人助理对待，勿用于无人值守的生产部署。
+
 ### category (会话分组管理)
 
 #### 获取用户自定义会话分组

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -1111,7 +1111,7 @@ search 与 find 选择指南:
 
 典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw / Hermes""provision a bot"。
 
-固定路线（前置闸门 → 建号 → 按宿主接入 → 交叉验证，缺一步不算闭环）:
+固定路线（前置闸门 → 建号 → 按宿主接入 → **审批闸门** → 交叉验证，缺一步不算闭环）:
 
 ```
 # 1. 前置闸门：确认存在【任一】受支持的宿主运行时，而不是硬卡 openclaw
@@ -1122,16 +1122,29 @@ openclaw -v 2>/dev/null || echo "无 OpenClaw/Hermes 宿主 → 改用 OpenAI-co
 # 2. 建号（宿主无关）：终端渲染钉钉二维码 → 手机钉钉扫码 → 一键创建新机器人 → 自动建号 + 授权
 npx -y @dingtalk-real-ai/dingtalk-connector install
 
-# 3. 按宿主验证接入：OpenClaw / Hermes 系 → channel 应 running + connected
+# 3. 接入状态：OpenClaw / Hermes 系 → channel 显示 running
+#    ⚠️ 注意：connected 只是 stream WS 连上，≠ 机器人能收发（真实判定见第 5 步）
 openclaw channels status --deep | grep -i dingtalk
 
-# 4. 交叉验证（宿主无关）：新建机器人 dws 应当能搜到（两个独立工具看到同一 robotCode 才算真成功）
-dws chat bot search --format json
+# 4. 身份交叉验证：用新应用凭据查它名下机器人，拿 robotName（appKey ≠ robotCode）
+dws chat bot search --client-id <新clientId> --client-secret <新secret> --format json
+
+# 5. 审批闸门【关键：建号 ≠ 可用】：robot 发消息能力需开通 scope qyapi_robot_sendmsg
+#    device-auth SUCCESS / 能换 token 只代表【应用凭据】有效，不代表【机器人能收发】，必须探测真实能力：
+TOKEN=$(curl -s -X POST 'https://api.dingtalk.com/v1.0/oauth2/accessToken' \
+  -H 'Content-Type: application/json' -d '{"appKey":"<新clientId>","appSecret":"<新secret>"}' | jq -r .accessToken)
+curl -s -X POST 'https://api.dingtalk.com/v1.0/robot/groupMessages/send' \
+  -H "x-acs-dingtalk-access-token: $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"robotCode":"<新clientId>","openConversationId":"__probe__","msgKey":"sampleText","msgParam":"{\"content\":\"probe\"}"}'
+#  → Forbidden.AccessDenied ...qyapi_robot_sendmsg = 审批未过：照报错里给的
+#    open-dev.dingtalk.com/appscope/apply?content=<appKey>%23qyapi_robot_sendmsg 开通后再用
+#  → 参数类错误（非 AccessDenied）            = scope 已通，机器人可收发
 ```
 
 注意:
   - **分层理解**：① 建号是钉钉 OpenAPI 能力，宿主无关；② 这条 skill 指南覆盖 dws 支持的全部主流 agent（Claude Code / Cursor / Codex / Qoder / opencode / Gemini / Windsurf / Cline / Kiro / Trae / Hermes / OpenClaw 等，约 14 个 agent home）；③ 收→回运行时有两条**对等**路径（`openclaw/plugin-sdk` 契约 / OpenAI-compatible endpoint）。**不是只支持 OpenClaw**（`peerDependencies.openclaw` 标记为 optional）。
-  - 这条 recipe 依赖 dws 之外的前置（宿主运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
+  - **建号 ≠ 可用（血泪闸门，最易踩）**：device-auth 返回 `SUCCESS` / 能换 `access_token` 只代表【应用凭据】生效；机器人真正收发还需 `qyapi_robot_sendmsg` 等 robot scope **审批开通**。`openclaw channels status` 显示 `connected` 只是 stream WS 连上，**不是** DingTalk 的能力回执——**绝不能拿它当"建联成功"**。唯一可靠判定 = 第 5 步真实能力探测；开通入口就在钉钉返回的报错里：`open-dev.dingtalk.com/appscope/apply?content=<appKey>%23qyapi_robot_sendmsg`。
+  - 这条 recipe 依赖 dws 之外的前置（宿主运行时 + npm 网络 + 手机扫码 + **robot scope 审批**），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
   - 创建成功后，发消息/拉群仍走上面的 `chat message send-by-bot` / `group members add-bot`，用 `dws chat bot search` 返回的 `robotCode`。
   - 安全: 机器人在你的授权范围内以你的身份行事，按个人助理对待，勿用于无人值守的生产部署。
 

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -1105,9 +1105,9 @@ search 与 find 选择指南:
 要"给我建一个新机器人 / 给 agent 接入钉钉"，走官方 Connector `@dingtalk-real-ai/dingtalk-connector`。它**分两层**——建号宿主无关，收发按宿主接入，不要把它当成 OpenClaw 专属：
 
 - **① 建号（host-agnostic）**: `npx -y @dingtalk-real-ai/dingtalk-connector install` 走钉钉 OpenAPI 设备授权（扫码一键建号），**与具体 agent 宿主无关**，任何能跑 Node 的环境都能建号。
-- **② 收→回（按宿主接入）**: 让机器人真正"收消息 → 回消息"需要一个宿主运行时。
-  - **OpenClaw 及其 fork（如 Hermes）**: 开箱即用，Connector 以 Stream 模式接入（无公网 IP / Webhook）。
-  - **其它主流 agent（Claude / Cursor / Codex / …）**: 通过宿主暴露的 **OpenAI Chat Completions endpoint** 接入（Connector 把钉钉消息桥接到该端点）。
+- **② 收→回（运行时）**: 让机器人真正"收消息 → 回消息"需要一个 agent 运行时。**这条 recipe（建号指南）随 dws skill 安装到 dws 支持的全部主流 agent**——Claude Code / Cursor / Codex / Qoder / opencode / Gemini / Windsurf / Cline / Kiro / Trae / Hermes / OpenClaw 等（约 14 个 agent home，见 `dws skill setup` 目标），它们都能驱动上面的建号流程。运行时桥接有两条**对等**路径：
+  - **OpenClaw 及其 fork（如 Hermes）**: 走 Connector 的 `openclaw/plugin-sdk` channel 契约，Stream 模式直连（无公网 IP / Webhook）。
+  - **其它 agent（Claude Code / Cursor / Codex / Qoder / …）**: 通过宿主暴露的 **OpenAI Chat Completions endpoint** 桥接（Connector 把钉钉消息转给该端点，agent 回流）；与 DEAP 架构同源。
 
 典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw / Hermes""provision a bot"。
 
@@ -1130,7 +1130,7 @@ dws chat bot search --format json
 ```
 
 注意:
-  - **分层理解**：建号是钉钉 OpenAPI 能力，宿主无关；收→回依赖宿主运行时——今天 OpenClaw 及其 fork（Hermes）开箱即用，其它主流 agent 经 OpenAI-compatible endpoint 接入。**不要因为包名含 openclaw 就以为只支持 OpenClaw**（`peerDependencies.openclaw` 标记为 optional）。
+  - **分层理解**：① 建号是钉钉 OpenAPI 能力，宿主无关；② 这条 skill 指南覆盖 dws 支持的全部主流 agent（Claude Code / Cursor / Codex / Qoder / opencode / Gemini / Windsurf / Cline / Kiro / Trae / Hermes / OpenClaw 等，约 14 个 agent home）；③ 收→回运行时有两条**对等**路径（`openclaw/plugin-sdk` 契约 / OpenAI-compatible endpoint）。**不是只支持 OpenClaw**（`peerDependencies.openclaw` 标记为 optional）。
   - 这条 recipe 依赖 dws 之外的前置（宿主运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
   - 创建成功后，发消息/拉群仍走上面的 `chat message send-by-bot` / `group members add-bot`，用 `dws chat bot search` 返回的 `robotCode`。
   - 安全: 机器人在你的授权范围内以你的身份行事，按个人助理对待，勿用于无人值守的生产部署。

--- a/skills/multi/dingtalk-chat/SKILL.md
+++ b/skills/multi/dingtalk-chat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dingtalk-chat
-description: 钉钉群聊与消息。Use when 用户提到 发消息/单聊/群聊/建群/拉人进群/改群名/搜索群/群成员管理/@消息/撤回消息/机器人群发/Webhook通知/发图片或文件到群/搜机器人/查我的机器人/创建机器人/给agent接入钉钉机器人/接入OpenClaw。Distinct from dingtalk-ding(紧急DING消息/短信/电话)、dingtalk-mail(邮件)、dingtalk-edu-group(班级群)。命令前缀：dws chat。
+description: 钉钉群聊与消息。Use when 用户提到 发消息/单聊/群聊/建群/拉人进群/改群名/搜索群/群成员管理/@消息/撤回消息/机器人群发/Webhook通知/发图片或文件到群/搜机器人/查我的机器人/创建机器人/给agent接入钉钉机器人/接入OpenClaw或Hermes/provision bot。Distinct from dingtalk-ding(紧急DING消息/短信/电话)、dingtalk-mail(邮件)、dingtalk-edu-group(班级群)。命令前缀：dws chat。
 cli_version: ">=0.2.14"
 metadata:
   category: product
@@ -36,7 +36,7 @@ metadata:
 | "Webhook 推一条" | `dws chat message send-by-webhook --token <token> --title "<标题>" --text "<内容>"` |
 | "撤回机器人消息" | `dws chat message recall-by-bot --robot-code <code> --group <openConversationId> --keys <processQueryKey>`（只能撤回机器人发的；撤回普通用户消息开源 dws v1.0.30 暂不支持）|
 | "搜机器人" / "查我创建的机器人" | `dws chat bot find --query "<关键词>"`（全部可用，带 openDingTalkId）/ `dws chat bot search`（仅我创建的）|
-| "给我建个机器人" / "给 agent 接入钉钉" / "接入 OpenClaw" | dws 无原生创建命令，走 OpenClaw 连接器：`npx -y @dingtalk-real-ai/dingtalk-connector install` → 扫码一键建号 → `dws chat bot search` 交叉验证。固定路线见 [chat.md](references/chat.md) 「创建【新】机器人」节 |
+| "给我建个机器人" / "给 agent 接入钉钉" / "接入 OpenClaw/Hermes" | dws 无原生创建命令，走官方 Connector（**宿主无关**）：`npx -y @dingtalk-real-ai/dingtalk-connector install` 扫码一键建号（host-agnostic）→ 收发按宿主接入（OpenClaw/Hermes 开箱即用，其它 agent 经 OpenAI-compatible endpoint）→ `dws chat bot search` 交叉验证。固定路线见 [chat.md](references/chat.md) 「创建【新】机器人」节 |
 
 > **注**：v1.0.30 起 `chat message send / send-by-bot / send-by-webhook` 全部强制 `--title` 必填（单聊群聊都要）。
 
@@ -46,4 +46,4 @@ metadata:
 - 要发图片/文件 → 先 `dt_media_upload` 上传 → `python scripts/extract_media_id.py "<URL>"` 提取 mediaId → 再用 `--media-id`
 - 紧急升级（应用内/短信/电话）→ 切到 `dingtalk-ding`
 - 发邮件 → 切到 `dingtalk-mail`
-- 要**新建**机器人 / 给 agent 接入钉钉 → dws 只能搜不能建，交给官方连接器 `@dingtalk-real-ai/dingtalk-connector`（见 [chat.md](references/chat.md) 「创建【新】机器人」节），建完用 `dws chat bot search` 交叉验证
+- 要**新建**机器人 / 给 agent 接入钉钉 → dws 只能搜不能建，交给官方 Connector `@dingtalk-real-ai/dingtalk-connector`（**宿主无关**：建号通用，收→回 OpenClaw/Hermes 开箱、其它主流 agent 经 OpenAI-compatible endpoint 接入；见 [chat.md](references/chat.md) 「创建【新】机器人」节），建完用 `dws chat bot search` 交叉验证

--- a/skills/multi/dingtalk-chat/SKILL.md
+++ b/skills/multi/dingtalk-chat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dingtalk-chat
-description: 钉钉群聊与消息。Use when 用户提到 发消息/单聊/群聊/建群/拉人进群/改群名/搜索群/群成员管理/@消息/撤回消息/机器人群发/Webhook通知/发图片或文件到群。Distinct from dingtalk-ding(紧急DING消息/短信/电话)、dingtalk-mail(邮件)、dingtalk-edu-group(班级群)。命令前缀：dws chat。
+description: 钉钉群聊与消息。Use when 用户提到 发消息/单聊/群聊/建群/拉人进群/改群名/搜索群/群成员管理/@消息/撤回消息/机器人群发/Webhook通知/发图片或文件到群/搜机器人/查我的机器人/创建机器人/给agent接入钉钉机器人/接入OpenClaw。Distinct from dingtalk-ding(紧急DING消息/短信/电话)、dingtalk-mail(邮件)、dingtalk-edu-group(班级群)。命令前缀：dws chat。
 cli_version: ">=0.2.14"
 metadata:
   category: product
@@ -35,6 +35,8 @@ metadata:
 | "用机器人发消息" | `dws chat message send-by-bot --robot-code <code> --group <id> --title "<标题>" --text "<内容>"` |
 | "Webhook 推一条" | `dws chat message send-by-webhook --token <token> --title "<标题>" --text "<内容>"` |
 | "撤回机器人消息" | `dws chat message recall-by-bot --robot-code <code> --group <openConversationId> --keys <processQueryKey>`（只能撤回机器人发的；撤回普通用户消息开源 dws v1.0.30 暂不支持）|
+| "搜机器人" / "查我创建的机器人" | `dws chat bot find --query "<关键词>"`（全部可用，带 openDingTalkId）/ `dws chat bot search`（仅我创建的）|
+| "给我建个机器人" / "给 agent 接入钉钉" / "接入 OpenClaw" | dws 无原生创建命令，走 OpenClaw 连接器：`npx -y @dingtalk-real-ai/dingtalk-connector install` → 扫码一键建号 → `dws chat bot search` 交叉验证。固定路线见 [chat.md](references/chat.md) 「创建【新】机器人」节 |
 
 > **注**：v1.0.30 起 `chat message send / send-by-bot / send-by-webhook` 全部强制 `--title` 必填（单聊群聊都要）。
 
@@ -44,3 +46,4 @@ metadata:
 - 要发图片/文件 → 先 `dt_media_upload` 上传 → `python scripts/extract_media_id.py "<URL>"` 提取 mediaId → 再用 `--media-id`
 - 紧急升级（应用内/短信/电话）→ 切到 `dingtalk-ding`
 - 发邮件 → 切到 `dingtalk-mail`
+- 要**新建**机器人 / 给 agent 接入钉钉 → dws 只能搜不能建，交给官方连接器 `@dingtalk-real-ai/dingtalk-connector`（见 [chat.md](references/chat.md) 「创建【新】机器人」节），建完用 `dws chat bot search` 交叉验证

--- a/skills/multi/dingtalk-chat/SKILL.md
+++ b/skills/multi/dingtalk-chat/SKILL.md
@@ -36,7 +36,7 @@ metadata:
 | "Webhook 推一条" | `dws chat message send-by-webhook --token <token> --title "<标题>" --text "<内容>"` |
 | "撤回机器人消息" | `dws chat message recall-by-bot --robot-code <code> --group <openConversationId> --keys <processQueryKey>`（只能撤回机器人发的；撤回普通用户消息开源 dws v1.0.30 暂不支持）|
 | "搜机器人" / "查我创建的机器人" | `dws chat bot find --query "<关键词>"`（全部可用，带 openDingTalkId）/ `dws chat bot search`（仅我创建的）|
-| "给我建个机器人" / "给 agent 接入钉钉" / "接入 OpenClaw/Hermes" | dws 无原生创建命令，走官方 Connector（**宿主无关**）：`npx -y @dingtalk-real-ai/dingtalk-connector install` 扫码一键建号（host-agnostic）→ 收发按宿主接入（OpenClaw/Hermes 开箱即用，其它 agent 经 OpenAI-compatible endpoint）→ `dws chat bot search` 交叉验证。固定路线见 [chat.md](references/chat.md) 「创建【新】机器人」节 |
+| "给我建个机器人" / "给 agent 接入钉钉" / "接入 OpenClaw/Hermes/Qoder/Claude Code" | dws 无原生创建命令，走官方 Connector（**宿主无关**）：`npx -y @dingtalk-real-ai/dingtalk-connector install` 扫码一键建号 → 该指南覆盖 dws 支持的全部主流 agent（Claude Code/Cursor/Codex/Qoder/opencode/Gemini/Windsurf/Cline/Kiro/Trae/Hermes/OpenClaw 等）；收发运行时两条对等路径（plugin-sdk 契约 / OpenAI-compatible endpoint）→ `dws chat bot search` 交叉验证。固定路线见 [chat.md](references/chat.md) 「创建【新】机器人」节 |
 
 > **注**：v1.0.30 起 `chat message send / send-by-bot / send-by-webhook` 全部强制 `--title` 必填（单聊群聊都要）。
 
@@ -46,4 +46,4 @@ metadata:
 - 要发图片/文件 → 先 `dt_media_upload` 上传 → `python scripts/extract_media_id.py "<URL>"` 提取 mediaId → 再用 `--media-id`
 - 紧急升级（应用内/短信/电话）→ 切到 `dingtalk-ding`
 - 发邮件 → 切到 `dingtalk-mail`
-- 要**新建**机器人 / 给 agent 接入钉钉 → dws 只能搜不能建，交给官方 Connector `@dingtalk-real-ai/dingtalk-connector`（**宿主无关**：建号通用，收→回 OpenClaw/Hermes 开箱、其它主流 agent 经 OpenAI-compatible endpoint 接入；见 [chat.md](references/chat.md) 「创建【新】机器人」节），建完用 `dws chat bot search` 交叉验证
+- 要**新建**机器人 / 给 agent 接入钉钉 → dws 只能搜不能建，交给官方 Connector `@dingtalk-real-ai/dingtalk-connector`（**宿主无关**：建号通用，指南覆盖 dws 支持的全部主流 agent——Claude Code/Cursor/Codex/Qoder/opencode/Gemini/Windsurf/Cline/Kiro/Trae/Hermes/OpenClaw 等；收→回两条对等路径 plugin-sdk 契约 / OpenAI-compatible endpoint；见 [chat.md](references/chat.md) 「创建【新】机器人」节），建完用 `dws chat bot search` 交叉验证

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -1099,30 +1099,39 @@ search 与 find 选择指南:
 | 额外返回 openDingTalkId | 无 | 有（可用于给机器人发单聊消息） |
 | 触发词 | "我创建的""我的""我自己的" | "搜索机器人""找机器人""查机器人" |
 
-#### 创建【新】机器人 — 通过 OpenClaw 连接器（dws 无原生创建命令）
+#### 创建【新】机器人 — 通过钉钉官方 Connector（dws 无原生创建命令，宿主无关）
 
 范围: `dws chat bot` 只能**搜索**（search / find）和**拉机器人进群**（group members add-bot），**不能创建**机器人。
-要"给我建一个新机器人/给 agent 接入钉钉/接入 OpenClaw"，走官方连接器 `@dingtalk-real-ai/dingtalk-connector`（Hermes / OpenClaw 原生方式），它会免控制台一键建号并以 Stream 模式接入 agent（无需公网 IP / Webhook）。
-典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw""provision a bot"。
+要"给我建一个新机器人 / 给 agent 接入钉钉"，走官方 Connector `@dingtalk-real-ai/dingtalk-connector`。它**分两层**——建号宿主无关，收发按宿主接入，不要把它当成 OpenClaw 专属：
 
-固定路线（前置闸门 → 创建 → 交叉验证，缺一步不算闭环）:
+- **① 建号（host-agnostic）**: `npx -y @dingtalk-real-ai/dingtalk-connector install` 走钉钉 OpenAPI 设备授权（扫码一键建号），**与具体 agent 宿主无关**，任何能跑 Node 的环境都能建号。
+- **② 收→回（按宿主接入）**: 让机器人真正"收消息 → 回消息"需要一个宿主运行时。
+  - **OpenClaw 及其 fork（如 Hermes）**: 开箱即用，Connector 以 Stream 模式接入（无公网 IP / Webhook）。
+  - **其它主流 agent（Claude / Cursor / Codex / …）**: 通过宿主暴露的 **OpenAI Chat Completions endpoint** 接入（Connector 把钉钉消息桥接到该端点）。
+
+典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw / Hermes""provision a bot"。
+
+固定路线（前置闸门 → 建号 → 按宿主接入 → 交叉验证，缺一步不算闭环）:
 
 ```
-# 1. 前置闸门：确认 OpenClaw 已安装且版本达标（< 2026.4.9 直接告知用户先升级，不要硬跑 npx）
-openclaw -v            # 需 OpenClaw CLI ≥ 2026.4.9
+# 1. 前置闸门：确认存在【任一】受支持的宿主运行时，而不是硬卡 openclaw
+#    OpenClaw / Hermes 系（Stream 宿主，≥ 2026.4.9）：openclaw -v
+#    其它 agent：确认有一个 OpenAI Chat Completions endpoint 可桥接
+openclaw -v 2>/dev/null || echo "无 OpenClaw/Hermes 宿主 → 改用 OpenAI-compatible endpoint 接入（见上层②）"
 
-# 2. 创建：连接器在终端渲染钉钉二维码；手机钉钉扫码 → 点「一键创建新机器人」→ 自动建号 + 授权 + Stream 接入
+# 2. 建号（宿主无关）：终端渲染钉钉二维码 → 手机钉钉扫码 → 一键创建新机器人 → 自动建号 + 授权
 npx -y @dingtalk-real-ai/dingtalk-connector install
 
-# 3. 验证 channel 已 running
-openclaw channels status --deep | grep DingTalk
+# 3. 按宿主验证接入：OpenClaw / Hermes 系 → channel 应 running + connected
+openclaw channels status --deep | grep -i dingtalk
 
-# 4. 交叉验证：连接器新建的机器人，dws 应当能搜到（两个独立工具看到同一个 robotCode 才算真创建成功）
+# 4. 交叉验证（宿主无关）：新建机器人 dws 应当能搜到（两个独立工具看到同一 robotCode 才算真成功）
 dws chat bot search --format json
 ```
 
 注意:
-  - 这条 recipe 依赖 dws 之外的前置（OpenClaw 运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
+  - **分层理解**：建号是钉钉 OpenAPI 能力，宿主无关；收→回依赖宿主运行时——今天 OpenClaw 及其 fork（Hermes）开箱即用，其它主流 agent 经 OpenAI-compatible endpoint 接入。**不要因为包名含 openclaw 就以为只支持 OpenClaw**（`peerDependencies.openclaw` 标记为 optional）。
+  - 这条 recipe 依赖 dws 之外的前置（宿主运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
   - 创建成功后，发消息/拉群仍走上面的 `chat message send-by-bot` / `group members add-bot`，用 `dws chat bot search` 返回的 `robotCode`。
   - 安全: 机器人在你的授权范围内以你的身份行事，按个人助理对待，勿用于无人值守的生产部署。
 

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -1099,6 +1099,33 @@ search 与 find 选择指南:
 | 额外返回 openDingTalkId | 无 | 有（可用于给机器人发单聊消息） |
 | 触发词 | "我创建的""我的""我自己的" | "搜索机器人""找机器人""查机器人" |
 
+#### 创建【新】机器人 — 通过 OpenClaw 连接器（dws 无原生创建命令）
+
+范围: `dws chat bot` 只能**搜索**（search / find）和**拉机器人进群**（group members add-bot），**不能创建**机器人。
+要"给我建一个新机器人/给 agent 接入钉钉/接入 OpenClaw"，走官方连接器 `@dingtalk-real-ai/dingtalk-connector`（Hermes / OpenClaw 原生方式），它会免控制台一键建号并以 Stream 模式接入 agent（无需公网 IP / Webhook）。
+典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw""provision a bot"。
+
+固定路线（前置闸门 → 创建 → 交叉验证，缺一步不算闭环）:
+
+```
+# 1. 前置闸门：确认 OpenClaw 已安装且版本达标（< 2026.4.9 直接告知用户先升级，不要硬跑 npx）
+openclaw -v            # 需 OpenClaw CLI ≥ 2026.4.9
+
+# 2. 创建：连接器在终端渲染钉钉二维码；手机钉钉扫码 → 点「一键创建新机器人」→ 自动建号 + 授权 + Stream 接入
+npx -y @dingtalk-real-ai/dingtalk-connector install
+
+# 3. 验证 channel 已 running
+openclaw channels status --deep | grep DingTalk
+
+# 4. 交叉验证：连接器新建的机器人，dws 应当能搜到（两个独立工具看到同一个 robotCode 才算真创建成功）
+dws chat bot search --format json
+```
+
+注意:
+  - 这条 recipe 依赖 dws 之外的前置（OpenClaw 运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
+  - 创建成功后，发消息/拉群仍走上面的 `chat message send-by-bot` / `group members add-bot`，用 `dws chat bot search` 返回的 `robotCode`。
+  - 安全: 机器人在你的授权范围内以你的身份行事，按个人助理对待，勿用于无人值守的生产部署。
+
 ### category (会话分组管理)
 
 #### 获取用户自定义会话分组

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -1111,7 +1111,7 @@ search 与 find 选择指南:
 
 典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw / Hermes""provision a bot"。
 
-固定路线（前置闸门 → 建号 → 按宿主接入 → 交叉验证，缺一步不算闭环）:
+固定路线（前置闸门 → 建号 → 按宿主接入 → **审批闸门** → 交叉验证，缺一步不算闭环）:
 
 ```
 # 1. 前置闸门：确认存在【任一】受支持的宿主运行时，而不是硬卡 openclaw
@@ -1122,16 +1122,29 @@ openclaw -v 2>/dev/null || echo "无 OpenClaw/Hermes 宿主 → 改用 OpenAI-co
 # 2. 建号（宿主无关）：终端渲染钉钉二维码 → 手机钉钉扫码 → 一键创建新机器人 → 自动建号 + 授权
 npx -y @dingtalk-real-ai/dingtalk-connector install
 
-# 3. 按宿主验证接入：OpenClaw / Hermes 系 → channel 应 running + connected
+# 3. 接入状态：OpenClaw / Hermes 系 → channel 显示 running
+#    ⚠️ 注意：connected 只是 stream WS 连上，≠ 机器人能收发（真实判定见第 5 步）
 openclaw channels status --deep | grep -i dingtalk
 
-# 4. 交叉验证（宿主无关）：新建机器人 dws 应当能搜到（两个独立工具看到同一 robotCode 才算真成功）
-dws chat bot search --format json
+# 4. 身份交叉验证：用新应用凭据查它名下机器人，拿 robotName（appKey ≠ robotCode）
+dws chat bot search --client-id <新clientId> --client-secret <新secret> --format json
+
+# 5. 审批闸门【关键：建号 ≠ 可用】：robot 发消息能力需开通 scope qyapi_robot_sendmsg
+#    device-auth SUCCESS / 能换 token 只代表【应用凭据】有效，不代表【机器人能收发】，必须探测真实能力：
+TOKEN=$(curl -s -X POST 'https://api.dingtalk.com/v1.0/oauth2/accessToken' \
+  -H 'Content-Type: application/json' -d '{"appKey":"<新clientId>","appSecret":"<新secret>"}' | jq -r .accessToken)
+curl -s -X POST 'https://api.dingtalk.com/v1.0/robot/groupMessages/send' \
+  -H "x-acs-dingtalk-access-token: $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"robotCode":"<新clientId>","openConversationId":"__probe__","msgKey":"sampleText","msgParam":"{\"content\":\"probe\"}"}'
+#  → Forbidden.AccessDenied ...qyapi_robot_sendmsg = 审批未过：照报错里给的
+#    open-dev.dingtalk.com/appscope/apply?content=<appKey>%23qyapi_robot_sendmsg 开通后再用
+#  → 参数类错误（非 AccessDenied）            = scope 已通，机器人可收发
 ```
 
 注意:
   - **分层理解**：① 建号是钉钉 OpenAPI 能力，宿主无关；② 这条 skill 指南覆盖 dws 支持的全部主流 agent（Claude Code / Cursor / Codex / Qoder / opencode / Gemini / Windsurf / Cline / Kiro / Trae / Hermes / OpenClaw 等，约 14 个 agent home）；③ 收→回运行时有两条**对等**路径（`openclaw/plugin-sdk` 契约 / OpenAI-compatible endpoint）。**不是只支持 OpenClaw**（`peerDependencies.openclaw` 标记为 optional）。
-  - 这条 recipe 依赖 dws 之外的前置（宿主运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
+  - **建号 ≠ 可用（血泪闸门，最易踩）**：device-auth 返回 `SUCCESS` / 能换 `access_token` 只代表【应用凭据】生效；机器人真正收发还需 `qyapi_robot_sendmsg` 等 robot scope **审批开通**。`openclaw channels status` 显示 `connected` 只是 stream WS 连上，**不是** DingTalk 的能力回执——**绝不能拿它当"建联成功"**。唯一可靠判定 = 第 5 步真实能力探测；开通入口就在钉钉返回的报错里：`open-dev.dingtalk.com/appscope/apply?content=<appKey>%23qyapi_robot_sendmsg`。
+  - 这条 recipe 依赖 dws 之外的前置（宿主运行时 + npm 网络 + 手机扫码 + **robot scope 审批**），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
   - 创建成功后，发消息/拉群仍走上面的 `chat message send-by-bot` / `group members add-bot`，用 `dws chat bot search` 返回的 `robotCode`。
   - 安全: 机器人在你的授权范围内以你的身份行事，按个人助理对待，勿用于无人值守的生产部署。
 

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -1105,9 +1105,9 @@ search 与 find 选择指南:
 要"给我建一个新机器人 / 给 agent 接入钉钉"，走官方 Connector `@dingtalk-real-ai/dingtalk-connector`。它**分两层**——建号宿主无关，收发按宿主接入，不要把它当成 OpenClaw 专属：
 
 - **① 建号（host-agnostic）**: `npx -y @dingtalk-real-ai/dingtalk-connector install` 走钉钉 OpenAPI 设备授权（扫码一键建号），**与具体 agent 宿主无关**，任何能跑 Node 的环境都能建号。
-- **② 收→回（按宿主接入）**: 让机器人真正"收消息 → 回消息"需要一个宿主运行时。
-  - **OpenClaw 及其 fork（如 Hermes）**: 开箱即用，Connector 以 Stream 模式接入（无公网 IP / Webhook）。
-  - **其它主流 agent（Claude / Cursor / Codex / …）**: 通过宿主暴露的 **OpenAI Chat Completions endpoint** 接入（Connector 把钉钉消息桥接到该端点）。
+- **② 收→回（运行时）**: 让机器人真正"收消息 → 回消息"需要一个 agent 运行时。**这条 recipe（建号指南）随 dws skill 安装到 dws 支持的全部主流 agent**——Claude Code / Cursor / Codex / Qoder / opencode / Gemini / Windsurf / Cline / Kiro / Trae / Hermes / OpenClaw 等（约 14 个 agent home，见 `dws skill setup` 目标），它们都能驱动上面的建号流程。运行时桥接有两条**对等**路径：
+  - **OpenClaw 及其 fork（如 Hermes）**: 走 Connector 的 `openclaw/plugin-sdk` channel 契约，Stream 模式直连（无公网 IP / Webhook）。
+  - **其它 agent（Claude Code / Cursor / Codex / Qoder / …）**: 通过宿主暴露的 **OpenAI Chat Completions endpoint** 桥接（Connector 把钉钉消息转给该端点，agent 回流）；与 DEAP 架构同源。
 
 典型触发词: "给我建个机器人""创建一个机器人""给 agent 接个钉钉机器人""接入 OpenClaw / Hermes""provision a bot"。
 
@@ -1130,7 +1130,7 @@ dws chat bot search --format json
 ```
 
 注意:
-  - **分层理解**：建号是钉钉 OpenAPI 能力，宿主无关；收→回依赖宿主运行时——今天 OpenClaw 及其 fork（Hermes）开箱即用，其它主流 agent 经 OpenAI-compatible endpoint 接入。**不要因为包名含 openclaw 就以为只支持 OpenClaw**（`peerDependencies.openclaw` 标记为 optional）。
+  - **分层理解**：① 建号是钉钉 OpenAPI 能力，宿主无关；② 这条 skill 指南覆盖 dws 支持的全部主流 agent（Claude Code / Cursor / Codex / Qoder / opencode / Gemini / Windsurf / Cline / Kiro / Trae / Hermes / OpenClaw 等，约 14 个 agent home）；③ 收→回运行时有两条**对等**路径（`openclaw/plugin-sdk` 契约 / OpenAI-compatible endpoint）。**不是只支持 OpenClaw**（`peerDependencies.openclaw` 标记为 optional）。
   - 这条 recipe 依赖 dws 之外的前置（宿主运行时 + npm 网络 + 手机扫码），**不是纯 dws 能闭环的**；前置不满足时明确告知用户，不要伪造创建成功。
   - 创建成功后，发消息/拉群仍走上面的 `chat message send-by-bot` / `group members add-bot`，用 `dws chat bot search` 返回的 `robotCode`。
   - 安全: 机器人在你的授权范围内以你的身份行事，按个人助理对待，勿用于无人值守的生产部署。


### PR DESCRIPTION
## Summary

- **What changed?** Adds a host-agnostic *“创建新机器人 (bot provisioning)”* recipe to the `dingtalk-chat` skill. `dws chat bot` can only **search** (`bot search`/`bot find`) and **add a bot to a group** (`group members add-bot`) — it **cannot create** a bot. So when a user says *“给我建个机器人 / 给 agent 接入钉钉”*, the agent previously had no guided path.
  - New `创建【新】机器人` subsection in the chat product reference, in **both** skill modes: `skills/mono/references/products/chat.md` and `skills/multi/dingtalk-chat/references/chat.md`.
  - Wired trigger words into `skills/multi/dingtalk-chat/SKILL.md` `description`, plus a 意图表 row and a 跨产品协作 handoff note, so dispatch can route the request.
- **Why?** Closes a real capability gap, framed for the actual goal: **any mainstream agent**, not just OpenClaw.

## Host-agnostic by design (two layers)

The official Connector `@dingtalk-real-ai/dingtalk-connector` separates into:

- **① 建号 (provisioning) — host-agnostic.** `npx -y @dingtalk-real-ai/dingtalk-connector install` runs a DingTalk OpenAPI device-auth (QR) flow with **zero OpenClaw dependency** (`peerDependencies.openclaw` is marked *optional*). Any Node env can mint the bot.
- **② 收→回 (runtime) — by host.** OpenClaw and its forks (e.g. **Hermes**) work out of the box via the `openclaw/plugin-sdk` channel contract; other mainstream agents (Claude / Cursor / Codex / …) connect via the host's **OpenAI Chat Completions endpoint**.

The recipe's preflight gate therefore accepts **any** supported host instead of hard-requiring `openclaw`, and cross-verifies the new `robotCode` via `dws chat bot search` (host-agnostic).

> Revision note: the first commit gated on `openclaw -v` (OpenClaw-only), which under-sold the mechanism. The second commit reframes it host-agnostic.

## Verification

- [x] `./scripts/policy/check-generated-drift.sh` → `generated drift check: ok`
- [ ] `make build` / `make lint` / `make test` / `make policy` — **N/A**: docs-only change (skill markdown), no Go source touched.
- [ ] `./scripts/policy/check-command-surface.sh --strict` — **N/A**: no command surface change.

## Notes

- **Intentional scope cut:** only the bot-provisioning (Case 4) recipe. Enriching the existing reporting / meeting / data-analytics recipes with the other verified best-practice cases is planned as a follow-up PR.
- Mono `SKILL.md` routing was left untouched (it intentionally only wires `04-document` / `06-data-analytics` full recipes); the guidance lives in the chat **product reference**, which mono reads when handling chat intents.
- **Roadmap flag for maintainers:** the connector repo name (`dingtalk-openclaw-connector`) still frames it as OpenClaw-specific. If the product goal is “all mainstream agents”, the connector side would benefit from explicitly surfacing the host-adapter abstraction (the OpenAI-compatible endpoint path is already half there). This PR keeps the dws-skill wording host-agnostic so the seam is described correctly today.