### PR TITLE
fix(discovery): tolerate cli.groups encoded as a JSON array

### DIFF
--- a/internal/market/registry.go
+++ b/internal/market/registry.go
@@ -400,6 +400,46 @@ func coerceScalarToString(raw json.RawMessage) string {
 	return s
 }
 
+// UnmarshalJSON tolerates discovery overlays that encode `groups` as a JSON
+// array instead of the schema-correct object (map[string]CLIGroupDef). Third
+// party MCP applications registered through the open platform have been
+// observed publishing `"groups": ["record","import",...]` — a list of group
+// names rather than a name->definition map. Go's strict decode would otherwise
+// fail the ENTIRE server list on a single such envelope, silently breaking
+// `dws cache refresh` for every product (not just the offending one): exactly
+// the failure mode the CLIFlagOverride scalar-default tolerance above guards
+// against. Coerce a non-object `groups` value to an empty map so one malformed
+// third-party envelope can no longer take down discovery.
+func (o *CLIOverlay) UnmarshalJSON(data []byte) error {
+	type alias CLIOverlay
+	aux := &struct {
+		Groups json.RawMessage `json:"groups,omitempty"`
+		*alias
+	}{alias: (*alias)(o)}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	o.Groups = coerceGroupsMap(aux.Groups)
+	return nil
+}
+
+// coerceGroupsMap decodes a JSON object into map[string]CLIGroupDef. Any other
+// shape (array, scalar, null) collapses to nil — the lenient path that keeps a
+// malformed third-party `groups` from failing the whole discovery decode.
+func coerceGroupsMap(raw json.RawMessage) map[string]CLIGroupDef {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" {
+		return nil
+	}
+	if strings.HasPrefix(s, "{") {
+		var m map[string]CLIGroupDef
+		if err := json.Unmarshal(raw, &m); err == nil {
+			return m
+		}
+	}
+	return nil
+}
+
 type CLITool struct {
 	Name        string                 `json:"name"`
 	CLIName     string                 `json:"cliName"`

--- a/internal/market/registry_test.go
+++ b/internal/market/registry_test.go
@@ -445,6 +445,96 @@ func TestNormalizeServersPreservesCLIMetadataAndLifecycle(t *testing.T) {
 	}
 }
 
