### PR TITLE
fix(cli): restore -y shorthand on todo task delete and skill setup

### DIFF
--- a/internal/app/skill_setup.go
+++ b/internal/app/skill_setup.go
@@ -69,7 +69,10 @@ multi 模式支持按产品挑选：
 	cmd.Flags().String("mode", "", "skill 模式：mono | multi（不指定则交互询问）")
 	cmd.Flags().String("target", "all", "目标 Agent：all | "+supportedTargets())
 	cmd.Flags().String("source", "", "skill 源目录（默认自动查找二进制旁边或当前目录）")
-	cmd.Flags().Bool("yes", false, "跳过所有确认提示")
+	// -y shorthand registered locally: the global persistent --yes/-y is
+	// shadowed by this same-named local flag during cobra's persistent-flag
+	// merge, so without it `-y` fails with "unknown shorthand flag: 'y'" (#370).
+	cmd.Flags().BoolP("yes", "y", false, "跳过所有确认提示")
 	cmd.Flags().StringSliceP("skill", "s", nil, "multi 模式：仅安装指定子 skill（可重复，接受短名 aitable 或全名 dingtalk-aitable）")
 	cmd.Flags().StringSliceP("exclude", "x", nil, "multi 模式：从全装中剔除指定子 skill（可重复，与 --skill 互斥）")
 	return cmd

--- a/internal/app/skill_setup_test.go
+++ b/internal/app/skill_setup_test.go
@@ -521,6 +521,25 @@ func TestSkillSetupMultiAdditivePreservesSiblings(t *testing.T) {
 	}
 }
 
+// TestSkillSetupHasYesShorthand is a regression test for #370: the local --yes
+// flag on `skill setup` shadows the global persistent --yes/-y during cobra's
+// flag merge, so the -y shorthand must be registered locally too, otherwise
+// `dws skill setup -y` fails with "unknown shorthand flag: 'y'".
+func TestSkillSetupHasYesShorthand(t *testing.T) {
+	cmd := newSkillSetupCommand()
+
+	yesFlag := cmd.Flags().Lookup("yes")
+	if yesFlag == nil {
+		t.Fatal("skill setup command is missing the --yes flag")
+	}
+	if yesFlag.Shorthand != "y" {
+		t.Errorf("--yes shorthand = %q, want %q (regression #370)", yesFlag.Shorthand, "y")
+	}
+	if cmd.Flags().ShorthandLookup("y") == nil {
+		t.Error("-y shorthand is not resolvable on `skill setup` (regression #370)")
+	}
+}
+
 // TestRunSkillSetupRejectsSkillFlagInMonoMode verifies that the new
 // -s/--skill and -x/--exclude flags are gated on --mode multi.
 func TestRunSkillSetupRejectsSkillFlagInMonoMode(t *testing.T) {

--- a/internal/helpers/todo.go
+++ b/internal/helpers/todo.go
@@ -466,7 +466,11 @@ func newTodoTaskDeleteCommand(runner executor.Runner) *cobra.Command {
 	preferLegacyLeaf(cmd)
 
 	cmd.Flags().String("task-id", "", i18n.T("待办任务 ID (必填)"))
-	cmd.Flags().Bool("yes", false, i18n.T("跳过确认直接删除"))
+	// Register the -y shorthand locally. The global persistent --yes/-y is
+	// shadowed by this same-named local flag during cobra's persistent-flag
+	// merge, so without the shorthand here `-y` reports "unknown shorthand
+	// flag: 'y'" on this subcommand (#370).
+	cmd.Flags().BoolP("yes", "y", false, i18n.T("跳过确认直接删除"))
 	return cmd
 }
 

--- a/internal/helpers/todo_yes_shorthand_test.go
+++ b/internal/helpers/todo_yes_shorthand_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0
+
+package helpers
+
+import "testing"
+
+// TestTodoTaskDeleteHasYesShorthand is a regression test for #370: the local
+// --yes flag on `todo task delete` shadows the global persistent --yes/-y, so
+// the -y shorthand must be registered on the local flag too, otherwise
+// `dws todo task delete -y` fails with "unknown shorthand flag: 'y'".
+func TestTodoTaskDeleteHasYesShorthand(t *testing.T) {
+	cmd := newTodoTaskDeleteCommand(nil)
+
+	yesFlag := cmd.Flags().Lookup("yes")
+	if yesFlag == nil {
+		t.Fatal("delete command is missing the --yes flag")
+	}
+	if yesFlag.Shorthand != "y" {
+		t.Errorf("--yes shorthand = %q, want %q (regression #370)", yesFlag.Shorthand, "y")
+	}
+	if cmd.Flags().ShorthandLookup("y") == nil {
+		t.Error("-y shorthand is not resolvable on `todo task delete` (regression #370)")
+	}
+}


### PR DESCRIPTION
## Summary

- **What changed?** Registered the `-y` shorthand on the local `--yes` flags of `dws todo task delete` (`internal/helpers/todo.go`) and `dws skill setup` (`internal/app/skill_setup.go`) — `Bool("yes")` → `BoolP("yes", "y", ...)`.
- **Why?** Both subcommands declare a local `--yes` flag with the same name as the global persistent `--yes/-y`. During cobra's persistent-flag merge, the same-named parent flag (and its `-y` shorthand) is skipped, so `-y` resolved to nothing:
  ```
  $ dws todo task delete --task-id <id> -y
  { "error": { "message": "unknown shorthand flag: 'y' in -y" } }
  ```
  Only the long `--yes` worked, which is surprising for an AI-agent-oriented CLI where `-y` is the documented global shorthand.

Fixes #370

## Verification

- [x] `make build`
- [ ] `make lint` — `go vet` passes; `staticcheck` not installed in my local env (CI covers it)
- [x] `go test ./internal/helpers/ ./internal/app/` (incl. new `TestTodoTaskDeleteHasYesShorthand`, `TestSkillSetupHasYesShorthand`)
- [x] `make policy`
- [x] `./scripts/policy/check-generated-drift.sh`
- [x] `./scripts/policy/check-command-surface.sh --strict`

## Notes

- **Why add the shorthand instead of removing the local flags** (the other option in the issue): removing them would also drop the shorthand and would break a standalone unit test (`TestRunSkillSetupRejectsSkillFlagInMonoMode`) that constructs `skill setup` without the root persistent flags and passes `--yes`. Adding `-y` is the smaller, safer change that directly fixes the reported symptom and keeps both standalone and mounted usage working — cobra's merge skips the duplicate-named persistent flag, so the local `-y` becomes the active shorthand with no collision.
- `RunE` reads via `cmd.Flags().GetBool("yes")` in both commands, so behavior is unchanged beyond the shorthand now resolving.