### PR TITLE
feat(connect): health contract for `connect status` (heartbeat + --json)

### DIFF
--- a/internal/helpers/connect_daemon.go
+++ b/internal/helpers/connect_daemon.go
@@ -565,6 +565,58 @@ func newDevAppRobotConnectStopCommand() *cobra.Command {
 	return cmd
 }
 
+// newDevAppRobotConnectListCommand implements `dws dev connect list`: enumerate
+// every connector on this machine and its health, so a developer running
+// several robots sees at a glance which are alive/degraded/down without
+// querying each clientId. `--json` emits the array for scripts.
+func newDevAppRobotConnectListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "list",
+		Short:             "列出本机所有连接器及健康状态（healthy/degraded/down）；--json 供脚本消费",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reports, err := listConnectors(time.Now())
+			if err != nil {
+				return apperrors.NewInternal(err.Error())
+			}
+			w := cmd.OutOrStdout()
+			if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+				data, merr := json.MarshalIndent(reports, "", "  ")
+				if merr != nil {
+					return apperrors.NewInternal(merr.Error())
+				}
+				fmt.Fprintln(w, string(data))
+				return nil
+			}
+			if len(reports) == 0 {
+				fmt.Fprintln(w, "no connectors found")
+				return nil
+			}
+			fmt.Fprintf(w, "%-11s %-24s %-8s %-10s %s\n", "STATE", "CLIENT", "PID", "CHANNEL", "UPTIME")
+			for _, r := range reports {
+				uptime := "-"
+				if r.UptimeSec > 0 {
+					uptime = (time.Duration(r.UptimeSec) * time.Second).Round(time.Second).String()
+				}
+				pid := "-"
+				if r.Pid > 0 {
+					pid = fmt.Sprintf("%d", r.Pid)
+				}
+				channel := r.Channel
+				if channel == "" {
+					channel = "-"
+				}
+				fmt.Fprintf(w, "%-11s %-24s %-8s %-10s %s\n", r.State, r.ClientID, pid, channel, uptime)
+			}
+			return nil
+		},
+	}
+	preferLegacyLeaf(cmd)
+	cmd.Flags().Bool("json", false, "以 JSON 数组输出（供脚本消费）")
+	return cmd
+}
+
 // connectDaemonDirKeyFromFlags resolves the daemon directory key from the
 // status/stop flags, requiring at least one identifier.
 func connectDaemonDirKeyFromFlags(cmd *cobra.Command) (string, error) {

--- a/internal/helpers/connect_daemon.go
+++ b/internal/helpers/connect_daemon.go
@@ -401,8 +401,12 @@ func superviseWait(ctx context.Context, worker *exec.Cmd) error {
 	}
 }
 
