### PR TITLE
feat(chat): make AI-sent badge opt-in via --ai-tag (default off)

### DIFF
--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -334,7 +334,17 @@ func newChatMessageSendCommand(runner executor.Runner) *cobra.Command {
 	cmd.Flags().String("file-type", "", "文件类型/扩展名 (msg-type=file)")
 	cmd.Flags().String("file-path", "", "文件展示路径 (msg-type=file)")
 	cmd.Flags().Int64("file-size", 0, "文件大小，单位字节 (msg-type=file)")
+	cmd.Flags().Bool("ai-tag", false, "标记为「通过AI发送」(默认不带；仅传 --ai-tag 时才在消息下方显示 AI 发送角标)")
 	return cmd
+}
+
+// attachAITag 仅在用户显式传入 --ai-tag 时，给发送参数加上 clawType，
+// 由 IM 服务端据此渲染「通过AI发送」角标 (悟空版渲染「悟空AI发送」)。
+// 默认不带：是否标记 AI 发送交由用户自行选择，不强加。
+func attachAITag(cmd *cobra.Command, params map[string]any) {
+	if on, _ := cmd.Flags().GetBool("ai-tag"); on {
+		params["clawType"] = edition.ClawType()
+	}
 }
 
 // deriveTitleFromText 在未显式指定 --title 时，从正文截取一个标题
@@ -442,7 +452,8 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 		default:
 			return nil, "", apperrors.NewValidation("unsupported --msg-type: " + msgType + " (supported: image, file)")
 		}
-		params := map[string]any{"msgType": msgType, "content": contentJSON, "clawType": edition.ClawType()}
+		params := map[string]any{"msgType": msgType, "content": contentJSON}
+		attachAITag(cmd, params)
 		if strings.TrimSpace(uuid) != "" {
 			params["uuid"] = uuid
 		}
@@ -481,8 +492,8 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 			"openConversationId": group,
 			"msgType":            "markdown",
 			"content":            marshalMessageContent(title, text),
-			"clawType":           edition.ClawType(),
 		}
+		attachAITag(cmd, params)
 		if atAll {
 			params["atAll"] = true
 		}
