### PR TITLE
docs: cut 1.0.40 changelog + fix gitee mirror gate

### DIFF
--- a/.github/workflows/mirror-to-gitee.yml
+++ b/.github/workflows/mirror-to-gitee.yml
@@ -18,13 +18,15 @@ on:
 jobs:
   mirror:
     runs-on: ubuntu-latest
-    # GitHub Actions 不允许在 job-level if 直接引用 secrets，
-    # 因此先用 env 暴露 GITEE_TOKEN，再在 step 里用 env.GITEE_TOKEN 做守卫判断。
+    # GitHub Actions 不允许在 job-level if 直接引用 secrets，因此先用 env 暴露 secret，
+    # 再在 step 里做守卫判断。hub-mirror 必须有 SSH 私钥(GITEE_PRIVATE_KEY)才能推送，
+    # 故以它为守卫：未配置时整步跳过(代码镜像可改由 Gitee 侧 pull-mirror 承担)，不报红叉。
     env:
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      GITEE_PRIVATE_KEY: ${{ secrets.GITEE_PRIVATE_KEY }}
     steps:
       - name: Mirror to Gitee
-        if: env.GITEE_TOKEN != ''
+        if: env.GITEE_PRIVATE_KEY != ''
         uses: Yikun/hub-mirror-action@master
         with:
           src: "github/DingTalk-Real-AI"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.40] - 2026-06-24
+
+This release adds China-accessible install mirrors so the CLI installs reliably from mainland China, where GitHub raw + Releases are slow or fail.
+
+### Added
+
+- **China mirror via Gitee + npmmirror** (#486; `scripts/install.sh`, `scripts/install.ps1`, `scripts/install-skills.sh`, `scripts/release/sync-to-gitee.sh`, `.github/workflows/release.yml`, `.github/workflows/mirror-to-gitee.yml`) — an opt-in `DWS_GITEE_REPO` env var makes all three installers resolve the latest version and every release asset (binary, `checksums.txt`, `dws-skills.zip`) from the Gitee OpenAPI v5 instead of GitHub; with it unset, installation defaults to GitHub (fully backward compatible). The release pipeline mirrors release attachments to the matching Gitee release after each tag (gated on `GITEE_TOKEN`/`GITEE_REPO`), and a hub-mirror workflow keeps the repo code in sync (gated on `GITEE_PRIVATE_KEY`). README documents three China install channels: Gitee raw script, Gitee release binaries, and the npm package via `registry.npmmirror.com`.
+
 ## [1.0.39] - 2026-06-18
 
 This release makes the AI-sent indicator opt-in. 1.0.38 unconditionally tagged every user-identity send/reply with the edition claw identity, so the IM server rendered a "Send from AI" badge under every message — and on the open edition a stale hardcoded value even leaked the Wukong-branded label (「悟空AI发送」) to external users. The badge is now off by default and shown only when the caller explicitly asks for it.


### PR DESCRIPTION
Cut the 1.0.40 changelog for the China-mirror feature (#486), and gate the Gitee code-mirror workflow on GITEE_PRIVATE_KEY so it skips cleanly (instead of failing) when the SSH key isn't configured — repo code sync is handled by the Gitee-side pull-mirror.

Prereq for tagging v1.0.40 (which triggers the release → Gitee binary sync).