-// daemonStatus reports the state of the connector daemon to w.
-func daemonStatus(w io.Writer, dirKey string) error {
+// daemonStatus reports connector health to w. It combines two independent
+// signals: the daemon supervisor pid file (is a supervisor alive) and the
+// connector heartbeat (is the connection live and receiving — see
+// connect_health.go). jsonOut emits the machine-readable health report an
+// external supervisor (launchd/systemd/pm2/cron) consumes to decide restarts.
+func daemonStatus(w io.Writer, dirKey string, jsonOut bool) error {
 	dir, err := connectDaemonDir(dirKey)
 	if err != nil {
 		return apperrors.NewInternal("resolve daemon dir: " + err.Error())
@@ -411,23 +415,59 @@ func daemonStatus(w io.Writer, dirKey string) error {
 	if err != nil {
 		return apperrors.NewInternal(err.Error())
 	}
-	if st == nil {
-		fmt.Fprintf(w, "connect daemon: not running (no pid file under %s)\n", dir)
+	supervised := st != nil && st.Pid > 0 && processAlive(st.Pid)
+
+	hb, err := readConnectHeartbeat(dir)
+	if err != nil {
+		return apperrors.NewInternal("read connector heartbeat: " + err.Error())
+	}
+	report := deriveConnectHealth(hb, supervised, time.Now())
+
+	if jsonOut {
+		data, merr := json.MarshalIndent(report, "", "  ")
+		if merr != nil {
+			return apperrors.NewInternal(merr.Error())
+		}
+		fmt.Fprintln(w, string(data))
 		return nil
 	}
-	if st.Pid <= 0 || !processAlive(st.Pid) {
-		fmt.Fprintf(w, "connect daemon: not running (stale pid file for pid %d at %s)\n", st.Pid, daemonPidPath(dir))
-		return nil
+
+	fmt.Fprintf(w, "connect: %s\n", report.State)
+	if report.Detail != "" {
+		fmt.Fprintf(w, "  detail:    %s\n", report.Detail)
 	}
-	uptime := time.Since(time.Unix(st.StartUnix, 0)).Round(time.Second)
-	fmt.Fprintf(w, "connect daemon: running\n")
-	fmt.Fprintf(w, "  pid:     %d\n", st.Pid)
-	fmt.Fprintf(w, "  uptime:  %s\n", uptime)
-	fmt.Fprintf(w, "  logs:    %s\n", st.LogPath)
-	if st.ClientID != "" {
-		fmt.Fprintf(w, "  client:  %s\n", st.ClientID)
+	if report.Pid > 0 {
+		fmt.Fprintf(w, "  pid:       %d\n", report.Pid)
+	}
+	if report.Channel != "" {
+		fmt.Fprintf(w, "  channel:   %s\n", report.Channel)
+	}
+	if report.ClientID != "" {
+		fmt.Fprintf(w, "  client:    %s\n", report.ClientID)
+	}
+	if report.UptimeSec > 0 {
+		fmt.Fprintf(w, "  uptime:    %s\n", (time.Duration(report.UptimeSec) * time.Second).Round(time.Second))
+	}
+	fmt.Fprintf(w, "  supervisor: %s\n", supervisedLabel(supervised))
+	if hb != nil {
+		if report.LastPushAgoSec > 0 {
+			fmt.Fprintf(w, "  last recv:  %s ago\n", (time.Duration(report.LastPushAgoSec) * time.Second).Round(time.Second))
+		} else {
+			fmt.Fprintf(w, "  last recv:  (none since start)\n")
+		}
+		if report.LastError != "" {
+			fmt.Fprintf(w, "  last error: %s\n", report.LastError)
+		}
+		fmt.Fprintf(w, "  logs:       %s\n", daemonLogPath(dir))
 	}
 	return nil
+}
+
+func supervisedLabel(supervised bool) string {
+	if supervised {
+		return "running (--daemon)"
+	}
+	return "none (foreground or external)"
 }
 
 // daemonStop gracefully stops the connector daemon: SIGTERM the supervisor (it
@@ -483,7 +523,7 @@ func daemonStop(w io.Writer, dirKey string) error {
 func newDevAppRobotConnectStatusCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "status",
-		Short:             "查看后台连接器守护进程状态（pid、运行时长、日志路径）",
+		Short:             "查看连接器健康状态（healthy/degraded/down，pid、收发活动、日志路径；--json 供外部托管消费）",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -491,12 +531,14 @@ func newDevAppRobotConnectStatusCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return daemonStatus(cmd.OutOrStdout(), dirKey)
+			jsonOut, _ := cmd.Flags().GetBool("json")
+			return daemonStatus(cmd.OutOrStdout(), dirKey, jsonOut)
 		},
 	}
 	preferLegacyLeaf(cmd)
 	cmd.Flags().String("robot-client-id", "", "机器人 clientId（定位守护进程）")
 	cmd.Flags().String("unified-app-id", "", "统一应用 ID（当未用 clientId 起守护进程时定位）")
+	cmd.Flags().Bool("json", false, "以 JSON 输出健康报告（供 launchd/systemd/pm2/cron 判断是否重启）")
 	return cmd
 }
 

--- a/internal/helpers/connect_daemon_test.go
+++ b/internal/helpers/connect_daemon_test.go
@@ -15,6 +15,7 @@ package helpers
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -152,48 +153,87 @@ func TestReadDaemonStateCorrupt(t *testing.T) {
 	}
 }
 
+// seedHeartbeat writes a connector heartbeat under dirKey for status tests.
+func seedHeartbeat(t *testing.T, dirKey string, hb connectHeartbeat) string {
+	t.Helper()
+	dir, err := connectDaemonDir(dirKey)
+	if err != nil {
+		t.Fatalf("connectDaemonDir: %v", err)
+	}
+	data, err := json.MarshalIndent(hb, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal heartbeat: %v", err)
+	}
+	if err := os.WriteFile(connectHeartbeatPath(dir), data, 0o644); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+	return dir
+}
+
 func TestDaemonStatusNotRunning(t *testing.T) {
 	connectDaemonDirOverride = t.TempDir()
 	t.Cleanup(func() { connectDaemonDirOverride = "" })
 	var buf bytes.Buffer
-	if err := daemonStatus(&buf, "nope"); err != nil {
+	// No daemon pid file and no connector heartbeat.
+	if err := daemonStatus(&buf, "nope", false); err != nil {
 		t.Fatalf("daemonStatus: %v", err)
 	}
-	if !strings.Contains(buf.String(), "not running") {
-		t.Errorf("expected 'not running', got %q", buf.String())
+	if !strings.Contains(buf.String(), healthNotRunning) {
+		t.Errorf("expected %q, got %q", healthNotRunning, buf.String())
 	}
 }
 
-func TestDaemonStatusStalePid(t *testing.T) {
+func TestDaemonStatusConnectorDown(t *testing.T) {
 	connectDaemonDirOverride = t.TempDir()
 	t.Cleanup(func() { connectDaemonDirOverride = "" })
-	dir, _ := connectDaemonDir("stale")
-	// pid that is essentially certain to be dead.
-	writeDaemonState(dir, daemonState{Pid: deadPid(t), StartUnix: time.Now().Unix(), LogPath: "/l", DirKey: "stale"})
+	// Heartbeat from a connector whose process is gone: down.
+	seedHeartbeat(t, "gone", connectHeartbeat{Pid: deadPid(t), StartUnix: time.Now().Unix() - 100, ConnectedUnix: time.Now().Unix() - 90})
 	var buf bytes.Buffer
-	if err := daemonStatus(&buf, "stale"); err != nil {
+	if err := daemonStatus(&buf, "gone", false); err != nil {
 		t.Fatalf("daemonStatus: %v", err)
 	}
-	if !strings.Contains(buf.String(), "stale pid file") {
-		t.Errorf("expected stale pid report, got %q", buf.String())
+	if !strings.Contains(buf.String(), healthDown) {
+		t.Errorf("expected %q, got %q", healthDown, buf.String())
 	}
 }
 
-func TestDaemonStatusRunning(t *testing.T) {
+func TestDaemonStatusHealthy(t *testing.T) {
 	connectDaemonDirOverride = t.TempDir()
 	t.Cleanup(func() { connectDaemonDirOverride = "" })
+	// Live connector (our pid) that connected: healthy. Also file a live
+	// supervisor to exercise the supervised label.
 	dir, _ := connectDaemonDir("live")
-	// Use our own pid: guaranteed alive.
 	writeDaemonState(dir, daemonState{Pid: os.Getpid(), StartUnix: time.Now().Add(-90 * time.Second).Unix(), LogPath: "/l.log", DirKey: "live", ClientID: "cidX"})
+	seedHeartbeat(t, "live", connectHeartbeat{Pid: os.Getpid(), Channel: "opencode", ClientID: "cidX", StartUnix: time.Now().Unix() - 90, ConnectedUnix: time.Now().Unix() - 88, LastReplyUnix: time.Now().Unix() - 5})
 	var buf bytes.Buffer
-	if err := daemonStatus(&buf, "live"); err != nil {
+	if err := daemonStatus(&buf, "live", false); err != nil {
 		t.Fatalf("daemonStatus: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"running", "pid:", "uptime:", "/l.log", "cidX"} {
+	for _, want := range []string{healthHealthy, "pid:", "channel:", "opencode", "cidX", "supervisor:"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("status output missing %q; got %q", want, out)
 		}
+	}
+}
+
+func TestDaemonStatusJSON(t *testing.T) {
+	connectDaemonDirOverride = t.TempDir()
+	t.Cleanup(func() { connectDaemonDirOverride = "" })
+	seedHeartbeat(t, "j", connectHeartbeat{Pid: os.Getpid(), Channel: "codex", ClientID: "cidJ", StartUnix: time.Now().Unix() - 30, ConnectedUnix: time.Now().Unix() - 28})
+	var buf bytes.Buffer
+	if err := daemonStatus(&buf, "j", true); err != nil {
+		t.Fatalf("daemonStatus json: %v", err)
+	}
+	var report connectHealthReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if report.State != healthHealthy {
+		t.Errorf("state = %q, want %q", report.State, healthHealthy)
+	}
+	if report.Channel != "codex" {
+		t.Errorf("channel = %q, want codex", report.Channel)
 	}
 }
 

--- a/internal/helpers/connect_health.go
+++ b/internal/helpers/connect_health.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -303,4 +305,53 @@ func deriveConnectHealth(hb *connectHeartbeat, supervised bool, now time.Time) c
 	}
 	r.State = healthHealthy
 	return r
+}
+
+// connectBaseDir returns <configDir>/connect — the directory holding one
+// subdirectory per connector (keyed by dirKey). Honours the test override.
+func connectBaseDir() string {
+	base := connectDaemonDirOverride
+	if base == "" {
+		base = config.DefaultConfigDir()
+	}
+	return filepath.Join(base, "connect")
+}
+
+// listConnectors enumerates every connector on this machine by scanning
+// connect/<dirKey>/ and deriving each one's health from its heartbeat plus any
+// supervising daemon. This is the multi-connector view behind `connect list` —
+// the same signal `status` reports for one robot, over all of them. Directories
+// with neither a heartbeat nor a daemon state are skipped (empty leftovers).
+// Results are sorted by clientId for stable output. now is injected for tests.
+func listConnectors(now time.Time) ([]connectHealthReport, error) {
+	ents, err := os.ReadDir(connectBaseDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []connectHealthReport
+	for _, e := range ents {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(connectBaseDir(), e.Name())
+		hb, herr := readConnectHeartbeat(dir)
+		if herr != nil {
+			continue // unreadable heartbeat: skip rather than fail the whole list
+		}
+		st, _ := readDaemonState(dir)
+		if hb == nil && st == nil {
+			continue // empty leftover dir
+		}
+		supervised := st != nil && st.Pid > 0 && processAlive(st.Pid)
+		r := deriveConnectHealth(hb, supervised, now)
+		if r.ClientID == "" {
+			r.ClientID = e.Name() // fall back to the dir key when no heartbeat identity
+		}
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ClientID < out[j].ClientID })
+	return out, nil
 }

--- a/internal/helpers/connect_health.go
+++ b/internal/helpers/connect_health.go
@@ -1,0 +1,306 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
+)
+
+// connect_health is the "does the bot actually work" side of connect
+// observability. The daemon (connect_daemon.go) answers "is a supervisor
+// process alive"; the single-instance lock (connect_lock.go) answers "is there
+// exactly one connector". Neither answers the question a developer actually
+// asks — "is my connection live and receiving?" — which is the gap raised in
+// the 0701 review: a foreground `connect` prints logs and looks busy, but if
+// the Stream silently dropped there is no way to tell a working-but-idle
+// connector from a dead one.
+//
+// The connector (runStreamConnector, foreground OR daemon worker) writes a
+// heartbeat file recording its pid, when it last connected, and when it last
+// received/answered a message. `connect status` reads it and derives a
+// healthy/degraded/down verdict, and `--json` exposes the raw signal so an
+// external supervisor (launchd / systemd / pm2 / cron watchdog) can decide
+// whether to restart without guessing from the process table.
+//
+// Scope note (honest limitation, documented in the PR): with the Stream SDK's
+// WithAutoReconnect(true) and no exposed disconnect callback, we cannot cheaply
+// detect a silently-deaf connection beyond "process alive + connected at least
+// once". lastPushAgoSec is surfaced as data, NOT as a degraded trigger, because
+// an idle bot legitimately receives nothing for hours. The single-instance lock
+// already rules out the duplicate-connection failure mode, so "alive +
+// connected" is a strong healthy signal in practice.
+
+const (
+	connectHeartbeatFile   = "heartbeat.json"
+	connectHeartbeatFlush  = 15 * time.Second
+	connectHealthStalePush = 5 * time.Minute // informational threshold only
+)
+
+// connectHeartbeat is the JSON persisted by a running connector. All times are
+// unix seconds; a zero value means "never happened".
+type connectHeartbeat struct {
+	Pid           int    `json:"pid"`
+	Channel       string `json:"channel,omitempty"`
+	ClientID      string `json:"clientId,omitempty"`
+	StartUnix     int64  `json:"startUnix"`
+	ConnectedUnix int64  `json:"connectedUnix,omitempty"`
+	LastPushUnix  int64  `json:"lastPushUnix,omitempty"`
+	LastReplyUnix int64  `json:"lastReplyUnix,omitempty"`
+	LastError     string `json:"lastError,omitempty"`
+	LastErrorUnix int64  `json:"lastErrorUnix,omitempty"`
+	UpdatedUnix   int64  `json:"updatedUnix"`
+}
+
+// connectHealth is the in-memory writer owned by a connector. Events update it
+// in memory (cheap, called on the message hot path); a background ticker flushes
+// to disk only when something changed, so a busy bot does not churn the disk and
+// an idle one writes nothing after the initial connect record.
+type connectHealth struct {
+	dir string
+	mu  sync.Mutex
+	hb  connectHeartbeat
+
+	flushedUnix int64
+}
+
+// newConnectHealth builds a health writer filed under connect/<dirKey>/. Returns
+// nil when no identity is available (dirKey empty) so every call site can treat
+// health as best-effort — a nil *connectHealth's methods are all no-ops.
+func newConnectHealth(clientID, channel string) *connectHealth {
+	dirKey := daemonDirKey(clientID, "")
+	if dirKey == "" {
+		return nil
+	}
+	dir, err := connectDaemonDir(dirKey)
+	if err != nil {
+		return nil
+	}
+	return &connectHealth{
+		dir: dir,
+		hb: connectHeartbeat{
+			Pid:       os.Getpid(),
+			Channel:   channel,
+			ClientID:  clientID,
+			StartUnix: time.Now().Unix(),
+		},
+	}
+}
+
+func (h *connectHealth) touch(mutate func(*connectHeartbeat)) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	mutate(&h.hb)
+	h.hb.UpdatedUnix = time.Now().Unix()
+	h.mu.Unlock()
+}
+
+// onConnected records a successful Stream connect. Called after cli.Start.
+func (h *connectHealth) onConnected() {
+	h.touch(func(hb *connectHeartbeat) { hb.ConnectedUnix = time.Now().Unix() })
+}
+
+// onPush records an inbound message accepted for forwarding.
+func (h *connectHealth) onPush() {
+	h.touch(func(hb *connectHeartbeat) { hb.LastPushUnix = time.Now().Unix() })
+}
+
+// onReply records a reply successfully produced by the agent.
+func (h *connectHealth) onReply() {
+	h.touch(func(hb *connectHeartbeat) { hb.LastReplyUnix = time.Now().Unix() })
+}
+
+// onError records the most recent forward/delivery error.
+func (h *connectHealth) onError(err error) {
+	if err == nil {
+		return
+	}
+	h.touch(func(hb *connectHeartbeat) {
+		hb.LastError = truncateRunes(err.Error(), 300)
+		hb.LastErrorUnix = time.Now().Unix()
+	})
+}
+
+// start writes an initial heartbeat and launches the flush ticker. It stops and
+// removes the heartbeat file when ctx is cancelled, so a graceful shutdown
+// leaves no stale "healthy" file behind.
+func (h *connectHealth) start(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	_ = h.flush()
+	go func() {
+		t := time.NewTicker(connectHeartbeatFlush)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				h.remove()
+				return
+			case <-t.C:
+				_ = h.flush()
+			}
+		}
+	}()
+}
+
+// flush persists the heartbeat only when it changed since the last write.
+func (h *connectHealth) flush() error {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	if h.hb.UpdatedUnix == h.flushedUnix {
+		h.mu.Unlock()
+		return nil
+	}
+	snapshot := h.hb
+	h.mu.Unlock()
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := connectHeartbeatPath(h.dir)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, config.FilePerm); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	h.mu.Lock()
+	h.flushedUnix = snapshot.UpdatedUnix
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *connectHealth) remove() {
+	if h == nil {
+		return
+	}
+	_ = os.Remove(connectHeartbeatPath(h.dir))
+}
+
+func connectHeartbeatPath(dir string) string {
+	return dir + string(os.PathSeparator) + connectHeartbeatFile
+}
+
+// readConnectHeartbeat loads the heartbeat file. Missing file yields (nil, nil)
+// so callers distinguish "no connector ran" from an I/O error.
+func readConnectHeartbeat(dir string) (*connectHeartbeat, error) {
+	data, err := os.ReadFile(connectHeartbeatPath(dir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var hb connectHeartbeat
+	if err := json.Unmarshal(data, &hb); err != nil {
+		return nil, err
+	}
+	return &hb, nil
+}
+
+// Health states, ordered worst-to-best for reporting.
+const (
+	healthNotRunning = "not_running"
+	healthDown       = "down"
+	healthDegraded   = "degraded"
+	healthHealthy    = "healthy"
+)
+
+// connectHealthReport is the derived, presentation-ready verdict combining the
+// connector heartbeat with the (optional) supervising daemon.
+type connectHealthReport struct {
+	State          string `json:"state"`
+	Pid            int    `json:"pid,omitempty"`
+	Channel        string `json:"channel,omitempty"`
+	ClientID       string `json:"clientId,omitempty"`
+	UptimeSec      int64  `json:"uptimeSec,omitempty"`
+	ConnectedAgo   int64  `json:"connectedAgoSec,omitempty"`
+	LastPushAgoSec int64  `json:"lastPushAgoSec,omitempty"`
+	LastReplyAgo   int64  `json:"lastReplyAgoSec,omitempty"`
+	LastError      string `json:"lastError,omitempty"`
+	Supervised     bool   `json:"supervised"`
+	Detail         string `json:"detail,omitempty"`
+}
+
+// deriveConnectHealth turns the raw heartbeat (and whether a daemon supervisor
+// is alive) into a verdict. now is injected so the logic is unit-testable.
+func deriveConnectHealth(hb *connectHeartbeat, supervised bool, now time.Time) connectHealthReport {
+	nowUnix := now.Unix()
+	if hb == nil {
+		return connectHealthReport{State: healthNotRunning, Supervised: supervised,
+			Detail: "no connector heartbeat found"}
+	}
+	r := connectHealthReport{
+		Pid:        hb.Pid,
+		Channel:    hb.Channel,
+		ClientID:   hb.ClientID,
+		Supervised: supervised,
+		LastError:  hb.LastError,
+	}
+	if hb.StartUnix > 0 {
+		r.UptimeSec = nowUnix - hb.StartUnix
+	}
+	if hb.ConnectedUnix > 0 {
+		r.ConnectedAgo = nowUnix - hb.ConnectedUnix
+	}
+	if hb.LastPushUnix > 0 {
+		r.LastPushAgoSec = nowUnix - hb.LastPushUnix
+	}
+	if hb.LastReplyUnix > 0 {
+		r.LastReplyAgo = nowUnix - hb.LastReplyUnix
+	}
+
+	// Connector process gone: down. A supervisor (if any) will restart it.
+	if hb.Pid <= 0 || !processAlive(hb.Pid) {
+		r.State = healthDown
+		if supervised {
+			r.Detail = "connector process not alive; supervisor should restart it"
+		} else {
+			r.Detail = "connector process not alive"
+		}
+		return r
+	}
+	// Alive but never reached a connected state: still starting or failing to
+	// establish the Stream.
+	if hb.ConnectedUnix == 0 {
+		r.State = healthDegraded
+		r.Detail = "process alive but never established a Stream connection"
+		return r
+	}
+	// Alive and connected, but the most recent event was an error with no
+	// successful activity after it: degraded.
+	lastOK := hb.ConnectedUnix
+	if hb.LastReplyUnix > lastOK {
+		lastOK = hb.LastReplyUnix
+	}
+	if hb.LastErrorUnix > lastOK {
+		r.State = healthDegraded
+		r.Detail = "last activity was an error after the last success"
+		return r
+	}
+	r.State = healthHealthy
+	return r
+}

--- a/internal/helpers/connect_health_test.go
+++ b/internal/helpers/connect_health_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDeriveConnectHealth(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	alive := os.Getpid()
+	dead := deadPid(t)
+
+	cases := []struct {
+		name       string
+		hb         *connectHeartbeat
+		supervised bool
+		want       string
+	}{
+		{"no heartbeat", nil, false, healthNotRunning},
+		{"no heartbeat but supervised", nil, true, healthNotRunning},
+		{
+			"connector dead",
+			&connectHeartbeat{Pid: dead, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90},
+			false, healthDown,
+		},
+		{
+			"alive never connected",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 5},
+			false, healthDegraded,
+		},
+		{
+			"alive and connected",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90, LastReplyUnix: now.Unix() - 10},
+			false, healthHealthy,
+		},
+		{
+			"idle but connected is still healthy",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100000, ConnectedUnix: now.Unix() - 100000},
+			false, healthHealthy,
+		},
+		{
+			"error after last success is degraded",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90, LastReplyUnix: now.Unix() - 50, LastErrorUnix: now.Unix() - 5, LastError: "boom"},
+			false, healthDegraded,
+		},
+		{
+			"error before last reply stays healthy",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90, LastErrorUnix: now.Unix() - 50, LastReplyUnix: now.Unix() - 5, LastError: "old"},
+			false, healthHealthy,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := deriveConnectHealth(c.hb, c.supervised, now)
+			if got.State != c.want {
+				t.Fatalf("state = %q, want %q (detail=%q)", got.State, c.want, got.Detail)
+			}
+			if got.Supervised != c.supervised {
+				t.Errorf("supervised = %v, want %v", got.Supervised, c.supervised)
+			}
+		})
+	}
+}
+
+func TestConnectHeartbeatRoundTrip(t *testing.T) {
+	connectDaemonDirOverride = t.TempDir()
+	t.Cleanup(func() { connectDaemonDirOverride = "" })
+
+	h := newConnectHealth("cid-round", "opencode")
+	if h == nil {
+		t.Fatal("newConnectHealth returned nil for a valid clientId")
+	}
+	h.onConnected()
+	h.onPush()
+	h.onReply()
+	if err := h.flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	hb, err := readConnectHeartbeat(h.dir)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if hb == nil {
+		t.Fatal("heartbeat not persisted")
+	}
+	if hb.Pid != os.Getpid() || hb.Channel != "opencode" || hb.ClientID != "cid-round" {
+		t.Errorf("unexpected heartbeat identity: %+v", hb)
+	}
+	if hb.ConnectedUnix == 0 || hb.LastPushUnix == 0 || hb.LastReplyUnix == 0 {
+		t.Errorf("expected all activity timestamps set: %+v", hb)
+	}
+}
+
+func TestConnectHeartbeatFlushSkipsUnchanged(t *testing.T) {
+	connectDaemonDirOverride = t.TempDir()
+	t.Cleanup(func() { connectDaemonDirOverride = "" })
+
+	h := newConnectHealth("cid-skip", "codex")
+	h.onConnected()
+	if err := h.flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	// Second flush with no new event must be a no-op (nothing to write).
+	fi1, _ := os.Stat(connectHeartbeatPath(h.dir))
+	if err := h.flush(); err != nil {
+		t.Fatalf("second flush: %v", err)
+	}
+	if h.hb.UpdatedUnix != h.flushedUnix {
+		t.Errorf("flushedUnix (%d) should track UpdatedUnix (%d) after flush", h.flushedUnix, h.hb.UpdatedUnix)
+	}
+	_ = fi1
+}
+
+func TestConnectHealthNilSafe(t *testing.T) {
+	var h *connectHealth // no clientId path yields nil
+	// None of these may panic.
+	h.onConnected()
+	h.onPush()
+	h.onReply()
+	h.onError(errors.New("x"))
+	h.start(nil)
+	if err := h.flush(); err != nil {
+		t.Fatalf("nil flush: %v", err)
+	}
+	h.remove()
+}
+
+func TestNewConnectHealthNoIdentity(t *testing.T) {
+	if h := newConnectHealth("", ""); h != nil {
+		t.Errorf("expected nil health writer with no clientId, got %+v", h)
+	}
+}

