### PR TITLE
feat(skill): 内嵌 skills/ 进二进制，skill setup 默认用内嵌源（修升级不刷新）

### DIFF
--- a/internal/app/skill_setup.go
+++ b/internal/app/skill_setup.go
@@ -97,10 +97,11 @@ func runSkillSetup(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--skill / --exclude 仅在 --mode multi 下有效（mono 只有一个 skill，无需挑选）")
 	}
 
-	skillSrc, err := resolveSkillSetupSource(source, mode)
+	skillSrc, srcCleanup, err := resolveSkillSetupSourceOrEmbedded(source, mode)
 	if err != nil {
 		return err
 	}
+	defer srcCleanup()
 
 	dests, err := resolveSkillSetupTargets(target, mode)
 	if err != nil {

--- a/internal/app/skill_setup_embed.go
+++ b/internal/app/skill_setup_embed.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	dwsroot "github.com/DingTalk-Real-AI/dingtalk-workspace-cli"
+)
+
+// resolveSkillSetupSourceOrEmbedded resolves the skill source for `skill
+// setup`. An explicit --source or DWS_SKILL_SOURCE is honored as a developer
+// override (validated as an on-disk dir). Otherwise it falls back to the skill
+// bundle embedded in THIS binary, so a plain `dws skill setup` always installs
+// the version shipped with the running binary — upgrading the binary therefore
+// refreshes the installed skill, instead of silently reusing a stale copy from
+// the current working directory.
+//
+// The returned cleanup func removes any temp dir created for the embedded
+// bundle; it is a no-op when an on-disk source is used. Always call it.
+func resolveSkillSetupSourceOrEmbedded(explicit, mode string) (string, func(), error) {
+	noop := func() {}
+	explicit = strings.TrimSpace(explicit)
+	env := strings.TrimSpace(os.Getenv("DWS_SKILL_SOURCE"))
+	if explicit != "" || env != "" {
+		dir, err := resolveSkillSetupSource(explicit, mode)
+		return dir, noop, err
+	}
+	return materializeEmbeddedSkillSource(mode)
+}
+
+// materializeEmbeddedSkillSource extracts the embedded skills/<mode> subtree
+// into a fresh temp dir and returns its path plus a cleanup func. Reusing a
+// real directory lets the existing dir-based install/copy logic stay unchanged.
+func materializeEmbeddedSkillSource(mode string) (string, func(), error) {
+	noop := func() {}
+	sub := "skills/" + mode // embed.FS always uses forward slashes
+	if _, err := fs.Stat(dwsroot.EmbeddedSkills, sub); err != nil {
+		return "", noop, fmt.Errorf("内嵌 skill 不含 %q（二进制可能未随 skills/ 重新构建）: %w", sub, err)
+	}
+
+	tmp, err := os.MkdirTemp("", "dws-skill-"+mode+"-")
+	if err != nil {
+		return "", noop, fmt.Errorf("创建临时 skill 目录失败: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmp) }
+
+	walkErr := fs.WalkDir(dwsroot.EmbeddedSkills, sub, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel := strings.TrimPrefix(strings.TrimPrefix(p, sub), "/")
+		dst := filepath.Join(tmp, filepath.FromSlash(rel))
+		if d.IsDir() {
+			return os.MkdirAll(dst, 0o755)
+		}
+		data, readErr := dwsroot.EmbeddedSkills.ReadFile(p)
+		if readErr != nil {
+			return readErr
+		}
+		if mkErr := os.MkdirAll(filepath.Dir(dst), 0o755); mkErr != nil {
+			return mkErr
+		}
+		return os.WriteFile(dst, data, 0o644)
+	})
+	if walkErr != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("展开内嵌 skill 到临时目录失败: %w", walkErr)
+	}
+	return tmp, cleanup, nil
+}

