### PR TITLE
fix(compat): guard envelope-driven flag registration against pflag panics

### DIFF
--- a/internal/compat/registry.go
+++ b/internal/compat/registry.go
@@ -415,6 +415,33 @@ func parseFlagDefault(kind ValueKind, raw string) (defStr string, defInt int, de
 	return
 }
 
+// canRegisterFlag reports whether a long flag named name can be registered
+// on cmd without panicking pflag ("flag redefined"). The reserved payload
+// names are excluded too: ApplyBindings unconditionally registers hidden
+// --json/--params after the bindings loop. The envelope is remote data —
+// a duplicate or reserved name there must degrade to "flag unavailable",
+// never abort the process.
+func canRegisterFlag(cmd *cobra.Command, name string) bool {
+	if name == "" || name == "json" || name == "params" {
+		return false
+	}
+	return cmd.Flags().Lookup(name) == nil
+}
+
+// safeShorthand returns short when it is a single-character shorthand not
+// yet bound on cmd; otherwise "" (drop the shorthand, keep the long flag).
+// pflag panics on both multi-character and duplicate shorthands.
+func safeShorthand(cmd *cobra.Command, short string) string {
+	short = strings.TrimSpace(short)
+	if len(short) != 1 {
+		return ""
+	}
+	if cmd.Flags().ShorthandLookup(short) != nil {
+		return ""
+	}
+	return short
+}
+
 func ApplyBindings(cmd *cobra.Command, bindings []FlagBinding) {
 	for _, binding := range bindings {
 		// Positional bindings are collected from cobra args rather than flags.
@@ -464,7 +491,7 @@ func ApplyBindings(cmd *cobra.Command, bindings []FlagBinding) {
 		defStr, defInt, defFloat, defBool, defSlice := parseFlagDefault(binding.Kind, binding.Default)
 
 		registerHidden := func(name string, suffix string) {
-			if name == "" {
+			if !canRegisterFlag(cmd, name) {
 				return
 			}
 			switch binding.Kind {
@@ -484,19 +511,27 @@ func ApplyBindings(cmd *cobra.Command, bindings []FlagBinding) {
 			_ = cmd.Flags().MarkHidden(name)
 		}
 
+		if !canRegisterFlag(cmd, primary) {
+			// Duplicate or reserved primary name in the envelope. Skip the
+			// whole binding: CollectBindings tolerates the missing flag
+			// (Lookup → nil → continue) and the value can still be supplied
+			// via the --params payload.
+			continue
+		}
+		short := safeShorthand(cmd, binding.Short)
 		switch binding.Kind {
 		case ValueString:
-			cmd.Flags().StringP(primary, binding.Short, defStr, binding.Usage)
+			cmd.Flags().StringP(primary, short, defStr, binding.Usage)
 		case ValueInt:
-			cmd.Flags().IntP(primary, binding.Short, defInt, binding.Usage)
+			cmd.Flags().IntP(primary, short, defInt, binding.Usage)
 		case ValueFloat:
-			cmd.Flags().Float64P(primary, binding.Short, defFloat, binding.Usage)
+			cmd.Flags().Float64P(primary, short, defFloat, binding.Usage)
 		case ValueBool:
-			cmd.Flags().BoolP(primary, binding.Short, defBool, binding.Usage)
+			cmd.Flags().BoolP(primary, short, defBool, binding.Usage)
 		case ValueStringSlice, ValueIntSlice, ValueFloatSlice, ValueBoolSlice:
-			cmd.Flags().StringSliceP(primary, binding.Short, defSlice, binding.Usage)
+			cmd.Flags().StringSliceP(primary, short, defSlice, binding.Usage)
 		case ValueJSON:
-			cmd.Flags().StringP(primary, binding.Short, defStr, binding.Usage+" (JSON)")
+			cmd.Flags().StringP(primary, short, defStr, binding.Usage+" (JSON)")
 		}
 		registerHidden(alias, " (alias)")
 		for _, extra := range extras {
@@ -513,8 +548,12 @@ func ApplyBindings(cmd *cobra.Command, bindings []FlagBinding) {
 			}
 		}
 	}
-	cmd.Flags().String("json", "", "Base JSON object payload for this command")
-	cmd.Flags().String("params", "", "Additional JSON object payload merged after --json")
+	if cmd.Flags().Lookup("json") == nil {
+		cmd.Flags().String("json", "", "Base JSON object payload for this command")
+	}
+	if cmd.Flags().Lookup("params") == nil {
+		cmd.Flags().String("params", "", "Additional JSON object payload merged after --json")
+	}
 	_ = cmd.Flags().MarkHidden("json")
 	_ = cmd.Flags().MarkHidden("params")
 }
@@ -553,12 +592,12 @@ func registerPositionalAliasFlags(cmd *cobra.Command, binding FlagBinding) {
 	defStr, defInt, defFloat, defBool, defSlice := parseFlagDefault(binding.Kind, binding.Default)
 
 	register := func(name string, withShort bool, hidden bool, usageSuffix string) {
-		if name == "" {
+		if !canRegisterFlag(cmd, name) {
 			return
 		}
 		short := ""
 		if withShort {
-			short = binding.Short
+			short = safeShorthand(cmd, binding.Short)
 		}
 		usage := binding.Usage + usageSuffix
 		switch binding.Kind {

--- a/internal/compat/registry_flag_guard_test.go
+++ b/internal/compat/registry_flag_guard_test.go
@@ -1,0 +1,135 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compat
+
+import (
+	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
+)
+
+// The envelope is remote data; none of these malformed shapes may panic the
+// command build — pflag panics on duplicate long names, duplicate shorthands,
+// and multi-character shorthands, and a poisoned discovery cache used to take
+// down every CLI invocation this way (pre-1.0.32 lockout class).
+func TestBuildDynamicCommandsSurvivesMalformedFlagEnvelope(t *testing.T) {
+	tests := []struct {
+		name  string
+		flags map[string]market.CLIFlagOverride
+	}{
+		{
+			name: "duplicate shorthand across two flags",
+			flags: map[string]market.CLIFlagOverride{
+				"alpha": {Shorthand: "x"},
+				"beta":  {Shorthand: "x"},
+			},
+		},
+		{
+			name: "multi-character shorthand",
+			flags: map[string]market.CLIFlagOverride{
+				"alpha": {Shorthand: "xy"},
+			},
+		},
+		{
+			name: "primary collides with reserved payload flag",
+			flags: map[string]market.CLIFlagOverride{
+				"params": {},
+				"json":   {},
+			},
+		},
+		{
+			name: "cross-binding duplicate primary via alias",
+			flags: map[string]market.CLIFlagOverride{
+				"user_id":   {Alias: "target"},
+				"member_id": {Alias: "target"},
+			},
+		},
+		{
+			name: "cross-binding alias collides with another primary",
+			flags: map[string]market.CLIFlagOverride{
+				"alpha": {},
+				"beta":  {Aliases: []string{"alpha"}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			servers := []market.ServerDescriptor{
+				{
+					Endpoint: "https://endpoint-guard",
+					CLI: market.CLIOverlay{
+						ID:      "guard",
+						Command: "guard",
+						ToolOverrides: map[string]market.CLIToolOverride{
+							"guard_tool": {
+								CLIName: "boom",
+								Flags:   tc.flags,
+							},
+						},
+					},
+				},
+			}
+
+			// Must not panic; the command must build and stay executable.
+			cmds := BuildDynamicCommands(servers, &captureRunner{}, nil)
+			if len(cmds) != 1 {
+				t.Fatalf("BuildDynamicCommands() = %d commands, want 1", len(cmds))
+			}
+			cmds[0].SetArgs([]string{"boom", "--help"})
+			cmds[0].SilenceErrors = true
+			cmds[0].SilenceUsage = true
+			if err := cmds[0].Execute(); err != nil {
+				t.Fatalf("execute --help: %v", err)
+			}
+		})
+	}
+}
+
+// TestBuildDynamicCommandsKeepsFirstShorthand pins the winner: when two
+// flags claim the same shorthand, the first (sorted param order) keeps it
+// and the second still registers its long flag.
+func TestBuildDynamicCommandsKeepsFirstShorthand(t *testing.T) {
+	servers := []market.ServerDescriptor{
+		{
+			Endpoint: "https://endpoint-guard",
+			CLI: market.CLIOverlay{
+				ID:      "guard",
+				Command: "guard",
+				ToolOverrides: map[string]market.CLIToolOverride{
+					"guard_tool": {
+						CLIName: "boom",
+						Flags: map[string]market.CLIFlagOverride{
+							"alpha": {Shorthand: "x"},
+							"beta":  {Shorthand: "x"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cmds := BuildDynamicCommands(servers, &captureRunner{}, nil)
+	boom, _, err := cmds[0].Find([]string{"boom"})
+	if err != nil {
+		t.Fatalf("find boom: %v", err)
+	}
+	short := boom.Flags().ShorthandLookup("x")
+	if short == nil || short.Name != "alpha" {
+		t.Fatalf("shorthand -x bound to %v, want alpha", short)
+	}
+	if boom.Flags().Lookup("beta") == nil {
+		t.Fatalf("long flag --beta missing; dropping the shorthand must not drop the flag")
+	}
+}


### PR DESCRIPTION
## Problem

Follow-up to the verification of #447 (see [this comment](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pull/447#issuecomment-4666245744)): while building the lockout repro, I found that four envelope shapes are still forwarded to pflag calls that **panic**, and since the command tree is built from the cached envelope before Cobra dispatches anything, each of them bricks every CLI invocation on `main` today:

1. A flag named `params` / `json` — collides with the reserved payload flags registered unconditionally at the end of `ApplyBindings`. This is the original pre-1.0.32 lockout (`chat_permission_grant flag redefined: params`); the earlier dedup fixes covered the alias list and the Detail-schema path, but **not the primary name**.
2. Two bindings resolving to the same long flag name (cross-binding duplicate primary/alias) — the existing `seen` dedup map is per-binding only.
3. Two flags claiming the same shorthand (`unable to redefine 'x' shorthand`).
4. A multi-character shorthand (`shorthand is more than one ANSI character`).

Reproduced on `main` @ eaa60f9 with a byte-correct cache snapshot (no instrumentation):

```
$ dws version
Error: internal panic: unable to redefine 'x' shorthand in "boom" flagset: it's already used for "alpha" flag
exit=5    # every command, including 'dws cache refresh'
```

## Fix

Two small helpers applied at every envelope-driven registration site (`ApplyBindings`, `registerPositionalAliasFlags`):

- `canRegisterFlag`: skip duplicate/reserved long names. `CollectBindings` already tolerates a missing flag (`Lookup → nil → continue`), and the value stays reachable via the `--params` payload.
- `safeShorthand`: drop an invalid or already-taken shorthand, keep the long flag.

The trailing `--json`/`--params` registration is also made idempotent.

## Relationship to #447

Defense in depth: #447 is the escape hatch (degrade + self-heal hint) for *unknown* panic classes during the build; this PR removes the *known* vectors so the hatch should never trigger for them. With both merged, the same poisoned cache that bricks `main` today yields a fully working CLI:

```
$ dws version          # guarded binary + poisoned cache: no panic, no degradation
Version:        dev
$ dws poison boom --help
  -x, --alpha string   alpha     # first flag keeps the shorthand
      --beta string    beta      # second keeps its long flag
```

## Tests

- `TestBuildDynamicCommandsSurvivesMalformedFlagEnvelope`: 5 table-driven vectors. Verified load-bearing: the same test file run against `main` panics the test binary on the first vector.
- `TestBuildDynamicCommandsKeepsFirstShorthand`: pins the winner semantics (first flag keeps `-x`, second keeps `--beta`).
- Full `go test ./internal/compat/ ./internal/app/ ./internal/cli/` passes.