--- a/internal/helpers/connect_health_test.go
+++ b/internal/helpers/connect_health_test.go
@@ -14,6 +14,7 @@
 package helpers
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"testing"
@@ -144,5 +145,44 @@ func TestConnectHealthNilSafe(t *testing.T) {
 func TestNewConnectHealthNoIdentity(t *testing.T) {
 	if h := newConnectHealth("", ""); h != nil {
 		t.Errorf("expected nil health writer with no clientId, got %+v", h)
+	}
+}
+
+func TestListConnectors(t *testing.T) {
+	connectDaemonDirOverride = t.TempDir()
+	t.Cleanup(func() { connectDaemonDirOverride = "" })
+	now := time.Unix(2_000_000, 0)
+	alive := os.Getpid()
+
+	dirA, _ := connectDaemonDir("dingAAA")
+	writeJSON(t, connectHeartbeatPath(dirA), connectHeartbeat{Pid: alive, Channel: "opencode", ClientID: "dingAAA", StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90})
+	dirB, _ := connectDaemonDir("dingBBB")
+	writeJSON(t, connectHeartbeatPath(dirB), connectHeartbeat{Pid: deadPid(t), Channel: "codex", ClientID: "dingBBB", StartUnix: now.Unix() - 50, ConnectedUnix: now.Unix() - 40})
+	// Empty leftover dir must be skipped.
+	_, _ = connectDaemonDir("emptyleftover")
+
+	reports, err := listConnectors(now)
+	if err != nil {
+		t.Fatalf("listConnectors: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("got %d reports, want 2 (empty dir skipped): %+v", len(reports), reports)
+	}
+	if reports[0].ClientID != "dingAAA" || reports[0].State != healthHealthy {
+		t.Errorf("report[0] = %+v, want dingAAA healthy", reports[0])
+	}
+	if reports[1].ClientID != "dingBBB" || reports[1].State != healthDown {
+		t.Errorf("report[1] = %+v, want dingBBB down", reports[1])
+	}
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/helpers/connect_stream.go
+++ b/internal/helpers/connect_stream.go
@@ -925,6 +925,12 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 	}
 	defer release()
 
+	// Health heartbeat: record connect/receive/reply/error so `connect status`
+	// can tell a live connector from a dead one (see connect_health.go). Nil
+	// when no clientId identity is available; all calls below are no-ops then.
+	health := newConnectHealth(clientID, channel)
+	health.start(ctx)
+
 	streamLoggerOnce.Do(func() { sdklogger.SetLogger(streamSDKLogger{}) })
 	replier := chatbot.NewChatbotReplier()
 	dedup := newMsgDedup(10000)
@@ -983,6 +989,7 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 		}
 		fmt.Fprintf(os.Stderr, "[connect] 收到 @%s: %s (convType=%s convId=%s staffId=%s msgId=%s)\n",
 			sender, truncateRunes(shown, 80), data.ConversationType, data.ConversationId, data.SenderStaffId, data.MsgId)
+		health.onPush()
 		// Ack-first: return now, reply asynchronously via sessionWebhook (which is
 		// independent of the Stream ack). Use a background context so the in-flight
 		// forward is not cancelled by the SDK when this callback returns.
@@ -1118,8 +1125,10 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "[connect] 转发失败 (%s, 耗时 %s): %v\n", channel, time.Since(started).Round(time.Millisecond), err)
 				reply = fmt.Sprintf("（%s 调用失败：%v）", channel, err)
