### PR TITLE
fix(connect): shorten keepAlive + ulimit check for multi-agent stability

### DIFF
--- a/internal/helpers/connect_codex_appserver.go
+++ b/internal/helpers/connect_codex_appserver.go
@@ -103,7 +103,7 @@ func (f *codexAppServerForwarder) forwardStream(ctx context.Context, convID, tex
 }
 
 func (f *codexAppServerForwarder) forwardAppServer(ctx context.Context, convID, text string, onDelta func(string)) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, f.timeout)
+	ctx, cancel := applyTimeout(ctx, f.timeout)
 	defer cancel()
 
 	var state *codexThreadState

--- a/internal/helpers/connect_daemon.go
+++ b/internal/helpers/connect_daemon.go
@@ -488,6 +488,28 @@ func daemonStop(w io.Writer, dirKey string) error {
 	}
 	if !processAlive(st.Pid) {
 		_ = os.Remove(daemonPidPath(dir))
+		// The supervisor is dead, but its worker may still be alive (e.g. the
+		// supervisor was kill -9'd). Check the heartbeat for the worker pid and
+		// stop it so we don't leave an orphan.
+		if hb, _ := readConnectHeartbeat(dir); hb != nil && hb.Pid > 0 && processAlive(hb.Pid) {
+			fmt.Fprintf(w, "connect daemon: supervisor (pid %d) was dead, stopping orphan worker (pid %d)...\n", st.Pid, hb.Pid)
+			if proc, perr := os.FindProcess(hb.Pid); perr == nil {
+				_ = proc.Signal(syscall.SIGTERM)
+				deadline := time.Now().Add(daemonStopTimeout)
+				for time.Now().Before(deadline) {
+					if !processAlive(hb.Pid) {
+						break
+					}
+					time.Sleep(200 * time.Millisecond)
+				}
+				if processAlive(hb.Pid) {
+					_ = proc.Signal(syscall.SIGKILL)
+					time.Sleep(200 * time.Millisecond)
+				}
+			}
+			fmt.Fprintf(w, "connect daemon: orphan worker stopped (pid %d)\n", hb.Pid)
+			return nil
+		}
 		fmt.Fprintf(w, "connect daemon: was not running (cleaned up stale pid file for pid %d)\n", st.Pid)
 		return nil
 	}

--- a/internal/helpers/connect_daemon.go
+++ b/internal/helpers/connect_daemon.go
@@ -565,6 +565,58 @@ func newDevAppRobotConnectStopCommand() *cobra.Command {
 	return cmd
 }
 
+// newDevAppRobotConnectListCommand implements `dws dev connect list`: enumerate
+// every connector on this machine and its health, so a developer running
+// several robots sees at a glance which are alive/degraded/down without
+// querying each clientId. `--json` emits the array for scripts.
+func newDevAppRobotConnectListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "list",
+		Short:             "列出本机所有连接器及健康状态（healthy/degraded/down）；--json 供脚本消费",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			reports, err := listConnectors(time.Now())
+			if err != nil {
+				return apperrors.NewInternal(err.Error())
+			}
+			w := cmd.OutOrStdout()
+			if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+				data, merr := json.MarshalIndent(reports, "", "  ")
+				if merr != nil {
+					return apperrors.NewInternal(merr.Error())
+				}
+				fmt.Fprintln(w, string(data))
+				return nil
+			}
+			if len(reports) == 0 {
+				fmt.Fprintln(w, "no connectors found")
+				return nil
+			}
+			fmt.Fprintf(w, "%-11s %-24s %-8s %-10s %s\n", "STATE", "CLIENT", "PID", "CHANNEL", "UPTIME")
+			for _, r := range reports {
+				uptime := "-"
+				if r.UptimeSec > 0 {
+					uptime = (time.Duration(r.UptimeSec) * time.Second).Round(time.Second).String()
+				}
+				pid := "-"
+				if r.Pid > 0 {
+					pid = fmt.Sprintf("%d", r.Pid)
+				}
+				channel := r.Channel
+				if channel == "" {
+					channel = "-"
+				}
+				fmt.Fprintf(w, "%-11s %-24s %-8s %-10s %s\n", r.State, r.ClientID, pid, channel, uptime)
+			}
+			return nil
+		},
+	}
+	preferLegacyLeaf(cmd)
+	cmd.Flags().Bool("json", false, "以 JSON 数组输出（供脚本消费）")
+	return cmd
+}
+
 // connectDaemonDirKeyFromFlags resolves the daemon directory key from the
 // status/stop flags, requiring at least one identifier.
 func connectDaemonDirKeyFromFlags(cmd *cobra.Command) (string, error) {

--- a/internal/helpers/connect_daemon.go
+++ b/internal/helpers/connect_daemon.go
@@ -28,6 +28,7 @@ import (
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/logging"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/tui"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
 	"github.com/spf13/cobra"
 )
@@ -432,35 +433,36 @@ func daemonStatus(w io.Writer, dirKey string, jsonOut bool) error {
 		return nil
 	}
 
-	fmt.Fprintf(w, "connect: %s\n", report.State)
+	var lines []string
+	lines = append(lines, fmt.Sprintf("%s  %s", tui.Key("state"), colorConnectState(report.State)))
 	if report.Detail != "" {
-		fmt.Fprintf(w, "  detail:    %s\n", report.Detail)
+		lines = append(lines, fmt.Sprintf("%s %s", tui.Key("detail"), report.Detail))
 	}
 	if report.Pid > 0 {
-		fmt.Fprintf(w, "  pid:       %d\n", report.Pid)
+		lines = append(lines, fmt.Sprintf("%s    %s", tui.Key("pid"), tui.White(fmt.Sprintf("%d", report.Pid))))
 	}
 	if report.Channel != "" {
-		fmt.Fprintf(w, "  channel:   %s\n", report.Channel)
+		lines = append(lines, fmt.Sprintf("%s %s", tui.Key("channel"), tui.White(report.Channel)))
 	}
 	if report.ClientID != "" {
-		fmt.Fprintf(w, "  client:    %s\n", report.ClientID)
+		lines = append(lines, fmt.Sprintf("%s %s", tui.Key("client"), tui.White(report.ClientID)))
 	}
 	if report.UptimeSec > 0 {
-		fmt.Fprintf(w, "  uptime:    %s\n", (time.Duration(report.UptimeSec) * time.Second).Round(time.Second))
+		lines = append(lines, fmt.Sprintf("%s %s", tui.Key("uptime"), tui.White((time.Duration(report.UptimeSec)*time.Second).Round(time.Second).String())))
 	}
-	fmt.Fprintf(w, "  supervisor: %s\n", supervisedLabel(supervised))
+	lines = append(lines, fmt.Sprintf("%s  %s", tui.Key("super"), supervisedLabel(supervised)))
 	if hb != nil {
 		if report.LastPushAgoSec > 0 {
-			fmt.Fprintf(w, "  last recv:  %s ago\n", (time.Duration(report.LastPushAgoSec) * time.Second).Round(time.Second))
+			lines = append(lines, fmt.Sprintf("%s  %s ago", tui.Key("recv"), tui.White((time.Duration(report.LastPushAgoSec)*time.Second).Round(time.Second).String())))
 		} else {
-			fmt.Fprintf(w, "  last recv:  (none since start)\n")
+			lines = append(lines, fmt.Sprintf("%s  %s", tui.Key("recv"), tui.Dim("(none since start)")))
 		}
 		if report.LastError != "" {
-			fmt.Fprintf(w, "  last error: %s\n", report.LastError)
+			lines = append(lines, fmt.Sprintf("%s  %s", tui.Key("error"), tui.Danger(report.LastError)))
 		}
-		fmt.Fprintf(w, "  logs:       %s\n", daemonLogPath(dir))
+		lines = append(lines, fmt.Sprintf("%s   %s", tui.Key("logs"), tui.Dim(daemonLogPath(dir))))
 	}
-	return nil
+	return tui.Panel(w, tui.Bold("connect status"), lines)
 }
 
 func supervisedLabel(supervised bool) string {
@@ -615,23 +617,7 @@ func newDevAppRobotConnectListCommand() *cobra.Command {
 				fmt.Fprintln(w, "no connectors found")
 				return nil
 			}
-			fmt.Fprintf(w, "%-11s %-24s %-8s %-10s %s\n", "STATE", "CLIENT", "PID", "CHANNEL", "UPTIME")
-			for _, r := range reports {
-				uptime := "-"
-				if r.UptimeSec > 0 {
-					uptime = (time.Duration(r.UptimeSec) * time.Second).Round(time.Second).String()
-				}
-				pid := "-"
-				if r.Pid > 0 {
-					pid = fmt.Sprintf("%d", r.Pid)
-				}
-				channel := r.Channel
-				if channel == "" {
-					channel = "-"
-				}
-				fmt.Fprintf(w, "%-11s %-24s %-8s %-10s %s\n", r.State, r.ClientID, pid, channel, uptime)
-			}
-			return nil
+			return writeConnectListTable(w, reports)
 		},
 	}
 	preferLegacyLeaf(cmd)
@@ -649,4 +635,103 @@ func connectDaemonDirKeyFromFlags(cmd *cobra.Command) (string, error) {
 		return "", apperrors.NewValidation("需要 --robot-client-id 或 --unified-app-id 以定位守护进程")
 	}
 	return dirKey, nil
