### PR TITLE
fix(install): define $LatestUrl in install.ps1 (fixes Windows install 闪退)

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -27,6 +27,8 @@ $ErrorActionPreference = "Stop"
 
 $Repo = "DingTalk-Real-AI/dingtalk-workspace-cli"
 $BinName = "dws"
+# GitHub "latest release" URL; Resolve-LatestVersion follows its redirect to get the tag.
+$LatestUrl = "https://github.com/$Repo/releases/latest"
 # China mirror: Gitee repo "owner/repo". When set, version + asset URLs resolve via the Gitee API.
 $GiteeRepo = if ($env:DWS_GITEE_REPO) { $env:DWS_GITEE_REPO } else { "" }
 # Auto-fallback Gitee mirror used when GitHub is unreachable (see Resolve-Source).


### PR DESCRIPTION
## 问题
Windows 上跑 `irm .../install.ps1 | iex`，新开的 PowerShell 窗口一闪就关、什么都没装上。

## 根因
`install.ps1` 的 `Resolve-LatestVersion` 在默认 GitHub 路径里用到了 `$LatestUrl`（185/197 行），但这个变量全文件**从未定义**。于是两次 `Invoke-WebRequest -Uri $LatestUrl` 都因 Uri 为空报错；配合 `$ErrorActionPreference = "Stop"`，脚本走到 `Write-Err` → `exit 1`，在新开的窗口里表现为瞬间闪退，用户连报错都看不到。默认 `latest` 路径的所有用户都会中招；Bash 安装脚本因为内联了 URL 不受影响。

## 修复
补上变量定义，与 Bash 脚本对齐：
```powershell
$LatestUrl = "https://github.com/$Repo/releases/latest"
```

## 验证
pwsh 7.5 端到端跑通：能解析到最新 tag、下载、校验 SHA256、安装完成。

## 同步说明
脚本改动合入 main 后，GitHub raw 安装命令立即生效；Gitee 由 `mirror-to-gitee.yml` 在 push main 时自动整库镜像（或当天 18:00 兜底），**无需打包/发版**。