@@ -494,15 +505,16 @@ func buildChatMessageSendInvocation(cmd *cobra.Command, args []string) (map[stri
 		}
 		return params, "send_personal_message", nil
 	case hasUser:
-		params := map[string]any{"title": title, "text": text, "receiverUserId": user, "clawType": edition.ClawType()}
+		params := map[string]any{"title": title, "text": text, "receiverUserId": user}
+		attachAITag(cmd, params)
 		return params, "send_direct_message_as_user", nil
 	default:
 		params := map[string]any{
 			"receiverOpenDingTalkId": openID,
 			"msgType":                "markdown",
 			"content":                marshalMessageContent(title, text),
-			"clawType":               edition.ClawType(),
 		}
+		attachAITag(cmd, params)
 		if strings.TrimSpace(uuid) != "" {
 			params["uuid"] = uuid
 		}
@@ -974,14 +986,14 @@ func newChatMessageReplyCommand(runner executor.Runner) *cobra.Command {
 			if err != nil {
 				return apperrors.NewInternal("marshal reply content: " + err.Error())
 			}
-			// clawType must reflect the actual edition: a hardcoded "wukong"
-			// here made open-source replies render the Wukong AI indicator.
 			params := map[string]any{
 				"openConversationId": convID,
 				"msgType":            "reply",
 				"content":            contentJSON,
-				"clawType":           edition.ClawType(),
 			}
+			// clawType 仅在 --ai-tag 时携带；默认不带，回复不强加 AI 角标。
+			// edition 决定取值 (开源 openClaw / 悟空 wukong)。
+			attachAITag(cmd, params)
 			if uuid, _ := cmd.Flags().GetString("uuid"); strings.TrimSpace(uuid) != "" {
 				params["uuid"] = uuid
 			}
@@ -1005,6 +1017,7 @@ func newChatMessageReplyCommand(runner executor.Runner) *cobra.Command {
 	cmd.Flags().String("ref-sender", "", "被引用消息发送者 openDingTalkId (必填)")
 	cmd.Flags().String("text", "", "回复正文 (必填)")
 	cmd.Flags().String("uuid", "", "可选 uuid（幂等标识）")
+	cmd.Flags().Bool("ai-tag", false, "标记为「通过AI发送」(默认不带；仅传 --ai-tag 时才显示 AI 发送角标)")
 	return cmd
 }
 

--- a/internal/helpers/chat_test.go
+++ b/internal/helpers/chat_test.go
@@ -310,13 +310,13 @@ func TestChatMessageSendRejectsAtMentionsOutsideGroup(t *testing.T) {
 	}
 }
 
-// TestChatMessageSendCarriesClawType guards the "Send from AI" indicator:
-// every user-identity send path must attach the edition claw identity as the
-// clawType tool argument so the IM server renders the AI-sent label on the
-// delivered message. The open-source build pins it to edition.DefaultOSSClawType
-// ("openClaw"); dropping the parameter (or hardcoding another edition's value,
-// as the reply command once did with "wukong") mislabels or unlabels messages.
-func TestChatMessageSendCarriesClawType(t *testing.T) {
+// TestChatMessageAITagControlsClawType guards the opt-in "Send from AI" indicator:
+// by default NO user-identity send carries the clawType tool argument (so the IM
+// server renders no AI badge). Only when --ai-tag is passed does each path attach
+// the edition claw identity (open-source build pins it to edition.DefaultOSSClawType,
+// "openClaw"); the wukong overlay would attach its own value. The label is opt-in so
+// dws does not surprise users by branding every message they send.
+func TestChatMessageAITagControlsClawType(t *testing.T) {
 	cases := []struct {
 		name string
 		make func(runner executor.Runner) *cobra.Command
@@ -354,7 +354,8 @@ func TestChatMessageSendCarriesClawType(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+		// Default: no --ai-tag → must omit clawType entirely (no badge).
+		t.Run(tc.name+"/default-no-tag", func(t *testing.T) {
 			runner := &captureRunner{}
 			cmd := tc.make(runner)
 			var out bytes.Buffer
@@ -364,9 +365,24 @@ func TestChatMessageSendCarriesClawType(t *testing.T) {
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
 			}
+			if v, ok := runner.last.Params["clawType"]; ok {
+				t.Fatalf("default send must omit clawType, got %#v", v)
+			}
+		})
+		// Opt-in: --ai-tag → attach the edition claw identity.
+		t.Run(tc.name+"/with-ai-tag", func(t *testing.T) {
+			runner := &captureRunner{}
+			cmd := tc.make(runner)
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(append(append([]string{}, tc.args...), "--ai-tag"))
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\noutput:\n%s", err, out.String())
+			}
 			got, ok := runner.last.Params["clawType"]
 			if !ok {
-				t.Fatalf("Params missing clawType; got %#v", runner.last.Params)
+				t.Fatalf("--ai-tag send missing clawType; got %#v", runner.last.Params)
 			}
 			if got != edition.DefaultOSSClawType {
 				t.Fatalf("clawType = %#v, want %q", got, edition.DefaultOSSClawType)


### PR DESCRIPTION
## What
Make the AI-sent badge **opt-in**. After #475 every user-identity send/reply attached `clawType = edition.ClawType()` unconditionally, so the DingTalk IM server rendered an AI-sent badge ("通过AI发送" on the open edition) under **every** message a user sent via dws. That surprises users by branding all their messages.

This changes the default to **no badge**, and lets the user choose per message.

## Behavior
- Default (no flag): no `clawType` attached → no badge.
- `--ai-tag`: attaches `edition.ClawType()` → badge shows (open edition `openClaw` → "通过AI发送"; wukong overlay → "悟空AI发送").
- Applies to `chat message send` (text/markdown, rich-media, `--user`/`--open-dingtalk-id` direct) and `chat message reply`.
- `send-by-bot` / `send-by-webhook` untouched (they render as bot messages already).

```
dws chat message send --text hi            # no badge (default)
dws chat message send --text hi --ai-tag   # shows 通过AI发送
dws chat message reply ... --ai-tag        # same
```

## Verification
- `go build ./...` — OK
- `go test ./internal/helpers/ ./pkg/edition/` — PASS (test now asserts: default omits clawType; `--ai-tag` attaches `DefaultOSSClawType`)
- dry-run all four combinations confirmed (send/reply × with/without `--ai-tag`).

Follow-up to #475 (which fixed the hardcoded `wukong` leak, #474). The branding leak is gone either way; this PR addresses whether the badge should appear at all by default.