+}
+
+func colorConnectState(state string) string {
+	switch state {
+	case healthHealthy:
+		return tui.Success(state)
+	case healthDegraded:
+		return tui.Warning(state)
+	case healthDown, healthNotRunning:
+		return tui.Danger(state)
+	default:
+		return tui.Cyan(state)
+	}
+}
+
+func writeConnectListTable(w io.Writer, reports []connectHealthReport) error {
+	type col struct {
+		header string
+		width  int
+	}
+	cols := []col{
+		{"STATE", 11},
+		{"CLIENT", 8},
+		{"PID", 6},
+		{"CHANNEL", 7},
+		{"UPTIME", 6},
+	}
+	// compute column widths from data
+	for _, r := range reports {
+		if w := tui.PlainRuneWidth(r.ClientID); w > cols[1].width {
+			cols[1].width = w
+		}
+		if w := tui.PlainRuneWidth(r.Channel); w > cols[3].width {
+			cols[3].width = w
+		}
+	}
+	for i := range cols {
+		if cols[i].width > tui.MaxTableColumnWidth {
+			cols[i].width = tui.MaxTableColumnWidth
+		}
+	}
+
+	writeBorder := func(left, mid, right string, colorFn func(string) string) {
+		fmt.Fprint(w, colorFn(left))
+		for i, c := range cols {
+			if i > 0 {
+				fmt.Fprint(w, colorFn(mid))
+			}
+			fmt.Fprint(w, colorFn(strings.Repeat("─", c.width+2)))
+		}
+		fmt.Fprintln(w, colorFn(right))
+	}
+	writeRowCells := func(cells []string) {
+		fmt.Fprint(w, tui.Gray("│"))
+		for i, c := range cols {
+			cell := ""
+			if i < len(cells) {
+				cell = cells[i]
+			}
+			fmt.Fprintf(w, " %s ", tui.PadRightANSI(cell, c.width))
+			fmt.Fprint(w, tui.Gray("│"))
+		}
+		fmt.Fprintln(w)
+	}
+
+	// header
+	writeBorder("╭", "┬", "╮", tui.Blue)
+	headers := make([]string, len(cols))
+	for i, c := range cols {
+		headers[i] = tui.Brand(c.header)
+	}
+	writeRowCells(headers)
+	writeBorder("├", "┼", "┤", tui.Gray)
+
+	// rows
+	for _, r := range reports {
+		uptime := tui.Dim("-")
+		if r.UptimeSec > 0 {
+			uptime = tui.White((time.Duration(r.UptimeSec) * time.Second).Round(time.Second).String())
+		}
+		pid := tui.Dim("-")
+		if r.Pid > 0 {
+			pid = tui.White(fmt.Sprintf("%d", r.Pid))
+		}
+		channel := tui.Dim("-")
+		if r.Channel != "" {
+			channel = tui.White(r.Channel)
+		}
+		writeRowCells([]string{
+			colorConnectState(r.State),
+			tui.White(r.ClientID),
+			pid,
+			channel,
+			uptime,
+		})
+	}
+
+	writeBorder("╰", "┴", "╯", tui.Blue)
+	return nil
 }

--- a/internal/helpers/connect_daemon.go
+++ b/internal/helpers/connect_daemon.go
@@ -401,8 +401,12 @@ func superviseWait(ctx context.Context, worker *exec.Cmd) error {
 	}
 }
 
