### PR TITLE
fix(chat): reply hardcoded clawType="wukong" leaks 悟空AI发送 on open edition

### DIFF
--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cobracmd"
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/spf13/cobra"
 )
 
@@ -441,7 +442,7 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 		default:
 			return nil, "", apperrors.NewValidation("unsupported --msg-type: " + msgType + " (supported: image, file)")
 		}
-		params := map[string]any{"msgType": msgType, "content": contentJSON}
+		params := map[string]any{"msgType": msgType, "content": contentJSON, "clawType": edition.ClawType()}
 		if strings.TrimSpace(uuid) != "" {
 			params["uuid"] = uuid
 		}
@@ -480,6 +481,7 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 			"openConversationId": group,
 			"msgType":            "markdown",
 			"content":            marshalMessageContent(title, text),
+			"clawType":           edition.ClawType(),
 		}
 		if atAll {
 			params["atAll"] = true
@@ -492,13 +494,14 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 		}
 		return params, "send_personal_message", nil
 	case hasUser:
-		params := map[string]any{"title": title, "text": text, "receiverUserId": user}
+		params := map[string]any{"title": title, "text": text, "receiverUserId": user, "clawType": edition.ClawType()}
 		return params, "send_direct_message_as_user", nil
 	default:
 		params := map[string]any{
 			"receiverOpenDingTalkId": openID,
 			"msgType":                "markdown",
 			"content":                marshalMessageContent(title, text),
+			"clawType":               edition.ClawType(),
 		}
 		if strings.TrimSpace(uuid) != "" {
 			params["uuid"] = uuid
@@ -971,11 +974,13 @@ func newChatMessageReplyCommand(runner executor.Runner) *cobra.Command {
 			if err != nil {
 				return apperrors.NewInternal("marshal reply content: " + err.Error())
 			}
+			// clawType must reflect the actual edition: a hardcoded "wukong"
+			// here made open-source replies render the Wukong AI indicator.
 			params := map[string]any{
 				"openConversationId": convID,
 				"msgType":            "reply",
 				"content":            contentJSON,
-				"clawType":           "wukong",
+				"clawType":           edition.ClawType(),
 			}
 			if uuid, _ := cmd.Flags().GetString("uuid"); strings.TrimSpace(uuid) != "" {
 				params["uuid"] = uuid

--- a/internal/helpers/chat_test.go
+++ b/internal/helpers/chat_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
+	"github.com/spf13/cobra"
 )
 
 type captureRunner struct {
@@ -305,6 +307,88 @@ func TestChatMessageSendRejectsAtMentionsOutsideGroup(t *testing.T) {
 				t.Fatalf("error = %q, want '...only apply when --group is set'", err.Error())
 			}
 		})
+	}
+}
+
+// TestChatMessageSendCarriesClawType guards the "Send from AI" indicator:
+// every user-identity send path must attach the edition claw identity as the
+// clawType tool argument so the IM server renders the AI-sent label on the
+// delivered message. The open-source build pins it to edition.DefaultOSSClawType
+// ("openClaw"); dropping the parameter (or hardcoding another edition's value,
+// as the reply command once did with "wukong") mislabels or unlabels messages.
+func TestChatMessageSendCarriesClawType(t *testing.T) {
+	cases := []struct {
+		name string
+		make func(runner executor.Runner) *cobra.Command
+		args []string
+	}{
+		{
+			name: "group-markdown",
+			make: newChatMessageSendCommand,
+			args: []string{"--group", "cid-xyz", "--title", "t", "--text", "hello"},
+		},
+		{
+			name: "user-direct",
+			make: newChatMessageSendCommand,
+			args: []string{"--user", "034766", "--title", "t", "--text", "hi"},
+		},
+		{
+			name: "open-dingtalk-id-direct",
+			make: newChatMessageSendCommand,
+			args: []string{"--open-dingtalk-id", "OP123", "--title", "t", "--text", "hi"},
+		},
+		{
+			name: "group-rich-media-image",
+			make: newChatMessageSendCommand,
+			args: []string{"--group", "cid-xyz", "--msg-type", "image", "--media-id", "media-1"},
+		},
+		{
+			name: "reply",
+			make: newChatMessageReplyCommand,
+			args: []string{
+				"--conversation-id", "cid-xyz",
+				"--ref-msg-id", "msg-1",
+				"--ref-sender", "op-1",
+				"--text", "got it",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &captureRunner{}
+			cmd := tc.make(runner)
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+			}
+			got, ok := runner.last.Params["clawType"]
+			if !ok {
+				t.Fatalf("Params missing clawType; got %#v", runner.last.Params)
+			}
+			if got != edition.DefaultOSSClawType {
+				t.Fatalf("clawType = %#v, want %q", got, edition.DefaultOSSClawType)
+			}
+		})
+	}
+}
+
+// Robot sends are rendered as bot messages already; they must NOT carry the
+// user-identity clawType argument.
+func TestChatMessageSendByBotOmitsClawType(t *testing.T) {
+	runner := &captureRunner{}
+	cmd := newChatMessageSendByBotCommand(runner)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--group", "cid-xyz", "--robot-code", "robot-001", "--title", "t", "--text", "x"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+	}
+	if _, ok := runner.last.Params["clawType"]; ok {
+		t.Fatalf("bot send must not carry clawType; got %#v", runner.last.Params)
 	}
 }
 

