### PR TITLE
fix(plugin): accept delivery beta version aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 - **Remove-discovery delivery seal** — pre-release validation line for the static-endpoint delivery branch. It removes dynamic service discovery, keeps legacy CLI compatibility aliases, syncs the open command/help/skill surface with the dws-wukong baseline, and includes the `dev connect` default-yolo behavior plus the beta upgrade track.
 - **Official beta packages stay out of normal `dws upgrade`** — publish the sealed beta as an upstream GitHub pre-release after merge, using a low pre-release tag such as `v0.0.48-beta.1`. Old clients' plain `dws upgrade` / `dws upgrade --check` follows GitHub `releases/latest`, so it does not install pre-releases. New clients' plain `dws upgrade` stays on the stable track, and the low numeric version prevents the sealed beta from being treated as newer than `v1.0.47`. Testers install this sealed beta only by specifying the exact tag.
+- **Plugin compatibility honors low-numbered delivery beta tags** — `v0.0.N-beta.M` tags are now treated as the `v1.0.N` capability line for plugin `minCLIVersion` checks, so managed plugins that require legacy versions such as `0.2.33` no longer warn and get skipped on the official beta build.
 - **Pinned curl install for the official beta package after the upstream pre-release exists**:
 
   ```sh

--- a/internal/plugin/manifest.go
+++ b/internal/plugin/manifest.go
@@ -29,6 +29,11 @@ import (
 // namePattern validates plugin names: lowercase kebab-case, 3–50 chars.
 var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{2,49}$`)
 
+// deliveryBetaVersionPattern matches official low-numbered delivery beta tags
+// such as v0.0.48-beta.1. Those tags are intentionally below v1.x for upgrade
+// ordering, but they carry the same CLI capability line as v1.0.<patch>.
+var deliveryBetaVersionPattern = regexp.MustCompile(`^v?0\.0\.([1-9][0-9]*)(-beta(?:\.[0-9A-Za-z-]+)*)$`)
+
 // Manifest represents the parsed contents of a plugin.json file.
 type Manifest struct {
 	Name          string                `json:"name"`
@@ -124,7 +129,7 @@ func (m *Manifest) Validate(cliVersion string) error {
 		return fmt.Errorf("invalid plugin type %q: must be \"managed\" or \"user\"", m.Type)
 	}
 	if m.MinCLIVersion != "" && cliVersion != "" && cliVersion != "dev" {
-		if compareSemver(cliVersion, m.MinCLIVersion) < 0 {
+		if compareSemver(normalizeCLIVersionForCompatibility(cliVersion), m.MinCLIVersion) < 0 {
 			return fmt.Errorf("plugin requires CLI >= %s, current is %s", m.MinCLIVersion, cliVersion)
 		}
 	}
@@ -231,6 +236,14 @@ func parseSemver(v string) (int, int, int) {
 	minor, _ := strconv.Atoi(nums[1])
 	patch, _ := strconv.Atoi(nums[2])
 	return major, minor, patch
+}
+
+func normalizeCLIVersionForCompatibility(v string) string {
+	trimmed := strings.TrimSpace(v)
+	if match := deliveryBetaVersionPattern.FindStringSubmatch(trimmed); match != nil {
+		return "v1.0." + match[1] + match[2]
+	}
+	return v
 }
 
 // compareSemver compares two semver strings. Returns -1, 0, or 1.

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -135,6 +135,36 @@ func TestManifestValidate(t *testing.T) {
 			wantErr:    true,
 		},
 		{
+			name: "delivery beta satisfies legacy plugin requirement",
+			manifest: Manifest{
+				Name:          "my-plugin",
+				Version:       "1.0.0",
+				MinCLIVersion: "0.2.33",
+			},
+			cliVersion: "v0.0.48-beta.1",
+			wantErr:    false,
+		},
+		{
+			name: "delivery beta satisfies one dot zero plugin requirement",
+			manifest: Manifest{
+				Name:          "my-plugin",
+				Version:       "1.0.0",
+				MinCLIVersion: "1.0.40",
+			},
+			cliVersion: "v0.0.48-beta.1",
+			wantErr:    false,
+		},
+		{
+			name: "delivery beta remains ordered by patch",
+			manifest: Manifest{
+				Name:          "my-plugin",
+				Version:       "1.0.0",
+				MinCLIVersion: "1.0.40",
+			},
+			cliVersion: "v0.0.35-beta.1",
+			wantErr:    true,
+		},
+		{
 			name: "streamable-http without endpoint",
 			manifest: Manifest{
 				Name:    "my-plugin",


### PR DESCRIPTION
## Summary
- Normalize official low-numbered delivery beta CLI tags like `v0.0.48-beta.1` to the `v1.0.48` capability line for plugin `minCLIVersion` checks.
- Preserve normal semver ordering for non-delivery versions and keep the original version string in validation errors.
- Add regression coverage for `v0.0.48-beta.1` against legacy plugin requirements such as `0.2.33` and `1.0.40`.

## Verification
- `go test ./internal/plugin`
- `go test ./internal/app -run 'TestPlugin|TestVersion'`\n- Built with `-X github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/app.version=v0.0.48-beta.1`; verified `dws version` and `dws plugin list` no longer emit `plugin requires CLI >= 0.2.33` and `conference` remains enabled.\n- `go test ./...` still fails in `test/scripts` on the post-goreleaser fixture with `tar: Error opening archive: Unrecognized archive format` while ad-hoc signing fake darwin archives; unrelated to this plugin validation change.