### PR TITLE
增加 Nix flake 支持，支持通过 nix run 直接从github拉取运行

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake path:.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ dist/
 .venv*/
 var/
 .DS_Store
+.direnv/
+result
 .agents/
 /.idea/
 /CLAUDE.md

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+{
+  description = "DingTalk Workspace CLI development environment";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        rec {
+          dws = pkgs.buildGoModule {
+            pname = "dingtalk-workspace-cli";
+            version = "dev";
+            src = ./.;
+
+            subPackages = [ "cmd" ];
+            vendorHash = "sha256-8pt8NE5JhY+Ewl528PGaCxTEH4N0rPZudPE8rfhiVrk=";
+
+            ldflags = [
+              "-s"
+              "-w"
+            ];
+
+            env.CGO_ENABLED = "0";
+
+            postInstall = ''
+              if [ -e "$out/bin/cmd" ] && [ ! -e "$out/bin/dws" ]; then
+                mv "$out/bin/cmd" "$out/bin/dws"
+              fi
+            '';
+
+            meta = with pkgs.lib; {
+              description = "DingTalk Workspace CLI";
+              homepage = "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli";
+              license = licenses.asl20;
+              mainProgram = "dws";
+              platforms = platforms.unix;
+            };
+          };
+
+          default = dws;
+        });
+
+      apps = forAllSystems (system: {
+        dws = {
+          type = "app";
+          program = "${self.packages.${system}.dws}/bin/dws";
+        };
+        default = self.apps.${system}.dws;
+      });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              go_1_25
+              gopls
+              delve
+              gotools
+              direnv
+              git
+            ];
+
+            env.CGO_ENABLED = "0";
+
+            shellHook = ''
+              echo "Entered dingtalk-workspace-cli dev shell (Go $(go version | awk '{ print $3 }'))"
+            '';
+          };
+        });
+    };
+}


### PR DESCRIPTION
## 背景

Nix 是一种强调可复现和声明式环境管理的包管理器，可以把开发环境、构建过程和运行入口统一描述在仓库里。这样拿到仓库后，不需要手动安装指定版本的 Go 或额外依赖，就可以进入一致的开发环境；同时也支持直接从 GitHub fetch 仓库并运行，例如 `nix run github:OWNER/REPO`。

## 变更说明

本 PR 为 `dingtalk-workspace-cli` 增加了 Nix flake 支持，并补充了 `direnv` 配置。同时将 CLI 封装为 flake package/app，使仓库既可以用于本地开发，也可以直接通过 `nix run` 运行。

## 主要改动

- 新增 `flake.nix`，提供 Go 1.25 开发环境
- 新增 `flake.lock`，固定 flake 依赖版本
- 新增 `.envrc`，支持 `direnv` 自动加载开发环境
- 暴露 flake `packages` 和 `apps`，支持 `nix run`
- 更新 `.gitignore`，忽略 `.direnv/` 等本地产物

## 使用方式

本地进入开发环境：

```bash
direnv allow
nix develop path:.
```

本地直接运行：

```bash
nix run . -- --help
```

从 GitHub 直接运行：

```bash
nix run github:et21ff/dingtalk-workspace-cli?ref=feat/nix-run-flake -- --help
```

## 说明

当前实现基于 `buildGoModule`，已补齐 `vendorHash`，可以正常构建并通过 `nix run` 启动。