-// daemonStatus reports the state of the connector daemon to w.
-func daemonStatus(w io.Writer, dirKey string) error {
+// daemonStatus reports connector health to w. It combines two independent
+// signals: the daemon supervisor pid file (is a supervisor alive) and the
+// connector heartbeat (is the connection live and receiving — see
+// connect_health.go). jsonOut emits the machine-readable health report an
+// external supervisor (launchd/systemd/pm2/cron) consumes to decide restarts.
+func daemonStatus(w io.Writer, dirKey string, jsonOut bool) error {
 	dir, err := connectDaemonDir(dirKey)
 	if err != nil {
 		return apperrors.NewInternal("resolve daemon dir: " + err.Error())
@@ -411,23 +415,59 @@ func daemonStatus(w io.Writer, dirKey string) error {
 	if err != nil {
 		return apperrors.NewInternal(err.Error())
 	}
-	if st == nil {
-		fmt.Fprintf(w, "connect daemon: not running (no pid file under %s)\n", dir)
+	supervised := st != nil && st.Pid > 0 && processAlive(st.Pid)
+
+	hb, err := readConnectHeartbeat(dir)
+	if err != nil {
+		return apperrors.NewInternal("read connector heartbeat: " + err.Error())
+	}
+	report := deriveConnectHealth(hb, supervised, time.Now())
+
+	if jsonOut {
+		data, merr := json.MarshalIndent(report, "", "  ")
+		if merr != nil {
+			return apperrors.NewInternal(merr.Error())
+		}
+		fmt.Fprintln(w, string(data))
 		return nil
 	}
-	if st.Pid <= 0 || !processAlive(st.Pid) {
-		fmt.Fprintf(w, "connect daemon: not running (stale pid file for pid %d at %s)\n", st.Pid, daemonPidPath(dir))
-		return nil
+
+	fmt.Fprintf(w, "connect: %s\n", report.State)
+	if report.Detail != "" {
+		fmt.Fprintf(w, "  detail:    %s\n", report.Detail)
 	}
-	uptime := time.Since(time.Unix(st.StartUnix, 0)).Round(time.Second)
-	fmt.Fprintf(w, "connect daemon: running\n")
-	fmt.Fprintf(w, "  pid:     %d\n", st.Pid)
-	fmt.Fprintf(w, "  uptime:  %s\n", uptime)
-	fmt.Fprintf(w, "  logs:    %s\n", st.LogPath)
-	if st.ClientID != "" {
-		fmt.Fprintf(w, "  client:  %s\n", st.ClientID)
+	if report.Pid > 0 {
+		fmt.Fprintf(w, "  pid:       %d\n", report.Pid)
+	}
+	if report.Channel != "" {
+		fmt.Fprintf(w, "  channel:   %s\n", report.Channel)
+	}
+	if report.ClientID != "" {
+		fmt.Fprintf(w, "  client:    %s\n", report.ClientID)
+	}
+	if report.UptimeSec > 0 {
+		fmt.Fprintf(w, "  uptime:    %s\n", (time.Duration(report.UptimeSec) * time.Second).Round(time.Second))
+	}
+	fmt.Fprintf(w, "  supervisor: %s\n", supervisedLabel(supervised))
+	if hb != nil {
+		if report.LastPushAgoSec > 0 {
+			fmt.Fprintf(w, "  last recv:  %s ago\n", (time.Duration(report.LastPushAgoSec) * time.Second).Round(time.Second))
+		} else {
+			fmt.Fprintf(w, "  last recv:  (none since start)\n")
+		}
+		if report.LastError != "" {
+			fmt.Fprintf(w, "  last error: %s\n", report.LastError)
+		}
+		fmt.Fprintf(w, "  logs:       %s\n", daemonLogPath(dir))
 	}
 	return nil
+}
+
+func supervisedLabel(supervised bool) string {
+	if supervised {
+		return "running (--daemon)"
+	}
+	return "none (foreground or external)"
 }
 
 // daemonStop gracefully stops the connector daemon: SIGTERM the supervisor (it
@@ -483,7 +523,7 @@ func daemonStop(w io.Writer, dirKey string) error {
 func newDevAppRobotConnectStatusCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "status",
-		Short:             "查看后台连接器守护进程状态（pid、运行时长、日志路径）",
+		Short:             "查看连接器健康状态（healthy/degraded/down，pid、收发活动、日志路径；--json 供外部托管消费）",
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -491,12 +531,14 @@ func newDevAppRobotConnectStatusCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return daemonStatus(cmd.OutOrStdout(), dirKey)
+			jsonOut, _ := cmd.Flags().GetBool("json")
+			return daemonStatus(cmd.OutOrStdout(), dirKey, jsonOut)
 		},
 	}
 	preferLegacyLeaf(cmd)
 	cmd.Flags().String("robot-client-id", "", "机器人 clientId（定位守护进程）")
 	cmd.Flags().String("unified-app-id", "", "统一应用 ID（当未用 clientId 起守护进程时定位）")
+	cmd.Flags().Bool("json", false, "以 JSON 输出健康报告（供 launchd/systemd/pm2/cron 判断是否重启）")
 	return cmd
 }
 

--- a/internal/helpers/connect_daemon_test.go
+++ b/internal/helpers/connect_daemon_test.go
@@ -15,6 +15,7 @@ package helpers
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -152,48 +153,87 @@ func TestReadDaemonStateCorrupt(t *testing.T) {
 	}
 }
 
+// seedHeartbeat writes a connector heartbeat under dirKey for status tests.
+func seedHeartbeat(t *testing.T, dirKey string, hb connectHeartbeat) string {
+	t.Helper()
+	dir, err := connectDaemonDir(dirKey)
+	if err != nil {
+		t.Fatalf("connectDaemonDir: %v", err)
+	}
+	data, err := json.MarshalIndent(hb, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal heartbeat: %v", err)
+	}
+	if err := os.WriteFile(connectHeartbeatPath(dir), data, 0o644); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+	return dir
+}
+
 func TestDaemonStatusNotRunning(t *testing.T) {
 	connectDaemonDirOverride = t.TempDir()
 	t.Cleanup(func() { connectDaemonDirOverride = "" })
 	var buf bytes.Buffer
-	if err := daemonStatus(&buf, "nope"); err != nil {
+	// No daemon pid file and no connector heartbeat.
+	if err := daemonStatus(&buf, "nope", false); err != nil {
 		t.Fatalf("daemonStatus: %v", err)
 	}
-	if !strings.Contains(buf.String(), "not running") {
-		t.Errorf("expected 'not running', got %q", buf.String())
+	if !strings.Contains(buf.String(), healthNotRunning) {
+		t.Errorf("expected %q, got %q", healthNotRunning, buf.String())
 	}
 }
 
-func TestDaemonStatusStalePid(t *testing.T) {
+func TestDaemonStatusConnectorDown(t *testing.T) {
 	connectDaemonDirOverride = t.TempDir()
 	t.Cleanup(func() { connectDaemonDirOverride = "" })
-	dir, _ := connectDaemonDir("stale")
-	// pid that is essentially certain to be dead.
-	writeDaemonState(dir, daemonState{Pid: deadPid(t), StartUnix: time.Now().Unix(), LogPath: "/l", DirKey: "stale"})
+	// Heartbeat from a connector whose process is gone: down.
+	seedHeartbeat(t, "gone", connectHeartbeat{Pid: deadPid(t), StartUnix: time.Now().Unix() - 100, ConnectedUnix: time.Now().Unix() - 90})
 	var buf bytes.Buffer
-	if err := daemonStatus(&buf, "stale"); err != nil {
+	if err := daemonStatus(&buf, "gone", false); err != nil {
 		t.Fatalf("daemonStatus: %v", err)
 	}
-	if !strings.Contains(buf.String(), "stale pid file") {
-		t.Errorf("expected stale pid report, got %q", buf.String())
+	if !strings.Contains(buf.String(), healthDown) {
+		t.Errorf("expected %q, got %q", healthDown, buf.String())
 	}
 }
 
-func TestDaemonStatusRunning(t *testing.T) {
+func TestDaemonStatusHealthy(t *testing.T) {
 	connectDaemonDirOverride = t.TempDir()
 	t.Cleanup(func() { connectDaemonDirOverride = "" })
+	// Live connector (our pid) that connected: healthy. Also file a live
+	// supervisor to exercise the supervised label.
 	dir, _ := connectDaemonDir("live")
-	// Use our own pid: guaranteed alive.
 	writeDaemonState(dir, daemonState{Pid: os.Getpid(), StartUnix: time.Now().Add(-90 * time.Second).Unix(), LogPath: "/l.log", DirKey: "live", ClientID: "cidX"})
+	seedHeartbeat(t, "live", connectHeartbeat{Pid: os.Getpid(), Channel: "opencode", ClientID: "cidX", StartUnix: time.Now().Unix() - 90, ConnectedUnix: time.Now().Unix() - 88, LastReplyUnix: time.Now().Unix() - 5})
 	var buf bytes.Buffer
-	if err := daemonStatus(&buf, "live"); err != nil {
+	if err := daemonStatus(&buf, "live", false); err != nil {
 		t.Fatalf("daemonStatus: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{"running", "pid:", "uptime:", "/l.log", "cidX"} {
+	for _, want := range []string{healthHealthy, "pid:", "channel:", "opencode", "cidX", "supervisor:"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("status output missing %q; got %q", want, out)
 		}
+	}
+}
+
+func TestDaemonStatusJSON(t *testing.T) {
+	connectDaemonDirOverride = t.TempDir()
+	t.Cleanup(func() { connectDaemonDirOverride = "" })
+	seedHeartbeat(t, "j", connectHeartbeat{Pid: os.Getpid(), Channel: "codex", ClientID: "cidJ", StartUnix: time.Now().Unix() - 30, ConnectedUnix: time.Now().Unix() - 28})
+	var buf bytes.Buffer
+	if err := daemonStatus(&buf, "j", true); err != nil {
+		t.Fatalf("daemonStatus json: %v", err)
+	}
+	var report connectHealthReport
+	if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if report.State != healthHealthy {
+		t.Errorf("state = %q, want %q", report.State, healthHealthy)
+	}
+	if report.Channel != "codex" {
+		t.Errorf("channel = %q, want codex", report.Channel)
 	}
 }
 

--- a/internal/helpers/connect_daemon_test.go
+++ b/internal/helpers/connect_daemon_test.go
@@ -210,7 +210,7 @@ func TestDaemonStatusHealthy(t *testing.T) {
 		t.Fatalf("daemonStatus: %v", err)
 	}
 	out := buf.String()
-	for _, want := range []string{healthHealthy, "pid:", "channel:", "opencode", "cidX", "supervisor:"} {
+	for _, want := range []string{healthHealthy, "pid:", "channel:", "opencode", "cidX", "super:"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("status output missing %q; got %q", want, out)
 		}

--- a/internal/helpers/connect_health.go
+++ b/internal/helpers/connect_health.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -303,4 +305,53 @@ func deriveConnectHealth(hb *connectHeartbeat, supervised bool, now time.Time) c
 	}
 	r.State = healthHealthy
 	return r
+}
+
+// connectBaseDir returns <configDir>/connect — the directory holding one
+// subdirectory per connector (keyed by dirKey). Honours the test override.
+func connectBaseDir() string {
+	base := connectDaemonDirOverride
+	if base == "" {
+		base = config.DefaultConfigDir()
+	}
+	return filepath.Join(base, "connect")
+}
+
+// listConnectors enumerates every connector on this machine by scanning
+// connect/<dirKey>/ and deriving each one's health from its heartbeat plus any
+// supervising daemon. This is the multi-connector view behind `connect list` —
+// the same signal `status` reports for one robot, over all of them. Directories
+// with neither a heartbeat nor a daemon state are skipped (empty leftovers).
+// Results are sorted by clientId for stable output. now is injected for tests.
+func listConnectors(now time.Time) ([]connectHealthReport, error) {
+	ents, err := os.ReadDir(connectBaseDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []connectHealthReport
+	for _, e := range ents {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(connectBaseDir(), e.Name())
+		hb, herr := readConnectHeartbeat(dir)
+		if herr != nil {
+			continue // unreadable heartbeat: skip rather than fail the whole list
+		}
+		st, _ := readDaemonState(dir)
+		if hb == nil && st == nil {
+			continue // empty leftover dir
+		}
+		supervised := st != nil && st.Pid > 0 && processAlive(st.Pid)
+		r := deriveConnectHealth(hb, supervised, now)
+		if r.ClientID == "" {
+			r.ClientID = e.Name() // fall back to the dir key when no heartbeat identity
+		}
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ClientID < out[j].ClientID })
+	return out, nil
 }

--- a/internal/helpers/connect_health.go
+++ b/internal/helpers/connect_health.go
@@ -1,0 +1,306 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
+)
+
+// connect_health is the "does the bot actually work" side of connect
+// observability. The daemon (connect_daemon.go) answers "is a supervisor
+// process alive"; the single-instance lock (connect_lock.go) answers "is there
+// exactly one connector". Neither answers the question a developer actually
+// asks — "is my connection live and receiving?" — which is the gap raised in
+// the 0701 review: a foreground `connect` prints logs and looks busy, but if
+// the Stream silently dropped there is no way to tell a working-but-idle
+// connector from a dead one.
+//
+// The connector (runStreamConnector, foreground OR daemon worker) writes a
+// heartbeat file recording its pid, when it last connected, and when it last
+// received/answered a message. `connect status` reads it and derives a
+// healthy/degraded/down verdict, and `--json` exposes the raw signal so an
+// external supervisor (launchd / systemd / pm2 / cron watchdog) can decide
+// whether to restart without guessing from the process table.
+//
+// Scope note (honest limitation, documented in the PR): with the Stream SDK's
+// WithAutoReconnect(true) and no exposed disconnect callback, we cannot cheaply
+// detect a silently-deaf connection beyond "process alive + connected at least
+// once". lastPushAgoSec is surfaced as data, NOT as a degraded trigger, because
+// an idle bot legitimately receives nothing for hours. The single-instance lock
+// already rules out the duplicate-connection failure mode, so "alive +
+// connected" is a strong healthy signal in practice.
+
+const (
+	connectHeartbeatFile   = "heartbeat.json"
+	connectHeartbeatFlush  = 15 * time.Second
+	connectHealthStalePush = 5 * time.Minute // informational threshold only
+)
+
+// connectHeartbeat is the JSON persisted by a running connector. All times are
+// unix seconds; a zero value means "never happened".
+type connectHeartbeat struct {
+	Pid           int    `json:"pid"`
+	Channel       string `json:"channel,omitempty"`
+	ClientID      string `json:"clientId,omitempty"`
+	StartUnix     int64  `json:"startUnix"`
+	ConnectedUnix int64  `json:"connectedUnix,omitempty"`
+	LastPushUnix  int64  `json:"lastPushUnix,omitempty"`
+	LastReplyUnix int64  `json:"lastReplyUnix,omitempty"`
+	LastError     string `json:"lastError,omitempty"`
+	LastErrorUnix int64  `json:"lastErrorUnix,omitempty"`
+	UpdatedUnix   int64  `json:"updatedUnix"`
+}
+
+// connectHealth is the in-memory writer owned by a connector. Events update it
+// in memory (cheap, called on the message hot path); a background ticker flushes
+// to disk only when something changed, so a busy bot does not churn the disk and
+// an idle one writes nothing after the initial connect record.
+type connectHealth struct {
+	dir string
+	mu  sync.Mutex
+	hb  connectHeartbeat
+
+	flushedUnix int64
+}
+
+// newConnectHealth builds a health writer filed under connect/<dirKey>/. Returns
+// nil when no identity is available (dirKey empty) so every call site can treat
+// health as best-effort — a nil *connectHealth's methods are all no-ops.
+func newConnectHealth(clientID, channel string) *connectHealth {
+	dirKey := daemonDirKey(clientID, "")
+	if dirKey == "" {
+		return nil
+	}
+	dir, err := connectDaemonDir(dirKey)
+	if err != nil {
+		return nil
+	}
+	return &connectHealth{
+		dir: dir,
+		hb: connectHeartbeat{
+			Pid:       os.Getpid(),
+			Channel:   channel,
+			ClientID:  clientID,
+			StartUnix: time.Now().Unix(),
+		},
+	}
+}
+
+func (h *connectHealth) touch(mutate func(*connectHeartbeat)) {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	mutate(&h.hb)
+	h.hb.UpdatedUnix = time.Now().Unix()
+	h.mu.Unlock()
+}
+
+// onConnected records a successful Stream connect. Called after cli.Start.
+func (h *connectHealth) onConnected() {
+	h.touch(func(hb *connectHeartbeat) { hb.ConnectedUnix = time.Now().Unix() })
+}
+
+// onPush records an inbound message accepted for forwarding.
+func (h *connectHealth) onPush() {
+	h.touch(func(hb *connectHeartbeat) { hb.LastPushUnix = time.Now().Unix() })
+}
+
+// onReply records a reply successfully produced by the agent.
+func (h *connectHealth) onReply() {
+	h.touch(func(hb *connectHeartbeat) { hb.LastReplyUnix = time.Now().Unix() })
+}
+
+// onError records the most recent forward/delivery error.
+func (h *connectHealth) onError(err error) {
+	if err == nil {
+		return
+	}
+	h.touch(func(hb *connectHeartbeat) {
+		hb.LastError = truncateRunes(err.Error(), 300)
+		hb.LastErrorUnix = time.Now().Unix()
+	})
+}
+
+// start writes an initial heartbeat and launches the flush ticker. It stops and
+// removes the heartbeat file when ctx is cancelled, so a graceful shutdown
+// leaves no stale "healthy" file behind.
+func (h *connectHealth) start(ctx context.Context) {
+	if h == nil {
+		return
+	}
+	_ = h.flush()
+	go func() {
+		t := time.NewTicker(connectHeartbeatFlush)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				h.remove()
+				return
+			case <-t.C:
+				_ = h.flush()
+			}
+		}
+	}()
+}
+
+// flush persists the heartbeat only when it changed since the last write.
+func (h *connectHealth) flush() error {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	if h.hb.UpdatedUnix == h.flushedUnix {
+		h.mu.Unlock()
+		return nil
+	}
+	snapshot := h.hb
+	h.mu.Unlock()
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := connectHeartbeatPath(h.dir)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, config.FilePerm); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return err
+	}
+	h.mu.Lock()
+	h.flushedUnix = snapshot.UpdatedUnix
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *connectHealth) remove() {
+	if h == nil {
+		return
+	}
+	_ = os.Remove(connectHeartbeatPath(h.dir))
+}
+
+func connectHeartbeatPath(dir string) string {
+	return dir + string(os.PathSeparator) + connectHeartbeatFile
+}
+
+// readConnectHeartbeat loads the heartbeat file. Missing file yields (nil, nil)
+// so callers distinguish "no connector ran" from an I/O error.
+func readConnectHeartbeat(dir string) (*connectHeartbeat, error) {
+	data, err := os.ReadFile(connectHeartbeatPath(dir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var hb connectHeartbeat
+	if err := json.Unmarshal(data, &hb); err != nil {
+		return nil, err
+	}
+	return &hb, nil
+}
+
+// Health states, ordered worst-to-best for reporting.
+const (
+	healthNotRunning = "not_running"
+	healthDown       = "down"
+	healthDegraded   = "degraded"
+	healthHealthy    = "healthy"
+)
+
+// connectHealthReport is the derived, presentation-ready verdict combining the
+// connector heartbeat with the (optional) supervising daemon.
+type connectHealthReport struct {
+	State          string `json:"state"`
+	Pid            int    `json:"pid,omitempty"`
+	Channel        string `json:"channel,omitempty"`
+	ClientID       string `json:"clientId,omitempty"`
+	UptimeSec      int64  `json:"uptimeSec,omitempty"`
+	ConnectedAgo   int64  `json:"connectedAgoSec,omitempty"`
+	LastPushAgoSec int64  `json:"lastPushAgoSec,omitempty"`
+	LastReplyAgo   int64  `json:"lastReplyAgoSec,omitempty"`
+	LastError      string `json:"lastError,omitempty"`
+	Supervised     bool   `json:"supervised"`
+	Detail         string `json:"detail,omitempty"`
+}
+
+// deriveConnectHealth turns the raw heartbeat (and whether a daemon supervisor
+// is alive) into a verdict. now is injected so the logic is unit-testable.
+func deriveConnectHealth(hb *connectHeartbeat, supervised bool, now time.Time) connectHealthReport {
+	nowUnix := now.Unix()
+	if hb == nil {
+		return connectHealthReport{State: healthNotRunning, Supervised: supervised,
+			Detail: "no connector heartbeat found"}
+	}
+	r := connectHealthReport{
+		Pid:        hb.Pid,
+		Channel:    hb.Channel,
+		ClientID:   hb.ClientID,
+		Supervised: supervised,
+		LastError:  hb.LastError,
+	}
+	if hb.StartUnix > 0 {
+		r.UptimeSec = nowUnix - hb.StartUnix
+	}
+	if hb.ConnectedUnix > 0 {
+		r.ConnectedAgo = nowUnix - hb.ConnectedUnix
+	}
+	if hb.LastPushUnix > 0 {
+		r.LastPushAgoSec = nowUnix - hb.LastPushUnix
+	}
+	if hb.LastReplyUnix > 0 {
+		r.LastReplyAgo = nowUnix - hb.LastReplyUnix
+	}
+
+	// Connector process gone: down. A supervisor (if any) will restart it.
+	if hb.Pid <= 0 || !processAlive(hb.Pid) {
+		r.State = healthDown
+		if supervised {
+			r.Detail = "connector process not alive; supervisor should restart it"
+		} else {
+			r.Detail = "connector process not alive"
+		}
+		return r
+	}
+	// Alive but never reached a connected state: still starting or failing to
+	// establish the Stream.
+	if hb.ConnectedUnix == 0 {
+		r.State = healthDegraded
+		r.Detail = "process alive but never established a Stream connection"
+		return r
+	}
+	// Alive and connected, but the most recent event was an error with no
+	// successful activity after it: degraded.
+	lastOK := hb.ConnectedUnix
+	if hb.LastReplyUnix > lastOK {
+		lastOK = hb.LastReplyUnix
+	}
+	if hb.LastErrorUnix > lastOK {
+		r.State = healthDegraded
+		r.Detail = "last activity was an error after the last success"
+		return r
+	}
+	r.State = healthHealthy
+	return r
+}

--- a/internal/helpers/connect_health.go
+++ b/internal/helpers/connect_health.go
@@ -285,6 +285,14 @@ func deriveConnectHealth(hb *connectHeartbeat, supervised bool, now time.Time) c
 		}
 		return r
 	}
+	// Guard against pid reuse: a live pid whose heartbeat is stale (no flush
+	// within 2× the flush interval) is not our connector.
+	heartbeatStaleThreshold := int64((2 * connectHeartbeatFlush).Seconds())
+	if hb.UpdatedUnix > 0 && (nowUnix-hb.UpdatedUnix) > heartbeatStaleThreshold {
+		r.State = healthDown
+		r.Detail = "heartbeat stale (pid may have been reused by another process)"
+		return r
+	}
 	// Alive but never reached a connected state: still starting or failing to
 	// establish the Stream.
 	if hb.ConnectedUnix == 0 {

--- a/internal/helpers/connect_health.go
+++ b/internal/helpers/connect_health.go
@@ -71,9 +71,10 @@ type connectHeartbeat struct {
 }
 
 // connectHealth is the in-memory writer owned by a connector. Events update it
-// in memory (cheap, called on the message hot path); a background ticker flushes
-// to disk only when something changed, so a busy bot does not churn the disk and
-// an idle one writes nothing after the initial connect record.
+// in memory (cheap, called on the message hot path); a background ticker bumps
+// UpdatedUnix and flushes on every tick — the periodic write IS the liveness
+// proof consumed by the staleness check in deriveConnectHealth, so an idle
+// connector must keep writing or it would be misreported as down (pid reuse).
 type connectHealth struct {
 	dir string
 	mu  sync.Mutex
@@ -94,13 +95,15 @@ func newConnectHealth(clientID, channel string) *connectHealth {
 	if err != nil {
 		return nil
 	}
+	now := time.Now().Unix()
 	return &connectHealth{
 		dir: dir,
 		hb: connectHeartbeat{
-			Pid:       os.Getpid(),
-			Channel:   channel,
-			ClientID:  clientID,
-			StartUnix: time.Now().Unix(),
+			Pid:         os.Getpid(),
+			Channel:     channel,
+			ClientID:    clientID,
+			StartUnix:   now,
+			UpdatedUnix: now,
 		},
 	}
 }
@@ -158,6 +161,10 @@ func (h *connectHealth) start(ctx context.Context) {
 				h.remove()
 				return
 			case <-t.C:
+				// Each tick is a liveness proof: advance UpdatedUnix even when
+				// nothing else changed, otherwise an idle connector's heartbeat
+				// goes stale and deriveConnectHealth misreports it as down.
+				h.touch(func(*connectHeartbeat) {})
 				_ = h.flush()
 			}
 		}

--- a/internal/helpers/connect_health_test.go
+++ b/internal/helpers/connect_health_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDeriveConnectHealth(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	alive := os.Getpid()
+	dead := deadPid(t)
+
+	cases := []struct {
+		name       string
+		hb         *connectHeartbeat
+		supervised bool
+		want       string
+	}{
+		{"no heartbeat", nil, false, healthNotRunning},
+		{"no heartbeat but supervised", nil, true, healthNotRunning},
+		{
+			"connector dead",
+			&connectHeartbeat{Pid: dead, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90},
+			false, healthDown,
+		},
+		{
+			"alive never connected",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 5},
+			false, healthDegraded,
+		},
+		{
+			"alive and connected",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90, LastReplyUnix: now.Unix() - 10},
+			false, healthHealthy,
+		},
+		{
+			"idle but connected is still healthy",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100000, ConnectedUnix: now.Unix() - 100000},
+			false, healthHealthy,
+		},
+		{
+			"error after last success is degraded",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90, LastReplyUnix: now.Unix() - 50, LastErrorUnix: now.Unix() - 5, LastError: "boom"},
+			false, healthDegraded,
+		},
+		{
+			"error before last reply stays healthy",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90, LastErrorUnix: now.Unix() - 50, LastReplyUnix: now.Unix() - 5, LastError: "old"},
+			false, healthHealthy,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := deriveConnectHealth(c.hb, c.supervised, now)
+			if got.State != c.want {
+				t.Fatalf("state = %q, want %q (detail=%q)", got.State, c.want, got.Detail)
+			}
+			if got.Supervised != c.supervised {
+				t.Errorf("supervised = %v, want %v", got.Supervised, c.supervised)
+			}
+		})
+	}
+}
+
+func TestConnectHeartbeatRoundTrip(t *testing.T) {
+	connectDaemonDirOverride = t.TempDir()
+	t.Cleanup(func() { connectDaemonDirOverride = "" })
+
+	h := newConnectHealth("cid-round", "opencode")
+	if h == nil {
+		t.Fatal("newConnectHealth returned nil for a valid clientId")
+	}
+	h.onConnected()
+	h.onPush()
+	h.onReply()
+	if err := h.flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	hb, err := readConnectHeartbeat(h.dir)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if hb == nil {
+		t.Fatal("heartbeat not persisted")
+	}
+	if hb.Pid != os.Getpid() || hb.Channel != "opencode" || hb.ClientID != "cid-round" {
+		t.Errorf("unexpected heartbeat identity: %+v", hb)
+	}
+	if hb.ConnectedUnix == 0 || hb.LastPushUnix == 0 || hb.LastReplyUnix == 0 {
+		t.Errorf("expected all activity timestamps set: %+v", hb)
+	}
+}
+
+func TestConnectHeartbeatFlushSkipsUnchanged(t *testing.T) {
+	connectDaemonDirOverride = t.TempDir()
+	t.Cleanup(func() { connectDaemonDirOverride = "" })
+
+	h := newConnectHealth("cid-skip", "codex")
+	h.onConnected()
+	if err := h.flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	// Second flush with no new event must be a no-op (nothing to write).
+	fi1, _ := os.Stat(connectHeartbeatPath(h.dir))
+	if err := h.flush(); err != nil {
+		t.Fatalf("second flush: %v", err)
+	}
+	if h.hb.UpdatedUnix != h.flushedUnix {
+		t.Errorf("flushedUnix (%d) should track UpdatedUnix (%d) after flush", h.flushedUnix, h.hb.UpdatedUnix)
+	}
+	_ = fi1
+}
+
+func TestConnectHealthNilSafe(t *testing.T) {
+	var h *connectHealth // no clientId path yields nil
+	// None of these may panic.
+	h.onConnected()
+	h.onPush()
+	h.onReply()
+	h.onError(errors.New("x"))
+	h.start(nil)
+	if err := h.flush(); err != nil {
+		t.Fatalf("nil flush: %v", err)
+	}
+	h.remove()
+}
+
+func TestNewConnectHealthNoIdentity(t *testing.T) {
+	if h := newConnectHealth("", ""); h != nil {
+		t.Errorf("expected nil health writer with no clientId, got %+v", h)
+	}
+}