--- a/pkg/edition/edition.go
+++ b/pkg/edition/edition.go
@@ -68,6 +68,12 @@ type Hooks struct {
 	Name         string // "open" (default) / overlay identifier
 	ScenarioCode string // injected into x-dingtalk-scenario-code header
 
+	// ClawTypeValue is the claw identity carried in message-send tool
+	// arguments (parameter clawType) so the IM server can render the
+	// "Send from AI" indicator on delivered messages. Empty → falls back
+	// to DefaultOSSClawType; overlays set their own value (e.g. "wukong").
+	ClawTypeValue string
+
 	// --- runtime mode ---
 	IsEmbedded     bool // true when running inside a host application
 	HideAuthLogin  bool // true suppresses the "dws auth login" command
@@ -164,4 +170,15 @@ func Override(h *Hooks) {
 	mu.Lock()
 	defer mu.Unlock()
 	current = h
+}
+
+// ClawType returns the claw identity for the active edition, falling back
+// to DefaultOSSClawType when the overlay does not set one. Message-send
+// helpers attach this value as the clawType tool argument so the IM server
+// can label delivered messages as sent via AI.
+func ClawType() string {
+	if v := Get().ClawTypeValue; v != "" {
+		return v
+	}
+	return DefaultOSSClawType
 }

--- a/pkg/edition/edition_test.go
+++ b/pkg/edition/edition_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edition
+
+import "testing"
+
+func TestClawTypeDefaultsToOSSValue(t *testing.T) {
+	prev := Get()
+	defer Override(prev)
+
+	Override(defaultHooks())
+	if got := ClawType(); got != DefaultOSSClawType {
+		t.Fatalf("ClawType() = %q, want %q", got, DefaultOSSClawType)
+	}
+}
+
+func TestClawTypeUsesOverlayValue(t *testing.T) {
+	prev := Get()
+	defer Override(prev)
+
+	Override(&Hooks{Name: "overlay", ClawTypeValue: "wukong"})
+	if got := ClawType(); got != "wukong" {
+		t.Fatalf("ClawType() = %q, want overlay value %q", got, "wukong")
+	}
+}


### PR DESCRIPTION
## What
Restore the edition-aware `clawType` on user-identity message sends. The `dws chat message reply` (引用回复) path hardcoded `clawType: "wukong"`, so open-source replies were tagged **"悟空AI发送"** by the DingTalk IM server, leaking Wukong branding to external users (reported by CATL / 宁德时代 via openclaw).

This cherry-picks the original fix (commit `a19942b`, PR #450) that was never merged into `main`.

## Changes
- `pkg/edition`: add `edition.ClawType()` accessor (returns `Hooks.ClawTypeValue`, falling back to `DefaultOSSClawType` = `"openClaw"`; the wukong overlay sets its own value to keep its branded badge).
- `internal/helpers/chat.go`: every user-identity send path (`send` text / rich-media / `--user` & `--open-dingtalk-id` direct / **`reply`**) now carries `edition.ClawType()` instead of a literal `"wukong"`.
- Bot sends (`send-by-bot`) intentionally stay untouched — they already render as bot messages.

## Verification
- `go build ./...` — OK
- `go test ./pkg/edition/ ./internal/helpers/` — PASS (incl. the `reply` subtest asserting open edition emits `openClaw`)
- Repro before fix (open edition, badge shows 悟空AI发送): see #474.

Closes #474