+				health.onError(err)
 			} else {
 				fmt.Fprintf(os.Stderr, "[connect] agent 已生成回复 (%s, 耗时 %s): %s\n", channel, time.Since(started).Round(time.Millisecond), truncateRunes(reply, 80))
+				health.onReply()
 			}
 
 			// Confirmation gate orchestration: if the agent's reply declared
@@ -1208,6 +1217,7 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 		return apperrors.NewInternal("stream 建连失败：" + err.Error())
 	}
 	defer cli.Close()
+	health.onConnected()
 	<-ctx.Done()
 	return nil
 }

--- a/internal/helpers/devapp_connect.go
+++ b/internal/helpers/devapp_connect.go
@@ -555,6 +555,7 @@ func newDevAppRobotConnectCommand(runner executor.Runner) *cobra.Command {
 	cmd.AddCommand(
 		newDevAppRobotConnectStatusCommand(),
 		newDevAppRobotConnectStopCommand(),
+		newDevAppRobotConnectListCommand(),
 	)
 	cmd.Flags().String("channel", "auto", "渠道：auto(默认,自动探测)|openclaw|qoder|qoderwork|hermes|workbuddy|claudecode|codebuddy|codex|gemini|opencode|custom(自研/未支持的 AI，配 --agent-cmd)")
 	cmd.Flags().String("agent-cmd", "", "自研/未支持的 AI 工具命令（无头/一次性：问题作为最后一个参数追加，答案打到 stdout）；用来接入内置渠道之外的 AI（如网易有道龙虾 LobsterAI）；等价于 --channel custom + 设 DWS_AGENT_CMD；env: DWS_AGENT_CMD")


### PR DESCRIPTION
## Background

In the 0701 review, 勤泽 raised that `dws dev connect` only does a **one-shot link**: after it connects a robot, a developer cannot tell whether the connection is still alive. His words — *"现在感觉像是一个玩具，而不是一个能够真正去使用的能力"*, *"一定要有状态，有状态以后你才好去做管理"*. This PR is the first of two addressing that.

## Current state (what already exists on main)

A lot of what the review asked for already landed and is **not** re-done here:

| Requirement | Status on main |
|---|---|
| Restart after crash | ✅ `connect --daemon` supervisor, exponential backoff (`connect_daemon.go`) |
| Process liveness | ✅ pid file + `processAlive` signal-0 probe (`connect_lock.go`) |
| No duplicate connections ("时灵时不灵") | ✅ single-instance lock (`connect_lock.go`) |
| Agent host (opencode) auto-heal | ✅ `ensure()` re-probes `/global/health`, respawns (`connect_opencode.go`) |
| Reconnect on network drop | ✅ Stream SDK `WithAutoReconnect(true)` (`connect_stream.go`) |
| `status` / `stop` commands | ✅ `dev connect status` / `stop` |

## The actual gap

These answer **"is a supervisor process alive"** and **"is there exactly one connector"**. Neither answers the question a developer actually asks: **"is my connection live and receiving?"** A `status` that only reports "pid N, uptime T" can say *running* while the bot is functionally deaf. That is the observability gap this PR closes.

Framing: the problem is really **two separate problems** — (1) *keep-alive/restart* (already solved many ways: our daemon, launchd, systemd, pm2…), and (2) *health truth* (solved by nobody — no external supervisor can see a deaf Stream). This PR does (2), which is the part only we can do.

## What this PR does (PR-1: the health contract)

- **`connect_health.go`** — the connector (foreground **or** daemon worker) writes a heartbeat file under `~/.dws/connect/<clientId>/heartbeat.json`: pid, channel, `connectedUnix`, `lastPushUnix`, `lastReplyUnix`, `lastError`. Updated in-memory on the message hot path; a ticker flushes to disk **only when it changed** (idle bot → no churn). Nil-safe: no clientId identity → all hooks are no-ops.
- **`runStreamConnector`** wires four hooks: `onConnected` (after `cli.Start`), `onPush`, `onReply`, `onError`. No change to reconnect/forwarding logic.
- **`dev connect status`** now derives `healthy` / `degraded` / `down` / `not_running` by combining the heartbeat with the supervisor pid, and gains **`--json`** so an external supervisor can decide restarts without guessing from the process table.

### `status --json` (the contract external supervisors consume)

```json
{
  "state": "healthy",
  "pid": 8123,
  "channel": "opencode",
  "clientId": "ding...",
  "uptimeSec": 3600,
  "connectedAgoSec": 3598,
  "lastPushAgoSec": 42,
  "lastReplyAgoSec": 40,
  "supervised": true
}
```

State machine (`deriveConnectHealth`, unit-tested):
- `not_running` — no heartbeat.
- `down` — heartbeat exists but the connector process is gone (a supervisor, if any, will restart it).
- `degraded` — process alive but never reached a connected state, **or** the last event was an error after the last success.
- `healthy` — process alive and connected.

## Honest limitation (intentional scope line)

With `WithAutoReconnect(true)` and no exposed disconnect callback, a *silently-deaf* connection can't be cheaply detected beyond "process alive + connected once". So `lastPushAgoSec` is surfaced as **data, not a degraded trigger** — an idle bot legitimately receives nothing for hours. The single-instance lock already rules out the duplicate-connection failure mode, so "alive + connected" is a strong healthy signal in practice. A future active self-probe could go further; out of scope here.

## Follow-up (PR-2, not in this PR): supervision as a recipe, not a dependency

Rather than marry one process manager, PR-2 will ship thin **hosting recipes** that all consume this PR's `status --json`:
- default: our zero-dependency `--daemon` (nothing to install)
- macOS: launchd plist · Linux: systemd `--user` unit · Windows: NSSM/service (fills the daemon's Windows gap)
- Node teams: an optional pm2 `ecosystem.config.js`

On **pm2 specifically**: not adopted as a core/hard dependency — it pulls a Node runtime into a single static Go binary and it supervises the wrong layer (it restarts on *process death*, but the real gap is a *deaf-but-alive* connection, which it can't see without the signal this PR adds). It fits only as one optional recipe for teams already living in pm2.

## Open questions for review (阈值待定)

1. `degraded` threshold when we later add push-staleness heuristics — default 5min?
2. Should a watchdog auto-restart on `degraded`, or alert-first-then-restart-on-second-strike?

## Testing

- `deriveConnectHealth` table tests (all state transitions incl. idle-is-still-healthy and error-ordering).
- heartbeat write/read round-trip, flush-skips-unchanged, nil-safety.
- `dev connect status` text + `--json` output tests (rewritten from the old daemon-only status tests, since pid-alive alone no longer implies healthy).
- `go build ./...`, `go vet`, full `internal/helpers` suite green; manual `go run ./cmd dev connect status --json` verified.

---

## 使用与验证（How to use / verify）

### 人怎么用
起连接器后（前台或 `--daemon`），任意时刻查健康：
```
dws dev connect status --robot-client-id <clientId>
```
一眼看到 `healthy / degraded / down`、最后收发消息时间、最后错误、日志路径。

### agent / 外部托管怎么用（稳定契约）
```
dws dev connect status --robot-client-id <clientId> --json
```
读 `.state`：`healthy` → 不动；`down` / `degraded` / `not_running` → 该重启。这就是外部保活器（launchd/systemd/pm2/cron watchdog）唯一要消费的信号，不用去 parse `ps`。

### 四态本地已实跑验证
用真命令跑过四种状态（造心跳文件 → 跑 `status --json`）：

| 造的场景 | state | detail |
|---|---|---|
| 活着 + 已建连 + 刚收发 | `healthy` | — |
| 活着 + 最近一件事是报错 | `degraded` | last activity was an error after the last success |
| 心跳在但进程没了 | `down` | connector process not alive |
| 无心跳文件 | `not_running` | no connector heartbeat found |

单测另覆盖状态机全迁移 + 心跳读写/去重/nil 安全 + status 文本与 JSON 输出。