--- a/internal/helpers/connect_health_test.go
+++ b/internal/helpers/connect_health_test.go
@@ -14,6 +14,7 @@
 package helpers
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"testing"
@@ -144,5 +145,44 @@ func TestConnectHealthNilSafe(t *testing.T) {
 func TestNewConnectHealthNoIdentity(t *testing.T) {
 	if h := newConnectHealth("", ""); h != nil {
 		t.Errorf("expected nil health writer with no clientId, got %+v", h)
+	}
+}
+
+func TestListConnectors(t *testing.T) {
+	connectDaemonDirOverride = t.TempDir()
+	t.Cleanup(func() { connectDaemonDirOverride = "" })
+	now := time.Unix(2_000_000, 0)
+	alive := os.Getpid()
+
+	dirA, _ := connectDaemonDir("dingAAA")
+	writeJSON(t, connectHeartbeatPath(dirA), connectHeartbeat{Pid: alive, Channel: "opencode", ClientID: "dingAAA", StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90})
+	dirB, _ := connectDaemonDir("dingBBB")
+	writeJSON(t, connectHeartbeatPath(dirB), connectHeartbeat{Pid: deadPid(t), Channel: "codex", ClientID: "dingBBB", StartUnix: now.Unix() - 50, ConnectedUnix: now.Unix() - 40})
+	// Empty leftover dir must be skipped.
+	_, _ = connectDaemonDir("emptyleftover")
+
+	reports, err := listConnectors(now)
+	if err != nil {
+		t.Fatalf("listConnectors: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("got %d reports, want 2 (empty dir skipped): %+v", len(reports), reports)
+	}
+	if reports[0].ClientID != "dingAAA" || reports[0].State != healthHealthy {
+		t.Errorf("report[0] = %+v, want dingAAA healthy", reports[0])
+	}
+	if reports[1].ClientID != "dingBBB" || reports[1].State != healthDown {
+		t.Errorf("report[1] = %+v, want dingBBB down", reports[1])
+	}
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/helpers/connect_health_test.go
+++ b/internal/helpers/connect_health_test.go
@@ -61,8 +61,13 @@ func TestDeriveConnectHealth(t *testing.T) {
 		},
 		{
 			"error before last reply stays healthy",
-			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90, LastErrorUnix: now.Unix() - 50, LastReplyUnix: now.Unix() - 5, LastError: "old"},
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90, LastErrorUnix: now.Unix() - 50, LastReplyUnix: now.Unix() - 5, LastError: "old", UpdatedUnix: now.Unix() - 5},
 			false, healthHealthy,
+		},
+		{
+			"stale heartbeat from pid reuse is down",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 1000, ConnectedUnix: now.Unix() - 900, UpdatedUnix: now.Unix() - 60},
+			false, healthDown,
 		},
 	}
 	for _, c := range cases {

--- a/internal/helpers/connect_health_test.go
+++ b/internal/helpers/connect_health_test.go
@@ -55,6 +55,13 @@ func TestDeriveConnectHealth(t *testing.T) {
 			false, healthHealthy,
 		},
 		{
+			// A long-idle connector whose ticker keeps refreshing UpdatedUnix
+			// must stay healthy — only a genuinely stale heartbeat means down.
+			"idle with fresh ticker heartbeat is healthy",
+			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100000, ConnectedUnix: now.Unix() - 100000, UpdatedUnix: now.Unix() - 10},
+			false, healthHealthy,
+		},
+		{
 			"error after last success is degraded",
 			&connectHeartbeat{Pid: alive, StartUnix: now.Unix() - 100, ConnectedUnix: now.Unix() - 90, LastReplyUnix: now.Unix() - 50, LastErrorUnix: now.Unix() - 5, LastError: "boom"},
 			false, healthDegraded,
@@ -131,6 +138,51 @@ func TestConnectHeartbeatFlushSkipsUnchanged(t *testing.T) {
 		t.Errorf("flushedUnix (%d) should track UpdatedUnix (%d) after flush", h.flushedUnix, h.hb.UpdatedUnix)
 	}
 	_ = fi1
+}
+
+// Regression for the v1.0.50-preview idle false-down: the flush ticker must
+// advance UpdatedUnix on every tick (bare touch) so an idle connector keeps
+// proving liveness; without it the heartbeat goes stale and
+// deriveConnectHealth misreports the connector as down after 30s.
+func TestConnectHeartbeatIdleTickKeepsFresh(t *testing.T) {
+	connectDaemonDirOverride = t.TempDir()
+	t.Cleanup(func() { connectDaemonDirOverride = "" })
+
+	h := newConnectHealth("cid-idle", "codex")
+	if h.hb.UpdatedUnix == 0 {
+		t.Fatal("newConnectHealth must seed UpdatedUnix so the initial flush persists")
+	}
+	h.onConnected()
+	if err := h.flush(); err != nil {
+		t.Fatalf("initial flush: %v", err)
+	}
+	if hb, err := readConnectHeartbeat(h.dir); err != nil || hb == nil {
+		t.Fatalf("initial heartbeat not persisted: hb=%v err=%v", hb, err)
+	}
+
+	// Backdate the heartbeat as if 40 idle seconds passed (beyond the 30s
+	// staleness threshold), then do exactly what the ticker does: a bare
+	// touch plus flush.
+	h.mu.Lock()
+	backdated := h.hb.UpdatedUnix - 40
+	h.hb.UpdatedUnix = backdated
+	h.flushedUnix = backdated
+	h.mu.Unlock()
+
+	h.touch(func(*connectHeartbeat) {})
+	if err := h.flush(); err != nil {
+		t.Fatalf("tick flush: %v", err)
+	}
+	hb, err := readConnectHeartbeat(h.dir)
+	if err != nil || hb == nil {
+		t.Fatalf("tick heartbeat not persisted: hb=%v err=%v", hb, err)
+	}
+	if hb.UpdatedUnix <= backdated {
+		t.Fatalf("bare tick touch must advance persisted UpdatedUnix past %d, got %d", backdated, hb.UpdatedUnix)
+	}
+	if got := deriveConnectHealth(hb, false, time.Now()); got.State != healthHealthy {
+		t.Fatalf("idle connector with ticker-fresh heartbeat = %q (detail=%q), want %q", got.State, got.Detail, healthHealthy)
+	}
 }
 
 func TestConnectHealthNilSafe(t *testing.T) {

--- a/internal/helpers/connect_opencode.go
+++ b/internal/helpers/connect_opencode.go
@@ -96,7 +96,7 @@ func (f *opencodeForwarder) forward(ctx context.Context, convID, text string) (s
 }
 
 func (f *opencodeForwarder) forwardStream(ctx context.Context, convID, text string, _ func(string)) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, f.timeout)
