### PR TITLE
fix(release): idempotent Gitee mirror + standalone repair workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 60 (not 30): mirroring every release asset to Gitee is slow; 30 min cut the
+    # Gitee step off mid-upload on the v1.0.42 release. The Gitee step is now also
+    # idempotent (re-runs only upload missing assets).
+    timeout-minutes: 60
 
     steps:
       - name: Check out repository

--- a/.github/workflows/sync-release-to-gitee.yml
+++ b/.github/workflows/sync-release-to-gitee.yml
@@ -1,0 +1,49 @@
+name: Sync release to Gitee
+
+# Manually mirror a published GitHub release's assets to the matching Gitee
+# release. Use this to repair a release whose Gitee mirror is incomplete (e.g.
+# the Release job timed out mid-upload). It runs ONLY the idempotent Gitee sync
+# step — it does not run GoReleaser and does not touch the GitHub release, so
+# there is no release outage. The sync script skips assets already on Gitee, so
+# this only uploads what is missing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to mirror to Gitee (e.g. v1.0.42)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  sync-gitee:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download GitHub release assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          mkdir -p dist
+          gh release download "${{ inputs.version }}" \
+            --repo "${{ github.repository }}" \
+            --dir dist \
+            --pattern 'dws-*' \
+            --pattern 'checksums.txt' \
+            --clobber
+          ls -la dist
+
+      - name: Mirror release to Gitee (China)
+        # Idempotent: uploads only assets not already present on the Gitee release.
+        run: ./scripts/release/sync-to-gitee.sh
+        env:
+          VERSION: ${{ inputs.version }}
+          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          GITEE_REPO: ${{ secrets.GITEE_REPO }}

--- a/scripts/release/sync-to-gitee.sh
+++ b/scripts/release/sync-to-gitee.sh
@@ -62,11 +62,29 @@ fi
 [ -n "$release_id" ] || { echo "❌ Could not get/create Gitee release for ${VERSION}. Response: ${rel_json}" >&2; exit 1; }
 echo "   Gitee release id = ${release_id}"
 
+# ── Names already attached to this Gitee release (for idempotent re-runs) ─────
+# Re-fetch the release so the asset list reflects a release we may have just
+# created. Skipping already-present files makes a re-run upload only what is
+# missing — so a previous run that timed out mid-upload can be repaired cheaply
+# instead of re-uploading everything (and creating duplicate attachments).
+existing_names="$(curl -fsSL "${base}/releases/${release_id}?access_token=${GITEE_TOKEN}" 2>/dev/null \
+  | python3 -c 'import json,sys
+try:
+    print("\n".join(a.get("name","") for a in json.load(sys.stdin).get("assets",[])))
+except Exception:
+    pass' 2>/dev/null || true)"
+
 # ── Upload each artifact as a release attachment ──────────────────────────────
 uploaded=0
+skipped=0
 for f in "$DIST_DIR"/dws-*.tar.gz "$DIST_DIR"/dws-*.zip "$DIST_DIR"/checksums.txt; do
   [ -f "$f" ] || continue
   fn="$(basename "$f")"
+  if printf '%s\n' "$existing_names" | grep -qxF "$fn"; then
+    echo "   ✓ ${fn} already on Gitee — skip"
+    skipped=$((skipped + 1))
+    continue
+  fi
   echo "   ⬆ ${fn}"
   resp="$(curl -fsSL -X POST "${base}/releases/${release_id}/attach_files" \
     -F "access_token=${GITEE_TOKEN}" \
@@ -78,7 +96,10 @@ for f in "$DIST_DIR"/dws-*.tar.gz "$DIST_DIR"/dws-*.zip "$DIST_DIR"/checksums.tx
   fi
 done
 
-[ "$uploaded" -gt 0 ] || { echo "❌ No artifacts uploaded. Did the build (goreleaser) run?" >&2; exit 1; }
-echo "✅ Uploaded ${uploaded} asset(s) to Gitee release ${VERSION}."
+if [ "$uploaded" -eq 0 ] && [ "$skipped" -eq 0 ]; then
+  echo "❌ No artifacts found to upload. Did the build (goreleaser) run / were assets downloaded into ${DIST_DIR}?" >&2
+  exit 1
+fi
+echo "✅ Gitee release ${VERSION}: uploaded ${uploaded} asset(s), skipped ${skipped} already present."
 echo "   China install:  DWS_GITEE_REPO=${GITEE_REPO} \\"
 echo "     curl -fsSL https://gitee.com/${GITEE_REPO}/raw/main/scripts/install.sh | sh"


### PR DESCRIPTION
## 背景
v1.0.42 的 Release job 卡 `timeout-minutes: 30`，在往 Gitee 镜像 release 资产时**传到一半被超时取消**，导致 Gitee release 缺 `dws-windows-arm64.zip` 和 `checksums.txt`（checksums 缺会影响国内 install 校验）。

## 根因修复
- **`sync-to-gitee.sh` 改幂等**：上传前查 Gitee release 已有资产，**已存在的跳过**——重跑只补缺的，不再全量重传/产生重复附件；全都在时也不再误报失败。
- **新增 `sync-release-to-gitee.yml`**（`workflow_dispatch`，传 `version`）：从 GitHub release 拉资产 → 跑幂等同步补传 Gitee，**不跑 GoReleaser、不动 GitHub release（零中断）**。用来修复同步不完整的 release。
- **Release job timeout 30 → 60**，给全量 Gitee 上传留足时间。

## 修复当前 v1.0.42
本 PR 合并后，跑一次 `Sync release to Gitee` 工作流（version=v1.0.42），幂等脚本只补传缺的 windows-arm64 + checksums → Gitee 即补全。

bash -n + YAML 已校验。