### PR TITLE
feat(skill): embed skills/ into the binary, default skill setup to it

### DIFF
--- a/internal/app/skill_setup.go
+++ b/internal/app/skill_setup.go
@@ -95,10 +95,11 @@ func runSkillSetup(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("--skill / --exclude 仅在 --mode multi 下有效（mono 只有一个 skill，无需挑选）")
 	}
 
-	skillSrc, err := resolveSkillSetupSource(source, mode)
+	skillSrc, srcCleanup, err := resolveSkillSetupSourceOrEmbedded(source, mode)
 	if err != nil {
 		return err
 	}
+	defer srcCleanup()
 
 	dests, err := resolveSkillSetupTargets(target, mode)
 	if err != nil {

--- a/internal/app/skill_setup_embed.go
+++ b/internal/app/skill_setup_embed.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	dwsroot "github.com/DingTalk-Real-AI/dingtalk-workspace-cli"
+)
+
+// resolveSkillSetupSourceOrEmbedded resolves the skill source for `skill
+// setup`. An explicit --source or DWS_SKILL_SOURCE is honored as a developer
+// override (validated as an on-disk dir). Otherwise it falls back to the skill
+// bundle embedded in THIS binary, so a plain `dws skill setup` always installs
+// the version shipped with the running binary — upgrading the binary therefore
+// refreshes the installed skill, instead of silently reusing a stale copy from
+// the current working directory.
+//
+// The returned cleanup func removes any temp dir created for the embedded
+// bundle; it is a no-op when an on-disk source is used. Always call it.
+func resolveSkillSetupSourceOrEmbedded(explicit, mode string) (string, func(), error) {
+	noop := func() {}
+	explicit = strings.TrimSpace(explicit)
+	env := strings.TrimSpace(os.Getenv("DWS_SKILL_SOURCE"))
+	if explicit != "" || env != "" {
+		dir, err := resolveSkillSetupSource(explicit, mode)
+		return dir, noop, err
+	}
+	return materializeEmbeddedSkillSource(mode)
+}
+
+// materializeEmbeddedSkillSource extracts the embedded skills/<mode> subtree
+// into a fresh temp dir and returns its path plus a cleanup func. Reusing a
+// real directory lets the existing dir-based install/copy logic stay unchanged.
+func materializeEmbeddedSkillSource(mode string) (string, func(), error) {
+	noop := func() {}
+	sub := "skills/" + mode // embed.FS always uses forward slashes
+	if _, err := fs.Stat(dwsroot.EmbeddedSkills, sub); err != nil {
+		return "", noop, fmt.Errorf("内嵌 skill 不含 %q（二进制可能未随 skills/ 重新构建）: %w", sub, err)
+	}
+
+	tmp, err := os.MkdirTemp("", "dws-skill-"+mode+"-")
+	if err != nil {
+		return "", noop, fmt.Errorf("创建临时 skill 目录失败: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmp) }
+
+	walkErr := fs.WalkDir(dwsroot.EmbeddedSkills, sub, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel := strings.TrimPrefix(strings.TrimPrefix(p, sub), "/")
+		dst := filepath.Join(tmp, filepath.FromSlash(rel))
+		if d.IsDir() {
+			return os.MkdirAll(dst, 0o755)
+		}
+		data, readErr := dwsroot.EmbeddedSkills.ReadFile(p)
+		if readErr != nil {
+			return readErr
+		}
+		if mkErr := os.MkdirAll(filepath.Dir(dst), 0o755); mkErr != nil {
+			return mkErr
+		}
+		return os.WriteFile(dst, data, 0o644)
+	})
+	if walkErr != nil {
+		cleanup()
+		return "", noop, fmt.Errorf("展开内嵌 skill 到临时目录失败: %w", walkErr)
+	}
+	return tmp, cleanup, nil
+}

--- a/internal/app/skill_setup_embed_test.go
+++ b/internal/app/skill_setup_embed_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMaterializeEmbeddedSkillSourceMono verifies that the mono skill bundle
+// baked into the binary can be extracted to a temp dir and is a valid skill
+// source root (so `dws skill setup` works with zero local checkout). The
+// nested-reference and _common checks guard against the embed dropping nested
+// docs or the `all:` prefix being lost (which would silently skip
+// dot/underscore dirs).
+func TestMaterializeEmbeddedSkillSourceMono(t *testing.T) {
+	dir, cleanup, err := materializeEmbeddedSkillSource(skillSetupModeMono)
+	if err != nil {
+		t.Fatalf("materializeEmbeddedSkillSource: %v", err)
+	}
+	defer cleanup()
+
+	if !isSkillSourceRoot(dir, skillSetupModeMono) {
+		t.Fatalf("extracted dir %s is not a valid mono skill source root", dir)
+	}
+	for _, rel := range []string{
+		"SKILL.md",
+		filepath.Join("references", "global-reference.md"),
+		filepath.Join("references", "best_practices", "_common"),
+	} {
+		if _, err := os.Stat(filepath.Join(dir, rel)); err != nil {
+			t.Errorf("expected embedded skill to contain %s: %v", rel, err)
+		}
+	}
+
+	// cleanup must actually remove the temp dir.
+	cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("cleanup did not remove temp dir %s (err=%v)", dir, err)
+	}
+}
+
+// TestResolveSkillSetupSourceOrEmbeddedFallsBackToEmbedded verifies that with
+// no --source and no DWS_SKILL_SOURCE, resolution uses the embedded bundle
+// rather than probing the current working directory (the stale-skill footgun).
+func TestResolveSkillSetupSourceOrEmbeddedFallsBackToEmbedded(t *testing.T) {
+	t.Setenv("DWS_SKILL_SOURCE", "")
+	dir, cleanup, err := resolveSkillSetupSourceOrEmbedded("", skillSetupModeMono)
+	if err != nil {
+		t.Fatalf("resolveSkillSetupSourceOrEmbedded: %v", err)
+	}
+	defer cleanup()
+	if !isSkillSourceRoot(dir, skillSetupModeMono) {
+		t.Fatalf("embedded fallback returned non-source-root dir %s", dir)
+	}
+}

