### PR TITLE
[codex] Fix chmod batch agent identity contract

### DIFF
--- a/internal/pat/chmod.go
+++ b/internal/pat/chmod.go
@@ -189,7 +189,12 @@ scope 格式: <product>.<entity>:<permission>
 grantType 规则:
   once       一次性，执行一次后自动失效
   session    当前会话有效（默认），需要 --session-id
-  permanent  永久有效`,
+  permanent  永久有效
+
+批量授权:
+  产品线批量授权推荐使用 --recommend --product <productCode[,productCode]>。
+  --products / --domain / --domains 保持兼容；裸 --recommend 保持可用，
+  但会按推荐集合规划，可能跨产品。`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			productCodes := collectChmodProductCodes(productFlags, productsFlag, domainFlags, domainsFlag)
 			if len(args) > 0 || recommend || len(productCodes) > 0 {
@@ -200,6 +205,7 @@ grantType 规则:
 		Example: `  dws pat chmod aitable.record:read --grant-type session --session-id session-xxx
   dws pat chmod chat.message:list --grant-type once
   dws pat chmod aitable.record:read aitable.record:write --grant-type permanent
+  dws pat chmod --recommend --product minutes --grant-type permanent --dry-run
   dws pat chmod --products calendar,aitable --grant-type session --session-id session-xxx
   dws pat chmod --recommend --grant-type session --session-id session-xxx`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/pat/chmod.go
+++ b/internal/pat/chmod.go
@@ -227,7 +227,7 @@ grantType 规则:
 
 			if c != nil && c.DryRun() {
 				if usesPlan {
-					planArgs := buildBatchPlanArgs(scopes, productCodes, recommend, grantType, agentCode, sessionID, true)
+					planArgs := buildBatchPlanArgs(scopes, productCodes, recommend, grantType, sessionID, true)
 					result, err := callPATBatchPlan(cmd.Context(), c, agentCode, sessionID, planArgs)
 					if err != nil {
 						return fmt.Errorf("pat chmod plan failed: %w", err)
@@ -255,7 +255,7 @@ grantType 规则:
 			}
 
 			if usesPlan {
-				planArgs := buildBatchPlanArgs(scopes, productCodes, recommend, grantType, agentCode, sessionID, true)
+				planArgs := buildBatchPlanArgs(scopes, productCodes, recommend, grantType, sessionID, true)
 				planResult, err := callPATBatchPlan(cmd.Context(), c, agentCode, sessionID, planArgs)
 				if err != nil {
 					return fmt.Errorf("pat chmod plan failed: %w", err)
@@ -277,7 +277,6 @@ grantType 规则:
 				"grantType": grantType,
 			}
 			if agentCode != "" {
-				batchArgs["agentCode"] = agentCode
 				toolArgs["agentCode"] = agentCode
 			}
 			if sessionID != "" {
@@ -419,16 +418,13 @@ func callPATBatchPlan(ctx context.Context, c edition.ToolCaller, agentCode, sess
 	})
 }
 
-func buildBatchPlanArgs(scopes []string, productCodes []string, recommend bool, grantType string, agentCode string, sessionID string, dryRun bool) map[string]any {
+func buildBatchPlanArgs(scopes []string, productCodes []string, recommend bool, grantType string, sessionID string, dryRun bool) map[string]any {
 	args := map[string]any{
 		"scopes":       scopes,
 		"productCodes": productCodes,
 		"recommend":    recommend,
 		"grantType":    grantType,
 		"dryRun":       dryRun,
-	}
-	if agentCode != "" {
-		args["agentCode"] = agentCode
 	}
 	if sessionID != "" {
 		args["sessionId"] = sessionID

--- a/internal/pat/chmod_test.go
+++ b/internal/pat/chmod_test.go
@@ -68,8 +68,9 @@ func (f *fakeToolCaller) Format() string { return "json" }
 func (f *fakeToolCaller) DryRun() bool   { return f.dryRun }
 
 type recordedToolCall struct {
-	tool string
-	args map[string]any
+	tool     string
+	args     map[string]any
+	agentEnv string
 }
 
 type fallbackToolCaller struct {
@@ -206,7 +207,11 @@ func (s *sequenceToolCaller) CallTool(_ context.Context, _ string, toolName stri
 	for k, v := range args {
 		copied[k] = v
 	}
-	s.calls = append(s.calls, recordedToolCall{tool: toolName, args: copied})
+	s.calls = append(s.calls, recordedToolCall{
+		tool:     toolName,
+		args:     copied,
+		agentEnv: os.Getenv(agentCodeEnv),
+	})
 	response := `{"success":true,"data":{}}`
 	if len(s.responses) >= len(s.calls) {
 		response = s.responses[len(s.calls)-1]
@@ -305,8 +310,11 @@ func TestChmod_productsFlagPlansThenGrantsSelectedScopes(t *testing.T) {
 	if got := fake.calls[0].args["recommend"]; got != false {
 		t.Fatalf("recommend = %#v, want false", got)
 	}
-	if got := fake.calls[0].args["agentCode"]; got != "qoderwork" {
-		t.Fatalf("plan agentCode = %#v, want qoderwork", got)
+	if got := fake.calls[0].agentEnv; got != "qoderwork" {
+		t.Fatalf("plan agent env = %q, want qoderwork", got)
+	}
+	if _, ok := fake.calls[0].args["agentCode"]; ok {
+		t.Fatalf("batch plan args must not carry agentCode identity field: %#v", fake.calls[0].args)
 	}
 	if fake.calls[1].tool != patBatchGrantToolName {
 		t.Fatalf("second tool = %q, want %q", fake.calls[1].tool, patBatchGrantToolName)
@@ -314,8 +322,11 @@ func TestChmod_productsFlagPlansThenGrantsSelectedScopes(t *testing.T) {
 	if got := fake.calls[1].args["scopes"]; !stringSliceArgEqual(got, []string{"calendar.event:read", "aitable.record:read"}) {
 		t.Fatalf("grant scopes = %#v, want selected scopes", got)
 	}
-	if got := fake.calls[1].args["agentCode"]; got != "qoderwork" {
-		t.Fatalf("grant agentCode = %#v, want qoderwork", got)
+	if got := fake.calls[1].agentEnv; got != "qoderwork" {
+		t.Fatalf("grant agent env = %q, want qoderwork", got)
+	}
+	if _, ok := fake.calls[1].args["agentCode"]; ok {
+		t.Fatalf("batch grant args must not carry agentCode identity field: %#v", fake.calls[1].args)
 	}
 }
 
@@ -342,8 +353,11 @@ func TestChmod_productsSessionModePassesSessionIDToPlanAndGrant(t *testing.T) {
 	if got := fake.calls[0].args["sessionId"]; got != "session-123" {
 		t.Fatalf("plan sessionId = %#v, want session-123", got)
 	}
-	if got := fake.calls[0].args["agentCode"]; got != "qoderwork" {
-		t.Fatalf("plan agentCode = %#v, want qoderwork", got)
+	if got := fake.calls[0].agentEnv; got != "qoderwork" {
+		t.Fatalf("plan agent env = %q, want qoderwork", got)
+	}
+	if _, ok := fake.calls[0].args["agentCode"]; ok {
+		t.Fatalf("batch plan args must not carry agentCode identity field: %#v", fake.calls[0].args)
 	}
 	if got := fake.calls[1].args["grantType"]; got != "session" {
 		t.Fatalf("grant grantType = %#v, want session", got)
@@ -351,8 +365,11 @@ func TestChmod_productsSessionModePassesSessionIDToPlanAndGrant(t *testing.T) {
 	if got := fake.calls[1].args["sessionId"]; got != "session-123" {
 		t.Fatalf("grant sessionId = %#v, want session-123", got)
 	}
-	if got := fake.calls[1].args["agentCode"]; got != "qoderwork" {
-		t.Fatalf("grant agentCode = %#v, want qoderwork", got)
+	if got := fake.calls[1].agentEnv; got != "qoderwork" {
+		t.Fatalf("grant agent env = %q, want qoderwork", got)
+	}
+	if _, ok := fake.calls[1].args["agentCode"]; ok {
+		t.Fatalf("batch grant args must not carry agentCode identity field: %#v", fake.calls[1].args)
 	}
 }
 
@@ -381,8 +398,11 @@ func TestChmod_productsDryRunUsesSessionIDFromEnv(t *testing.T) {
 	if got := fake.calls[0].args["sessionId"]; got != "env-session-123" {
 		t.Fatalf("plan sessionId = %#v, want env-session-123", got)
 	}
-	if got := fake.calls[0].args["agentCode"]; got != "qoderwork" {
-		t.Fatalf("plan agentCode = %#v, want qoderwork", got)
+	if got := fake.calls[0].agentEnv; got != "qoderwork" {
+		t.Fatalf("plan agent env = %q, want qoderwork", got)
+	}
+	if _, ok := fake.calls[0].args["agentCode"]; ok {
+		t.Fatalf("batch plan args must not carry agentCode identity field: %#v", fake.calls[0].args)
 	}
 }
 
@@ -523,7 +543,7 @@ func TestChmod_explicitScopesDryRunShowsBatchGrantTool(t *testing.T) {
 
 // TestChmod_agentCode_env_fallback verifies that when --agentCode is
 // omitted but DINGTALK_DWS_AGENTCODE is exported, the resolver picks
-// the env value up and forwards it verbatim in the MCP argv.
+// the env value up and forwards it through the MCP call environment.
 func TestChmod_agentCode_env_fallback(t *testing.T) {
 	t.Setenv(agentCodeEnv, "qoderwork")
 
@@ -542,8 +562,8 @@ func TestChmod_agentCode_env_fallback(t *testing.T) {
 	if got := fake.gotAgentEnv; got != "qoderwork" {
 		t.Fatalf("agent env = %q, want %q", got, "qoderwork")
 	}
-	if got := fake.gotArgs["agentCode"]; got != "qoderwork" {
-		t.Fatalf("batch argv agentCode = %#v, want qoderwork", got)
+	if _, ok := fake.gotArgs["agentCode"]; ok {
+		t.Fatalf("batch argv must not carry agentCode identity field: %#v", fake.gotArgs)
 	}
 	if got := fake.gotArgs["scopes"]; !stringSliceArgEqual(got, []string{"aitable.record:read"}) {
 		t.Fatalf("scopes in argv = %#v, want %#v", got, []string{"aitable.record:read"})
@@ -977,8 +997,8 @@ func TestChmod_agentCode_flag_wins_over_env(t *testing.T) {
 	if got := fake.gotAgentEnv; got != "flagval" {
 		t.Fatalf("agent env = %q, want %q (flag must win over env)", got, "flagval")
 	}
-	if got := fake.gotArgs["agentCode"]; got != "flagval" {
-		t.Fatalf("batch argv agentCode = %#v, want flagval", got)
+	if _, ok := fake.gotArgs["agentCode"]; ok {
+		t.Fatalf("batch argv must not carry agentCode identity field: %#v", fake.gotArgs)
 	}
 }
 


### PR DESCRIPTION
## Background

PR #414 changed `dws pat chmod` batch plan/grant payloads to include `agentCode`. Shell verification against the real batch plan endpoint showed that the batch service rejects this as a forged identity field:

`PAT_FORGED_IDENTITY_FIELD: PAT batch identity field 'agentCode' must be derived by gateway.`

The correct contract is: `DINGTALK_DWS_AGENTCODE` is picked up by the CLI and made visible to the MCP call environment/header path; `pat.batch_plan` and `pat.batch_grant` must not carry `agentCode` in the tool arguments.

## Changes

- Remove `agentCode` from `pat.batch_plan` / `pat.batch_grant` arguments.
- Keep canonical/legacy single-grant fallback behavior unchanged.
- Extend chmod tests to assert batch plan/grant calls see the env value while their args omit the identity field.

## Shell smoke

Built the PR binary locally as `/tmp/dws-chmod-agentcode` and checked:

- `env DINGTALK_DWS_AGENTCODE=qoderwork /tmp/dws-chmod-agentcode --dry-run pat chmod aitable.record:read calendar.event:read --grant-type once` prints `AgentCode: qoderwork`.
- `env -u DINGTALK_DWS_AGENTCODE /tmp/dws-chmod-agentcode --dry-run pat chmod aitable.record:read calendar.event:read --grant-type once` prints `AgentCode: (server default)`.
- `env DINGTALK_DWS_AGENTCODE=envval /tmp/dws-chmod-agentcode --dry-run pat chmod aitable.record:read calendar.event:read --grant-type once --agentCode flagval` prints `AgentCode: flagval`.
- `env DINGTALK_DWS_AGENTCODE=qoderwork /tmp/dws-chmod-agentcode --dry-run -f json pat chmod --products calendar,aitable --grant-type once` succeeds; summarized response: `success=true agentCode=dingmbw5n9ktkkbbjv3g selected=0 skipped=32`.

## Verification

- `go test ./internal/pat`
- `go test ./internal/app`
