### PR TITLE
docs(changelog): cut 1.0.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.46] - 2026-07-01
+
 ### Fixed
 
 - **PAT agentCode grants no longer split from follow-up command checks** (`internal/auth/agent_code_detect.go`, `internal/app/runner.go`, `internal/pat/chmod_test.go`) — explicit `DINGTALK_DWS_AGENTCODE` declarations are now forwarded verbatim as the common cross-host contract, and unknown hosts no longer synthesize `custom` into `x-dingtalk-dws-agent-code` / `x-dws-agent-instance-id`. `pat chmod --agentCode` remains the highest-priority grant target and still wins over the env fallback.


### PR DESCRIPTION
## 内容

Cut `1.0.46`。相对 `v1.0.45` 唯一待发内容是 #536 —— PAT agentCode grants 与后续命令校验对齐（`internal/auth/agent_code_detect.go`、`internal/app/runner.go`）。changelog 把 `[Unreleased]` 落成 `## [1.0.46] - 2026-07-01`，仅 +2 行。

## 验证

- 被测对象：`origin/main`(fe4a7928) 构建的 open 版二进制（Edition: open）
- 环境：生产，wukong01 沙盒账号（钉钉iPaaS）
- cli_to_mcp 端到端：2357 用例，**综合通过率 94.1%**（上一发布基线 v1.0.37 为 85.2%），每个产品持平或更好，**无回归**
- 78 个 CLI报错 / 124 失败逐个核过：全部是 open 版未接的 wukong 命令（考勤管理 / contact label / conference invite 等，真实用户命令树里不存在）或用例断言层 / 上游返回，非 CLI bug；contact 产品代码 `git diff v1.0.45..HEAD` 为空

合并后打 `v1.0.46` tag 走 goreleaser。