### PR TITLE
fix(discovery): bound refresh concurrency and retry rate-limited servers

### DIFF
--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -586,6 +586,16 @@ func newCacheCommand() *cobra.Command {
 				transportClient,
 				store,
 			)
+			// cache refresh is explicit and user-initiated: give slow servers a
+			// more generous per-server budget than the 2s hot-path default, and
+			// let DiscoverAllRuntime bound parallel handshakes (default 8) so a
+			// large registry (46+ servers in pre) does not overwhelm the gateway
+			// and make healthy servers time out. Both honor DWS_DISCOVERY_TIMEOUT
+			// / DWS_DISCOVERY_CONCURRENCY overrides.
+			service.PerServerTimeout = discovery.RefreshTimeout()
+			// Wire the diagnostics logger so per-server discovery failures land
+			// in ~/.dws/logs/dws.log with the underlying error and timeout flag.
+			service.Logger = slog.Default()
 
 			resp, err := fetchRegistryServers(cmd.Context(), ipv4HTTPClient(config.HTTPTimeout))
 			if err != nil {
@@ -608,10 +618,18 @@ func newCacheCommand() *cobra.Command {
 
 			refreshable := filterRefreshableServers(selected)
 			_, failures := service.DiscoverAllRuntime(cmd.Context(), refreshable)
+			// A weak/rate-limited gateway (e.g. pre) can squeeze out servers
+			// under parallel load even though each is healthy on its own. Retry
+			// just the failures once, serialized, so the happy path stays fast
+			// while stragglers get a contention-free second chance.
+			if retry := failedDescriptors(refreshable, failures); len(retry) > 0 {
+				service.Concurrency = 1
+				_, failures = service.DiscoverAllRuntime(cmd.Context(), retry)
+			}
 			_, err = fmt.Fprintf(
 				cmd.OutOrStdout(),
 				"[OK] 缓存刷新完成：已刷新 %d 个服务，失败 %d 个\n缓存目录: %s\n",
-				len(refreshable),
+				len(refreshable)-len(failures),
 				len(failures),
 				store.Root,
 			)
@@ -1144,6 +1162,26 @@ func filterRefreshableServers(servers []market.ServerDescriptor) []market.Server
 		filtered = append(filtered, server)
 	}
 	return filtered
+}
+
+// failedDescriptors maps a set of runtime failures back to the descriptors
+// that produced them, preserving order, so the caller can retry just those
+// servers without re-running the whole registry.
+func failedDescriptors(servers []market.ServerDescriptor, failures []discovery.RuntimeFailure) []market.ServerDescriptor {
+	if len(failures) == 0 {
+		return nil
+	}
+	failed := make(map[string]struct{}, len(failures))
+	for _, f := range failures {
+		failed[f.ServerKey] = struct{}{}
+	}
+	retry := make([]market.ServerDescriptor, 0, len(failures))
+	for _, server := range servers {
+		if _, ok := failed[server.Key]; ok {
+			retry = append(retry, server)
+		}
+	}
+	return retry
 }
 
 func clearRuntimeCacheForServers(store *cache.Store, partition string, servers []market.ServerDescriptor) error {

--- a/internal/discovery/service.go
+++ b/internal/discovery/service.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -43,11 +44,25 @@ func init() {
 		Description:  "缓存分区的认证身份标识",
 		DefaultValue: "default",
 	})
+	configmeta.Register(configmeta.ConfigItem{
+		Name:         discoveryTimeoutEnv,
+		Category:     configmeta.CategoryCore,
+		Description:  "单个服务运行时发现的超时时间（如 2s、5s）；留空使用内置默认值",
+		DefaultValue: defaultPerServerDiscoveryTimeout.String(),
+	})
+	configmeta.Register(configmeta.ConfigItem{
+		Name:         discoveryConcurrencyEnv,
+		Category:     configmeta.CategoryCore,
+		Description:  "运行时发现的并发握手上限；留空使用内置默认值",
+		DefaultValue: strconv.Itoa(defaultDiscoveryConcurrency),
+	})
 }
 
 const (
-	tenantEnv       = "DWS_TENANT"
-	authIdentityEnv = "DWS_AUTH_IDENTITY"
+	tenantEnv               = "DWS_TENANT"
+	authIdentityEnv         = "DWS_AUTH_IDENTITY"
+	discoveryTimeoutEnv     = "DWS_DISCOVERY_TIMEOUT"
+	discoveryConcurrencyEnv = "DWS_DISCOVERY_CONCURRENCY"
 )
 
 var errCLIServerSkipped = errors.New("server marked cli.skip")