--- a/internal/app/skill_setup_embed_test.go
+++ b/internal/app/skill_setup_embed_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMaterializeEmbeddedSkillSourceMono verifies that the mono skill bundle
+// baked into the binary can be extracted to a temp dir and is a valid skill
+// source root (so `dws skill setup` works with zero local checkout). The
+// connect.md / _common checks guard against the embed dropping the connect
+// routing docs or the `all:` prefix being lost (which would silently skip
+// dot/underscore dirs).
+func TestMaterializeEmbeddedSkillSourceMono(t *testing.T) {
+	dir, cleanup, err := materializeEmbeddedSkillSource(skillSetupModeMono)
+	if err != nil {
+		t.Fatalf("materializeEmbeddedSkillSource: %v", err)
+	}
+	defer cleanup()
+
+	if !isSkillSourceRoot(dir, skillSetupModeMono) {
+		t.Fatalf("extracted dir %s is not a valid mono skill source root", dir)
+	}
+	for _, rel := range []string{
+		"SKILL.md",
+		filepath.Join("references", "connect.md"),
+		filepath.Join("references", "best_practices", "_common"),
+	} {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Errorf("expected embedded skill to contain %s: %v", rel, err)
+		}
+	}
+
+	// cleanup must actually remove the temp dir.
+	cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("cleanup did not remove temp dir %s (err=%v)", dir, err)
+	}
+}
+
+// TestResolveSkillSetupSourceOrEmbeddedFallsBackToEmbedded verifies that with
+// no --source and no DWS_SKILL_SOURCE, resolution uses the embedded bundle
+// rather than probing the current working directory (the stale-skill footgun).
+func TestResolveSkillSetupSourceOrEmbeddedFallsBackToEmbedded(t *testing.T) {
+	t.Setenv("DWS_SKILL_SOURCE", "")
+	dir, cleanup, err := resolveSkillSetupSourceOrEmbedded("", skillSetupModeMono)
+	if err != nil {
+		t.Fatalf("resolveSkillSetupSourceOrEmbedded: %v", err)
+	}
+	defer cleanup()
+	if !isSkillSourceRoot(dir, skillSetupModeMono) {
+		t.Fatalf("embedded fallback returned non-source-root dir %s", dir)
+	}
+}

--- a/skills_embed.go
+++ b/skills_embed.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dws is the module-root package. Its sole purpose is to bake the
+// skills/ documentation tree into the binary at build time so that
+// `dws skill setup` installs the skill version shipped with THIS binary,
+// independent of any local checkout. See internal/app/skill_setup.go.
+package dws
+
+import "embed"
+
+// EmbeddedSkills holds the bundled skills/ tree (mono + multi) compiled into
+// the binary. The `all:` prefix is required so dot/underscore entries — e.g.
+// references/best_practices/_common — are included rather than skipped.
+//
+//go:embed all:skills
+var EmbeddedSkills embed.FS


### PR DESCRIPTION
## 背景

`dws skill setup` 此前从**当前工作目录 / 二进制旁**探测 `skills/` 源安装，二进制本身**不内嵌** skill（无 `go:embed skills/`）。后果：

- **升级二进制后已装 skill 不会刷新**——若曾在某个旧分支目录跑过 setup，装上的就是旧路由，长期踩坑；
- agent 被问"创建钉钉机器人"时读到旧 skill、找不到 `dws connect bot create`，扎进 `chat` 死胡同（见 issue 复盘）。

## 改了什么

1. **根包内嵌**：新增 `skills_embed.go`（module 根包 `dws`）`//go:embed all:skills`。用 `all:` 前缀以包含 `references/best_practices/_common` 等下划线目录（否则 go:embed 会静默跳过）。
2. **setup 默认用内嵌源**：新增 `resolveSkillSetupSourceOrEmbedded` —— 不带 `--source` / `DWS_SKILL_SOURCE` 时，把内嵌的 `skills/<mode>` 解到临时目录安装（复用既有目录拷贝逻辑），用完即清理。这样 `dws skill setup` **始终安装与当前二进制同版本的 skill**，升级二进制即刷新。
3. **dev 覆盖保留**：`--source` / `DWS_SKILL_SOURCE` 仍优先，方便本地改 skill 时指向 checkout。

## 验证

- `go build ./...` / `go vet` / skill 相关单测 全过；
- 新增单测：内嵌提取产出合法 mono 源根 + 含 `connect.md` / `_common`（守住 `all:` 前缀不被改丢）+ 临时目录清理 + 无 flag 时回退内嵌；
- **端到端**：编出二进制，在**无 cwd `skills/`、独立假 HOME**、不带 `--source` 下跑 `skill setup`，装出的 skill 含 `connect.md`、`chat.md` 的 connect 挡板、`SKILL.md` 的建机器人→connect 路由；`--source` 显式覆盖仍正常。

## 影响

- 二进制体积 +~3.3M（skills/ 内嵌）。
- 行为变更：默认源从"探测 cwd/二进制旁"改为"内嵌"。开发者改 skill 需显式 `--source .`（已在 help/注释说明）。

> base 选 `feat/chat-bot-provisioning-openclaw`（#407 线），diff 仅含本特性，与 #407 解耦。#407 合并后可改 base 到 main。
