### PR TITLE
fix(cli): treat ASCII-led @-mentions as text, not @file

### DIFF
--- a/internal/cli/stdin.go
+++ b/internal/cli/stdin.go
@@ -124,11 +124,17 @@ func readStdinBounded() (string, error) {
 }
 
 // looksLikeFilePath returns true when value should be interpreted as the
-// `@<path>` file-injection syntax. Heuristic: value must start with '@', and
-// the character right after '@' must be ASCII (letter, digit, or one of the
-// common path-prefix characters: . / ~ _ -). This rules out mistaken matches
-// for natural-language messages that happen to start with '@' followed by
-// non-ASCII text — e.g. "@所有人" should be a chat mention, not a file path.
+// `@<path>` file-injection syntax. A real @file reference is a single shell
+// token: it starts with '@', its first character is an ASCII path char
+// (letter, digit, or one of . / ~ _ -), and the whole candidate path contains
+// no whitespace and no multi-byte (e.g. CJK) runes.
+//
+// The whole-token rule is what keeps natural-language chat messages out of the
+// file branch even when they start with an ASCII '@'-mention. "@所有人 早上好"
+// is ruled out by the non-ASCII bytes; "@qoderwake数据员 在的…" — an at-mention
+// of an English-named member — is ruled out by both the space and the CJK
+// runes, so it reaches the message payload as literal text instead of being
+// mis-read as a missing filename.
 func looksLikeFilePath(value string) bool {
 	if !strings.HasPrefix(value, "@") || len(value) < 2 {
 		return false
@@ -137,11 +143,14 @@ func looksLikeFilePath(value string) bool {
 	if rest == "-" {
 		return true // @- = stdin
 	}
-	first := rune(rest[0])
-	if first > unicode.MaxASCII {
-		// First byte is part of a multi-byte rune (e.g. Chinese) — not a path.
-		return false
+	// A path token has no whitespace and no multi-byte runes. Anything else
+	// is natural-language text that merely happens to begin with '@'.
+	for _, r := range rest {
+		if r > unicode.MaxASCII || unicode.IsSpace(r) {
+			return false
+		}
 	}
+	first := rune(rest[0])
 	switch {
 	case first >= 'A' && first <= 'Z',
 		first >= 'a' && first <= 'z',

--- a/internal/cli/stdin_test.go
+++ b/internal/cli/stdin_test.go
@@ -48,8 +48,10 @@ func TestReadFileArgPlainValue(t *testing.T) {
 }
 
 // TestReadFileArgChineseAtMention guards the @所有人-style mentions that the
-// chat bot Webhook tests rely on: an '@' followed by non-ASCII text must be
-// treated as a literal message, not as the @file injection syntax.
+// chat bot Webhook tests rely on: an '@' followed by chat text must be treated
+// as a literal message, not as the @file injection syntax. A value is only a
+// file path when it is a single token (no whitespace, no multi-byte runes), so
+// an ASCII-led mention like "@A 但接下来都是中文" stays plain text too.
 func TestReadFileArgChineseAtMention(t *testing.T) {
 	t.Parallel()
 	cases := []string{
@@ -59,13 +61,34 @@ func TestReadFileArgChineseAtMention(t *testing.T) {
 	}
 	for _, in := range cases {
 		val, isFile, err := ReadFileArg(in)
-		if in == "@A 但接下来都是中文@测试" {
-			// '@A' starts with ASCII, treated as path → expect file error
-			if err == nil {
-				t.Errorf("@A... should attempt file lookup; got val=%q isFile=%v", val, isFile)
-			}
+		if err != nil {
+			t.Errorf("%q: unexpected error %v", in, err)
 			continue
 		}
+		if isFile {
+			t.Errorf("%q: should be plain text, got isFile=true", in)
+		}
+		if val != in {
+			t.Errorf("%q: got %q", in, val)
+		}
+	}
+}
+
+// TestReadFileArgAsciiLedMention is the regression guard for the reported bug:
+// `--text "@qoderwake数据员 在的，有什么可以帮你？"` was mis-read as the @file
+// syntax because the byte after '@' is ASCII ('q'), so the whole string was
+// passed to os.Open and failed with "no such file or directory". An at-mention
+// of an English-named member must reach the payload as literal text.
+func TestReadFileArgAsciiLedMention(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"@qoderwake数据员 在的，有什么可以帮你？",
+		"@qoderwake数据员",                  // CJK with no space
+		"@bot hello there",              // pure ASCII with a space
+		"@team\n下一行",                    // newline counts as whitespace
+	}
+	for _, in := range cases {
+		val, isFile, err := ReadFileArg(in)
 		if err != nil {
 			t.Errorf("%q: unexpected error %v", in, err)
 			continue


### PR DESCRIPTION
Reported by 言宥(王彦彬) in the 集团dws 对接 group, 2026-06-30: sending a message whose `--text` begins with an `@`-mention of an English-named member was rejected as a missing file.

## Symptom

```
dws chat message send --group <id> \
  --at-open-dingtalk-ids <id> \
  --title 通知 \
  --text "@qoderwake数据员 在的，有什么可以帮你？"
{
  "error": {
    "category": "validation",
    "code": 3,
    "message": "--text: @file: open qoderwake数据员 在的，有什么可以帮你？: no such file or directory"
  }
}
```

Reproduces on every version, including current `main` (observed on 1.0.39 by the reporter).

## Root cause

`looksLikeFilePath` (internal/cli/stdin.go) only exempted values whose first byte after `@` was non-ASCII (so `@所有人` was safe). An at-mention of an English-named member starts with an ASCII letter (`q` in `@qoderwake…`), so the whole string fell into the `@file` branch and was handed to `os.Open`.

## Fix

internal/cli/stdin.go — a value is the `@file` injection syntax only when the candidate path is a single token: no whitespace and no multi-byte (CJK) runes. Real references (`@file.txt`, `@./a.json`, `@~/x`, `@-`) are unaffected; chat text that merely begins with `@` now reaches the payload as literal text.

## Verification

- `go test ./internal/cli/` passes.
- internal/cli/stdin_test.go — updated the mention test that encoded the old behavior; added a regression test for the reported `@qoderwake数据员 …` case (also covers pure-ASCII-with-space and newline).
- End-to-end `--dry-run`: `@qoderwake数据员 …` now passes through as `text`, while `--text @/tmp/file.txt` still reads the file.