+	ctx, cancel := applyTimeout(ctx, f.timeout)
 	defer cancel()
 
 	client, err := f.server.ensure(ctx)
@@ -204,10 +204,9 @@ func newOpencodeServer(bin string, env []string, workDir string) *opencodeServer
 		bin:     bin,
 		env:     env,
 		workDir: workDir,
-		// No client-level Timeout: a turn can legitimately run for minutes, so the
-		// per-request ctx (forwardStream's f.timeout, default 300s) governs instead.
-		// A hardcoded 30s here used to abort long agent replies mid-flight with
-		// "Client.Timeout exceeded while awaiting headers".
+		// No client-level Timeout: a turn can legitimately run for minutes.
+		// f.timeout (from --agent-timeout / DWS_AGENT_TIMEOUT_MS, default 0 =
+		// no limit) governs via the per-request ctx when set.
 		httpClient: &http.Client{},
 	}
 }

--- a/internal/helpers/connect_opencode_test.go
+++ b/internal/helpers/connect_opencode_test.go
@@ -16,6 +16,7 @@ package helpers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -246,17 +247,17 @@ func TestOpencodeSessionsPersist(t *testing.T) {
 	}
 }
 
-// TestNewOpencodeServerHasNoClientTimeout pins the fix: the shared HTTP client
-// must not carry an overall deadline, otherwise long agent turns get aborted
-// with "Client.Timeout exceeded while awaiting headers". The per-turn ctx is
-// the only thing allowed to bound a message round-trip.
+// TestNewOpencodeServerHasNoClientTimeout pins: the shared HTTP client
+// must not carry an overall deadline — long agent turns would be aborted
+// mid-flight. The per-turn ctx (f.timeout, default 0 = no limit) governs
+// only when the user explicitly sets --agent-timeout / DWS_AGENT_TIMEOUT_MS.
 func TestNewOpencodeServerHasNoClientTimeout(t *testing.T) {
 	s := newOpencodeServer("opencode", nil, "")
 	if s.httpClient == nil {
 		t.Fatal("httpClient must be initialized")
 	}
 	if s.httpClient.Timeout != 0 {
-		t.Fatalf("opencode http client Timeout = %s, want 0 (per-turn ctx governs long agent replies)", s.httpClient.Timeout)
+		t.Fatalf("opencode http client Timeout = %s, want 0 (no client-level cap)", s.httpClient.Timeout)
 	}
 }
 
