### PR TITLE
fix(cli): don't hang on stdin for destructive ops in non-interactive sessions

### DIFF
--- a/internal/compat/registry.go
+++ b/internal/compat/registry.go
@@ -298,6 +298,16 @@ func NewDirectCommand(route Route, runner executor.Runner) *cobra.Command {
 				}
 			}
 			if blocked, _ := params["_blocked"].(bool); blocked {
+				// Non-interactive stdin (pipe / CI / test harness / AI agent):
+				// we cannot read a confirmation. Previously the prompt below hit
+				// EOF immediately, printed "Operation cancelled" to stderr, left
+				// stdout empty and returned nil with exit 0 — silently no-op'ing
+				// the destructive command while reporting success, and breaking
+				// any -f json caller that parses the empty stdout as a failure.
+				// Refuse with a structured error telling the caller to pass --yes.
+				if fi, err := os.Stdin.Stat(); err != nil || (fi.Mode()&os.ModeCharDevice) == 0 {
+					return apperrors.NewValidation("this is a destructive operation; re-run with --yes to confirm (cannot prompt for confirmation in a non-interactive session)")
+				}
 				// Interactive confirmation for destructive operations (consistent with Helper commands)
 				fmt.Fprintln(cmd.ErrOrStderr(), "⚠️  This is a destructive operation.")
 				fmt.Fprint(cmd.ErrOrStderr(), "Confirm? (yes/no): ")


### PR DESCRIPTION
## Problem

Destructive compat commands (e.g. `calendar room delete`, `calendar participant delete`) unconditionally read a yes/no confirmation from stdin when `--yes` is not passed. In a non-interactive session (pipe / CI / test harness / AI agent), stdin hits EOF immediately, so the command:

- prints the confirmation prompt + `Operation cancelled` to **stderr**
- leaves **stdout empty** (no JSON)
- returns **exit code 0**

The destructive operation silently does not run, yet reports success. Any `-f json` caller parsing the empty stdout treats it as a failure. This is the root cause of the `calendar` failures in the cli_to_mcp evaluation.

### Reproduce (before)

```
printf '' | dws calendar room delete --event FAKE --rooms FAKE -f json ; echo "exit=$?"
# stderr: "⚠️  This is a destructive operation. Confirm? (yes/no): Operation cancelled"
# stdout: (empty)
# exit=0
```

## Fix

Before falling into the interactive prompt, detect a non-interactive stdin (`os.Stdin` is not a character device) and return a structured validation error instructing the caller to pass `--yes`, instead of hanging on / EOF-ing the prompt.

### After

```
printf '' | dws calendar room delete --event FAKE --rooms FAKE -f json ; echo "exit=$?"
# structured JSON validation error: "...re-run with --yes to confirm..."
# exit=non-zero

printf '' | dws calendar room delete --event FAKE --rooms FAKE --yes -f json
# bypasses the gate, reaches real execution (business API error for the fake event)
```

Interactive TTY sessions are unaffected — they still get the confirmation prompt.