--- a/skills_embed.go
+++ b/skills_embed.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dws is the module-root package. Its sole purpose is to bake the
+// skills/ documentation tree into the binary at build time so that
+// `dws skill setup` installs the skill version shipped with THIS binary,
+// independent of any local checkout. See internal/app/skill_setup.go.
+package dws
+
+import "embed"
+
+// EmbeddedSkills holds the bundled skills/ tree (mono + multi) compiled into
+// the binary. The `all:` prefix is required so dot/underscore entries — e.g.
+// references/best_practices/_common — are included rather than skipped.
+//
+//go:embed all:skills
+var EmbeddedSkills embed.FS


### PR DESCRIPTION
## What

`go:embed` the `skills/` tree (mono + multi) into the binary and make `dws skill setup` install from the **embedded** bundle by default. Upgrading the binary now refreshes the installed skill, instead of silently reusing a stale copy probed from the current working directory.

An explicit `--source` / `DWS_SKILL_SOURCE` still overrides (developer escape hatch, validated as an on-disk dir).

## Why this is a new PR instead of #441

This replants the change from #441 onto `main`. #441 was stacked on the abandoned `feat/chat-bot-provisioning-openclaw` base branch (its PRs #407/#397 are both closed), which dragged in ~2000 lines of dropped connect work and is why #441's CI was red — the failure was in `internal/transport`, inherited from that dead base, unrelated to the embed change.

Here the change is isolated to the 4 files that actually matter:
- `skills_embed.go` — module-root `package dws` holding the `embed.FS` (`//go:embed all:skills`)
- `internal/app/skill_setup_embed.go` — resolve-or-embed + materialize-to-tempdir
- `internal/app/skill_setup.go` — call site switched to `resolveSkillSetupSourceOrEmbedded` + `defer srcCleanup()`
- `internal/app/skill_setup_embed_test.go` — tests

The embedded-bundle test asserted a `references/connect.md` doc that only existed on the dead base; retargeted it to `references/global-reference.md` which exists on `main`. The `_common` assertion (the `all:` prefix guard) is unchanged.

## Verification (local)

- `go build ./...` OK (compiles the `//go:embed all:skills` directive)
- `go vet . ./internal/app/` OK
- `go test ./internal/app/` OK (full package, incl. the two embed tests)

Supersedes #441.