@@ -311,6 +312,65 @@ func TestOpencodeForwarderMessageGovernedByTurnCtx(t *testing.T) {
 	// the round-trip, so this must error out (proving ctx, not a client cap, wins).
 	if _, err := newForwarder(50*time.Millisecond).forwardStream(context.Background(), "conv-cut", "hi", nil); err == nil {
 		t.Fatal("a reply slower than the turn ctx should fail")
+	}
+}
+
+// TestOpencodeForwarderContextDeadlineExceededRepro reproduces the error seen
+// in the wild: user sends "run tech report", the opencode server processes for
+// longer than the user-configured turn timeout, and the context deadline kills
+// the POST /session/:id/message. The error must surface "context deadline
+// exceeded" so the higher-level formatter produces a meaningful reply.
+func TestOpencodeForwarderContextDeadlineExceededRepro(t *testing.T) {
+	dir := t.TempDir()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/global/health":
+			_, _ = w.Write([]byte(`{"healthy":true}`))
+		case r.URL.Path == "/session":
+			_, _ = w.Write([]byte(`{"id":"ses_1065c16edffeC46Oie6v9WY11l"}`))
+		case r.URL.Path == "/session/ses_1065c16edffeC46Oie6v9WY11l/message":
+			// Simulate a long-running agent that never responds within the turn budget.
+			// Fallback timeout ensures ts.Close() does not hang waiting on the handler.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(1 * time.Second):
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	f := &opencodeForwarder{
+		bin:      "opencode",
+		timeout:  100 * time.Millisecond, // short turn budget to trigger deadline quickly
+		workDir:  dir,
+		sessions: newOpencodeSessions(filepath.Join(dir, "s.json")),
+		server:   &opencodeServer{baseURL: ts.URL, httpClient: &http.Client{}},
+	}
+
+	_, err := f.forwardStream(context.Background(), "conv-1", "run tech report", nil)
+	if err == nil {
+		t.Fatal("expected context deadline exceeded error, got nil")
+	}
+
+	errStr := err.Error()
+	if !strings.Contains(errStr, "context deadline exceeded") {
+		t.Fatalf("error = %q, want it to contain 'context deadline exceeded'", errStr)
+	}
+	if !strings.Contains(errStr, "/session/ses_1065c16edffeC46Oie6v9WY11l/message") {
+		t.Fatalf("error = %q, want it to contain the session message path", errStr)
+	}
+
+	// Verify the higher-level format matches the screenshot.
+	formatted := fmt.Sprintf("（opencode 调用失败：%v）", err)
+	if !strings.Contains(formatted, "context deadline exceeded") {
+		t.Fatalf("formatted reply = %q, want 'context deadline exceeded'", formatted)
+	}
+	if !strings.HasPrefix(formatted, "（opencode 调用失败：") {
+		t.Fatalf("formatted reply = %q, want prefix '（opencode 调用失败：'", formatted)
 	}
 }
 

--- a/internal/helpers/connect_qoder_stream.go
+++ b/internal/helpers/connect_qoder_stream.go
@@ -79,7 +79,7 @@ func (f *qoderStreamForwarder) forward(ctx context.Context, convID, text string)
 }
 
 func (f *qoderStreamForwarder) forwardStream(ctx context.Context, convID, text string, onDelta func(string)) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, f.timeout)
+	ctx, cancel := applyTimeout(ctx, f.timeout)
 	defer cancel()
 
 	f.mu.Lock()

--- a/internal/helpers/connect_stream.go
+++ b/internal/helpers/connect_stream.go
@@ -16,6 +16,7 @@ package helpers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
@@ -187,6 +189,9 @@ type connectAgentOptions struct {
 	// "remember" asks once per action kind then reuses that decision. Sourced
 	// from RoleConfig.confirm_policy; empty = manual.
 	ConfirmPolicy string
+	// Timeout caps each agent turn (--agent-timeout seconds /
+	// DWS_AGENT_TIMEOUT_MS milliseconds). 0 = no limit (default).
+	Timeout time.Duration
 }
 
 // isStreamBridgeChannel reports whether a channel is wired through the Go-native
@@ -239,7 +244,7 @@ func (f *execForwarder) label() string {
 }
 
 func (f *execForwarder) forward(ctx context.Context, convID, text string) (string, error) {
-	ctx, cancel := context.WithTimeout(ctx, f.timeout)
+	ctx, cancel := applyTimeout(ctx, f.timeout)
 	defer cancel()
 	// Session args go right after the binary, before the spec tail — some specs
 	// (qoder) end the tail with `-p` so the prompt must stay the trailing
@@ -765,7 +770,10 @@ func resolveExecAgent(channel string) (argv []string, env []string, err error) {
 // dependency on a live interactive session. opts applies the user-facing agent
 // tuning (--agent-model / --agent-workdir / --agent-memory).
 func forwarderForChannel(channel, clientID string, opts connectAgentOptions) (forwarder, error) {
-	timeout := envDurationMS("DWS_AGENT_TIMEOUT_MS", 300*time.Second)
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = envDurationMS("DWS_AGENT_TIMEOUT_MS", 0)
+	}
 	spec, ok := agentSpecs[channel]
 	if !ok {
 		return nil, apperrors.NewValidation(fmt.Sprintf("渠道 %q 不是 stream-bridge 渠道，无 forwarder", channel))
@@ -909,6 +917,7 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 	if extras == nil {
 		extras = &connectExtras{}
 	}
+	checkFDLimit()
 	if closer, ok := fwd.(forwarderCloser); ok {
 		defer func() {
 			if err := closer.close(); err != nil {
@@ -942,9 +951,12 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 		mediaCli = newAICardClient(clientID, clientSecret, "")
 	}
 
+	keepAlive := envDurationMS("DWS_CONNECT_KEEPALIVE_MS", 30000)
+	fmt.Fprintf(os.Stderr, "[connect] keepAlive=%s autoReconnect=true\n", keepAlive)
 	cli := client.NewStreamClient(
 		client.WithAppCredential(client.NewAppCredentialConfig(clientID, clientSecret)),
 		client.WithAutoReconnect(true),
+		client.WithKeepAlive(keepAlive),
 	)
 	cli.RegisterChatBotCallbackRouter(func(_ context.Context, data *chatbot.BotCallbackDataModel) ([]byte, error) {
 		text := strings.TrimSpace(data.Text.Content)
@@ -1124,7 +1136,16 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 			}
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "[connect] 转发失败 (%s, 耗时 %s): %v\n", channel, time.Since(started).Round(time.Millisecond), err)
-				reply = fmt.Sprintf("（%s 调用失败：%v）", channel, err)
+				if errors.Is(err, context.DeadlineExceeded) {
+					// Self-recovery: drop the conversation's session so the next
+					// message starts fresh instead of reusing a stuck one.
+					if r, ok := fwd.(sessionResetter); ok {
+						r.resetSession(convID)
+					}
+					reply = fmt.Sprintf("（%s 回复超时，已自动重置会话，请重试。如需调整超时上限可用 --agent-timeout）", channel)
+				} else {
+					reply = fmt.Sprintf("（%s 调用失败：%v）", channel, err)
+				}
 				health.onError(err)
 			} else {
 				fmt.Fprintf(os.Stderr, "[connect] agent 已生成回复 (%s, 耗时 %s): %s\n", channel, time.Since(started).Round(time.Millisecond), truncateRunes(reply, 80))
@@ -1239,6 +1260,29 @@ func envDurationMS(key string, def time.Duration) time.Duration {
 		}
 	}
 	return def
+}
+
+// checkFDLimit warns when the soft RLIMIT_NOFILE is below 512. Each connector
+// needs a WebSocket fd + agent subprocess pipes + session files; with 3+
+// connectors a low ulimit causes fd exhaustion → WebSocket abnormal closure.
+func checkFDLimit() {
+	var rlim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlim); err != nil {
+		return
+	}
+	if rlim.Cur < 512 {
+		fmt.Fprintf(os.Stderr, "[connect][warn] 文件描述符上限 %d 偏低，多 agent 并发连接可能不稳定；建议 ulimit -n 1024\n", rlim.Cur)
+	}
+}
+
+// applyTimeout returns a context bounded by timeout when timeout > 0, or the
+// original context unchanged when timeout == 0 (no limit). The returned cancel
+// func is always safe to defer.
+func applyTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout > 0 {
+		return context.WithTimeout(ctx, timeout)
+	}
+	return ctx, func() {}
 }
 
 // truncateRunes truncates by rune so multi-byte characters are never split.

--- a/internal/helpers/connect_stream.go
+++ b/internal/helpers/connect_stream.go
@@ -925,6 +925,12 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 	}
 	defer release()
 
+	// Health heartbeat: record connect/receive/reply/error so `connect status`
+	// can tell a live connector from a dead one (see connect_health.go). Nil
+	// when no clientId identity is available; all calls below are no-ops then.
+	health := newConnectHealth(clientID, channel)
+	health.start(ctx)
+
 	streamLoggerOnce.Do(func() { sdklogger.SetLogger(streamSDKLogger{}) })
 	replier := chatbot.NewChatbotReplier()
 	dedup := newMsgDedup(10000)
@@ -983,6 +989,7 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 		}
 		fmt.Fprintf(os.Stderr, "[connect] 收到 @%s: %s (convType=%s convId=%s staffId=%s msgId=%s)\n",
 			sender, truncateRunes(shown, 80), data.ConversationType, data.ConversationId, data.SenderStaffId, data.MsgId)
+		health.onPush()
 		// Ack-first: return now, reply asynchronously via sessionWebhook (which is
 		// independent of the Stream ack). Use a background context so the in-flight
 		// forward is not cancelled by the SDK when this callback returns.
@@ -1118,8 +1125,10 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "[connect] 转发失败 (%s, 耗时 %s): %v\n", channel, time.Since(started).Round(time.Millisecond), err)
 				reply = fmt.Sprintf("（%s 调用失败：%v）", channel, err)
+				health.onError(err)
 			} else {
 				fmt.Fprintf(os.Stderr, "[connect] agent 已生成回复 (%s, 耗时 %s): %s\n", channel, time.Since(started).Round(time.Millisecond), truncateRunes(reply, 80))
+				health.onReply()
 			}
 
 			// Confirmation gate orchestration: if the agent's reply declared
