### PR TITLE
fix(doc): strip duplicate title H1 on `doc update --mode overwrite`

### DIFF
--- a/internal/helpers/doc.go
+++ b/internal/helpers/doc.go
@@ -512,6 +512,19 @@ func jsonmlNodeText(node any) string {
 	}
 }
 
+// docLookupNodeName best-effort fetches a document node's current title via
+// get_document_info. Used by `update --mode overwrite` to strip a leading
+// heading that duplicates the title (mirroring the create path, which has the
+// name from --name). Returns "" on any failure so the caller proceeds without
+// stripping rather than blocking the update.
+func docLookupNodeName(cmd *cobra.Command, runner executor.Runner, nodeID string) string {
+	res, err := docInvocationResult(cmd, runner, "doc", "get_document_info", map[string]any{"nodeId": nodeID})
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(docFirstStringRecursive(res.Response, "name", "title"))
+}
+
 func newDocUpdateCommand(runner executor.Runner) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update",
@@ -553,12 +566,35 @@ func newDocUpdateCommand(runner executor.Runner) *cobra.Command {
 				if err != nil {
 					return err
 				}
+				// overwrite replaces the whole body, so a leading heading equal to
+				// the doc title duplicates the page title (same as create). create
+				// strips it using --name; here we look the title up first. Skipped
+				// on dry-run so a preview never issues a live read.
+				if strings.TrimSpace(mode) == "overwrite" && !commandDryRun(cmd) {
+					if name := docLookupNodeName(cmd, runner, nodeID); name != "" {
+						if stripped, ok := stripLeadingDuplicateTitleJSONML(jsonml, name); ok {
+							fmt.Fprintln(cmd.ErrOrStderr(), `note: 正文首个与文档标题相同的一级标题已自动移除（文档标题会单独渲染为页面标题，保留会出现两个标题）。`)
+							jsonml = stripped
+						}
+					}
+				}
 				params["format"] = "jsonml"
 				params["jsonml"] = jsonml
 				addDocIntParam(cmd, params, "revision", "revision")
 			} else {
 				if sniffJsonMLLike(content) {
 					fmt.Fprintln(cmd.ErrOrStderr(), `warning: 输入内容看起来是 JSONML 结构；若要按 JSONML 解析，请加 --content-format jsonml，否则将按 markdown 解析。`)
+				}
+				// See the jsonml branch: strip a leading H1 that duplicates the
+				// title on overwrite, mirroring create's behaviour. Skipped on
+				// dry-run so a preview never issues a live read.
+				if strings.TrimSpace(mode) == "overwrite" && !commandDryRun(cmd) {
+					if name := docLookupNodeName(cmd, runner, nodeID); name != "" {
+						if stripped, ok := stripLeadingDuplicateTitleHeading(content, name); ok {
+							fmt.Fprintln(cmd.ErrOrStderr(), `note: 正文首行与文档标题相同的一级标题已自动移除（文档标题会单独渲染为页面标题，保留会出现两个标题）。`)
+							content = stripped
+						}
+					}
 				}
 				params["markdown"] = stripDocInputUnsafe(content)
 				addDocIntParam(cmd, params, "index", "index")

--- a/internal/helpers/doc_test.go
+++ b/internal/helpers/doc_test.go
@@ -171,9 +171,12 @@ func TestDocUpdateOverwriteAllowsYesAndDryRun(t *testing.T) {
 		name       string
 		extraArgs  []string
 		wantDryRun bool
+		// Real overwrite looks the title up first (get_document_info) to strip a
+		// duplicate leading H1, so it makes 2 calls; dry-run skips the live read.
+		wantCalls int
 	}{
-		{name: "yes", extraArgs: []string{"--yes"}},
-		{name: "dry run", extraArgs: []string{"--dry-run"}, wantDryRun: true},
+		{name: "yes", extraArgs: []string{"--yes"}, wantCalls: 2},
+		{name: "dry run", extraArgs: []string{"--dry-run"}, wantDryRun: true, wantCalls: 1},
 	}
 
 	for _, tc := range cases {
@@ -194,8 +197,12 @@ func TestDocUpdateOverwriteAllowsYesAndDryRun(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Execute() error = %v\nstderr:\n%s", err, errOut)
 			}
-			if runner.calls != 1 {
-				t.Fatalf("runner calls = %d, want 1", runner.calls)
+			if runner.calls != tc.wantCalls {
+				t.Fatalf("runner calls = %d, want %d", runner.calls, tc.wantCalls)
+			}
+			// The write is always the last call; its DryRun must reflect the flag.
+			if runner.last.Tool != "update_document" {
+				t.Fatalf("last tool = %q, want update_document", runner.last.Tool)
 			}
 			if runner.last.DryRun != tc.wantDryRun {
 				t.Fatalf("DryRun = %v, want %v", runner.last.DryRun, tc.wantDryRun)

--- a/internal/helpers/doc_title_dedup_test.go
+++ b/internal/helpers/doc_title_dedup_test.go
@@ -16,6 +16,8 @@ package helpers
 import (
 	"strings"
 	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
 )
 
 func TestStripLeadingDuplicateTitleHeading(t *testing.T) {
@@ -265,4 +267,106 @@ func TestStripLeadingDuplicateTitleJSONML(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDocUpdateOverwriteStripsDuplicateTitleHeading verifies the overwrite path
+// mirrors create: it looks up the node title (get_document_info) and drops a
+// leading H1 that duplicates it, so `doc update --mode overwrite` no longer
+// re-introduces the two-headings effect create already guards against.
+func TestDocUpdateOverwriteStripsDuplicateTitleHeading(t *testing.T) {
+	runner := &docCommandRunner{responses: []map[string]any{{"name": "命令树参考"}}}
+	root := newDocTestRoot(runner)
+
+	_, errOut, err := executeDocCommand(t, root,
+		"update", "--node", "NODE_1", "--mode", "overwrite", "--yes",
+		"--content", "# 命令树参考\n\n正文内容。")
+	if err != nil {
+		t.Fatalf("execute: %v\nstderr:\n%s", err, errOut)
+	}
+	if len(runner.all) != 2 {
+		t.Fatalf("calls = %d, want 2 (get_document_info + update_document)", len(runner.all))
+	}
+	if runner.all[0].Tool != "get_document_info" {
+		t.Fatalf("first tool = %q, want get_document_info", runner.all[0].Tool)
+	}
+	if runner.all[1].Tool != "update_document" {
+		t.Fatalf("second tool = %q, want update_document", runner.all[1].Tool)
+	}
+	if got, _ := runner.all[1].Params["markdown"].(string); got != "正文内容。" {
+		t.Errorf("markdown param = %q, want duplicate H1 stripped", got)
+	}
+	if !strings.Contains(errOut, "已自动移除") {
+		t.Errorf("stderr = %q, want a note about the removed heading", errOut)
+	}
+}
+
+// TestDocUpdateOverwriteKeepsDistinctHeading ensures the overwrite guard never
+// eats an H1 that differs from the document title.
+func TestDocUpdateOverwriteKeepsDistinctHeading(t *testing.T) {
+	runner := &docCommandRunner{responses: []map[string]any{{"name": "命令树参考"}}}
+	root := newDocTestRoot(runner)
+
+	_, _, err := executeDocCommand(t, root,
+		"update", "--node", "NODE_1", "--mode", "overwrite", "--yes",
+		"--content", "# 背景\n正文")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got, _ := runner.all[1].Params["markdown"].(string); got != "# 背景\n正文" {
+		t.Errorf("markdown param = %q, want content untouched", got)
+	}
+}
+
+// TestDocUpdateAppendDoesNotLookupTitle ensures the title lookup (and strip)
+// only runs for overwrite: append inserts content, so a leading H1 there is not
+// a duplicate title and no extra get_document_info call should be made.
+func TestDocUpdateAppendDoesNotLookupTitle(t *testing.T) {
+	runner := &docCommandRunner{}
+	root := newDocTestRoot(runner)
+
+	_, _, err := executeDocCommand(t, root,
+		"update", "--node", "NODE_1", "--mode", "append",
+		"--content", "# 命令树参考\n正文")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(runner.all) != 1 || runner.all[0].Tool != "update_document" {
+		t.Fatalf("calls = %v, want a single update_document (no title lookup on append)", toolNames(runner.all))
+	}
+	if got, _ := runner.all[0].Params["markdown"].(string); got != "# 命令树参考\n正文" {
+		t.Errorf("markdown param = %q, want content untouched on append", got)
+	}
+}
+
+// TestDocUpdateOverwriteStripsDuplicateTitleJSONML covers the JSONML overwrite
+// path counterpart.
+func TestDocUpdateOverwriteStripsDuplicateTitleJSONML(t *testing.T) {
+	runner := &docCommandRunner{responses: []map[string]any{{"name": "命令树参考"}}}
+	root := newDocTestRoot(runner)
+
+	body := `{"jsonml":[["h1",{},"命令树参考"],["p",{},"正文"]]}`
+	_, errOut, err := executeDocCommand(t, root,
+		"update", "--node", "NODE_1", "--mode", "overwrite", "--yes",
+		"--content-format", "jsonml", "--content", body)
+	if err != nil {
+		t.Fatalf("execute: %v\nstderr:\n%s", err, errOut)
+	}
+	if len(runner.all) != 2 || runner.all[1].Tool != "update_document" {
+		t.Fatalf("calls = %v, want get_document_info + update_document", toolNames(runner.all))
+	}
+	got, _ := runner.all[1].Params["jsonml"].(string)
+	if strings.Contains(got, "命令树参考") {
+		t.Errorf("jsonml = %q, want duplicate h1 stripped", got)
+	}
+	if !strings.Contains(got, "正文") {
+		t.Errorf("jsonml = %q, want body kept", got)
+	}
+}
+
+func toolNames(inv []executor.Invocation) []string {
+	names := make([]string, len(inv))
+	for i, v := range inv {
+		names[i] = v.Tool
+	}
+	return names
 }


### PR DESCRIPTION
## Problem

`doc create` strips a leading H1 that equals `--name` (the platform renders the doc name as the page title, so a body opening with the same H1 shows **two titles**). But `doc update --mode overwrite` never got that guard: overwriting a doc with content whose first line is `# <title>` re-introduces the double-title effect.

Repro (before): create a doc, then `doc update --mode overwrite --content "# <same title>\n..."` → page shows the title twice.

## Fix

`update` has no `--name`, so overwrite now looks the current title up via `get_document_info` (best-effort: on lookup failure it proceeds without stripping, never blocks the update), then applies the **existing** `stripLeadingDuplicateTitleHeading` / `stripLeadingDuplicateTitleJSONML` helpers — same behaviour as create, both markdown and JSONML paths.

- **Skipped on `--dry-run`** so a preview never issues a live read.
- **`append` untouched** — a leading H1 in appended content is not a duplicate title.

## Testing

- New: overwrite strips a dup H1 (markdown + JSONML), keeps a *distinct* H1, and append makes no title lookup.
- Updated the existing yes/dry-run gate test for the extra lookup call on real overwrite.
- End-to-end on the live API (`go run ./cmd`): create plain → `update overwrite` with matching H1 → note printed, read-back has no H1 → throwaway deleted.
- `go build ./...`, `go vet`, full `internal/helpers` suite green.

> Found while writing the connect design doc (#543/#544): overwriting the doc re-added the H1. Independent of that work — this is the `doc update` path that #448 (create-path fix) never covered.
