### PR TITLE
fix: pipeline PollUntil case-insensitive comparison to fix sheet export hang

### DIFF
--- a/internal/compat/pipeline.go
+++ b/internal/compat/pipeline.go
@@ -185,7 +185,7 @@ func executePipelineCall(
 			return nil, err
 		}
 		actual := getDotPath(resp, step.PollUntilField)
-		if actual != nil && fmt.Sprint(actual) == step.PollUntilValue {
+		if actual != nil && strings.EqualFold(fmt.Sprint(actual), step.PollUntilValue) {
 			return resp, nil
 		}
 		if time.Now().After(deadline) {


### PR DESCRIPTION
## Problem

`dws sheet export` hangs for the full poll timeout (~5 minutes) instead of completing.

The pipeline executor's polling loop uses `==` (case-sensitive) to compare the API response status against the configured `pollUntilValue`. The API returns `"success"` (lowercase) but the pipeline config declares `"SUCCESS"` (uppercase), so the comparison never matches and the loop spins until the 5-minute timeout.

## Fix

Change the comparison in `executePipelineCall` from `==` to `strings.EqualFold` for case-insensitive matching.

This aligns with the existing `normalizeAsyncStatus` helper in `aitable_export_import.go` which already handles status variants case-insensitively for `doc export` and `aitable export`.

## Verification

```bash
go test ./internal/compat/ -timeout 120s
# ok  github.com/.../internal/compat  3.590s
```

- **Pre-fix**: `pipeline step 1 (query_export_job): pipeline poll timeout after 300s: field "content.status" never reached value "SUCCESS" (last seen: success)`
- **Post-fix**: `strings.EqualFold` matches immediately regardless of case