@@ -1208,6 +1217,7 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 		return apperrors.NewInternal("stream 建连失败：" + err.Error())
 	}
 	defer cli.Close()
+	health.onConnected()
 	<-ctx.Done()
 	return nil
 }

--- a/internal/helpers/connect_stream_test.go
+++ b/internal/helpers/connect_stream_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestBrandReply covers the qoderwork identity rewrite using the exact replies
@@ -120,5 +121,27 @@ func TestClaudeUserSettingsEnv(t *testing.T) {
 		if !seen {
 			t.Fatalf("missing %q in %v", kv, got)
 		}
+	}
+}
+
+// TestCheckFDLimit verifies that checkFDLimit runs without panic and respects
+// the envDurationMS pattern for the keepAlive default.
+func TestCheckFDLimit(t *testing.T) {
+	// Should not panic regardless of the actual ulimit.
+	checkFDLimit()
+}
+
+func TestEnvDurationMS(t *testing.T) {
+	def := 30000 * time.Millisecond // 30s
+	if got := envDurationMS("DWS_CONNECT_KEEPALIVE_MS_TEST_ABSENT", def); got != def {
+		t.Fatalf("default keepAlive = %v, want %v", got, def)
+	}
+	t.Setenv("DWS_CONNECT_KEEPALIVE_MS_TEST", "10000")
+	if got := envDurationMS("DWS_CONNECT_KEEPALIVE_MS_TEST", def); got != 10*time.Second {
+		t.Fatalf("env override = %v, want 10s", got)
+	}
+	t.Setenv("DWS_CONNECT_KEEPALIVE_MS_TEST", "bogus")
+	if got := envDurationMS("DWS_CONNECT_KEEPALIVE_MS_TEST", def); got != def {
+		t.Fatalf("invalid env falls back to default = %v, want %v", got, def)
 	}
 }

--- a/internal/helpers/connect_streaming.go
+++ b/internal/helpers/connect_streaming.go
@@ -50,7 +50,7 @@ func (f *execForwarder) forwardStream(ctx context.Context, convID, text string, 
 	if !f.canStream() || onDelta == nil {
 		return f.forward(ctx, convID, text)
 	}
-	ctx, cancel := context.WithTimeout(ctx, f.timeout)
+	ctx, cancel := applyTimeout(ctx, f.timeout)
 	defer cancel()
 
 	var args []string

--- a/internal/helpers/devapp_connect.go
+++ b/internal/helpers/devapp_connect.go
@@ -568,6 +568,7 @@ func newDevAppRobotConnectCommand(runner executor.Runner) *cobra.Command {
 	cmd.Flags().String("agent-model", "", "覆盖本地 agent 模型（如 claude 的 sonnet/opus；默认用渠道内置模型，求快）；env: DWS_AGENT_MODEL")
 	cmd.Flags().String("agent-workdir", "", "本地 agent 的运行目录（放知识文件可给机器人上下文；默认空白临时目录，求快）；env: DWS_AGENT_WORKDIR")
 	cmd.Flags().Bool("agent-memory", true, "按会话续聊：同一群/单聊共享 agent 会话上下文（codex/opencode/qoder/qoderwork/claudecode/codebuddy/workbuddy 支持；--agent-memory=false 关闭）")
+	cmd.Flags().Int("agent-timeout", 0, "每次 agent 调用的超时时间（秒），0=不限制（默认）；env: DWS_AGENT_TIMEOUT_MS（毫秒）")
 	cmd.Flags().Bool("reply-card", true, "用 AI 卡片回复（思考中→完成状态，同官方渠道体验）；卡片失败自动回退普通消息；--reply-card=false 关闭")
 	cmd.Flags().String("card-template", "", "AI 卡片模板 ID（开发者后台·本应用·AI 卡片设置里获取；模板按应用授权，强烈建议注册自己应用的模板）；env: DWS_CARD_TEMPLATE")
 	cmd.Flags().String("knowledge-dir", "", "答疑知识目录（.md/.txt）：每条消息本地检索 top-k 片段拼进 prompt，agent 仍在空目录跑、不拖慢回复；env: DWS_KNOWLEDGE_DIR")
@@ -596,6 +597,7 @@ func connectAgentOptionsFromCommand(cmd *cobra.Command) connectAgentOptions {
 		workDir = strings.TrimSpace(os.Getenv("DWS_AGENT_WORKDIR"))
 	}
 	memory, _ := cmd.Flags().GetBool("agent-memory")
+	agentTimeoutSec, _ := cmd.Flags().GetInt("agent-timeout")
 	replyCard, _ := cmd.Flags().GetBool("reply-card")
 	// Env kill-switch for scripted/service runs: DWS_REPLY_CARD=0 disables
 	// cards regardless of the flag default.
@@ -659,6 +661,7 @@ func connectAgentOptionsFromCommand(cmd *cobra.Command) connectAgentOptions {
 		auditSheetTab = "Sheet1"
 	}
 	return connectAgentOptions{Model: model, WorkDir: workDir, Memory: memory,
+		Timeout: time.Duration(agentTimeoutSec) * time.Second,
 		ReplyCard: replyCard, CardTemplate: cardTemplate,
 		KnowledgeDir:    knowledgeDir,
 		KnowledgeSource: knowledgeSource,

--- a/internal/helpers/devapp_connect.go
+++ b/internal/helpers/devapp_connect.go
@@ -555,6 +555,7 @@ func newDevAppRobotConnectCommand(runner executor.Runner) *cobra.Command {
 	cmd.AddCommand(
 		newDevAppRobotConnectStatusCommand(),
 		newDevAppRobotConnectStopCommand(),
+		newDevAppRobotConnectListCommand(),
 	)
 	cmd.Flags().String("channel", "auto", "渠道：auto(默认,自动探测)|openclaw|qoder|qoderwork|hermes|workbuddy|claudecode|codebuddy|codex|gemini|opencode|custom(自研/未支持的 AI，配 --agent-cmd)")
 	cmd.Flags().String("agent-cmd", "", "自研/未支持的 AI 工具命令（无头/一次性：问题作为最后一个参数追加，答案打到 stdout）；用来接入内置渠道之外的 AI（如网易有道龙虾 LobsterAI）；等价于 --channel custom + 设 DWS_AGENT_CMD；env: DWS_AGENT_CMD")

--- a/scripts/dev/connect-watchdog.sh
+++ b/scripts/dev/connect-watchdog.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env sh
+# connect-watchdog.sh — keep a `dws dev connect` connector alive using the
+# health contract from `dws dev connect status --json`.
+#
+# This is the "脚本" side of the 0701 review: a small, inspectable local watchdog
+# that (1) asks dws whether the connection is actually healthy — not just whether
+# a process exists — and (2) relaunches it when it is down/degraded. Drop it into
+# cron or launchd; it is idempotent, so running it every few minutes is safe.
+#
+# It consumes the machine-readable contract, so it never parses `ps` or guesses.
+#
+# Usage:
+#   connect-watchdog.sh --client-id <clientId> [--dry-run] -- <launch command...>
+#
+# Example (relaunch a daemon connector if it is not healthy):
+#   connect-watchdog.sh --client-id ding123 -- \
+#     dws dev connect --robot-client-id ding123 --channel opencode --daemon
+#
+# cron (every 5 minutes):
+#   */5 * * * * /path/to/connect-watchdog.sh --client-id ding123 -- \
+#     dws dev connect --robot-client-id ding123 --channel opencode --daemon >> ~/.dws/connect/ding123/watchdog.log 2>&1
+#
+# Exit codes: 0 = healthy (no action) or relaunch issued; 1 = usage error.
+
+set -eu
+
+DWS="${DWS_BIN:-dws}"
+CLIENT_ID=""
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --client-id) CLIENT_ID="$2"; shift 2 ;;
+    --dry-run)   DRY_RUN=1; shift ;;
+    --)          shift; break ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [ -z "$CLIENT_ID" ]; then
+  echo "usage: connect-watchdog.sh --client-id <clientId> [--dry-run] -- <launch command...>" >&2
+  exit 1
+fi
+if [ $# -eq 0 ]; then
+  echo "error: missing launch command after --" >&2
+  exit 1
+fi
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+
+# Ask dws for the health verdict. `--json` is the stable contract.
+STATUS_JSON="$("$DWS" dev connect status --robot-client-id "$CLIENT_ID" --json 2>/dev/null || true)"
+
+# Extract "state" without a hard jq dependency (fall back to jq when present).
+if command -v jq >/dev/null 2>&1; then
+  STATE="$(printf '%s' "$STATUS_JSON" | jq -r '.state // "unknown"')"
+else
+  STATE="$(printf '%s' "$STATUS_JSON" | sed -n 's/.*"state"[[:space:]]*:[[:space:]]*"\([a-z_]*\)".*/\1/p' | head -n1)"
+  [ -n "$STATE" ] || STATE="unknown"
+fi
+
+case "$STATE" in
+  healthy)
+    echo "$(ts) [watchdog] $CLIENT_ID healthy — no action"
+    exit 0
+    ;;
+  not_running|down|degraded|unknown)
+    echo "$(ts) [watchdog] $CLIENT_ID state=$STATE — relaunching: $*"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "$(ts) [watchdog] dry-run, not executing"
+      exit 0
+    fi
+    # For down/degraded, stop the old connector first so we do not fight the
+    # single-instance lock; not_running has nothing to stop (ignore failures).
+    if [ "$STATE" = "down" ] || [ "$STATE" = "degraded" ]; then
+      "$DWS" dev connect stop --robot-client-id "$CLIENT_ID" >/dev/null 2>&1 || true
+    fi
+    exec "$@"
+    ;;
+  *)
+    echo "$(ts) [watchdog] $CLIENT_ID unexpected state=$STATE — no action" >&2
+    exit 0
+    ;;
+esac

--- a/scripts/dev/connect-watchdog.sh
+++ b/scripts/dev/connect-watchdog.sh
@@ -53,11 +53,12 @@ STATUS_JSON="$("$DWS" dev connect status --robot-client-id "$CLIENT_ID" --json 2
 
 # Extract "state" without a hard jq dependency (fall back to jq when present).
 if command -v jq >/dev/null 2>&1; then
