### PR TITLE
feat(install): auto-fallback to Gitee when GitHub is unreachable

### DIFF
--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -19,6 +19,8 @@ set -eu
 REPO="DingTalk-Real-AI/dingtalk-workspace-cli"
 # China mirror: Gitee repo "owner/repo". When set, version + asset URLs resolve via Gitee API.
 GITEE_REPO="${DWS_GITEE_REPO:-}"
+# Auto-fallback Gitee mirror used when GitHub is unreachable (see pick_source).
+GITEE_FALLBACK_REPO="${DWS_GITEE_FALLBACK_REPO:-DingTalk-Real-AI/dingtalk-workspace-cli}"
 VERSION="${DWS_VERSION:-latest}"
 SKILL_NAME="dws"
 ROOT="${DWS_SKILLS_ROOT:-$PWD}"
@@ -46,6 +48,14 @@ gitee_api() {
     sleep 2
   done
   return 1
+}
+
+pick_source() {
+  [ -n "$GITEE_REPO" ] && return 0
+  [ "${DWS_NO_FALLBACK:-0}" = "1" ] && return 0
+  curl -fsS --connect-timeout 5 --max-time 12 -o /dev/null "https://github.com/${REPO}/releases/latest" 2>/dev/null && return 0
+  GITEE_REPO="$GITEE_FALLBACK_REPO"
+  printf '  ⚠ GitHub 不可达，自动切换国内 Gitee 镜像: %s\n' "$GITEE_REPO"
 }
 
 resolve_version() {
@@ -197,6 +207,7 @@ install_skills_to_root() {
 
 main() {
   need_cmd curl
+  pick_source
   resolve_version
 
   printf '\n'

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -29,6 +29,8 @@ $Repo = "DingTalk-Real-AI/dingtalk-workspace-cli"
 $BinName = "dws"
 # China mirror: Gitee repo "owner/repo". When set, version + asset URLs resolve via the Gitee API.
 $GiteeRepo = if ($env:DWS_GITEE_REPO) { $env:DWS_GITEE_REPO } else { "" }
+# Auto-fallback Gitee mirror used when GitHub is unreachable (see Resolve-Source).
+$GiteeFallbackRepo = if ($env:DWS_GITEE_FALLBACK_REPO) { $env:DWS_GITEE_FALLBACK_REPO } else { "DingTalk-Real-AI/dingtalk-workspace-cli" }
 $InstallDir = if ($env:DWS_INSTALL_DIR) { $env:DWS_INSTALL_DIR } else { Join-Path $HOME ".local\bin" }
 $Version = if ($env:DWS_VERSION) { $env:DWS_VERSION } else { "latest" }
 $NoSkills = $env:DWS_NO_SKILLS -eq "1"
@@ -144,6 +146,20 @@ function Get-GiteeAssetUrl {
         if ($a.name -eq $Name) { return $a.browser_download_url }
     }
     return ""
+}
+
+function Resolve-Source {
+    # Explicit DWS_GITEE_REPO wins; else probe GitHub and fall back to Gitee when unreachable.
+    if ($GiteeRepo -ne "") { return }
+    if ($env:DWS_NO_FALLBACK -eq "1") { return }
+    try {
+        Invoke-WebRequest -Uri "https://github.com/$Repo/releases/latest" -Method Head `
+            -TimeoutSec 12 -UseBasicParsing -ErrorAction Stop 2>$null | Out-Null
+        return
+    } catch {
+        $script:GiteeRepo = $GiteeFallbackRepo
+        Write-Say "⚠ GitHub 不可达，自动切换国内 Gitee 镜像: $script:GiteeRepo"
+    }
 }
 
 function Resolve-LatestVersion {
@@ -590,6 +606,10 @@ function Install-Skills {
 $SourceRoot = Resolve-SourceRoot
 
 Write-Banner
+
+# Pick GitHub vs Gitee mirror (auto-fallback when GitHub is unreachable).
+# Skipped when installing from a local source checkout (no download needed).
+if (-not $SourceRoot) { Resolve-Source }
 
 if (!$NoSkills) {
     Resolve-SkillMode

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,6 +28,11 @@ BIN_NAME="dws"
 # the Gitee API (https://gitee.com/api/v5) instead of GitHub. Gitee attachment URLs
 # carry an unstable numeric id, so every asset is resolved by name at install time.
 GITEE_REPO="${DWS_GITEE_REPO:-}"
+# Auto-fallback: when DWS_GITEE_REPO is not set, the installer probes GitHub and,
+# if it is unreachable (typical in mainland China), automatically switches to this
+# Gitee mirror — so a plain `curl … | sh` works everywhere with no env var.
+# Set DWS_NO_FALLBACK=1 to disable the probe and force GitHub.
+GITEE_FALLBACK_REPO="${DWS_GITEE_FALLBACK_REPO:-DingTalk-Real-AI/dingtalk-workspace-cli}"
 INSTALL_DIR="${DWS_INSTALL_DIR:-$HOME/.local/bin}"
 INSTALL_NAME="${DWS_INSTALL_NAME:-$BIN_NAME}"
 VERSION="${DWS_VERSION:-latest}"
@@ -151,6 +156,21 @@ detect_arch() {
     arm64|aarch64) echo "arm64" ;;
     *) err "Unsupported architecture: $arch" ;;
   esac
+}
+
+# Decide the download source. An explicit DWS_GITEE_REPO always wins. Otherwise
+# probe GitHub Releases; if it is unreachable (typical in mainland China), switch
+# GITEE_REPO to the mirror so every subsequent resolve/download uses Gitee.
+pick_source() {
+  [ -n "$GITEE_REPO" ] && return 0
+  [ "${DWS_NO_FALLBACK:-0}" = "1" ] && return 0
+  if need_cmd curl; then
+    curl -fsS --connect-timeout 5 --max-time 12 -o /dev/null "https://github.com/${REPO}/releases/latest" 2>/dev/null && return 0
+  elif need_cmd wget; then
+    wget -q --timeout=12 --tries=1 -O /dev/null "https://github.com/${REPO}/releases/latest" 2>/dev/null && return 0
+  fi
+  GITEE_REPO="$GITEE_FALLBACK_REPO"
+  say "⚠ GitHub 不可达，自动切换国内 Gitee 镜像: ${GITEE_REPO}"
 }
 
 # Resolve the latest version tag from GitHub
@@ -612,6 +632,10 @@ main() {
   fi
 
   print_banner
+
+  # Pick GitHub vs Gitee mirror (auto-fallback when GitHub is unreachable).
+  # Skipped when installing from a local source checkout (no download needed).
+  [ -z "$source_root" ] && pick_source
 
   # Resolve skill mode only when we are actually going to touch skills.
   if [ "$NO_SKILLS" != "1" ]; then


### PR DESCRIPTION
## 目的
让国内用户**不用手动加 `DWS_GITEE_REPO=`**——裸命令 `curl … | sh` 即可全球通用。

## 改动（install.sh / install.ps1 / install-skills.sh）
- 启动时探测 GitHub Releases（curl --max-time 12 / Invoke-WebRequest Head -TimeoutSec 12）。
- 探测不通（国内常见）→ **自动把 GITEE_REPO 切到 Gitee 镜像** `DingTalk-Real-AI/dingtalk-workspace-cli`，后续版本解析+资产下载全走 Gitee。
- 探测通过 → 照常用 GitHub（海外无感、不变慢）。
- 显式 `DWS_GITEE_REPO` 仍优先；`DWS_NO_FALLBACK=1` 可关探测强制 GitHub；本地源码安装跳过探测。

## 效果
国内一键：`curl -fsSL https://gitee.com/DingTalk-Real-AI/dingtalk-workspace-cli/raw/main/scripts/install.sh | sh`（无需任何 env）。

## 验证
sh -n（install.sh / install-skills.sh）+ PowerShell Parser（install.ps1）全过；兜底逻辑模拟：探测失败→GITEE_REPO 正确切到镜像。