### PR TITLE
feat: 增加单组织多账号登录

### DIFF
--- a/docs/multi-account-login.md
+++ b/docs/multi-account-login.md
@@ -35,6 +35,35 @@ dws auth login --recommend
 
 `--recommend` 是正确拼写；不要写成 `--recommand`。
 
+登录成功后，普通输出会展示本次登录账号的 `profileId`：
+
+```text
+[OK] 登录成功！
+企业:          邦道科技有限公司
+企业 ID:       ding7779cf9da65ca5ea
+用户:          张三
+profileId:     ding7779cf9da65ca5ea:user123
+有效期:        30 天后
+```
+
+如果使用 JSON 输出，`auth login` 也会返回本次登录账号的 `profileId`：
+
+```bash
+dws auth login --format json
+```
+
+```json
+{
+  "success": true,
+  "profileId": "ding7779cf9da65ca5ea:user123",
+  "corp_id": "ding7779cf9da65ca5ea",
+  "user_id": "user123",
+  "user_name": "张三"
+}
+```
+
+edition overlay 的 `SaveToken` hook 收到的 token JSON 也会包含 `profile_id`。当已拿到 `corp_id` 和 `user_id` 时，值为 `corpId:userId`；如果保存时还没有 `user_id`，会按兼容逻辑退化为 `corpId`。
+
 ### 查看已登录账号
 
 ```bash

--- a/docs/multi-account-login.md
+++ b/docs/multi-account-login.md
@@ -1,0 +1,169 @@
+# 钉钉同组织多账号登录说明
+
+本文说明本次新增的本地多账号能力、涉及的 CLI 命令，以及如何登录、切换和退出账号。
+
+## 新增能力
+
+`dws` 现在用 `profileId` 作为本地账号标识。新的钉钉登录在拿到用户信息后会生成：
+
+```text
+profileId = corpId:userId
+```
+
+因此同一台机器可以保存同一个钉钉组织下的多个账号。例如：
+
+```text
+ding7779cf9da65ca5ea:226841201924277381
+ding7779cf9da65ca5ea:011352590165863362195
+```
+
+`corpId` 仍然兼容，但只有在本地唯一匹配一个 profile 时才建议使用。如果同一个 `corpId` 下有多个账号，请使用完整 `profileId` 或唯一 profile 名。
+
+## 相关命令
+
+### 登录
+
+```bash
+dws auth login --recommend
+```
+
+本地开发时如果要使用当前源码构建出的二进制：
+
+```bash
+./dws auth login --recommend
+```
+
+`--recommend` 是正确拼写；不要写成 `--recommand`。
+
+### 查看已登录账号
+
+```bash
+dws profile list --format json
+```
+
+输出中重点看：
+
+```json
+{
+  "profileId": "dingxxx:user123",
+  "corpId": "dingxxx",
+  "userId": "user123",
+  "userName": "张三"
+}
+```
+
+### 切换默认账号
+
+```bash
+dws profile switch 'dingxxx:user123'
+```
+
+兼容命令：
+
+```bash
+dws profile use 'dingxxx:user123'
+```
+
+也可以使用唯一的 profile 名或唯一 `corpId`：
+
+```bash
+dws profile switch "钉钉"
+dws profile switch dingxxx
+```
+
+如果 `corpId` 对应多个账号，会产生歧义，请改用完整 `profileId`。
+
+### 单次命令指定账号
+
+不想修改默认账号，只想让一次业务命令使用某个账号：
+
+```bash
+dws --profile 'dingxxx:user123' contact user get-self
+```
+
+同一个命令也可以对多个账号执行：
+
+```bash
+dws --profile 'dingxxx:user123,dingxxx:user456' contact user get-self
+```
+
+### 查看指定账号认证状态
+
+```bash
+dws auth status --profile 'dingxxx:user123'
+```
+
+### 退出指定账号
+
+```bash
+dws auth logout --profile 'dingxxx:user123'
+```
+
+不带 `--profile` 时会退出本机所有已登录 profile：
+
+```bash
+dws auth logout
+```
+
+## 同组织登录两个账号的流程
+
+1. 登录第一个账号：
+
+```bash
+dws auth login --recommend
+```
+
+2. 在浏览器或钉钉授权页切换到第二个钉钉账号。
+
+3. 再登录一次：
+
+```bash
+dws auth login --recommend
+```
+
+4. 查看结果：
+
+```bash
+dws profile list --format json
+```
+
+期望看到同一个 `corpId` 下多个不同 `profileId`。
+
+## 存储与隔离
+
+非敏感 profile 元数据保存在：
+
+```text
+profiles.json
+```
+
+其中：
+
+```text
+primaryProfile/currentProfile/previousProfile = profileId
+profiles[].profileId = corpId:userId
+```
+
+token 材料保存在 profile 维度的 keychain slot：
+
+```text
+dingtalk-workspace-profile-<profileId>
+```
+
+账号相关的 runtime/tools/detail 缓存按 profile 隔离：
+
+```text
+<edition-partition>/profile/<profileId>
+```
+
+全局 registry 缓存仍按 edition 共享，不按账号重复保存。
+
+## 旧数据兼容
+
+旧版本可能已经存在 `profileId = corpId` 的本地数据。新版加载 profile 时，如果该 profile 已有 `userId`，会自动升级为：
+
+```text
+corpId:userId
+```
+
+因此通常不需要手动删除本地配置。

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -43,6 +43,22 @@ dws schema -f pretty ding.send_ding_message          # Pretty (ANSI-colored, sch
 dws todo task list --dry-run    # Preview MCP call without executing / 预览但不执行
 ```
 
+## Profiles / 本地账号
+
+`profileId` is the stable local profile key. New DingTalk logins use `corpId:userId`, so one machine can keep multiple accounts under the same DingTalk organization.
+
+`profileId` 是稳定的本地 profile 标识。新的钉钉登录使用 `corpId:userId`，因此同一台机器可以保存同一组织下的多个账号。
+
+```bash
+dws profile list --format json
+dws profile switch 'dingxxx:user123'
+dws auth logout --profile 'dingxxx:user123'
+```
+
+`corpId` remains a compatibility selector only when it uniquely matches one local profile. If multiple local accounts share the same `corpId`, use `profileId` or a unique profile name.
+
+`corpId` 仍可作为兼容选择器，但必须唯一匹配一个本地 profile；多个本地账号共用同一 `corpId` 时，请使用 `profileId` 或唯一 profile 名。
+
 ## Output to File / 输出到文件
 
 ```bash

--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -238,20 +238,7 @@ func newAuthLoginCommand(patCaller edition.ToolCaller) *cobra.Command {
 			} else {
 				fmt.Fprintln(w, authLoginStatusLine("登录成功！"))
 			}
-			if tokenData != nil {
-				if tokenData.CorpName != "" {
-					fmt.Fprintln(w, authLoginInfoLine("企业", tokenData.CorpName))
-				}
-				if tokenData.CorpID != "" {
-					fmt.Fprintln(w, authLoginInfoLine("企业 ID", tokenData.CorpID))
-				}
-				if tokenData.UserName != "" {
-					fmt.Fprintln(w, authLoginInfoLine("用户", tokenData.UserName))
-				}
-				if expiry := authLoginDisplayExpiry(tokenData); expiry != "" {
-					fmt.Fprintln(w, authLoginInfoLine("有效期", expiry))
-				}
-			}
+			writeAuthLoginInfoLines(w, tokenData)
 			fmt.Fprintln(w, authLoginMutedStyle().Render("Token 将自动刷新，无需重复登录"))
 			return nil
 		},
@@ -947,6 +934,27 @@ func authLoginStatusLine(message string) string {
 	)
 }
 
+func writeAuthLoginInfoLines(w io.Writer, tokenData *authpkg.TokenData) {
+	if tokenData == nil {
+		return
+	}
+	if tokenData.CorpName != "" {
+		fmt.Fprintln(w, authLoginInfoLine("企业", tokenData.CorpName))
+	}
+	if tokenData.CorpID != "" {
+		fmt.Fprintln(w, authLoginInfoLine("企业 ID", tokenData.CorpID))
+	}
+	if tokenData.UserName != "" {
+		fmt.Fprintln(w, authLoginInfoLine("用户", tokenData.UserName))
+	}
+	if profileID := authpkg.ProfileIDFromToken(tokenData); profileID != "" {
+		fmt.Fprintln(w, authLoginInfoLine("profileId", profileID))
+	}
+	if expiry := authLoginDisplayExpiry(tokenData); expiry != "" {
+		fmt.Fprintln(w, authLoginInfoLine("有效期", expiry))
+	}
+}
+
 func authLoginInfoLine(key, value string) string {
 	label := authLoginMutedStyle().Width(14).Render(key + ":")
 	return fmt.Sprintf("%s %s", label, value)
@@ -1268,6 +1276,7 @@ func writeAuthStatusJSON(w io.Writer, authenticated, refreshed bool, data *authp
 type authLoginResponse struct {
 	Success           bool   `json:"success"`
 	Message           string `json:"message"`
+	ProfileID         string `json:"profileId,omitempty"`
 	TokenValid        bool   `json:"token_valid,omitempty"`
 	RefreshTokenValid bool   `json:"refresh_token_valid,omitempty"`
 	ExpiresAt         string `json:"expires_at,omitempty"`
@@ -1300,6 +1309,7 @@ func writeAuthLoginJSON(w io.Writer, data *authpkg.TokenData, forced bool) error
 		resp.CorpName = data.CorpName
 		resp.UserID = data.UserID
 		resp.UserName = data.UserName
+		resp.ProfileID = authpkg.ProfileIDFromToken(data)
 	}
 
 	enc := json.NewEncoder(w)

--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -111,7 +111,7 @@ func newAuthLoginCommand(patCaller edition.ToolCaller) *cobra.Command {
 
 示例:
   dws auth login              # 本机登录并新增/刷新一个组织 profile
-  dws auth login --profile <corpId>  # 指定本次授权目标组织，不持久切换当前组织
+  dws auth login --profile <profileId|name|corpId>  # 指定本次授权目标组织，不持久切换当前组织
   dws auth login --recommend  # 无交互批量授权服务端推荐权限
   dws auth login --device     # SSH 远程 / 无头环境登录 (设备流)
   dws auth login --force      # 兼容保留；login 默认已忽略缓存并进入授权流程
@@ -388,7 +388,7 @@ func newAuthLogoutCommand() *cobra.Command {
 
 默认退出所有已登录组织 profile；指定 --profile 时只退出该组织，不影响其他组织。`,
 		Example: `  dws auth logout
-  dws auth logout --profile <corpId>
+  dws auth logout --profile <profileId|name|corpId>
   dws auth logout --profile "钉钉"`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -418,7 +418,7 @@ func newAuthLogoutCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().String("profile", "", "指定要退出的 profile 名或 corpId")
