### PR TITLE
Revert "fix(cli): JSON errors to stdout; no interactive confirm on piped stdin (#413)"

### DIFF
--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -182,10 +182,7 @@ func printExecutionError(root *cobra.Command, stdout, stderr io.Writer, err erro
 		return writeErr
 	}
 	if wantsJSONErrors(root) {
-		// In JSON mode the structured error is the command's machine-readable
-		// output, so it goes to stdout (consistent with successful results).
-		// Emitting it to stderr would leave stdout empty and break JSON consumers.
-		return apperrors.PrintJSON(stdout, err)
+		return apperrors.PrintJSON(stderr, err)
 	}
 	return apperrors.PrintHumanAt(stderr, err, resolveVerbosity(root))
 }

--- a/internal/app/root_execute_test.go
+++ b/internal/app/root_execute_test.go
@@ -51,11 +51,11 @@ func TestPrintExecutionErrorDefaultsToJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("printExecutionError() error = %v", err)
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty when JSON errors go to stdout", stderr.String())
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty when errors go to stderr", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "\"category\": \"validation\"") {
-		t.Fatalf("stdout = %q, want JSON error payload", stdout.String())
+	if !strings.Contains(stderr.String(), "\"category\": \"validation\"") {
+		t.Fatalf("stderr = %q, want JSON error payload", stderr.String())
 	}
 }
 
@@ -73,11 +73,11 @@ func TestPrintExecutionErrorUsesJSONWhenFormatIsJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("printExecutionError() error = %v", err)
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty when JSON errors go to stdout", stderr.String())
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty when errors go to stderr", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "\"category\": \"validation\"") {
-		t.Fatalf("stdout = %q, want JSON error payload", stdout.String())
+	if !strings.Contains(stderr.String(), "\"category\": \"validation\"") {
+		t.Fatalf("stderr = %q, want JSON error payload", stderr.String())
 	}
 }
 
@@ -105,11 +105,11 @@ func TestPrintExecutionErrorUsesJSONWhenCommandSetsJSONFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("printExecutionError() error = %v", err)
 	}
-	if stderr.Len() != 0 {
-		t.Fatalf("stderr = %q, want empty when JSON errors go to stdout", stderr.String())
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty when errors go to stderr", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "\"category\": \"validation\"") {
-		t.Fatalf("stdout = %q, want JSON error payload", stdout.String())
+	if !strings.Contains(stderr.String(), "\"category\": \"validation\"") {
+		t.Fatalf("stderr = %q, want JSON error payload", stderr.String())
 	}
 }
 

--- a/internal/compat/registry.go
+++ b/internal/compat/registry.go
@@ -298,16 +298,6 @@ func NewDirectCommand(route Route, runner executor.Runner) *cobra.Command {
 				}
 			}
 			if blocked, _ := params["_blocked"].(bool); blocked {
-				// Non-interactive invocation (piped stdin / scripts / JSON pipelines):
-				// an interactive prompt would emit non-JSON to stderr and block on
-				// stdin. Require an explicit --yes and return a structured error so
-				// machine consumers get a deterministic, parseable result.
-				if cli.StdinIsPipe() {
-					return apperrors.NewValidation(
-						"this is a destructive operation; pass --yes to confirm",
-						apperrors.WithHint("re-run the command with --yes to skip the interactive confirmation"),
-					)
-				}
 				// Interactive confirmation for destructive operations (consistent with Helper commands)
 				fmt.Fprintln(cmd.ErrOrStderr(), "⚠️  This is a destructive operation.")
 				fmt.Fprint(cmd.ErrOrStderr(), "Confirm? (yes/no): ")


### PR DESCRIPTION
Reverts #413 (commit f826375).

Restores the prior behavior:
- `printExecutionError`: JSON-mode structured errors go back to **stderr** (not stdout).
- `requireYesForDelete`: removes the non-TTY short-circuit that returned a structured validation error requiring `--yes` on piped stdin; the interactive confirm path is restored.
- Reverts the 3 `root_execute` test assertions to expect JSON errors on stderr.

Build and the affected package tests (`internal/app`, `internal/compat`) pass locally.