+// TestCLIOverlayToleratesGroupsAsArray pins the lenient decode that keeps a
+// single third-party overlay publishing `"groups": [...]` (an array instead of
+// the schema-correct object) from failing the entire server-list decode and
+// breaking `dws cache refresh` for every product. See registry.go
+// CLIOverlay.UnmarshalJSON.
+func TestCLIOverlayToleratesGroupsAsArray(t *testing.T) {
+	t.Parallel()
+
+	// groups encoded as an array of group names (the real malformed shape
+	// observed from pre-env business apps, e.g. 智能合同 / 宜搭).
+	raw := []byte(`{
+		"id": "contract",
+		"command": "contract",
+		"prefixes": ["contract"],
+		"groups": ["record", "import", "review"],
+		"toolOverrides": {"query_contract": {"cliName": "query"}}
+	}`)
+
+	var overlay CLIOverlay
+	if err := json.Unmarshal(raw, &overlay); err != nil {
+		t.Fatalf("Unmarshal() with array groups error = %v, want nil", err)
+	}
+	if overlay.Groups != nil {
+		t.Fatalf("Groups = %#v, want nil (array coerced away)", overlay.Groups)
+	}
+	// Every other field must survive the lenient path untouched.
+	if overlay.ID != "contract" || overlay.Command != "contract" {
+		t.Fatalf("overlay id/command = %q/%q, want contract/contract", overlay.ID, overlay.Command)
+	}
+	if len(overlay.Prefixes) != 1 || overlay.Prefixes[0] != "contract" {
+		t.Fatalf("overlay prefixes = %#v, want [contract]", overlay.Prefixes)
+	}
+	if ov, ok := overlay.ToolOverrides["query_contract"]; !ok || ov.CLIName != "query" {
+		t.Fatalf("overlay toolOverrides = %#v, want query_contract->query", overlay.ToolOverrides)
+	}
+}
+
+// TestCLIOverlayPreservesGroupsAsObject confirms the well-formed object shape
+// still decodes normally — the tolerance must not regress the happy path.
+func TestCLIOverlayPreservesGroupsAsObject(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"id": "report",
+		"groups": {"template": {"description": "日志模版"}, "entry": {"description": "单份日报"}}
+	}`)
+
+	var overlay CLIOverlay
+	if err := json.Unmarshal(raw, &overlay); err != nil {
+		t.Fatalf("Unmarshal() with object groups error = %v, want nil", err)
+	}
+	if len(overlay.Groups) != 2 {
+		t.Fatalf("Groups len = %d, want 2", len(overlay.Groups))
+	}
+	if overlay.Groups["template"].Description != "日志模版" {
+		t.Fatalf("Groups[template] = %#v, want description 日志模版", overlay.Groups["template"])
+	}
+}
+
+// TestFetchServersDecodesWhenOneEnvelopeHasArrayGroups proves the headline
+// failure is fixed end to end: one bad-groups envelope alongside a good one
+// no longer fails the whole list decode — both servers come through.
+func TestFetchServersDecodesWhenOneEnvelopeHasArrayGroups(t *testing.T) {
+	t.Parallel()
+
+	body := `{"metadata":{"count":2},"servers":[
+		{"server":{"name":"智能合同","remotes":[{"type":"streamable-http","url":"https://example.com/server/contract"}]},
+		 "_meta":{"com.dingtalk.mcp.registry/metadata":{"status":"active"},
+		          "com.dingtalk.mcp.registry/cli":{"id":"contract","groups":["record","import"]}}},
+		{"server":{"name":"钉钉日志","remotes":[{"type":"streamable-http","url":"https://example.com/server/report"}]},
+		 "_meta":{"com.dingtalk.mcp.registry/metadata":{"status":"active"},
+		          "com.dingtalk.mcp.registry/cli":{"id":"report","groups":{"template":{"description":"日志模版"}}}}}
+	]}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, server.Client())
+	resp, err := client.FetchServers(context.Background(), 200)
+	if err != nil {
+		t.Fatalf("FetchServers() error = %v, want nil (array groups must not fail decode)", err)
+	}
+	if len(resp.Servers) != 2 {
+		t.Fatalf("FetchServers() decoded %d servers, want 2", len(resp.Servers))
+	}
+}
+
 func mustParseRFC3339(t *testing.T, value string) (parsed time.Time) {
 	t.Helper()
 


### PR DESCRIPTION
## 问题

预发 `dws cache refresh` 报 `failed to decode market servers response` 整个失败，生产正常。

根因：预发网关下发的服务里，有若干第三方业务应用（智能合同 / 宜搭 / AI诚聘 / 家校系列等，开放平台动态合入预发）把 `_meta.cli.groups` 写成了 **JSON 数组**（如 `["record","import",...]` 一串组名），而 schema 要求是对象 `map[string]CLIGroupDef`。Go 的严格解码碰到一个写错的字段，就会让**整包** server 列表解码失败——一个第三方坏信封，把每个产品的 `cache refresh` 全部带崩。生产环境不暴露这些应用，所以不受影响。

精确报错：

```
json: cannot unmarshal array into Go struct field CLIOverlay...groups of type map[string]market.CLIGroupDef
```

## 修复

给 `CLIOverlay` 加一个宽容的 `UnmarshalJSON`：`groups` 不是对象时（数组 / 标量 / null）降级成空 map，其余字段照常解码。完全对齐已有的 `CLIFlagOverride.UnmarshalJSON` 对标量 `default` 的容错先例——一个写坏的第三方信封不能再拖垮整个 discovery。

写对的 object 形式 `groups` 不受影响。

## 验证

- 新增 3 个单测：array→空 map 且其余字段无损、object 正常保留、整包列表里混入一个坏信封仍能解出全部 server。
- `internal/market` / `discovery` / `editionmerge` / `compat` 回归全绿，`go build ./...` + `go vet` 通过。
- 用预发**真实**返回（46 个服务、含 10 个数组 `groups`）端到端验证：解码从硬报错变为 46/46 全解出，21 个写对的 `groups` 完整保留。`go run ./cmd cache refresh` 切预发从 `failed to decode` 变为 `已刷新 46 个服务`。

## 说明

这是 CLI 侧防御，让任何第三方填错不再致命。数据源头那 10 个应用的 `groups` 错在开放平台各自的 MCP 注册，根治需 portal（`lippi-openmcp-portal`）merge 下发侧也做兜底，已同步该模块 owner。