+	cmd.Flags().String("profile", "", "指定要退出的 profileId、profile 名或唯一 corpId")
 	return cmd
 }
 
@@ -430,9 +430,9 @@ func newAuthStatusCommand() *cobra.Command {
 
 指定 --profile 时只读取并刷新被选中的 token slot，不会修改 currentProfile。`,
 		Example: `  dws auth status
-  dws auth status --profile <corpId>
+  dws auth status --profile <profileId|name|corpId>
   dws auth status --profile "钉钉"
-  dws auth status --profile <corpId> --format json`,
+  dws auth status --profile <profileId|name|corpId> --format json`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configDir := defaultConfigDir()
@@ -462,7 +462,7 @@ func newAuthStatusCommand() *cobra.Command {
 					} else if edition.Get().AutoPurgeToken {
 						_ = authpkg.DeleteTokenData(configDir)
 					} else if tokenData != nil {
-						_ = authpkg.MarkProfileStatus(configDir, tokenData.CorpID, authpkg.ProfileStatusExpired)
+						_ = authpkg.MarkProfileStatus(configDir, authpkg.ProfileIDFromToken(tokenData), authpkg.ProfileStatusExpired)
 					}
 				}
 				if authStatusAuthenticated(tokenData) {
@@ -510,7 +510,7 @@ func newAuthStatusCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().String("profile", "", "指定要查看的 profile 名或 corpId")
+	cmd.Flags().String("profile", "", "指定要查看的 profileId、profile 名或唯一 corpId")
 	return cmd
 }
 