-  STATE="$(printf '%s' "$STATUS_JSON" | jq -r '.state // "unknown"')"
+  STATE="$(printf '%s' "$STATUS_JSON" | jq -r '.state // empty' 2>/dev/null)"
 else
   STATE="$(printf '%s' "$STATUS_JSON" | sed -n 's/.*"state"[[:space:]]*:[[:space:]]*"\([a-z_]*\)".*/\1/p' | head -n1)"
-  [ -n "$STATE" ] || STATE="unknown"
 fi
+# Treat empty, "null", or any non-word value as unknown so the watchdog relaunches.
+case "$STATE" in ""|null) STATE="unknown" ;; esac
 
 case "$STATE" in
   healthy)

--- a/scripts/dev/recipes/README.md
+++ b/scripts/dev/recipes/README.md
@@ -1,0 +1,80 @@
+# connect supervision recipes
+
+Keep a `dws dev connect` connector alive across crashes, logout, and reboots —
+**without** marrying one process manager. Every recipe here consumes the same
+health contract, `dws dev connect status --json` (see PR #543), so they restart
+on a *real* health verdict instead of guessing from the process table.
+
+Two layers, pick per host:
+
+| Host | Recipe | Boot persistence | Extra dependency |
+|------|--------|------------------|------------------|
+| anywhere (default) | `dws dev connect --daemon` | no | none (built-in) |
+| macOS | `launchd.dws-connect.plist` | yes | none (OS built-in) |
+| Linux | `systemd.dws-connect.service` | yes | none (OS built-in) |
+| Windows | NSSM (see below) | yes | NSSM |
+| Node teams | `pm2.ecosystem.config.js` | yes | Node + pm2 |
+
+All of them run `connect-watchdog.sh`, which is the "脚本" from the 0701 review:
+poll `status --json`, and relaunch when `state` is `down`/`degraded`/`not_running`.
+
+## Why a watchdog on top of a supervisor?
+
+`--daemon`, launchd, systemd, and pm2 all restart on **process death**. The
+failure mode the review flagged — a connection that is *alive but deaf* — never
+kills the process, so none of them see it. The watchdog closes that by asking
+dws for the health verdict, not the OS for the pid.
+
+## The watchdog
+
+```sh
+connect-watchdog.sh --client-id <clientId> [--dry-run] -- <launch command...>
+```
+
+- `--client-id` — the robot clientId (how the connector is keyed on disk).
+- everything after `--` — the command to run when unhealthy.
+- reads `dws dev connect status --robot-client-id <id> --json`, relaunches only
+  when needed; on `down`/`degraded` it stops the old connector first to avoid the
+  single-instance lock. Idempotent, safe to run every few minutes.
+
+## macOS (launchd)
+
+Edit `launchd.dws-connect.plist` (clientId, channel, absolute paths), then:
+
+```sh
+cp launchd.dws-connect.plist ~/Library/LaunchAgents/com.dingtalk.dws.connect.plist
+launchctl load ~/Library/LaunchAgents/com.dingtalk.dws.connect.plist
+```
+
+## Linux (systemd --user)
+
+Edit `systemd.dws-connect.service`, then:
+
+```sh
+mkdir -p ~/.config/systemd/user
+cp systemd.dws-connect.service ~/.config/systemd/user/dws-connect.service
+systemctl --user daemon-reload
+systemctl --user enable --now dws-connect.service
+loginctl enable-linger "$USER"   # keep running after logout
+```
+
+## Windows (NSSM)
+
+`--daemon` is not supported on Windows; run the foreground connector as a
+service. Install NSSM, then:
+
+```
+nssm install dws-connect "C:\path\to\dws.exe" dev connect --robot-client-id <id> --channel opencode
+nssm set dws-connect AppExit Default Restart
+nssm start dws-connect
+```
+
+## Node teams (pm2)
+
+Only if you already run pm2 — it is **not** a dependency of dws. It supervises
+the foreground connector (not `--daemon`, to avoid double supervision):
+
+```sh
+pm2 start pm2.ecosystem.config.js
+pm2 save && pm2 startup   # boot persistence
+```

--- a/scripts/dev/recipes/launchd.dws-connect.plist
+++ b/scripts/dev/recipes/launchd.dws-connect.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- macOS launchd agent: keep a dws connector alive + watchdog every 5 min.
+     Edit: <clientId>, --channel, and the absolute paths, then load with
+     launchctl (see recipes/README.md). Consumes `dws dev connect status --json`. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.dingtalk.dws.connect</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/absolute/path/to/scripts/dev/connect-watchdog.sh</string>
+    <string>--client-id</string>
+    <string>REPLACE_CLIENT_ID</string>
+    <string>--</string>
+    <string>/usr/local/bin/dws</string>
+    <string>dev</string>
+    <string>connect</string>
+    <string>--robot-client-id</string>
+    <string>REPLACE_CLIENT_ID</string>
+    <string>--channel</string>
+    <string>opencode</string>
+    <string>--daemon</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>DWS_BIN</key>
+    <string>/usr/local/bin/dws</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>300</integer>
+  <key>StandardOutPath</key>
+  <string>REPLACE_HOME/.dws/connect/REPLACE_CLIENT_ID/watchdog.log</string>
+  <key>StandardErrorPath</key>
+  <string>REPLACE_HOME/.dws/connect/REPLACE_CLIENT_ID/watchdog.log</string>
+</dict>
+</plist>

--- a/scripts/dev/recipes/pm2.ecosystem.config.js
+++ b/scripts/dev/recipes/pm2.ecosystem.config.js
@@ -1,0 +1,23 @@
+// pm2 ecosystem for teams already running pm2. pm2 is NOT a dependency of dws —
+// this is one optional host, not the default. It supervises the FOREGROUND
+// connector (not --daemon) to avoid double supervision. pm2 restarts on process
+// death; pair with connect-watchdog (a pm2 cron_restart or an OS cron) for the
+// alive-but-deaf case, which only `dws dev connect status --json` can detect.
+//
+//   pm2 start pm2.ecosystem.config.js
+//   pm2 save && pm2 startup   // boot persistence
+module.exports = {
+  apps: [
+    {
+      name: 'dws-connect',
+      script: 'dws',
+      args: 'dev connect --robot-client-id REPLACE_CLIENT_ID --channel opencode',
+      autorestart: true,
+      restart_delay: 5000,
+      max_restarts: 50,
+      // Optional: periodic health-driven restart. A cleaner setup runs
+      // connect-watchdog.sh from cron so restarts key off `status --json`.
+      // cron_restart: '*/30 * * * *',
+    },
+  ],
+}

--- a/scripts/dev/recipes/systemd.dws-connect.service
+++ b/scripts/dev/recipes/systemd.dws-connect.service
@@ -1,0 +1,19 @@
+# Linux systemd --user unit: keep a dws connector alive. systemd restarts on
+# process death; connect-watchdog (run via a companion timer, or fold the poll
+# into ExecStart) catches the alive-but-deaf case via `status --json`.
+# Edit ExecStart (clientId, channel, absolute dws path), install per README.
+[Unit]
+Description=dws dev connect (DingTalk robot connector)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment=DWS_BIN=/usr/local/bin/dws
+# Foreground connector (NOT --daemon: systemd is the supervisor here).
+ExecStart=/usr/local/bin/dws dev connect --robot-client-id REPLACE_CLIENT_ID --channel opencode
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/skills/mono/references/products/aitable.md
+++ b/skills/mono/references/products/aitable.md
@@ -316,7 +316,7 @@ dws aitable chart get --base-id <BASE_ID> --dashboard-id <DASHBOARD_ID> --chart-
 
 ```bash
 # 第一步：创建任务（按 scope 传必要参数）
-dws aitable export data --base-id <BASE_ID> --scope table --table-id <TABLE_ID> --format excel --timeout-ms 1000
+dws aitable export data --base-id <BASE_ID> --scope table --table-id <TABLE_ID> --export-format excel --timeout-ms 1000
 
 # 第二步：拿 taskId 继续轮询，直到返回 downloadUrl
 dws aitable export data --base-id <BASE_ID> --task-id <TASK_ID> --timeout-ms 3000

--- a/skills/multi/dingtalk-aitable/references/aitable.md
+++ b/skills/multi/dingtalk-aitable/references/aitable.md
@@ -316,7 +316,7 @@ dws aitable chart get --base-id <BASE_ID> --dashboard-id <DASHBOARD_ID> --chart-
 
 ```bash
 # 第一步：创建任务（按 scope 传必要参数）
-dws aitable export data --base-id <BASE_ID> --scope table --table-id <TABLE_ID> --format excel --timeout-ms 1000
+dws aitable export data --base-id <BASE_ID> --scope table --table-id <TABLE_ID> --export-format excel --timeout-ms 1000
 
 # 第二步：拿 taskId 继续轮询，直到返回 downloadUrl
 dws aitable export data --base-id <BASE_ID> --task-id <TASK_ID> --timeout-ms 3000


### PR DESCRIPTION
## Summary

- **keepAlive 120s → 30s**: SDK 默认 120s keepAlive 导致断连后最多 125s 才能发现，期间表现为"connect success 但收不到消息"。缩短到 30s，支持 `DWS_CONNECT_KEEPALIVE_MS` 环境变量覆盖
- **ulimit 检查**: 多 agent 同时连接时，低 ulimit 导致 fd 耗尽 → WebSocket abnormal closure。启动时检测 RLIMIT_NOFILE < 512 并告警
- 包含超时自恢复改进（applyTimeout + DeadlineExceeded 会话重置），与稳定性修复互补

## 背景

勤泽反馈：本地同时启动 opencode / cc / hermes 三个连接器时连接不稳定，显示 connect success 但 WebSocket 异常关闭。

根因：
1. SDK keepAlive 120s 太长，断连检测窗口 125s
2. 多连接器并发时 ulimit 可能不足
3. SDK 自动重连无退避（上游限制，daemon supervisor 已有指数退避兜底）

## Test plan

- [x] `go build ./...` 通过
- [x] `go test ./internal/helpers/` 全部通过
- [x] 新增 `TestCheckFDLimit` 和 `TestEnvDurationMS` 验证
- [ ] 多 agent 同时连接实测验证（需勤泽配合）