### PR TITLE
ci: harden Gitee mirror synchronization

### DIFF
--- a/.github/workflows/mirror-to-gitee.yml
+++ b/.github/workflows/mirror-to-gitee.yml
@@ -16,6 +16,10 @@ on:
     - cron: '0 18 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: gitee-code-mirror
+  cancel-in-progress: false
+
 jobs:
   mirror:
     runs-on: ubuntu-latest
@@ -36,6 +40,14 @@ jobs:
         run: |
           set -eu
           REMOTE="https://${GITEE_USER}:${GITEE_TOKEN}@gitee.com/${GITEE_REPO}.git"
+
+          if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+            git fetch --force --tags origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+            git push --force "$REMOTE" "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+            echo "✅ 已镜像 tag ${GITHUB_REF_NAME} 到 Gitee ${GITEE_REPO}"
+            exit 0
+          fi
+
           # 取到 main 与所有 tag（落到 origin/* 与本地 tags，避免推当前分支引用冲突）
           git fetch --force --tags origin 'refs/heads/main:refs/remotes/origin/main'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
         env:
           VERSION: ${{ github.ref_name }}
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          GITEE_USER: ${{ secrets.GITEE_USER }}
           GITEE_REPO: ${{ secrets.GITEE_REPO }}
 
       - name: Setup Node.js

--- a/.github/workflows/sync-release-to-gitee.yml
+++ b/.github/workflows/sync-release-to-gitee.yml
@@ -46,4 +46,5 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+          GITEE_USER: ${{ secrets.GITEE_USER }}
           GITEE_REPO: ${{ secrets.GITEE_REPO }}

--- a/scripts/release/sync-to-gitee.sh
+++ b/scripts/release/sync-to-gitee.sh
@@ -14,14 +14,15 @@
 #
 # Required environment (CI secrets):
 #   GITEE_TOKEN   Gitee private access token (scopes: projects)
+#   GITEE_USER    Gitee username for git push authentication
 #   GITEE_REPO    "owner/repo" on Gitee, e.g. DingTalk-Real-AI/dingtalk-workspace-cli
 # Optional:
 #   VERSION       release tag (default: git describe)
 #   DIST_DIR      artifacts dir (default: ./dist)
 #   GITEE_API     API base (default: https://gitee.com/api/v5)
 #
-# Gating: if GITEE_TOKEN / GITEE_REPO are unset, exit 0 with a notice so the
-# step can live in release.yml without breaking forks that lack the secret.
+# Gating: if GITEE_TOKEN / GITEE_USER / GITEE_REPO are unset, exit 0 with a
+# notice so the step can live in release.yml without breaking forks.
 
 set -eu
 
@@ -30,6 +31,7 @@ GITEE_API="${GITEE_API:-https://gitee.com/api/v5}"
 
 missing=""
 [ -z "${GITEE_TOKEN:-}" ] && missing="$missing GITEE_TOKEN"
+[ -z "${GITEE_USER:-}" ]  && missing="$missing GITEE_USER"
 [ -z "${GITEE_REPO:-}" ]  && missing="$missing GITEE_REPO"
 if [ -n "$missing" ]; then
   echo "ℹ️  Gitee mirror sync skipped — missing:${missing}"
@@ -41,11 +43,46 @@ VERSION="${VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)}"
 OWNER="${GITEE_REPO%%/*}"
 NAME="${GITEE_REPO##*/}"
 base="${GITEE_API}/repos/${OWNER}/${NAME}"
+git_remote="https://${GITEE_USER}:${GITEE_TOKEN}@gitee.com/${GITEE_REPO}.git"
+public_git_remote="https://gitee.com/${GITEE_REPO}.git"
 
 echo "📦 Mirroring release ${VERSION} → Gitee ${GITEE_REPO}"
 