@@ -61,9 +76,14 @@ type Service struct {
 	Logger       *slog.Logger
 	// PerServerTimeout overrides the default per-server discovery timeout
 	// when greater than zero. Useful for tests and for callers that need a
-	// tighter or looser bound. When zero, defaultPerServerDiscoveryTimeout
-	// applies.
+	// tighter or looser bound. When zero, DWS_DISCOVERY_TIMEOUT or
+	// defaultPerServerDiscoveryTimeout applies.
 	PerServerTimeout time.Duration
+	// Concurrency caps the number of servers discovered in parallel when
+	// greater than zero. When zero, DWS_DISCOVERY_CONCURRENCY or
+	// defaultDiscoveryConcurrency applies. Bounding concurrency avoids a
+	// thundering herd of handshakes when the registry lists many servers.
+	Concurrency int
 }
 
 type RuntimeServer struct {
@@ -178,8 +198,62 @@ func (s *Service) DiscoverServerRuntime(ctx context.Context, server market.Serve
 // defaultPerServerDiscoveryTimeout bounds the time spent discovering tools on
 // a single registry-listed server. Tightened to 2s so a slow/unreachable
 // server cannot stall every CLI command — a healthy MCP endpoint negotiates
-// well under a second. See issue #119.
+// well under a second. See issue #119. Explicit callers such as `cache refresh`
+// raise this via Service.PerServerTimeout; power users can override it globally
+// with DWS_DISCOVERY_TIMEOUT.
 const defaultPerServerDiscoveryTimeout = 2 * time.Second
+
+// refreshDiscoveryTimeout is the per-server budget for the explicit, user-
+// initiated `cache refresh` command. It is deliberately more generous than the
+// 2s hot-path default because completeness matters more than snappiness there.
+const refreshDiscoveryTimeout = 8 * time.Second
+
+// RefreshTimeout returns the per-server timeout `cache refresh` should use:
+// DWS_DISCOVERY_TIMEOUT when set to a valid duration, otherwise the generous
+// refresh default. This lets operators widen the budget against a slow gateway
+// (e.g. pre) without touching the latency-sensitive hot-path default.
+func RefreshTimeout() time.Duration {
+	if v := strings.TrimSpace(os.Getenv(discoveryTimeoutEnv)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return refreshDiscoveryTimeout
+}
+
+// defaultDiscoveryConcurrency caps how many servers are discovered in parallel.
+// The registry can list dozens of servers (46+ in pre); firing every handshake
+// at once overwhelms the gateway and makes healthy servers time out too. A
+// modest cap keeps each handshake within its per-server budget.
+const defaultDiscoveryConcurrency = 8
+
+// resolveDiscoveryTimeout picks the per-server timeout: an explicit override
+// wins, then DWS_DISCOVERY_TIMEOUT, then the built-in default.
+func resolveDiscoveryTimeout(override time.Duration) time.Duration {
+	if override > 0 {
+		return override
+	}
+	if v := strings.TrimSpace(os.Getenv(discoveryTimeoutEnv)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultPerServerDiscoveryTimeout
+}
+
+// resolveDiscoveryConcurrency picks the parallel-handshake cap: an explicit
+// override wins, then DWS_DISCOVERY_CONCURRENCY, then the built-in default.
+func resolveDiscoveryConcurrency(override int) int {
+	if override > 0 {
+		return override
+	}
+	if v := strings.TrimSpace(os.Getenv(discoveryConcurrencyEnv)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultDiscoveryConcurrency
+}
 
 func (s *Service) DiscoverAllRuntime(ctx context.Context, servers []market.ServerDescriptor) ([]RuntimeServer, []RuntimeFailure) {
 	type discoveryResult struct {
@@ -187,10 +261,7 @@ func (s *Service) DiscoverAllRuntime(ctx context.Context, servers []market.Serve
 		failure *RuntimeFailure
 	}
 
-	perServerTimeout := defaultPerServerDiscoveryTimeout
-	if s.PerServerTimeout > 0 {
-		perServerTimeout = s.PerServerTimeout
-	}
+	perServerTimeout := resolveDiscoveryTimeout(s.PerServerTimeout)
 
 	filtered := make([]market.ServerDescriptor, 0, len(servers))
 	for _, srv := range servers {
@@ -202,12 +273,28 @@ func (s *Service) DiscoverAllRuntime(ctx context.Context, servers []market.Serve
 		return nil, nil
 	}
 
+	concurrency := resolveDiscoveryConcurrency(s.Concurrency)
+	if concurrency > len(filtered) {
+		concurrency = len(filtered)
+	}
+	// sem bounds parallel handshakes. Acquisition happens before the
+	// per-server timeout starts so queue wait is not charged against a
+	// server's discovery budget.
+	sem := make(chan struct{}, concurrency)
+
 	ch := make(chan discoveryResult, len(filtered))
 	var wg sync.WaitGroup
 	for _, srv := range filtered {
 		wg.Add(1)
 		go func(server market.ServerDescriptor) {
 			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				ch <- discoveryResult{failure: &RuntimeFailure{ServerKey: server.Key, Err: ctx.Err()}}
+				return
+			}
 			serverCtx, cancel := context.WithTimeout(ctx, perServerTimeout)
 			defer cancel()
 			start := time.Now()

--- a/internal/discovery/service_test.go
+++ b/internal/discovery/service_test.go
@@ -3,9 +3,12 @@ package discovery
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cache"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
@@ -334,6 +337,120 @@ func TestDiscoverAllRuntime_SkipsCLISkippedServersWithoutWritingCache(t *testing
 
 	if _, _, err := svc.Cache.LoadTools("test-tenant/test-identity", "skipped"); err == nil {
 		t.Fatal("LoadTools(skipped) error = nil, want skipped service to avoid cache writes")
+	}
+}
+
+func TestDiscoverAllRuntime_BoundsConcurrency(t *testing.T) {
+	t.Parallel()
+
+	var inFlight int32
+	var maxObserved int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		cur := atomic.AddInt32(&inFlight, 1)
+		for {
+			prev := atomic.LoadInt32(&maxObserved)
+			if cur <= prev || atomic.CompareAndSwapInt32(&maxObserved, prev, cur) {
+				break
+			}
+		}
+		// Hold the request open briefly so overlapping handshakes stack up and
+		// the semaphore's effect becomes observable.
+		time.Sleep(15 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+
+		var req map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		method, _ := req["method"].(string)
+		id := req["id"]
+		switch method {
+		case "initialize":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]any{
+					"protocolVersion": "2025-03-26",
+					"capabilities":    map[string]any{"tools": map[string]any{"listChanged": false}},
+					"serverInfo":      map[string]any{"name": "test", "version": "1.0"},
+				},
+			})
+		case "notifications/initialized":
+			w.WriteHeader(http.StatusOK)
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": id,
+				"result": map[string]any{"tools": []map[string]any{}},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": id,
+				"error": map[string]any{"code": -32601, "message": "method not found"},
+			})
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	svc := newTestService(t, srv.URL, srv)
+	svc.Concurrency = 2
+
+	servers := make([]market.ServerDescriptor, 0, 8)
+	for i := 0; i < 8; i++ {
+		servers = append(servers, market.ServerDescriptor{
+			Key:      fmt.Sprintf("srv-%d", i),
+			Endpoint: srv.URL + "/mcp",
+		})
+	}
+
+	results, failures := svc.DiscoverAllRuntime(context.Background(), servers)
+	if len(failures) != 0 {
+		t.Fatalf("failures = %d, want 0", len(failures))
+	}
+	if len(results) != len(servers) {
+		t.Fatalf("results = %d, want %d", len(results), len(servers))
+	}
+	if got := atomic.LoadInt32(&maxObserved); got > 2 {
+		t.Fatalf("max concurrent handshakes = %d, want <= 2 (semaphore not enforced)", got)
+	}
+}
+
+func TestResolveDiscoveryTimeout(t *testing.T) {
+	if got := resolveDiscoveryTimeout(3 * time.Second); got != 3*time.Second {
+		t.Fatalf("override should win: got %v", got)
+	}
+	t.Setenv(discoveryTimeoutEnv, "5s")
+	if got := resolveDiscoveryTimeout(0); got != 5*time.Second {
+		t.Fatalf("env should apply when no override: got %v", got)
+	}
+	if got := resolveDiscoveryTimeout(3 * time.Second); got != 3*time.Second {
+		t.Fatalf("override should still win over env: got %v", got)
+	}
+	t.Setenv(discoveryTimeoutEnv, "garbage")
+	if got := resolveDiscoveryTimeout(0); got != defaultPerServerDiscoveryTimeout {
+		t.Fatalf("invalid env should fall back to default: got %v", got)
+	}
+}
+
+func TestResolveDiscoveryConcurrency(t *testing.T) {
+	if got := resolveDiscoveryConcurrency(4); got != 4 {
+		t.Fatalf("override should win: got %d", got)
+	}
+	t.Setenv(discoveryConcurrencyEnv, "3")
+	if got := resolveDiscoveryConcurrency(0); got != 3 {
+		t.Fatalf("env should apply: got %d", got)
+	}
+	t.Setenv(discoveryConcurrencyEnv, "0")
+	if got := resolveDiscoveryConcurrency(0); got != defaultDiscoveryConcurrency {
+		t.Fatalf("non-positive env should fall back to default: got %d", got)
+	}
+}
+
+func TestRefreshTimeout(t *testing.T) {
+	if got := RefreshTimeout(); got != refreshDiscoveryTimeout {
+		t.Fatalf("default refresh timeout = %v, want %v", got, refreshDiscoveryTimeout)
+	}
+	t.Setenv(discoveryTimeoutEnv, "12s")
+	if got := RefreshTimeout(); got != 12*time.Second {
+		t.Fatalf("env override for refresh = %v, want 12s", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

`dws cache refresh` fired one MCP handshake per registry-listed server with **no concurrency cap**. Against a rate-limited gateway this backfires.

Verified on **pre** (lists 46 servers):
- Failures are **not timeouts** — `tools/list` returns in ~150ms with JSON-RPC `code -32603: 请求被限流。当前请求过于频繁` (`is_timeout=false`).
- Failure count scales with concurrency, i.e. the burst trips the gateway's per-window QPS guard:

  | concurrency | failed |
  |---|---|
  | 1 | 1 |
  | 2 | 12 |
  | 4 | 26 |
  | 8 | 37 |

  So most "failures" were **healthy servers rejected under load**, not broken servers.
- Production (22 curated servers) has always refreshed clean because its gateway absorbs 22 concurrent handshakes.

## Fix (CLI-side resilience)

- **Bound parallel handshakes** with a semaphore — default 8, override via `DWS_DISCOVERY_CONCURRENCY`.
- **Serialized retry** of just the failures, so stragglers squeezed out by the rate limit get a contention-free second chance without slowing the happy path.
- **Configurable per-server timeout** via `DWS_DISCOVERY_TIMEOUT`; `cache refresh` (explicit, user-initiated) gets a more generous budget than the 2s hot-path default.
- **Wire the diagnostics logger** into the refresh path so per-server failures land in `~/.dws/logs/dws.log` with the real error + timeout flag (this gap is what made the root cause hard to find).
- Report `已刷新 N` as **successes** (total − failures) instead of the raw total.

## Result (verified)

- **pre**: refresh failures cut from ~36 to ~1. The residual is `blackboard`'s own `tools/list` returning `参数错误` — an upstream server bug, unrelated to dws.
- **prod**: 22 servers, 0 failures, ~2s; retry never triggers (no penalty).
- New tests: concurrency is bounded, env resolvers, refresh timeout.

## Out of scope

The pre gateway's rate limit is **server-side** (owner: MCP gateway side). This PR makes the CLI tolerate it; it does not remove it. `blackboard` needs its own server owner.