### PR TITLE
[codex] fix root help usage contrast

### DIFF
--- a/internal/app/root_help.go
+++ b/internal/app/root_help.go
@@ -71,9 +71,9 @@ func renderRootHelp(root *cobra.Command) {
 	}
 
 	_, _ = fmt.Fprintln(w, tui.Section("Usage:"))
-	_, _ = fmt.Fprintf(w, "  %s %s\n", tui.Bullet(), tui.White("dws <service> [command] [flags]"))
+	_, _ = fmt.Fprintf(w, "  %s dws <service> [command] [flags]\n", tui.Bullet())
 	if len(utilities) > 0 {
-		_, _ = fmt.Fprintf(w, "  %s %s\n", tui.Bullet(), tui.White("dws <command> [flags]"))
+		_, _ = fmt.Fprintf(w, "  %s dws <command> [flags]\n", tui.Bullet())
 	}
 	_, _ = fmt.Fprintln(w)
 	if len(utilities) > 0 {


### PR DESCRIPTION
## Summary

Fix the top-level `dws --help` Usage examples so the command text uses the terminal default foreground color instead of forcing bright white.

## Context

A user reported that the `Usage:` examples in the root scaffold/help output were nearly invisible on a light terminal background. The selected-text screenshot confirmed that the text was present but rendered with very low contrast.

Root cause: `renderRootHelp` wrapped the two Usage example strings with `tui.White(...)`, and `tui.White` maps to `color.FgHiWhite`. That emits bright-white ANSI (`\x1b[97m`), which is unreadable in light themes.

Screenshots: 
Issue：
<img width="1274" height="1894" alt="image" src="https://github.com/user-attachments/assets/4ad309f4-52a4-4bf2-b257-f00c8ddb6475" />
Fixed：
<img width="1276" height="1914" alt="image" src="https://github.com/user-attachments/assets/5bfddfa4-1a86-4f08-a99d-af1b0e022ee2" />
<img width="2458" height="1366" alt="image" src="https://github.com/user-attachments/assets/97955a80-ba1e-4616-9f8e-80596e5948f3" />

## Change

- Remove `tui.White(...)` from the two top-level Usage example lines.
- Keep the existing colored bullet while leaving the command text as plain terminal text.

## Validation

Passed:

- `gofmt -w internal/app/root_help.go internal/app/visibility_test.go && git diff --check`
- `go test -count=1 ./internal/app -run 'TestRenderRootHelpIncludesLong|TestRootHelpDoesNotRequirePINOrLogin'`
- `go build -o /tmp/dws-root-help-contrast ./cmd`
- Manual root help check with `env -u NO_COLOR TERM=xterm-256color CLICOLOR_FORCE=1 /tmp/dws-root-help-contrast --help`; the requester confirmed the output is readable.

Known unrelated failures observed while validating:

- `make lint` fails on existing `staticcheck` findings outside this change, including unused functions in `internal/app/auth_command.go`, `internal/helpers/devapp.go`, `internal/helpers/devdoc.go`, `internal/helpers/wiki.go`, `internal/transport/diagnostics.go`, plus `SA4017` in `internal/helpers/connect_daemon_test.go`.
- `make test` fails in existing integration/script suites: auth required in `integration/extensions`, missing recovery temp file in `integration/recovery`, and tar archive format errors in `test/scripts`.