+# ── Keep the Gitee git tag aligned with the GitHub release tag ───────────────
+# Creating a Gitee release with target_commitish=main can silently create a tag
+# at the Gitee-localized main commit. Always push the exact GitHub tag first,
+# then verify the peeled commit before touching release attachments.
+git fetch --force --tags origin "refs/tags/${VERSION}:refs/tags/${VERSION}" >/dev/null 2>&1 || true
+target_commit="$(git rev-parse "${VERSION}^{commit}" 2>/dev/null || true)"
+[ -n "$target_commit" ] || { echo "❌ Could not resolve local release tag ${VERSION}; fetch tags before syncing." >&2; exit 1; }
+
+gitee_tag_commit() {
+  git ls-remote "$public_git_remote" "refs/tags/${VERSION}*" 2>/dev/null \
+    | awk -v tag="refs/tags/${VERSION}" '
+        $2 == tag "^{}" { peeled=$1 }
+        $2 == tag { direct=$1 }
+        END {
+          if (peeled != "") print peeled;
+          else if (direct != "") print direct;
+        }'
+}
+
+echo "   Syncing Gitee tag ${VERSION} -> ${target_commit}"
+git push --force "$git_remote" "refs/tags/${VERSION}:refs/tags/${VERSION}" >/dev/null
+
+gitee_commit=""
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  gitee_commit="$(gitee_tag_commit || true)"
+  [ "$gitee_commit" = "$target_commit" ] && break
+  sleep 5
+done
+[ "$gitee_commit" = "$target_commit" ] || {
+  echo "❌ Gitee tag ${VERSION} is not aligned after push: got ${gitee_commit:-<missing>}, want ${target_commit}" >&2
+  exit 1
+}
+echo "   Gitee tag ${VERSION} is aligned."
+
 # ── Resolve or create the Gitee release for this tag ──────────────────────────
-# Gitee mirror sync brings the git tag over, so the tag should already exist.
 rel_json="$(curl -fsSL "${base}/releases/tags/${VERSION}?access_token=${GITEE_TOKEN}" 2>/dev/null || true)"
 release_id="$(printf '%s' "$rel_json" | grep -o '"id":[ ]*[0-9]*' | head -1 | grep -o '[0-9]*' || true)"
 
@@ -56,7 +93,7 @@ if [ -z "$release_id" ]; then
     -F "tag_name=${VERSION}" \
     -F "name=${VERSION}" \
     -F "body=Mirror of GitHub release ${VERSION} for China users." \
-    -F "target_commitish=main" 2>/dev/null || true)"
+    -F "target_commitish=${target_commit}" 2>/dev/null || true)"
   release_id="$(printf '%s' "$rel_json" | grep -o '"id":[ ]*[0-9]*' | head -1 | grep -o '[0-9]*' || true)"
 fi
 [ -n "$release_id" ] || { echo "❌ Could not get/create Gitee release for ${VERSION}. Response: ${rel_json}" >&2; exit 1; }


### PR DESCRIPTION
## Summary

Fix the Gitee mirror race observed while publishing `v0.0.48-beta.1`.

What happened:
- the `main` push mirror and the tag push mirror ran concurrently
- the tag-triggered `Mirror code to Gitee` job tried to force-push `main` again and Gitee rejected it with `incorrect old value provided`
- the release asset sync then created the Gitee release with `target_commitish=main`, which can create/move the tag to the Gitee-localized main commit instead of the GitHub release commit

Changes:
- serialize `Mirror code to Gitee` jobs with workflow concurrency
- make tag-triggered code mirror jobs push only the current tag, not `main`
- pass `GITEE_USER` into release-to-Gitee sync jobs
- before uploading Gitee release assets, force-push the exact GitHub tag to Gitee and verify the peeled commit matches
- create missing Gitee releases with `target_commitish=<release tag commit>` instead of `main`

## Validation

- `bash -n scripts/release/sync-to-gitee.sh`
- `git diff --check`
- YAML parse check for the changed workflow files
- manually reran `Mirror code to Gitee` for `main`: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/28865205084
- verified Gitee `v0.0.48-beta.1^{}` now points to `d808843f75972094554d79f1c4e07d5f20e4f200`, matching GitHub