@@ -539,7 +539,7 @@ func logoutAllProfiles(_ *cobra.Command, ctx context.Context, configDir string) 
 		_ = authpkg.RevokeTokenRemote(ctx)
 	} else {
 		for _, profile := range cfg.Profiles {
-			restoreProfile := pushRuntimeProfile(profile.CorpID)
+			restoreProfile := pushRuntimeProfile(profile.ProfileID)
 			_ = authpkg.RevokeTokenRemote(ctx)
 			restoreProfile()
 		}

--- a/internal/app/auth_command_test.go
+++ b/internal/app/auth_command_test.go
@@ -228,7 +228,7 @@ func TestAuthStatusProfileOverrideDoesNotSwitchCurrentProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.CurrentProfile != "corp_secondary" {
+	if cfg.CurrentProfile != "corp_secondary:user-corp_secondary" {
 		t.Fatalf("currentProfile = %q, want unchanged corp_secondary", cfg.CurrentProfile)
 	}
 }
@@ -274,10 +274,10 @@ func TestAuthLogoutDefaultDeletesAllProfilesAndPreservesAppConfig(t *testing.T) 
 	if cfg.PrimaryProfile != "" || cfg.CurrentProfile != "" || cfg.PreviousProfile != "" || len(cfg.Profiles) != 0 {
 		t.Fatalf("profiles after logout = %#v, want empty", cfg)
 	}
-	if authpkg.TokenDataExistsKeychainForCorpID("corp_primary") {
+	if authpkg.TokenDataExistsKeychainForProfileID("corp_primary:user-corp_primary") {
 		t.Fatal("primary profile token should be deleted")
 	}
-	if authpkg.TokenDataExistsKeychainForCorpID("corp_secondary") {
+	if authpkg.TokenDataExistsKeychainForProfileID("corp_secondary:user-corp_secondary") {
 		t.Fatal("secondary profile token should be deleted")
 	}
 	if authpkg.TokenDataExistsKeychain() {
@@ -318,16 +318,16 @@ func TestAuthLogoutProfileDeletesOnlySelectedProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.PrimaryProfile != "corp_secondary" || cfg.CurrentProfile != "corp_secondary" {
+	if cfg.PrimaryProfile != "corp_secondary:user-corp_secondary" || cfg.CurrentProfile != "corp_secondary:user-corp_secondary" {
 		t.Fatalf("profiles pointers = primary %q current %q, want corp_secondary/corp_secondary", cfg.PrimaryProfile, cfg.CurrentProfile)
 	}
 	if len(cfg.Profiles) != 1 || cfg.Profiles[0].CorpID != "corp_secondary" {
 		t.Fatalf("profiles = %#v, want only corp_secondary retained", cfg.Profiles)
 	}
-	if authpkg.TokenDataExistsKeychainForCorpID("corp_primary") {
+	if authpkg.TokenDataExistsKeychainForProfileID("corp_primary:user-corp_primary") {
 		t.Fatal("selected primary profile token should be deleted")
 	}
-	if !authpkg.TokenDataExistsKeychainForCorpID("corp_secondary") {
+	if !authpkg.TokenDataExistsKeychainForProfileID("corp_secondary:user-corp_secondary") {
 		t.Fatal("unselected secondary profile token should be retained")
 	}
 	loaded, err := authpkg.LoadTokenData(configDir)

--- a/internal/app/auth_command_test.go
+++ b/internal/app/auth_command_test.go
@@ -16,6 +16,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"os"
@@ -198,6 +199,50 @@ func TestAuthStatusTableIncludesCorpName(t *testing.T) {
 	for _, want := range []string{"企业:", "corp_primary org", "企业 ID:", "corp_primary"} {
 		if !bytes.Contains(out.Bytes(), []byte(want)) {
 			t.Fatalf("auth status table missing %q in output:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestWriteAuthLoginJSONIncludesProfileID(t *testing.T) {
+	token := &authpkg.TokenData{
+		AccessToken: "access",
+		CorpID:      "corp_same",
+		CorpName:    "Same Org",
+		UserID:      "user_1",
+		UserName:    "张三",
+		ExpiresAt:   time.Now().Add(time.Hour),
+	}
+	var out bytes.Buffer
+	if err := writeAuthLoginJSON(&out, token, true); err != nil {
+		t.Fatalf("writeAuthLoginJSON() error = %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\noutput:\n%s", err, out.String())
+	}
+	if payload["profileId"] != "corp_same:user_1" {
+		t.Fatalf("profileId = %#v, want corp_same:user_1", payload["profileId"])
+	}
+	if payload["corp_id"] != "corp_same" || payload["user_id"] != "user_1" || payload["user_name"] != "张三" {
+		t.Fatalf("login JSON identity fields = %#v", payload)
+	}
+}
+
+func TestWriteAuthLoginInfoLinesIncludesProfileID(t *testing.T) {
+	token := &authpkg.TokenData{
+		CorpID:    "corp_same",
+		CorpName:  "Same Org",
+		UserID:    "user_1",
+		UserName:  "张三",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	var out bytes.Buffer
+	writeAuthLoginInfoLines(&out, token)
+
+	for _, want := range []string{"企业:", "Same Org", "企业 ID:", "corp_same", "用户:", "张三", "profileId:", "corp_same:user_1", "有效期:"} {
+		if !bytes.Contains(out.Bytes(), []byte(want)) {
+			t.Fatalf("login info output missing %q:\n%s", want, out.String())
 		}
 	}
 }

--- a/internal/app/help_source_test.go
+++ b/internal/app/help_source_test.go
@@ -227,8 +227,9 @@ func TestProfileHelpDocumentsMultiProfileUsage(t *testing.T) {
 	for _, want := range []string{
 		"切换默认组织 profile",
 		"需要只影响单次业务命令时，请使用全局 --profile",
+		"dws profile switch <profileId|name|corpId>",
 		"dws profile switch --corpId <corpId>",
-		"dws --profile <corpId> contact user get-self",
+		"dws --profile <profileId|name|corpId> contact user get-self",
 		"--corpId string",
 		"--name string",
 	} {
@@ -250,7 +251,7 @@ func TestProfileHelpDocumentsMultiProfileUsage(t *testing.T) {
 
 func TestAuthHelpDocumentsProfileUsage(t *testing.T) {
 	got := executeHelpForTest(t, "auth", "login", "--help")
-	if !strings.Contains(got, "dws auth login --profile <corpId>") {
+	if !strings.Contains(got, "dws auth login --profile <profileId|name|corpId>") {
 		t.Fatalf("auth login help missing --profile example:\n%s", got)
 	}
 
@@ -258,7 +259,7 @@ func TestAuthHelpDocumentsProfileUsage(t *testing.T) {
 	for _, want := range []string{
 		"查看当前或指定组织 profile 的认证状态",
 		"只读取并刷新被选中的 token slot",
-		"dws auth status --profile <corpId>",
+		"dws auth status --profile <profileId|name|corpId>",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("auth status help missing %q:\n%s", want, got)
@@ -268,7 +269,7 @@ func TestAuthHelpDocumentsProfileUsage(t *testing.T) {
 	got = executeHelpForTest(t, "auth", "logout", "--help")
 	for _, want := range []string{
 		"默认退出所有已登录组织 profile",
-		"dws auth logout --profile <corpId>",
+		"dws auth logout --profile <profileId|name|corpId>",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("auth logout help missing %q:\n%s", want, got)

--- a/internal/app/legacy.go
+++ b/internal/app/legacy.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cache"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cobracmd"
@@ -206,6 +207,25 @@ func editionPartition() string {
 	return config.EditionPartition(edition.Get().Name)
 }
 
+func runtimeCachePartition() string {
+	base := editionPartition()
+	profile := runtimeCacheProfileID()
+	if profile == "" {
+		return base
+	}
+	return base + "/profile/" + profile
+}
+
+func runtimeCacheProfileID() string {
+	if profile := strings.TrimSpace(authpkg.RuntimeProfile()); profile != "" {
+		return profile
+	}
+	if current, err := authpkg.ResolveProfile(defaultConfigDir(), ""); err == nil && current != nil {
+		return strings.TrimSpace(current.ProfileID)
+	}
+	return ""
+}
+
 // discoveryTraceEnabled reports whether the user asked for discovery-path diagnostics.
 // loadDynamicCommands runs while building the command tree, before PersistentPreRun
 // applies --debug to slog; we also accept argv --debug and DWS_PERF_DEBUG for consistency.
@@ -381,7 +401,7 @@ func loadCachedToolNames(store *cache.Store, servers []market.ServerDescriptor) 
 	if store == nil {
 		return result
 	}
-	partition := editionPartition()
+	partition := runtimeCachePartition()
 	for _, server := range servers {
 		slug := strings.TrimSpace(server.CLI.ID)
 		if slug == "" || strings.TrimSpace(server.Key) == "" {
@@ -411,7 +431,7 @@ func loadCachedDetailsFast(store *cache.Store, servers []market.ServerDescriptor
 	if store == nil {
 		return result
 	}
-	partition := editionPartition()
+	partition := runtimeCachePartition()
 	for _, server := range servers {
 		if server.DetailLocator.MCPID <= 0 {
 			continue
@@ -442,7 +462,7 @@ func fetchDetailsByServerID(ctx context.Context, client *market.Client, servers 
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	partition := editionPartition()
+	partition := runtimeCachePartition()
 	now := time.Now().UTC()
 	if store != nil && store.Now != nil {
 		now = store.Now().UTC()

--- a/internal/app/legacy_wukong_partition_e2e_test.go
+++ b/internal/app/legacy_wukong_partition_e2e_test.go
@@ -14,8 +14,10 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
+	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
@@ -60,5 +62,33 @@ func TestEditionPartition_SingleSourceOfTruth(t *testing.T) {
 				t.Fatalf("editionPartition()=%q, want %q for edition %q", legacy, tc.want, tc.edition)
 			}
 		})
+	}
+}
+
+func TestRuntimeCachePartitionUsesProfileIdentity(t *testing.T) {
+	t.Setenv("DWS_CONFIG_DIR", t.TempDir())
+	t.Cleanup(func() {
+		authpkg.SetRuntimeProfile("")
+		edition.Override(&edition.Hooks{})
+	})
+	edition.Override(&edition.Hooks{})
+
+	authpkg.SetRuntimeProfile("")
+	if got := runtimeCachePartition(); got != editionPartition() {
+		t.Fatalf("runtimeCachePartition()=%q, want edition partition %q without profile", got, editionPartition())
+	}
+
+	authpkg.SetRuntimeProfile("corp_same:user_a")
+	partitionA := runtimeCachePartition()
+	authpkg.SetRuntimeProfile("corp_same:user_b")
+	partitionB := runtimeCachePartition()
+
+	if partitionA == partitionB {
+		t.Fatalf("runtime cache partitions should differ for two profiles: %q", partitionA)
+	}
+	for _, got := range []string{partitionA, partitionB} {
+		if !strings.Contains(got, "/profile/") {
+			t.Fatalf("runtime cache partition %q missing profile namespace", got)
+		}
 	}
 }

--- a/internal/app/multi_profile_runner_test.go
+++ b/internal/app/multi_profile_runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
@@ -43,6 +44,10 @@ func TestRuntimeRunnerAggregatesCommaSeparatedProfiles(t *testing.T) {
 	}
 	for i, wantCorpID := range []string{"corp_a", "corp_b"} {
 		entry := profiles[i].(map[string]any)
+		wantProfileID := wantCorpID + ":user-" + wantCorpID
+		if entry["profileId"] != wantProfileID {
+			t.Fatalf("profiles[%d].profileId = %#v, want %q", i, entry["profileId"], wantProfileID)
+		}
 		if entry["corpId"] != wantCorpID {
 			t.Fatalf("profiles[%d].corpId = %#v, want %q", i, entry["corpId"], wantCorpID)
 		}
@@ -50,13 +55,57 @@ func TestRuntimeRunnerAggregatesCommaSeparatedProfiles(t *testing.T) {
 			t.Fatalf("profiles[%d].ok = %#v, want true", i, entry["ok"])
 		}
 		resultPayload := entry["result"].(map[string]any)
-		if resultPayload["runtimeProfile"] != wantCorpID {
-			t.Fatalf("profiles[%d].result.runtimeProfile = %#v, want %q", i, resultPayload["runtimeProfile"], wantCorpID)
+		if resultPayload["runtimeProfile"] != wantProfileID {
+			t.Fatalf("profiles[%d].result.runtimeProfile = %#v, want %q", i, resultPayload["runtimeProfile"], wantProfileID)
 		}
 	}
 }
 
-func TestRuntimeRunnerDeduplicatesCommaSeparatedProfilesByCorpID(t *testing.T) {
+func TestRuntimeRunnerRunsSameCorpDifferentUsers(t *testing.T) {
+	setupAuthLogoutProfiles(t,
+		&authpkg.TokenData{
+			AccessToken:  "access-a",
+			RefreshToken: "refresh-a",
+			ExpiresAt:    time.Now().Add(time.Hour),
+			RefreshExpAt: time.Now().Add(24 * time.Hour),
+			CorpID:       "corp_same",
+			CorpName:     "same org",
+			UserID:       "user_a",
+		},
+		&authpkg.TokenData{
+			AccessToken:  "access-b",
+			RefreshToken: "refresh-b",
+			ExpiresAt:    time.Now().Add(time.Hour),
+			RefreshExpAt: time.Now().Add(24 * time.Hour),
+			CorpID:       "corp_same",
+			CorpName:     "same org",
+			UserID:       "user_b",
+		},
+	)
+	authpkg.SetRuntimeProfile("corp_same:user_a,corp_same:user_b")
+
+	runner := &runtimeRunner{fallback: multiProfileFallbackRunner{}}
+	result, err := runner.Run(context.Background(), executor.Invocation{
+		Kind:             "helper_invocation",
+		CanonicalProduct: "contact",
+		Tool:             "get_current_user_profile",
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	profiles := result.Response["content"].(map[string]any)["profiles"].([]any)
+	if len(profiles) != 2 {
+		t.Fatalf("profiles len = %d, want 2", len(profiles))
+	}
+	for i, want := range []string{"corp_same:user_a", "corp_same:user_b"} {
+		entry := profiles[i].(map[string]any)
+		if entry["profileId"] != want {
+			t.Fatalf("profiles[%d].profileId = %#v, want %q", i, entry["profileId"], want)
+		}
+	}
+}
+
+func TestRuntimeRunnerDeduplicatesCommaSeparatedProfilesByProfileID(t *testing.T) {
 	configDir := setupAuthLogoutProfiles(t, authLogoutTestToken("corp_a"), authLogoutTestToken("corp_b"))
 	authpkg.SetRuntimeProfile("corp_a, corp_a org,corp_b")
 

--- a/internal/app/profile_command.go
+++ b/internal/app/profile_command.go
@@ -40,9 +40,9 @@ func newProfileCommand() *cobra.Command {
 profile switch/use 才会持久修改默认组织上下文。`,
 		Example: `  dws profile list
   dws profile switch
-  dws profile switch <corpId>
+  dws profile switch <profileId|name|corpId>
   dws profile switch -
-  dws --profile <corpId> contact user get-self`,
+  dws --profile <profileId|name|corpId> contact user get-self`,
 		Args:              cobra.NoArgs,
 		TraverseChildren:  true,
 		DisableAutoGenTag: true,
@@ -85,10 +85,10 @@ func newProfileListCommand() *cobra.Command {
 
 func newProfileUseCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "use [name|corpId|-]",
+		Use:   "use [profileId|name|corpId|-]",
 		Short: "切换当前组织 profile（兼容 profile switch）",
-		Long:  "兼容命令，语义等同于 dws profile switch。可用组织名、profile 名、corpId 或 - 切回上一个组织。",
-		Example: `  dws profile use <corpId>
+		Long:  "兼容命令，语义等同于 dws profile switch。可用 profileId、组织名、profile 名、唯一 corpId 或 - 切回上一个组织。",
+		Example: `  dws profile use <profileId|name|corpId>
   dws profile use --name "钉钉"
   dws profile use -`,
 		Args:              cobra.MaximumNArgs(1),
@@ -103,18 +103,18 @@ func newProfileUseCommand() *cobra.Command {
 
 func newProfileSwitchCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "switch [name|corpId|-]",
+		Use:   "switch [profileId|name|corpId|-]",
 		Short: "切换当前组织 profile",
 		Long: `切换默认组织 profile，并记录 previousProfile 以支持 dws profile switch - 快速切回。
 
-不带参数时，交互终端会展示组织选择器；非交互环境请显式传入组织名、profile 名或 corpId。
+不带参数时，交互终端会展示组织选择器；非交互环境请显式传入 profileId、组织名、profile 名或唯一 corpId。
 需要只影响单次业务命令时，请使用全局 --profile。`,
 		Example: `  dws profile switch
-  dws profile switch <corpId>
+  dws profile switch <profileId|name|corpId>
   dws profile switch --corpId <corpId>
   dws profile switch --name "钉钉"
   dws profile switch -
-  dws --profile <corpId> contact user get-self`,
+  dws --profile <profileId|name|corpId> contact user get-self`,
 		Args:              cobra.MaximumNArgs(1),
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -241,7 +241,7 @@ func switchProfileAndWrite(cmd *cobra.Command, configDir, selector string, usedT
 
 func selectProfileSwitchProfile(cmd *cobra.Command, configDir string) (string, error) {
 	if !profileSwitchInteractiveTerminal() {
-		return "", apperrors.NewValidation("profile selector required in non-interactive mode; use dws profile switch <name|corpId>")
+		return "", apperrors.NewValidation("profile selector required in non-interactive mode; use dws profile switch <profileId|name|corpId>")
 	}
 	if err := authpkg.EnsureProfilesMigration(configDir); err != nil {
 		return "", apperrors.NewInternal(fmt.Sprintf("failed to migrate profiles: %v", err))
@@ -263,8 +263,8 @@ func selectProfileSwitchProfile(cmd *cobra.Command, configDir string) (string, e
 	return runProfileSwitchTUI(cmd, cfg, choice)
 }
 
-func runProfileSwitchTUI(cmd *cobra.Command, cfg *authpkg.ProfilesConfig, selectedCorpID string) (string, error) {
-	model := newProfileSwitchTUIModel(cfg, selectedCorpID)
+func runProfileSwitchTUI(cmd *cobra.Command, cfg *authpkg.ProfilesConfig, selectedProfileID string) (string, error) {
+	model := newProfileSwitchTUIModel(cfg, selectedProfileID)
 	program := tea.NewProgram(
 		model,
 		tea.WithAltScreen(),
@@ -283,7 +283,7 @@ func runProfileSwitchTUI(cmd *cobra.Command, cfg *authpkg.ProfilesConfig, select
 	if !ok || final.aborted || !final.submitted {
 		return "", apperrors.NewValidation("组织选择中止: user aborted")
 	}
-	return final.selectedCorpID(), nil
+	return final.selectedProfileID(), nil
 }
 
 type profileSwitchTUIModel struct {
@@ -295,12 +295,12 @@ type profileSwitchTUIModel struct {
 	aborted   bool
 }
 
-func newProfileSwitchTUIModel(cfg *authpkg.ProfilesConfig, selectedCorpID string) profileSwitchTUIModel {
+func newProfileSwitchTUIModel(cfg *authpkg.ProfilesConfig, selectedProfileID string) profileSwitchTUIModel {
 	model := profileSwitchTUIModel{cfg: cfg}
 	if cfg != nil {
 		model.profiles = profileSwitchSortedProfiles(cfg.Profiles)
 	}
-	model.selected = profileSwitchProfileIndex(model.profiles, selectedCorpID)
+	model.selected = profileSwitchProfileIndex(model.profiles, selectedProfileID)
 	if model.selected < 0 {
 		model.selected = 0
 	}
@@ -449,17 +449,17 @@ func (m *profileSwitchTUIModel) ensureSelectedVisible() {
 	}
 }
 
-func (m profileSwitchTUIModel) selectedCorpID() string {
+func (m profileSwitchTUIModel) selectedProfileID() string {
 	if m.selected < 0 || m.selected >= len(m.profiles) {
 		return ""
 	}
-	return strings.TrimSpace(m.profiles[m.selected].CorpID)
+	return profileLocalID(m.profiles[m.selected])
 }
 
-func profileSwitchProfileIndex(profiles []authpkg.Profile, corpID string) int {
-	corpID = strings.TrimSpace(corpID)
+func profileSwitchProfileIndex(profiles []authpkg.Profile, profileID string) int {
+	profileID = strings.TrimSpace(profileID)
 	for i, p := range profiles {
-		if strings.TrimSpace(p.CorpID) == corpID {
+		if profileLocalID(p) == profileID {
 			return i
 		}
 	}
@@ -479,7 +479,7 @@ func profileSwitchProfileCells(p authpkg.Profile, cfg *authpkg.ProfilesConfig) (
 }
 
 func profileSwitchProfileStatus(p authpkg.Profile, cfg *authpkg.ProfilesConfig) string {
-	if cfg != nil && p.CorpID == cfg.CurrentProfile {
+	if cfg != nil && profileLocalID(p) == cfg.CurrentProfile {
 		return "当前组织"
 	}
 	return ""
@@ -569,6 +569,7 @@ type profileUseResponse struct {
 }
 
 type profileView struct {
+	ProfileID         string   `json:"profileId,omitempty"`
 	CorpID            string   `json:"corpId"`
 	CorpName          string   `json:"corpName"`
 	UserID            string   `json:"userId,omitempty"`
@@ -621,11 +622,11 @@ func writeProfileListTable(w io.Writer, cfg *authpkg.ProfilesConfig) {
 	fmt.Fprintf(w, "%-3s %-3s %-28s %-34s %-10s %s\n", "CUR", "PRI", "ORG_NAME", "CORP_ID", "STATUS", "USER")
 	for _, p := range cfg.Profiles {
 		current := ""
-		if p.CorpID == cfg.CurrentProfile {
+		if profileLocalID(p) == cfg.CurrentProfile {
 			current = "*"
 		}
 		primary := ""
-		if p.CorpID == cfg.PrimaryProfile {
+		if profileLocalID(p) == cfg.PrimaryProfile {
 			primary = "*"
 		}
 		user := p.UserName
@@ -683,7 +684,9 @@ func profileViews(cfg *authpkg.ProfilesConfig) []profileView {
 }
 
 func profileViewFromProfile(p authpkg.Profile, primaryProfile, currentProfile string) profileView {
+	profileID := profileLocalID(p)
 	return profileView{
+		ProfileID:         profileID,
 		CorpID:            p.CorpID,
 		CorpName:          profileOrgName(p),
 		UserID:            p.UserID,
@@ -695,9 +698,19 @@ func profileViewFromProfile(p authpkg.Profile, primaryProfile, currentProfile st
 		RefreshExpAt:      p.RefreshExpAt,
 		LastLoginAt:       p.LastLoginAt,
 		LastUsedAt:        p.LastUsedAt,
-		IsPrimary:         p.CorpID == primaryProfile,
-		IsCurrent:         p.CorpID == currentProfile,
+		IsPrimary:         profileID == primaryProfile,
+		IsCurrent:         profileID == currentProfile,
 	}
+}
+
+func profileLocalID(p authpkg.Profile) string {
+	if id := strings.TrimSpace(p.ProfileID); id != "" {
+		return id
+	}
+	if corpID, userID := strings.TrimSpace(p.CorpID), strings.TrimSpace(p.UserID); corpID != "" && userID != "" {
+		return corpID + ":" + userID
+	}
+	return strings.TrimSpace(p.CorpID)
 }
 
 func clipProfileCell(value string, limit int) string {

--- a/internal/app/profile_command_test.go
+++ b/internal/app/profile_command_test.go
@@ -80,7 +80,7 @@ func TestProfileListRootCommandJSONIncludesCorpName(t *testing.T) {
 	if !resp.Success {
 		t.Fatal("success = false, want true")
 	}
-	if resp.PrimaryProfile != "corp_primary" || resp.CurrentProfile != "corp_secondary" || resp.PreviousProfile != "corp_primary" {
+	if resp.PrimaryProfile != "corp_primary:user-corp_primary" || resp.CurrentProfile != "corp_secondary:user-corp_secondary" || resp.PreviousProfile != "corp_primary:user-corp_primary" {
 		t.Fatalf("profile pointers = primary %q current %q previous %q, want corp_primary/corp_secondary/corp_primary", resp.PrimaryProfile, resp.CurrentProfile, resp.PreviousProfile)
 	}
 	if len(resp.Profiles) != 2 {
@@ -117,7 +117,7 @@ func TestProfileUseRootCommandSwitchesOrganizationAndLegacyMirror(t *testing.T) 
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.CurrentProfile != "corp_primary" || cfg.PreviousProfile != "corp_secondary" {
+	if cfg.CurrentProfile != "corp_primary:user-corp_primary" || cfg.PreviousProfile != "corp_secondary:user-corp_secondary" {
 		t.Fatalf("profile pointers = current %q previous %q, want corp_primary/corp_secondary", cfg.CurrentProfile, cfg.PreviousProfile)
 	}
 	legacyToken, err := authpkg.LoadTokenData(configDir)
@@ -143,7 +143,7 @@ func TestProfileUseRootCommandSwitchesOrganizationAndLegacyMirror(t *testing.T) 
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.CurrentProfile != "corp_secondary" || cfg.PreviousProfile != "corp_primary" {
+	if cfg.CurrentProfile != "corp_secondary:user-corp_secondary" || cfg.PreviousProfile != "corp_primary:user-corp_primary" {
 		t.Fatalf("profile pointers = current %q previous %q, want corp_secondary/corp_primary", cfg.CurrentProfile, cfg.PreviousProfile)
 	}
 	legacyToken, err = authpkg.LoadTokenData(configDir)
@@ -176,7 +176,7 @@ func TestProfileSwitchRootCommandSwitchesPrimaryOrganizationAndLegacyMirror(t *t
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.CurrentProfile != "corp_primary" || cfg.PreviousProfile != "corp_secondary" {
+	if cfg.CurrentProfile != "corp_primary:user-corp_primary" || cfg.PreviousProfile != "corp_secondary:user-corp_secondary" {
 		t.Fatalf("profile pointers = current %q previous %q, want corp_primary/corp_secondary", cfg.CurrentProfile, cfg.PreviousProfile)
 	}
 	legacyToken, err := authpkg.LoadTokenData(configDir)
@@ -206,7 +206,7 @@ func TestProfileSwitchRootCommandSupportsCorpIDFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.CurrentProfile != "corp_primary" {
+	if cfg.CurrentProfile != "corp_primary:user-corp_primary" {
 		t.Fatalf("currentProfile = %q, want corp_primary", cfg.CurrentProfile)
 	}
 
@@ -222,7 +222,7 @@ func TestProfileSwitchRootCommandSupportsCorpIDFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.CurrentProfile != "corp_secondary" {
+	if cfg.CurrentProfile != "corp_secondary:user-corp_secondary" {
 		t.Fatalf("currentProfile = %q, want corp_secondary", cfg.CurrentProfile)
 	}
 }
@@ -283,7 +283,7 @@ func TestProfileSwitchNoArgsUsesTUISelector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.CurrentProfile != "corp_primary" {
+	if cfg.CurrentProfile != "corp_primary:user-corp_primary" {
 		t.Fatalf("currentProfile = %q, want corp_primary", cfg.CurrentProfile)
 	}
 }
@@ -370,8 +370,8 @@ func TestProfileSwitchTUISortsLatestLoggedInProfilesFirst(t *testing.T) {
 	if strings.Join(gotOrder, ",") != strings.Join(wantOrder, ",") {
 		t.Fatalf("profile order = %v, want %v", gotOrder, wantOrder)
 	}
-	if got := model.selectedCorpID(); got != "old" {
-		t.Fatalf("selectedCorpID = %q, want old", got)
+	if got := model.selectedProfileID(); got != "old" {
+		t.Fatalf("selectedProfileID = %q, want old", got)
 	}
 }
 
@@ -503,7 +503,7 @@ func TestProfileUseNoArgsUsesTUISelector(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.CurrentProfile != "corp_primary" {
+	if cfg.CurrentProfile != "corp_primary:user-corp_primary" {
 		t.Fatalf("currentProfile = %q, want corp_primary", cfg.CurrentProfile)
 	}
 }

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -586,13 +586,17 @@ func newCacheCommand() *cobra.Command {
 				transportClient,
 				store,
 			)
+			if profileID := runtimeCacheProfileID(); profileID != "" {
+				service.Tenant = editionPartition() + "/profile"
+				service.AuthIdentity = profileID
+			}
 
 			resp, err := fetchRegistryServers(cmd.Context(), ipv4HTTPClient(config.HTTPTimeout))
 			if err != nil {
 				return apperrors.NewDiscovery(fmt.Sprintf("cache refresh: fetch server list failed: %v", err))
 			}
 			servers := market.NormalizeServersForBaseURL(resp, "live_market", registryDiscoveryBaseURL())
-			_ = store.SaveRegistry(service.CachePartition(), cache.RegistrySnapshot{Servers: servers})
+			_ = store.SaveRegistry(editionPartition(), cache.RegistrySnapshot{Servers: servers})
 
 			selected := selectServersForProduct(servers, product)
 			if strings.TrimSpace(product) != "" && len(selected) == 0 {

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -282,10 +282,10 @@ func resolveMultiProfileSelections(configDir, rawSelector string) ([]multiProfil
 		if profile == nil {
 			return nil, false, fmt.Errorf("profile %q not found", selector)
 		}
-		if seen[profile.CorpID] {
+		if seen[profile.ProfileID] {
 			continue
 		}
-		seen[profile.CorpID] = true
+		seen[profile.ProfileID] = true
 		selections = append(selections, multiProfileSelection{
 			Selector: selector,
 			Profile:  *profile,
@@ -306,14 +306,16 @@ func (r *runtimeRunner) runMultiProfile(ctx context.Context, invocation executor
 	failed := 0
 
 	for _, selection := range selections {
-		authpkg.SetRuntimeProfile(selection.Profile.CorpID)
+		authpkg.SetRuntimeProfile(selection.Profile.ProfileID)
 		result, err := r.runSingle(ctx, cloneInvocation(invocation), false)
 
 		entry := map[string]any{
-			"selector": selection.Selector,
-			"corpId":   selection.Profile.CorpID,
-			"corpName": selection.Profile.CorpName,
-			"ok":       err == nil,
+			"selector":  selection.Selector,
+			"profileId": selection.Profile.ProfileID,
+			"corpId":    selection.Profile.CorpID,
+			"corpName":  selection.Profile.CorpName,
+			"userId":    selection.Profile.UserID,
+			"ok":        err == nil,
 		}
 		if err != nil {
 			failed++

--- a/internal/auth/keychain_store.go
+++ b/internal/auth/keychain_store.go
@@ -39,6 +39,11 @@ func TokenAccountForCorpID(corpID string) string {
 	return keychain.AccountToken + ":" + strings.TrimSpace(corpID)
 }
 
+// TokenAccountForProfileID returns the keychain account used for a profile-bound token.
+func TokenAccountForProfileID(profileID string) string {
+	return keychain.AccountToken + ":" + strings.TrimSpace(profileID)
+}
+
 // SaveTokenDataKeychainForCorpID saves TokenData to a corp-scoped keychain slot.
 func SaveTokenDataKeychainForCorpID(corpID string, data *TokenData) error {
 	corpID = strings.TrimSpace(corpID)
@@ -46,6 +51,15 @@ func SaveTokenDataKeychainForCorpID(corpID string, data *TokenData) error {
 		return fmt.Errorf("corpId is required for profile token storage")
 	}
 	return saveTokenDataKeychainAccount(TokenAccountForCorpID(corpID), data)
+}
+
+// SaveTokenDataKeychainForProfileID saves TokenData to a profile-scoped keychain slot.
+func SaveTokenDataKeychainForProfileID(profileID string, data *TokenData) error {
+	profileID = strings.TrimSpace(profileID)
+	if profileID == "" {
+		return fmt.Errorf("profileId is required for profile token storage")
+	}
+	return saveTokenDataKeychainAccount(TokenAccountForProfileID(profileID), data)
 }
 
 func saveTokenDataKeychainAccount(account string, data *TokenData) error {
@@ -80,6 +94,15 @@ func LoadTokenDataKeychainForCorpID(corpID string) (*TokenData, error) {
 	return loadTokenDataKeychainAccount(TokenAccountForCorpID(corpID))
 }
 
+// LoadTokenDataKeychainForProfileID loads TokenData from a profile-scoped keychain slot.
+func LoadTokenDataKeychainForProfileID(profileID string) (*TokenData, error) {
+	profileID = strings.TrimSpace(profileID)
+	if profileID == "" {
+		return nil, fmt.Errorf("profileId is required for profile token storage")
+	}
+	return loadTokenDataKeychainAccount(TokenAccountForProfileID(profileID))
+}
+
 func loadTokenDataKeychainAccount(account string) (*TokenData, error) {
 	jsonStr, err := keychain.Get(keychain.Service, account)
 	if err != nil {
@@ -110,6 +133,15 @@ func DeleteTokenDataKeychainForCorpID(corpID string) error {
 	return keychain.Remove(keychain.Service, TokenAccountForCorpID(corpID))
 }
 
+// DeleteTokenDataKeychainForProfileID removes TokenData from a profile-scoped keychain slot.
+func DeleteTokenDataKeychainForProfileID(profileID string) error {
+	profileID = strings.TrimSpace(profileID)
+	if profileID == "" {
+		return fmt.Errorf("profileId is required for profile token storage")
+	}
+	return keychain.Remove(keychain.Service, TokenAccountForProfileID(profileID))
+}
+
 // TokenDataExistsKeychain checks if token data exists in keychain.
 func TokenDataExistsKeychain() bool {
 	return keychain.Exists(keychain.Service, keychain.AccountToken)
@@ -122,6 +154,15 @@ func TokenDataExistsKeychainForCorpID(corpID string) bool {
 		return false
 	}
 	return keychain.Exists(keychain.Service, TokenAccountForCorpID(corpID))
+}
+
+// TokenDataExistsKeychainForProfileID checks if a profile-scoped token exists.
+func TokenDataExistsKeychainForProfileID(profileID string) bool {
+	profileID = strings.TrimSpace(profileID)
+	if profileID == "" {
+		return false
+	}
+	return keychain.Exists(keychain.Service, TokenAccountForProfileID(profileID))
 }
 
 // EnsureMigration performs one-time migration from legacy .data to keychain.

--- a/internal/auth/oauth_provider.go
+++ b/internal/auth/oauth_provider.go
@@ -548,12 +548,12 @@ func (p *OAuthProvider) GetAccessToken(ctx context.Context) (string, error) {
 		if rErr == nil {
 			return refreshed.AccessToken, nil
 		}
-		_ = MarkProfileStatus(p.configDir, data.CorpID, ProfileStatusExpired)
+		_ = MarkProfileStatus(p.configDir, ProfileIDFromToken(data), ProfileStatusExpired)
 		if p.logger != nil {
 			p.logger.Warn(i18n.T("refresh_token 刷新失败"), "error", rErr)
 		}
 	} else {
-		_ = MarkProfileStatus(p.configDir, data.CorpID, ProfileStatusExpired)
+		_ = MarkProfileStatus(p.configDir, ProfileIDFromToken(data), ProfileStatusExpired)
 	}
 
 	return "", errors.New(i18n.T("所有凭证已失效，请运行 dws auth login 重新登录"))

--- a/internal/auth/profiles.go
+++ b/internal/auth/profiles.go
@@ -65,6 +65,7 @@ type ProfilesConfig struct {
 // Profile is a logged-in DingTalk organization identity.
 type Profile struct {
 	Name              string   `json:"name"`
+	ProfileID         string   `json:"profileId,omitempty"`
 	CorpID            string   `json:"corpId"`
 	CorpName          string   `json:"corpName,omitempty"`
 	UserID            string   `json:"userId,omitempty"`
@@ -180,7 +181,8 @@ func ensureProfilesMigrationLocked(configDir string) error {
 	if err != nil || data == nil || strings.TrimSpace(data.CorpID) == "" {
 		return nil
 	}
-	if err := SaveTokenDataKeychainForCorpID(data.CorpID, data); err != nil {
+	data.ProfileID = ProfileIDFromToken(data)
+	if err := SaveTokenDataKeychainForProfileID(data.ProfileID, data); err != nil {
 		return err
 	}
 	return upsertProfileFromToken(configDir, cfg, data, false)
@@ -215,12 +217,15 @@ func upsertProfileFromToken(configDir string, cfg *ProfilesConfig, data *TokenDa
 	if corpID == "" {
 		return nil
 	}
+	profileID := ProfileIDFromToken(data)
+	data.ProfileID = profileID
 	normalizeProfilesConfig(cfg)
 	now := time.Now().Format(time.RFC3339)
-	idx := profileIndexByCorpID(cfg, corpID)
+	idx := profileIndexByProfileID(cfg, profileID)
 	if idx < 0 {
 		profile := Profile{
 			Name:         chooseProfileName(cfg, data),
+			ProfileID:    profileID,
 			CorpID:       corpID,
 			CorpName:     strings.TrimSpace(data.CorpName),
 			UserID:       strings.TrimSpace(data.UserID),
@@ -236,6 +241,7 @@ func upsertProfileFromToken(configDir string, cfg *ProfilesConfig, data *TokenDa
 		cfg.Profiles = append(cfg.Profiles, profile)
 	} else {
 		p := &cfg.Profiles[idx]
+		p.ProfileID = profileID
 		if shouldRefreshProfileName(p, data) {
 			p.Name = chooseProfileName(cfg, data)
 		}
@@ -259,18 +265,40 @@ func upsertProfileFromToken(configDir string, cfg *ProfilesConfig, data *TokenDa
 		p.UpdatedAt = now
 	}
 	if cfg.PrimaryProfile == "" {
-		cfg.PrimaryProfile = corpID
+		cfg.PrimaryProfile = profileID
 	}
-	if makeCurrent && cfg.CurrentProfile != corpID {
+	if makeCurrent && cfg.CurrentProfile != profileID {
 		if cfg.CurrentProfile != "" {
 			cfg.PreviousProfile = cfg.CurrentProfile
 		}
-		cfg.CurrentProfile = corpID
+		cfg.CurrentProfile = profileID
 	}
 	if cfg.CurrentProfile == "" {
-		cfg.CurrentProfile = corpID
+		cfg.CurrentProfile = profileID
 	}
 	return SaveProfiles(configDir, cfg)
+}
+
+// ProfileIDFromToken returns the stable local profile key for a token.
+func ProfileIDFromToken(data *TokenData) string {
+	if data == nil {
+		return ""
+	}
+	corpID := strings.TrimSpace(data.CorpID)
+	userID := strings.TrimSpace(data.UserID)
+	if corpID == "" {
+		return ""
+	}
+	if userID == "" {
+		if id := strings.TrimSpace(data.ProfileID); id != "" {
+			return id
+		}
+		return corpID
+	}
+	if id := strings.TrimSpace(data.ProfileID); id != "" && id != corpID {
+		return id
+	}
+	return corpID + ":" + userID
 }
 
 // ResolveProfile returns a profile selected by name/corpId or by current/primary fallback.
@@ -316,7 +344,7 @@ func resolveProfileForLoad(configDir, selector string) (*Profile, error) {
 		return p, nil
 	}
 	for _, candidate := range []string{cfg.CurrentProfile, cfg.PrimaryProfile} {
-		if p := findProfile(cfg, candidate); p != nil && TokenDataExistsKeychainForCorpID(p.CorpID) {
+		if p := findProfile(cfg, candidate); p != nil && TokenDataExistsKeychainForProfileID(p.ProfileID) {
 			return p, nil
 		}
 	}
@@ -352,20 +380,20 @@ func setCurrentProfileLocked(configDir, selector string) (*Profile, error) {
 	if p == nil {
 		return nil, fmt.Errorf("profile %q not found", strings.TrimSpace(selector))
 	}
-	if cfg.CurrentProfile != p.CorpID {
+	if cfg.CurrentProfile != p.ProfileID {
 		if cfg.CurrentProfile != "" {
 			cfg.PreviousProfile = cfg.CurrentProfile
 		}
-		cfg.CurrentProfile = p.CorpID
+		cfg.CurrentProfile = p.ProfileID
 	}
-	touchProfile(cfg, p.CorpID)
+	touchProfile(cfg, p.ProfileID)
 	if err := SaveProfiles(configDir, cfg); err != nil {
 		return nil, err
 	}
 	if err := syncLegacyTokenMirrorLocked(configDir); err != nil {
 		return nil, err
 	}
-	return findProfile(cfg, p.CorpID), nil
+	return findProfile(cfg, p.ProfileID), nil
 }
 
 // UsePreviousProfile toggles currentProfile and previousProfile.
@@ -395,15 +423,15 @@ func usePreviousProfileLocked(configDir string) (*Profile, error) {
 	if p == nil {
 		return nil, fmt.Errorf("previous profile %q not found", prev)
 	}
-	cfg.PreviousProfile, cfg.CurrentProfile = cfg.CurrentProfile, p.CorpID
-	touchProfile(cfg, p.CorpID)
+	cfg.PreviousProfile, cfg.CurrentProfile = cfg.CurrentProfile, p.ProfileID
+	touchProfile(cfg, p.ProfileID)
 	if err := SaveProfiles(configDir, cfg); err != nil {
 		return nil, err
 	}
 	if err := syncLegacyTokenMirrorLocked(configDir); err != nil {
 		return nil, err
 	}
-	return findProfile(cfg, p.CorpID), nil
+	return findProfile(cfg, p.ProfileID), nil
 }
 
 // RemoveProfile removes a profile from metadata and returns the removed profile.
@@ -429,21 +457,56 @@ func removeProfileLocked(configDir, selector string) (*Profile, error) {
 	removed := *p
 	kept := cfg.Profiles[:0]
 	for _, profile := range cfg.Profiles {
-		if profile.CorpID != removed.CorpID {
+		if profile.ProfileID != removed.ProfileID {
 			kept = append(kept, profile)
 		}
 	}
 	cfg.Profiles = kept
-	if cfg.PrimaryProfile == removed.CorpID {
-		cfg.PrimaryProfile = firstProfileCorpID(cfg)
+	if cfg.PrimaryProfile == removed.ProfileID {
+		cfg.PrimaryProfile = firstProfileID(cfg)
 	}
-	if cfg.CurrentProfile == removed.CorpID {
+	if cfg.CurrentProfile == removed.ProfileID {
 		cfg.CurrentProfile = cfg.PrimaryProfile
 		if cfg.CurrentProfile == "" {
-			cfg.CurrentProfile = firstProfileCorpID(cfg)
+			cfg.CurrentProfile = firstProfileID(cfg)
 		}
 	}
-	if cfg.PreviousProfile == removed.CorpID {
+	if cfg.PreviousProfile == removed.ProfileID {
+		cfg.PreviousProfile = ""
+	}
+	if len(cfg.Profiles) == 0 {
+		cfg.PrimaryProfile = ""
+		cfg.CurrentProfile = ""
+		cfg.PreviousProfile = ""
+	}
+	if err := SaveProfiles(configDir, cfg); err != nil {
+		return nil, err
+	}
+	return &removed, nil
+}
+
+func removeExactProfileIDLocked(configDir, profileID string) (*Profile, error) {
+	profileID = strings.TrimSpace(profileID)
+	if profileID == "" {
+		return nil, fmt.Errorf("profileId is empty")
+	}
+	cfg, err := LoadProfiles(configDir)
+	if err != nil {
+		return nil, err
+	}
+	idx := profileIndexByProfileID(cfg, profileID)
+	if idx < 0 {
+		return nil, fmt.Errorf("profile %q not found", profileID)
+	}
+	removed := cfg.Profiles[idx]
+	cfg.Profiles = append(cfg.Profiles[:idx], cfg.Profiles[idx+1:]...)
+	if cfg.PrimaryProfile == removed.ProfileID {
+		cfg.PrimaryProfile = firstProfileID(cfg)
+	}
+	if cfg.CurrentProfile == removed.ProfileID {
+		cfg.CurrentProfile = cfg.PrimaryProfile
+	}
+	if cfg.PreviousProfile == removed.ProfileID {
 		cfg.PreviousProfile = ""
 	}
 	if len(cfg.Profiles) == 0 {
@@ -499,7 +562,7 @@ func syncLegacyTokenMirrorLocked(configDir string) error {
 		if p == nil {
 			continue
 		}
-		data, loadErr := LoadTokenDataKeychainForCorpID(p.CorpID)
+		data, loadErr := LoadTokenDataKeychainForProfileID(p.ProfileID)
 		if loadErr != nil {
 			// Transient keychain read failure: do NOT touch the existing mirror.
 			hadReadError = true
@@ -527,15 +590,28 @@ func normalizeProfilesConfig(cfg *ProfilesConfig) {
 	if cfg == nil {
 		return
 	}
-	cfg.Version = 1
+	cfg.Version = 2
 	seen := make(map[string]bool, len(cfg.Profiles))
+	pointerMap := make(map[string]string, len(cfg.Profiles))
 	profiles := cfg.Profiles[:0]
 	for _, p := range cfg.Profiles {
 		p.CorpID = strings.TrimSpace(p.CorpID)
-		if p.CorpID == "" || seen[p.CorpID] {
+		p.UserID = strings.TrimSpace(p.UserID)
+		p.ProfileID = strings.TrimSpace(p.ProfileID)
+		if p.ProfileID == "" || (p.ProfileID == p.CorpID && p.UserID != "") {
+			p.ProfileID = p.CorpID
+			if p.UserID != "" {
+				p.ProfileID = p.CorpID + ":" + p.UserID
+			}
+		}
+		if p.CorpID == "" || p.ProfileID == "" || seen[p.ProfileID] {
 			continue
 		}
-		seen[p.CorpID] = true
+		seen[p.ProfileID] = true
+		if _, ok := pointerMap[p.CorpID]; !ok {
+			pointerMap[p.CorpID] = p.ProfileID
+		}
+		pointerMap[p.ProfileID] = p.ProfileID
 		p.Name = strings.TrimSpace(p.Name)
 		if p.Name == "" {
 			p.Name = p.CorpID
@@ -549,6 +625,9 @@ func normalizeProfilesConfig(cfg *ProfilesConfig) {
 		profiles = append(profiles, p)
 	}
 	cfg.Profiles = profiles
+	cfg.PrimaryProfile = migrateProfilePointer(cfg.PrimaryProfile, pointerMap)
+	cfg.CurrentProfile = migrateProfilePointer(cfg.CurrentProfile, pointerMap)
+	cfg.PreviousProfile = migrateProfilePointer(cfg.PreviousProfile, pointerMap)
 	if cfg.PrimaryProfile != "" && findProfile(cfg, cfg.PrimaryProfile) == nil {
 		cfg.PrimaryProfile = ""
 	}
@@ -559,11 +638,22 @@ func normalizeProfilesConfig(cfg *ProfilesConfig) {
 		cfg.PreviousProfile = ""
 	}
 	if cfg.PrimaryProfile == "" {
-		cfg.PrimaryProfile = firstProfileCorpID(cfg)
+		cfg.PrimaryProfile = firstProfileID(cfg)
 	}
 	if cfg.CurrentProfile == "" {
 		cfg.CurrentProfile = cfg.PrimaryProfile
 	}
+}
+
+func migrateProfilePointer(value string, pointerMap map[string]string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if mapped := pointerMap[value]; mapped != "" {
+		return mapped
+	}
+	return value
 }
 
 func chooseProfileName(cfg *ProfilesConfig, data *TokenData) string {
@@ -621,9 +711,16 @@ func findProfile(cfg *ProfilesConfig, selector string) *Profile {
 		return nil
 	}
 	var corpNameMatch *Profile
+	var corpIDMatch *Profile
 	for i := range cfg.Profiles {
-		if cfg.Profiles[i].CorpID == selector || cfg.Profiles[i].Name == selector {
+		if cfg.Profiles[i].ProfileID == selector || cfg.Profiles[i].Name == selector {
 			return &cfg.Profiles[i]
+		}
+		if cfg.Profiles[i].CorpID == selector {
+			if corpIDMatch != nil {
+				return nil
+			}
+			corpIDMatch = &cfg.Profiles[i]
 		}
 		if strings.TrimSpace(cfg.Profiles[i].CorpName) == selector {
 			if corpNameMatch != nil {
@@ -632,30 +729,33 @@ func findProfile(cfg *ProfilesConfig, selector string) *Profile {
 			corpNameMatch = &cfg.Profiles[i]
 		}
 	}
+	if corpIDMatch != nil {
+		return corpIDMatch
+	}
 	return corpNameMatch
 }
 
-func profileIndexByCorpID(cfg *ProfilesConfig, corpID string) int {
+func profileIndexByProfileID(cfg *ProfilesConfig, profileID string) int {
 	if cfg == nil {
 		return -1
 	}
 	for i := range cfg.Profiles {
-		if cfg.Profiles[i].CorpID == corpID {
+		if cfg.Profiles[i].ProfileID == profileID {
 			return i
 		}
 	}
 	return -1
 }
 
-func firstProfileCorpID(cfg *ProfilesConfig) string {
+func firstProfileID(cfg *ProfilesConfig) string {
 	if cfg == nil || len(cfg.Profiles) == 0 {
 		return ""
 	}
-	return cfg.Profiles[0].CorpID
+	return cfg.Profiles[0].ProfileID
 }
 
-func touchProfile(cfg *ProfilesConfig, corpID string) {
-	if p := findProfile(cfg, corpID); p != nil {
+func touchProfile(cfg *ProfilesConfig, profileID string) {
+	if p := findProfile(cfg, profileID); p != nil {
 		now := time.Now().Format(time.RFC3339)
 		p.LastUsedAt = now
 		p.UpdatedAt = now

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -37,6 +37,7 @@ type TokenData struct {
 	PersistentCode string    `json:"persistent_code"`
 	ExpiresAt      time.Time `json:"expires_at"`
 	RefreshExpAt   time.Time `json:"refresh_expires_at"`
+	ProfileID      string    `json:"profile_id,omitempty"`
 	CorpID         string    `json:"corp_id"`
 	UserID         string    `json:"user_id,omitempty"`
 	UserName       string    `json:"user_name,omitempty"`
@@ -122,12 +123,18 @@ func saveTokenDataLocked(configDir string, data *TokenData) error {
 		return saveTokenViaHook(h, configDir, data)
 	}
 	if data != nil && strings.TrimSpace(data.CorpID) != "" {
-		if err := SaveTokenDataKeychainForCorpID(data.CorpID, data); err != nil {
+		profileID := ProfileIDFromToken(data)
+		data.ProfileID = profileID
+		if err := SaveTokenDataKeychainForProfileID(profileID, data); err != nil {
 			return err
 		}
 		makeCurrent := strings.TrimSpace(RuntimeProfile()) == ""
 		if err := upsertProfileFromTokenWithCurrentLocked(configDir, data, makeCurrent); err != nil {
 			return err
+		}
+		if profileID != strings.TrimSpace(data.CorpID) {
+			_ = DeleteTokenDataKeychainForProfileID(strings.TrimSpace(data.CorpID))
+			_, _ = removeExactProfileIDLocked(configDir, strings.TrimSpace(data.CorpID))
 		}
 		if makeCurrent {
 			if err := SaveTokenDataKeychain(data); err != nil {
@@ -183,9 +190,16 @@ func LoadTokenDataForProfile(configDir, profile string) (*TokenData, error) {
 		return nil, err
 	}
 	if selected != nil {
-		data, err := LoadTokenDataKeychainForCorpID(selected.CorpID)
+		data, err := LoadTokenDataKeychainForProfileID(selected.ProfileID)
 		if err == nil {
 			return data, nil
+		}
+		if selected.ProfileID != selected.CorpID {
+			if data, legacyErr := LoadTokenDataKeychainForCorpID(selected.CorpID); legacyErr == nil && data != nil {
+				data.ProfileID = selected.ProfileID
+				_ = SaveTokenDataKeychainForProfileID(selected.ProfileID, data)
+				return data, nil
+			}
 		}
 		if strings.TrimSpace(profile) != "" {
 			return nil, err
@@ -242,8 +256,8 @@ func deleteTokenDataForProfileLocked(configDir, profile string) error {
 		return err
 	}
 	if selected != nil {
-		keychainErr := DeleteTokenDataKeychainForCorpID(selected.CorpID)
-		_, removeErr := removeProfileLocked(configDir, selected.CorpID)
+		keychainErr := DeleteTokenDataKeychainForProfileID(selected.ProfileID)
+		_, removeErr := removeProfileLocked(configDir, selected.ProfileID)
 		legacyErr := syncLegacyTokenMirrorLocked(configDir)
 		secureErr := DeleteSecureData(configDir)
 		if keychainErr != nil {
@@ -281,7 +295,7 @@ func DeleteAllTokenData(configDir string) error {
 		// other slot so the user can always self-heal via auth reset / logout.
 		if cfg, err := LoadProfiles(configDir); err == nil {
 			for _, profile := range cfg.Profiles {
-				if e := DeleteTokenDataKeychainForCorpID(profile.CorpID); e != nil && firstErr == nil {
+				if e := DeleteTokenDataKeychainForProfileID(profile.ProfileID); e != nil && firstErr == nil {
 					firstErr = e
 				}
 			}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -152,6 +152,9 @@ func saveTokenDataLocked(configDir string, data *TokenData) error {
 }
 
 func saveTokenViaHook(h *edition.Hooks, configDir string, data *TokenData) error {
+	if data != nil {
+		data.ProfileID = ProfileIDFromToken(data)
+	}
 	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling token data for hook: %w", err)

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -147,7 +147,7 @@ func TestMultiProfileSaveLoadAndSwitch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.PrimaryProfile != "corp_a" || cfg.CurrentProfile != "corp_b" || cfg.PreviousProfile != "corp_a" {
+	if cfg.PrimaryProfile != "corp_a:user_corp_a" || cfg.CurrentProfile != "corp_b:user_corp_b" || cfg.PreviousProfile != "corp_a:user_corp_a" {
 		t.Fatalf("profile pointers = primary %q current %q previous %q", cfg.PrimaryProfile, cfg.CurrentProfile, cfg.PreviousProfile)
 	}
 
@@ -212,7 +212,7 @@ func TestRuntimeProfileOverrideDoesNotMutateCurrent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.CurrentProfile != "corp_a" {
+	if cfg.CurrentProfile != "corp_a:user_corp_a" {
 		t.Fatalf("current profile = %q, want corp_a", cfg.CurrentProfile)
 	}
 	loadedB, err := LoadTokenDataForProfile(configDir, "corp_b")
@@ -258,22 +258,24 @@ func TestDeleteProfilePreservesOtherProfiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if len(cfg.Profiles) != 1 || cfg.CurrentProfile != "corp_a" {
+	if len(cfg.Profiles) != 1 || cfg.CurrentProfile != "corp_a:user_corp_a" {
 		t.Fatalf("profiles after delete = %#v", cfg)
 	}
 }
 
-func TestUpsertProfileFromTokenOverwritesSameCorp(t *testing.T) {
+func TestSameCorpDifferentUsersCreateDistinctProfiles(t *testing.T) {
 	cleanupKeychain(t)
 	configDir := t.TempDir()
 
 	first := testToken("at_first", "corp_same", "旧组织名")
+	first.UserID = "user_first"
+	first.UserName = "First User"
 	if err := SaveTokenData(configDir, first); err != nil {
 		t.Fatalf("SaveTokenData(first) error = %v", err)
 	}
 	second := testToken("at_second", "corp_same", "新组织名")
-	second.UserID = "user_updated"
-	second.UserName = "Updated User"
+	second.UserID = "user_second"
+	second.UserName = "Second User"
 	second.ClientID = "client_updated"
 	if err := SaveTokenData(configDir, second); err != nil {
 		t.Fatalf("SaveTokenData(second) error = %v", err)
@@ -283,22 +285,38 @@ func TestUpsertProfileFromTokenOverwritesSameCorp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if len(cfg.Profiles) != 1 {
-		t.Fatalf("profiles len = %d, want 1: %#v", len(cfg.Profiles), cfg.Profiles)
+	if len(cfg.Profiles) != 2 {
+		t.Fatalf("profiles len = %d, want 2: %#v", len(cfg.Profiles), cfg.Profiles)
 	}
-	profile := cfg.Profiles[0]
-	if profile.CorpName != "新组织名" {
-		t.Fatalf("corpName = %q, want 新组织名", profile.CorpName)
+	if cfg.PrimaryProfile != "corp_same:user_first" || cfg.CurrentProfile != "corp_same:user_second" {
+		t.Fatalf("profile pointers = primary %q current %q, want first/current second", cfg.PrimaryProfile, cfg.CurrentProfile)
 	}
-	if profile.UserID != "user_updated" || profile.UserName != "Updated User" || profile.ClientID != "client_updated" {
-		t.Fatalf("profile metadata was not overwritten: %#v", profile)
+	if _, err := LoadTokenDataForProfile(configDir, "corp_same"); err == nil {
+		t.Fatal("LoadTokenDataForProfile(corp_same) error = nil, want ambiguous selector")
 	}
-	loaded, err := LoadTokenDataForProfile(configDir, "corp_same")
+	loaded, err := LoadTokenDataForProfile(configDir, "corp_same:user_first")
 	if err != nil {
-		t.Fatalf("LoadTokenDataForProfile() error = %v", err)
+		t.Fatalf("LoadTokenDataForProfile(first profileId) error = %v", err)
+	}
+	if loaded.AccessToken != "at_first" {
+		t.Fatalf("first access token = %q, want at_first", loaded.AccessToken)
+	}
+	loaded, err = LoadTokenDataForProfile(configDir, "corp_same:user_second")
+	if err != nil {
+		t.Fatalf("LoadTokenDataForProfile(second profileId) error = %v", err)
 	}
 	if loaded.AccessToken != "at_second" {
-		t.Fatalf("access token = %q, want at_second", loaded.AccessToken)
+		t.Fatalf("second access token = %q, want at_second", loaded.AccessToken)
+	}
+}
+
+func TestProfileIDFromTokenRecomputesLegacyCorpOnlyIDWhenUserAppears(t *testing.T) {
+	data := testToken("at", "corp_same", "Same Org")
+	data.ProfileID = data.CorpID
+	data.UserID = "user_later"
+
+	if got := ProfileIDFromToken(data); got != "corp_same:user_later" {
+		t.Fatalf("ProfileIDFromToken() = %q, want corp_same:user_later", got)
 	}
 }
 
@@ -332,6 +350,43 @@ func TestUpsertProfileFromTokenPromotesCorpIDNameToCorpName(t *testing.T) {
 	}
 	if resolved.CorpID != "corp_same" {
 		t.Fatalf("resolved corpId = %q, want corp_same", resolved.CorpID)
+	}
+}
+
+func TestLoadProfilesMigratesLegacyPointersToProfileID(t *testing.T) {
+	configDir := t.TempDir()
+	raw := `{
+  "version": 1,
+  "primaryProfile": "corp_same",
+  "currentProfile": "corp_same",
+  "profiles": [
+    {
+      "name": "Legacy Org",
+      "corpId": "corp_same",
+      "corpName": "Legacy Org",
+      "userId": "user_legacy"
+    }
+  ]
+}`
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(ProfilesPath(configDir), []byte(raw), 0o600); err != nil {
+		t.Fatalf("WriteFile(profiles.json) error = %v", err)
+	}
+
+	cfg, err := LoadProfiles(configDir)
+	if err != nil {
+		t.Fatalf("LoadProfiles() error = %v", err)
+	}
+	if cfg.Version != 2 {
+		t.Fatalf("version = %d, want 2", cfg.Version)
+	}
+	if cfg.PrimaryProfile != "corp_same:user_legacy" || cfg.CurrentProfile != "corp_same:user_legacy" {
+		t.Fatalf("profile pointers = primary %q current %q, want migrated profileId", cfg.PrimaryProfile, cfg.CurrentProfile)
+	}
+	if cfg.Profiles[0].ProfileID != "corp_same:user_legacy" {
+		t.Fatalf("profileId = %q, want corp_same:user_legacy", cfg.Profiles[0].ProfileID)
 	}
 }
 
@@ -387,11 +442,11 @@ func TestLegacyKeychainMigrationInitializesProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadProfiles() error = %v", err)
 	}
-	if cfg.PrimaryProfile != "corp_legacy" || cfg.CurrentProfile != "corp_legacy" {
+	if cfg.PrimaryProfile != "corp_legacy:user_corp_legacy" || cfg.CurrentProfile != "corp_legacy:user_corp_legacy" {
 		t.Fatalf("profile pointers after migration = %#v", cfg)
 	}
-	if !TokenDataExistsKeychainForCorpID("corp_legacy") {
-		t.Fatal("corp-scoped token should exist after migration")
+	if !TokenDataExistsKeychainForProfileID("corp_legacy:user_corp_legacy") {
+		t.Fatal("profile-scoped token should exist after migration")
 	}
 }
 

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -14,11 +14,13 @@
 package auth
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
 
 // cleanupKeychain isolates keychain state to a per-test temporary directory
@@ -317,6 +319,48 @@ func TestProfileIDFromTokenRecomputesLegacyCorpOnlyIDWhenUserAppears(t *testing.
 
 	if got := ProfileIDFromToken(data); got != "corp_same:user_later" {
 		t.Fatalf("ProfileIDFromToken() = %q, want corp_same:user_later", got)
+	}
+}
+
+func TestSaveTokenHookReceivesProfileID(t *testing.T) {
+	var payload TokenData
+	edition.Override(&edition.Hooks{
+		SaveToken: func(configDir string, data []byte) error {
+			return json.Unmarshal(data, &payload)
+		},
+	})
+	t.Cleanup(func() { edition.Override(&edition.Hooks{}) })
+
+	if err := SaveTokenData(t.TempDir(), &TokenData{
+		AccessToken: "at",
+		CorpID:      "corp_same",
+		UserID:      "user_1",
+		UserName:    "张三",
+	}); err != nil {
+		t.Fatalf("SaveTokenData() error = %v", err)
+	}
+	if payload.ProfileID != "corp_same:user_1" {
+		t.Fatalf("hook profile_id = %q, want corp_same:user_1", payload.ProfileID)
+	}
+}
+
+func TestSaveTokenHookProfileIDFallsBackToCorpID(t *testing.T) {
+	var payload TokenData
+	edition.Override(&edition.Hooks{
+		SaveToken: func(configDir string, data []byte) error {
+			return json.Unmarshal(data, &payload)
+		},
+	})
+	t.Cleanup(func() { edition.Override(&edition.Hooks{}) })
+
+	if err := SaveTokenData(t.TempDir(), &TokenData{
+		AccessToken: "at",
+		CorpID:      "corp_only",
+	}); err != nil {
+		t.Fatalf("SaveTokenData() error = %v", err)
+	}
+	if payload.ProfileID != "corp_only" {
+		t.Fatalf("hook profile_id = %q, want corp_only", payload.ProfileID)
 	}
 }
 

--- a/test/integration/extensions/protocol_evolution_test.go
+++ b/test/integration/extensions/protocol_evolution_test.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/app"
+	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/market"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/transport"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/test/mock_mcp"
@@ -22,6 +24,7 @@ import (
 )
 
 func TestCLIAdaptsToProtocolAddDeleteModifyAfterDiscoveryRefresh(t *testing.T) {
+	useIsolatedProfileConfig(t)
 	server := newEvolvingRuntimeMarketServer(t, protocolFixturePhase1(t))
 	defer server.Close()
 
@@ -50,7 +53,7 @@ func TestCLIAdaptsToProtocolAddDeleteModifyAfterDiscoveryRefresh(t *testing.T) {
 		t.Fatalf("help output missing --folder-id:\n%s", help)
 	}
 
-	payload := mustRunRootJSON(t, []string{"mcp", "doc", "create-doc-v2", "--name", "协议升级文档", "--folder-id", "folder-a"})
+	payload := mustRunRootJSON(t, []string{"mcp", "doc", "create-doc-v2", "--name", "协议升级文档", "--folder-id", "folder-a", "--token", "test-token"})
 	invocation, ok := payload["invocation"].(map[string]any)
 	if !ok {
 		t.Fatalf("invocation payload missing: %#v", payload)
@@ -80,6 +83,7 @@ func TestCLIAdaptsToProtocolAddDeleteModifyAfterDiscoveryRefresh(t *testing.T) {
 }
 
 func TestCLIKeepsCachedProtocolSurfaceUntilManualRefreshAfterCacheAges(t *testing.T) {
+	useIsolatedProfileConfig(t)
 	server := newEvolvingRuntimeMarketServer(t, protocolFixturePhase1(t))
 	defer server.Close()
 
@@ -628,6 +632,7 @@ func mcpSurface(t *testing.T) map[string][]string {
 }
 
 func TestCLIDoesNotSynchronouslyRevalidateWhenCacheAges(t *testing.T) {
+	useIsolatedProfileConfig(t)
 	server := newEvolvingRuntimeMarketServer(t, protocolFixturePhase2(t))
 	defer server.Close()
 
@@ -675,6 +680,7 @@ func TestCLIDoesNotSynchronouslyRevalidateWhenCacheAges(t *testing.T) {
 }
 
 func TestCLIDoesNotSynchronouslyRevalidateWhenRegistryTTLExpires(t *testing.T) {
+	useIsolatedProfileConfig(t)
 	server := newEvolvingRuntimeMarketServer(t, protocolFixturePhase2(t))
 	defer server.Close()
 
@@ -808,6 +814,14 @@ func runRoot(t *testing.T, args []string) (string, error) {
 	cmd.SetArgs(args)
 	err := cmd.Execute()
 	return out.String(), err
+}
+
+func useIsolatedProfileConfig(t *testing.T) {
+	t.Helper()
+	authpkg.SetRuntimeProfile("")
+	t.Setenv("DWS_CONFIG_DIR", t.TempDir())
+	t.Setenv(keychain.StorageDirEnv, t.TempDir())
+	t.Cleanup(func() { authpkg.SetRuntimeProfile("") })
 }
 
 func ageCacheSnapshots(t *testing.T, root string, savedAt time.Time) {


### PR DESCRIPTION
## Summary

- 新增同组织多账号登录支持，本地账号标识从单纯 corpId 扩展为 profileId（corpId:userId）。

- 调整 profile 选择、切换、退出登录、token 存储、运行时缓存分区及相关文档/测试，使同一 corpId 下多个用户可以共存。

- 补充协议缓存测试隔离，避免本机真实 keychain/profile 状态影响测试结果。

本次改动用于解决同一钉钉组织下多个账号登录时，仅用 corpId 无法区分不同用户的问题。

## Verification

- [x] `make build`
- [ ] `make lint`
- [ ] `make test`
- [x] `make policy`
- [x] `./scripts/policy/check-generated-drift.sh`
- [x] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed)

## Notes

- make lint 仍失败，原因是上游 main 已存在的 staticcheck 问题，已在上游复现。

- make test 仍只在 test/scripts 打包脚本测试失败，已在上游 main 复现；其他 suite 均通过。

- 未修改版本号，也未提交构建产物；正式版本号由 tag / GoReleaser 注入。
