### PR TITLE
fix: keep keychain reads side-effect free

### DIFF
--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -1226,7 +1226,17 @@ type authStatusDiagnostic struct {
 }
 
 func authStatusDiagnosticFromError(err error) *authStatusDiagnostic {
-	if err == nil || !keychain.IsUnavailable(err) {
+	if err == nil {
+		return nil
+	}
+	if keychain.IsDEKMissing(err) {
+		return &authStatusDiagnostic{
+			Reason:  "dek_missing",
+			Message: "本地登录密钥缺失，无法解密已保存的登录态",
+			Hint:    "重新登录以生成新的本地登录密钥；如仍异常，可先清理本地登录态后再登录。",
+		}
+	}
+	if !keychain.IsUnavailable(err) {
 		return nil
 	}
 	return &authStatusDiagnostic{

--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -446,6 +446,7 @@ func newAuthStatusCommand() *cobra.Command {
 			authenticated := false
 			refreshed := false
 			var tokenData *authpkg.TokenData
+			var statusErr error
 			provider := authpkg.NewOAuthProvider(configDir, nil)
 			configureOAuthProviderCompatibility(provider, configDir)
 			if data, err := provider.Status(); err == nil {
@@ -468,12 +469,15 @@ func newAuthStatusCommand() *cobra.Command {
 				if authStatusAuthenticated(tokenData) {
 					authenticated = true
 				}
+			} else {
+				statusErr = err
 			}
+			diagnostic := authStatusDiagnosticFromError(statusErr)
 
 			// Check if JSON output is requested
 			format, _ := cmd.Root().PersistentFlags().GetString("format")
 			if strings.EqualFold(strings.TrimSpace(format), "json") {
-				return writeAuthStatusJSON(cmd.OutOrStdout(), authenticated, refreshed, tokenData)
+				return writeAuthStatusJSON(cmd.OutOrStdout(), authenticated, refreshed, tokenData, diagnostic)
 			}
 
 			// Default table output
@@ -503,7 +507,10 @@ func newAuthStatusCommand() *cobra.Command {
 				}
 			} else {
 				fmt.Fprintf(w, "%-16s%s\n", "状态:", "未登录")
-				if !edition.Get().IsEmbedded {
+				if diagnostic != nil {
+					fmt.Fprintf(w, "%-16s%s\n", "原因:", diagnostic.Message)
+					fmt.Fprintf(w, "%-16s%s\n", "提示:", diagnostic.Hint)
+				} else if !edition.Get().IsEmbedded {
 					fmt.Fprintln(w, "运行 dws auth login --recommend 进行登录")
 				}
 			}
@@ -1199,6 +1206,8 @@ type authStatusResponse struct {
 	Success           bool   `json:"success"`
 	Authenticated     bool   `json:"authenticated"`
 	Message           string `json:"message,omitempty"`
+	Reason            string `json:"reason,omitempty"`
+	Hint              string `json:"hint,omitempty"`
 	Refreshed         bool   `json:"refreshed,omitempty"`
 	TokenValid        bool   `json:"token_valid,omitempty"`
 	RefreshTokenValid bool   `json:"refresh_token_valid,omitempty"`
@@ -1210,14 +1219,37 @@ type authStatusResponse struct {
 	UserName          string `json:"user_name,omitempty"`
 }
 
-func writeAuthStatusJSON(w io.Writer, authenticated, refreshed bool, data *authpkg.TokenData) error {
+type authStatusDiagnostic struct {
+	Reason  string
+	Message string
+	Hint    string
+}
+
+func authStatusDiagnosticFromError(err error) *authStatusDiagnostic {
+	if err == nil || !keychain.IsUnavailable(err) {
+		return nil
+	}
+	return &authStatusDiagnostic{
+		Reason:  "keychain_unavailable",
+		Message: "无法读取 macOS Keychain 中的登录密钥，无法判断登录状态",
+		Hint:    "检查 macOS 默认钥匙串是否存在且已解锁；修复后重试，或在测试环境设置 DWS_DISABLE_KEYCHAIN=1 后重新登录。",
+	}
+}
+
+func writeAuthStatusJSON(w io.Writer, authenticated, refreshed bool, data *authpkg.TokenData, diagnostic *authStatusDiagnostic) error {
 	resp := authStatusResponse{
 		Success:       true,
 		Authenticated: authenticated,
 	}
 
 	if !authenticated {
-		resp.Message = "未登录"
+		if diagnostic != nil {
+			resp.Message = diagnostic.Message
+			resp.Reason = diagnostic.Reason
+			resp.Hint = diagnostic.Hint
+		} else {
+			resp.Message = "未登录"
+		}
 	} else if data != nil {
 		resp.Refreshed = refreshed
 		resp.TokenValid = data.IsAccessTokenValid()

--- a/internal/app/auth_command_test.go
+++ b/internal/app/auth_command_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -180,6 +181,56 @@ func TestAuthStatusJSONReportsKeychainUnavailable(t *testing.T) {
 	}
 	if !strings.Contains(resp.Hint, keychain.DisableKeychainEnv) {
 		t.Fatalf("hint should mention %s; response=%+v", keychain.DisableKeychainEnv, resp)
+	}
+}
+
+func TestAuthStatusJSONReportsDEKMissing(t *testing.T) {
+	t.Setenv("DWS_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+
+	prev := edition.Get()
+	edition.Override(&edition.Hooks{
+		LoadToken: func(configDir string) ([]byte, error) {
+			return nil, fmt.Errorf("load from keychain: %w", keychain.ErrDEKMissing)
+		},
+	})
+	t.Cleanup(func() {
+		edition.Override(prev)
+	})
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--format", "json", "auth", "status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth status --format json error = %v\noutput:\n%s", err, out.String())
+	}
+
+	var resp struct {
+		Success       bool   `json:"success"`
+		Authenticated bool   `json:"authenticated"`
+		Reason        string `json:"reason"`
+		Message       string `json:"message"`
+		Hint          string `json:"hint"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal auth status JSON error = %v\noutput:\n%s", err, out.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false, want true; response=%+v", resp)
+	}
+	if resp.Authenticated {
+		t.Fatalf("authenticated = true, want false; response=%+v", resp)
+	}
+	if resp.Reason != "dek_missing" {
+		t.Fatalf("reason = %q, want dek_missing; response=%+v", resp.Reason, resp)
+	}
+	if !strings.Contains(resp.Message, "登录密钥") {
+		t.Fatalf("message should mention 登录密钥; response=%+v", resp)
+	}
+	if !strings.Contains(resp.Hint, "重新登录") {
+		t.Fatalf("hint should mention 重新登录; response=%+v", resp)
 	}
 }
 

--- a/internal/app/auth_command_test.go
+++ b/internal/app/auth_command_test.go
@@ -16,6 +16,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"os"
@@ -129,6 +130,56 @@ func TestAuthImportRequiresForceWhenPopulated(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--force") {
 		t.Fatalf("error = %v, want --force hint", err)
+	}
+}
+
+func TestAuthStatusJSONReportsKeychainUnavailable(t *testing.T) {
+	t.Setenv("DWS_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+
+	prev := edition.Get()
+	edition.Override(&edition.Hooks{
+		LoadToken: func(configDir string) ([]byte, error) {
+			return nil, keychain.NewUnavailableError("read DEK from macOS Keychain", errors.New("default keychain missing"))
+		},
+	})
+	t.Cleanup(func() {
+		edition.Override(prev)
+	})
+
+	cmd := NewRootCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--format", "json", "auth", "status"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth status --format json error = %v\noutput:\n%s", err, out.String())
+	}
+
+	var resp struct {
+		Success       bool   `json:"success"`
+		Authenticated bool   `json:"authenticated"`
+		Reason        string `json:"reason"`
+		Message       string `json:"message"`
+		Hint          string `json:"hint"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal auth status JSON error = %v\noutput:\n%s", err, out.String())
+	}
+	if !resp.Success {
+		t.Fatalf("success = false, want true; response=%+v", resp)
+	}
+	if resp.Authenticated {
+		t.Fatalf("authenticated = true, want false; response=%+v", resp)
+	}
+	if resp.Reason != "keychain_unavailable" {
+		t.Fatalf("reason = %q, want keychain_unavailable; response=%+v", resp.Reason, resp)
+	}
+	if !strings.Contains(resp.Message, "Keychain") && !strings.Contains(resp.Message, "钥匙串") {
+		t.Fatalf("message should mention Keychain/钥匙串; response=%+v", resp)
+	}
+	if !strings.Contains(resp.Hint, keychain.DisableKeychainEnv) {
+		t.Fatalf("hint should mention %s; response=%+v", keychain.DisableKeychainEnv, resp)
 	}
 }
 

--- a/internal/app/doctor_command.go
+++ b/internal/app/doctor_command.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/tui"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/upgrade"
@@ -28,6 +29,8 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/spf13/cobra"
 )
+
+var doctorKeychainDiagnose = keychain.Diagnose
 
 // checkStatus represents the outcome of a single doctor check.
 type checkStatus string
@@ -75,6 +78,9 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 
 	authResult := doctorCheckAuth(cmd.Context(), w, jsonOut)
 	checks = append(checks, authResult)
+
+	keychainResult := doctorCheckKeychain(w, jsonOut)
+	checks = append(checks, keychainResult)
 
 	networkResult := doctorCheckNetwork(cmd.Context(), w, jsonOut, networkTimeout)
 	checks = append(checks, networkResult)
@@ -132,6 +138,19 @@ func doctorCheckAuth(ctx context.Context, w io.Writer, jsonOut bool) checkResult
 
 	data, err := provider.Status()
 	if err != nil || data == nil {
+		if diagnostic := authStatusDiagnosticFromError(err); diagnostic != nil {
+			r := checkResult{
+				Name:    "auth",
+				Status:  statusFail,
+				Message: diagnostic.Message,
+				Hint:    diagnostic.Hint,
+				Detail:  map[string]string{"reason": diagnostic.Reason},
+			}
+			if !jsonOut {
+				printCheckResult(w, r)
+			}
+			return r
+		}
 		r := checkResult{Name: "auth", Status: statusFail, Message: "未登录"}
 		if !edition.Get().IsEmbedded {
 			r.Hint = "运行 dws auth login 进行登录"
@@ -175,6 +194,40 @@ func doctorCheckAuth(ctx context.Context, w io.Writer, jsonOut bool) checkResult
 	r := checkResult{Name: "auth", Status: statusFail, Message: "登录已过期"}
 	if !edition.Get().IsEmbedded {
 		r.Hint = "运行 dws auth login 重新登录"
+	}
+	if !jsonOut {
+		printCheckResult(w, r)
+	}
+	return r
+}
+
+// ── Keychain check ─────────────────────────────────────────────────────
+
+func doctorCheckKeychain(w io.Writer, jsonOut bool) checkResult {
+	if !jsonOut {
+		fmt.Fprint(w, tui.Dim("检查钥匙串状态...     "))
+	}
+
+	diagnostic := doctorKeychainDiagnose()
+	r := checkResult{
+		Name:    "keychain",
+		Status:  statusPass,
+		Message: diagnostic.Message,
+		Detail:  diagnostic.Detail,
+	}
+	if !diagnostic.OK {
+		r.Status = statusFail
+		r.Hint = diagnostic.Hint
+		if diagnostic.Detail == nil {
+			r.Detail = map[string]string{"reason": diagnostic.Reason}
+		} else if diagnostic.Reason != "" {
+			detail := make(map[string]string, len(diagnostic.Detail)+1)
+			for k, v := range diagnostic.Detail {
+				detail[k] = v
+			}
+			detail["reason"] = diagnostic.Reason
+			r.Detail = detail
+		}
 	}
 	if !jsonOut {
 		printCheckResult(w, r)

--- a/internal/app/doctor_command_test.go
+++ b/internal/app/doctor_command_test.go
@@ -15,9 +15,15 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
 
 func TestCountResults(t *testing.T) {
@@ -124,6 +130,74 @@ func TestDoctorCheckCacheEmptyJSON(t *testing.T) {
 	}
 	if buf.Len() != 0 {
 		t.Error("expected no output in JSON mode")
+	}
+}
+
+func TestDoctorCheckAuthReportsKeychainUnavailable(t *testing.T) {
+	t.Setenv("DWS_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+
+	prev := edition.Get()
+	edition.Override(&edition.Hooks{
+		LoadToken: func(configDir string) ([]byte, error) {
+			return nil, keychain.NewUnavailableError("read DEK from macOS Keychain", errors.New("default keychain missing"))
+		},
+	})
+	t.Cleanup(func() {
+		edition.Override(prev)
+	})
+
+	var buf bytes.Buffer
+	r := doctorCheckAuth(context.Background(), &buf, false)
+
+	if r.Name != "auth" {
+		t.Fatalf("name = %q, want auth", r.Name)
+	}
+	if r.Status != statusFail {
+		t.Fatalf("status = %q, want fail", r.Status)
+	}
+	if !strings.Contains(r.Message, "Keychain") && !strings.Contains(r.Message, "钥匙串") {
+		t.Fatalf("message should mention Keychain/钥匙串; result=%+v", r)
+	}
+	if !strings.Contains(r.Hint, keychain.DisableKeychainEnv) {
+		t.Fatalf("hint should mention %s; result=%+v", keychain.DisableKeychainEnv, r)
+	}
+}
+
+func TestDoctorCheckKeychainReportsUnavailable(t *testing.T) {
+	prev := doctorKeychainDiagnose
+	doctorKeychainDiagnose = func() keychain.Diagnostic {
+		return keychain.Diagnostic{
+			OK:      false,
+			Reason:  "keychain_unavailable",
+			Message: "macOS 默认钥匙串不存在",
+			Hint:    "恢复默认钥匙串后重试",
+			Detail: map[string]string{
+				"default_keychain": "/tmp/missing.keychain-db",
+			},
+		}
+	}
+	t.Cleanup(func() {
+		doctorKeychainDiagnose = prev
+	})
+
+	var buf bytes.Buffer
+	r := doctorCheckKeychain(&buf, false)
+
+	if r.Name != "keychain" {
+		t.Fatalf("name = %q, want keychain", r.Name)
+	}
+	if r.Status != statusFail {
+		t.Fatalf("status = %q, want fail", r.Status)
+	}
+	if r.Message != "macOS 默认钥匙串不存在" {
+		t.Fatalf("message = %q", r.Message)
+	}
+	if r.Hint == "" {
+		t.Fatalf("hint is empty; result=%+v", r)
+	}
+	detail, ok := r.Detail.(map[string]string)
+	if !ok || detail["default_keychain"] == "" {
+		t.Fatalf("detail = %#v, want default_keychain", r.Detail)
 	}
 }
 

--- a/internal/app/doctor_command_test.go
+++ b/internal/app/doctor_command_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -160,6 +161,40 @@ func TestDoctorCheckAuthReportsKeychainUnavailable(t *testing.T) {
 	}
 	if !strings.Contains(r.Hint, keychain.DisableKeychainEnv) {
 		t.Fatalf("hint should mention %s; result=%+v", keychain.DisableKeychainEnv, r)
+	}
+}
+
+func TestDoctorCheckAuthReportsDEKMissing(t *testing.T) {
+	t.Setenv("DWS_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+
+	prev := edition.Get()
+	edition.Override(&edition.Hooks{
+		LoadToken: func(configDir string) ([]byte, error) {
+			return nil, fmt.Errorf("load from keychain: %w", keychain.ErrDEKMissing)
+		},
+	})
+	t.Cleanup(func() {
+		edition.Override(prev)
+	})
+
+	var buf bytes.Buffer
+	r := doctorCheckAuth(context.Background(), &buf, false)
+
+	if r.Name != "auth" {
+		t.Fatalf("name = %q, want auth", r.Name)
+	}
+	if r.Status != statusFail {
+		t.Fatalf("status = %q, want fail", r.Status)
+	}
+	if !strings.Contains(r.Message, "登录密钥") {
+		t.Fatalf("message should mention 登录密钥; result=%+v", r)
+	}
+	if !strings.Contains(r.Hint, "重新登录") {
+		t.Fatalf("hint should mention 重新登录; result=%+v", r)
+	}
+	detail, ok := r.Detail.(map[string]string)
+	if !ok || detail["reason"] != "dek_missing" {
+		t.Fatalf("detail = %#v, want reason=dek_missing", r.Detail)
 	}
 }
 

--- a/internal/keychain/diagnose_default.go
+++ b/internal/keychain/diagnose_default.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !darwin
+
+package keychain
+
+func platformDiagnose() Diagnostic {
+	return Diagnostic{
+		OK:      true,
+		Message: "当前平台使用本地加密凭据后端",
+		Detail: map[string]string{
+			"service": Service,
+		},
+	}
+}

--- a/internal/keychain/file_dek.go
+++ b/internal/keychain/file_dek.go
@@ -63,3 +63,18 @@ func fileDEK(service string) ([]byte, error) {
 
 	return key, nil
 }
+
+func fileDEKReadOnly(service string) ([]byte, error) {
+	keyPath := filepath.Join(StorageDir(service), "dek")
+	key, err := os.ReadFile(keyPath)
+	if err == nil && len(key) == dekBytes {
+		return key, nil
+	}
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrDEKMissing
+		}
+		return nil, fmt.Errorf("read dek: %w", err)
+	}
+	return nil, fmt.Errorf("read dek: %w", ErrDEKMissing)
+}

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -17,6 +17,8 @@
 // - Windows: DPAPI + Registry storage
 package keychain
 
+import "errors"
+
 const (
 	// Service is the unified keychain service name for all secrets.
 	Service = "dws-cli"
@@ -45,6 +47,60 @@ type KeychainAccess interface {
 	Get(service, account string) (string, error)
 	Set(service, account, value string) error
 	Remove(service, account string) error
+}
+
+// Diagnostic is a read-only health report for the platform keychain backend.
+// It never mutates credentials, DEKs, or OS keychain settings.
+type Diagnostic struct {
+	OK      bool              `json:"ok"`
+	Reason  string            `json:"reason,omitempty"`
+	Message string            `json:"message"`
+	Hint    string            `json:"hint,omitempty"`
+	Detail  map[string]string `json:"detail,omitempty"`
+}
+
+// UnavailableError marks failures where the platform keychain itself could
+// not be reached, unlocked, or created. Callers can surface a diagnostic
+// instead of treating the result as a normal missing credential.
+type UnavailableError struct {
+	Op  string
+	Err error
+}
+
+func NewUnavailableError(op string, err error) error {
+	return &UnavailableError{Op: op, Err: err}
+}
+
+func (e *UnavailableError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Op == "" {
+		if e.Err != nil {
+			return e.Err.Error()
+		}
+		return "keychain unavailable"
+	}
+	if e.Err == nil {
+		return e.Op + ": keychain unavailable"
+	}
+	return e.Op + ": " + e.Err.Error()
+}
+
+func (e *UnavailableError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func IsUnavailable(err error) bool {
+	var unavailable *UnavailableError
+	return errors.As(err, &unavailable)
+}
+
+func Diagnose() Diagnostic {
+	return platformDiagnose()
 }
 
 // Get retrieves a value from the keychain.

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -42,6 +42,11 @@ const (
 	DisableKeychainEnv = "DWS_DISABLE_KEYCHAIN"
 )
 
+// ErrDEKMissing means encrypted local data may exist, but the Data Encryption
+// Key needed to decrypt it is missing. Read paths must not create a new DEK,
+// because a fresh key cannot decrypt existing ciphertext.
+var ErrDEKMissing = errors.New("dek missing")
+
 // KeychainAccess abstracts keychain Get/Set/Remove for dependency injection.
 type KeychainAccess interface {
 	Get(service, account string) (string, error)
@@ -97,6 +102,10 @@ func (e *UnavailableError) Unwrap() error {
 func IsUnavailable(err error) bool {
 	var unavailable *UnavailableError
 	return errors.As(err, &unavailable)
+}
+
+func IsDEKMissing(err error) bool {
+	return errors.Is(err, ErrDEKMissing)
 }
 
 func Diagnose() Diagnostic {

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -21,10 +21,14 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -59,6 +63,103 @@ func safeFileName(account string) string {
 	return safeFileNameRe.ReplaceAllString(account, "_") + ".enc"
 }
 
+var readDefaultKeychain = func() ([]byte, error) {
+	return exec.Command("security", "default-keychain", "-d", "user").Output()
+}
+
+func defaultKeychainPathFromSecurityOutput(output []byte) string {
+	value := strings.TrimSpace(string(output))
+	if value == "" {
+		return ""
+	}
+	if unquoted, err := strconv.Unquote(value); err == nil {
+		return unquoted
+	}
+	return strings.Trim(value, `"`)
+}
+
+func checkDefaultKeychainAvailable() error {
+	output, err := readDefaultKeychain()
+	if err != nil {
+		return nil
+	}
+	path := defaultKeychainPathFromSecurityOutput(output)
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
+		return NewUnavailableError("read macOS default Keychain", fmt.Errorf("default keychain %q does not exist", path))
+	}
+	return nil
+}
+
+func platformDiagnose() Diagnostic {
+	detail := map[string]string{
+		"platform": "darwin",
+		"service":  Service,
+		"account":  "dek",
+	}
+	if os.Getenv(DisableKeychainEnv) != "" {
+		detail["mode"] = "file_dek"
+		detail["storage_dir"] = StorageDir(Service)
+		return Diagnostic{
+			OK:      true,
+			Message: "macOS Keychain 已禁用, 当前使用 file-DEK 测试模式",
+			Detail:  detail,
+		}
+	}
+
+	output, err := readDefaultKeychain()
+	if err != nil {
+		detail["error"] = err.Error()
+		return Diagnostic{
+			OK:      false,
+			Reason:  "keychain_check_failed",
+			Message: "无法读取 macOS 默认钥匙串配置",
+			Hint:    "检查 /usr/bin/security 是否可用, 并确认当前用户钥匙串配置正常。",
+			Detail:  detail,
+		}
+	}
+
+	path := defaultKeychainPathFromSecurityOutput(output)
+	if path != "" {
+		detail["default_keychain"] = path
+	}
+	if path == "" {
+		return Diagnostic{
+			OK:      false,
+			Reason:  "keychain_unavailable",
+			Message: "macOS 默认钥匙串未配置",
+			Hint:    "恢复默认钥匙串后重试；测试环境可设置 DWS_DISABLE_KEYCHAIN=1 后重新登录。",
+			Detail:  detail,
+		}
+	}
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
+		return Diagnostic{
+			OK:      false,
+			Reason:  "keychain_unavailable",
+			Message: "macOS 默认钥匙串不存在",
+			Hint:    "恢复默认钥匙串后重试；测试环境可设置 DWS_DISABLE_KEYCHAIN=1 后重新登录。",
+			Detail:  detail,
+		}
+	} else if err != nil {
+		detail["error"] = err.Error()
+		return Diagnostic{
+			OK:      false,
+			Reason:  "keychain_check_failed",
+			Message: "无法访问 macOS 默认钥匙串",
+			Hint:    "检查默认钥匙串路径权限与挂载状态。",
+			Detail:  detail,
+		}
+	}
+
+	return Diagnostic{
+		OK:      true,
+		Message: "macOS 默认钥匙串可用",
+		Detail:  detail,
+	}
+}
+
 // getDEK retrieves or generates the Data Encryption Key.
 // When DWS_DISABLE_KEYCHAIN=1 (set in sandboxed runtimes like Codex App
 // where Keychain APIs are blocked), falls back to a file-based DEK
@@ -67,6 +168,9 @@ func safeFileName(account string) string {
 func getDEK(service string) ([]byte, error) {
 	if os.Getenv(DisableKeychainEnv) != "" {
 		return fileDEK(service)
+	}
+	if err := checkDefaultKeychainAvailable(); err != nil {
+		return nil, err
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), keychainTimeout)
@@ -89,6 +193,9 @@ func getDEK(service string) ([]byte, error) {
 				resCh <- result{key: key, err: nil}
 				return
 			}
+		} else if !errors.Is(err, keyring.ErrNotFound) {
+			resCh <- result{key: nil, err: NewUnavailableError("read DEK from macOS Keychain", err)}
+			return
 		}
 
 		// Generate new DEK if not found or invalid
@@ -100,15 +207,18 @@ func getDEK(service string) ([]byte, error) {
 
 		// Store in system Keychain
 		encodedKey = base64.StdEncoding.EncodeToString(key)
-		setErr := keyring.Set(service, "dek", encodedKey)
-		resCh <- result{key: key, err: setErr}
+		if setErr := keyring.Set(service, "dek", encodedKey); setErr != nil {
+			resCh <- result{key: nil, err: NewUnavailableError("store DEK in macOS Keychain", setErr)}
+			return
+		}
+		resCh <- result{key: key, err: nil}
 	}()
 
 	select {
 	case res := <-resCh:
 		return res.key, res.err
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, NewUnavailableError("read DEK from macOS Keychain", ctx.Err())
 	}
 }
 

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -67,6 +67,11 @@ var readDefaultKeychain = func() ([]byte, error) {
 	return exec.Command("security", "default-keychain", "-d", "user").Output()
 }
 
+var (
+	keyringGet = keyring.Get
+	keyringSet = keyring.Set
+)
+
 func defaultKeychainPathFromSecurityOutput(output []byte) string {
 	value := strings.TrimSpace(string(output))
 	if value == "" {
@@ -166,6 +171,55 @@ func platformDiagnose() Diagnostic {
 // identical to the Linux scheme. See DisableKeychainEnv docs for the
 // security tradeoff.
 func getDEK(service string) ([]byte, error) {
+	return getOrCreateDEK(service)
+}
+
+func getDEKReadOnly(service string) ([]byte, error) {
+	if os.Getenv(DisableKeychainEnv) != "" {
+		return fileDEKReadOnly(service)
+	}
+	if err := checkDefaultKeychainAvailable(); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), keychainTimeout)
+	defer cancel()
+
+	type result struct {
+		key []byte
+		err error
+	}
+	resCh := make(chan result, 1)
+
+	go func() {
+		defer func() { recover() }()
+
+		encodedKey, err := keyringGet(service, "dek")
+		if err == nil {
+			key, decodeErr := base64.StdEncoding.DecodeString(encodedKey)
+			if decodeErr == nil && len(key) == dekBytes {
+				resCh <- result{key: key, err: nil}
+				return
+			}
+			resCh <- result{key: nil, err: fmt.Errorf("read DEK from macOS Keychain: %w", ErrDEKMissing)}
+			return
+		}
+		if errors.Is(err, keyring.ErrNotFound) {
+			resCh <- result{key: nil, err: fmt.Errorf("read DEK from macOS Keychain: %w", ErrDEKMissing)}
+			return
+		}
+		resCh <- result{key: nil, err: NewUnavailableError("read DEK from macOS Keychain", err)}
+	}()
+
+	select {
+	case res := <-resCh:
+		return res.key, res.err
+	case <-ctx.Done():
+		return nil, NewUnavailableError("read DEK from macOS Keychain", ctx.Err())
+	}
+}
+
+func getOrCreateDEK(service string) ([]byte, error) {
 	if os.Getenv(DisableKeychainEnv) != "" {
 		return fileDEK(service)
 	}
@@ -186,7 +240,7 @@ func getDEK(service string) ([]byte, error) {
 		defer func() { recover() }()
 
 		// Try to get existing DEK from system Keychain
-		encodedKey, err := keyring.Get(service, "dek")
+		encodedKey, err := keyringGet(service, "dek")
 		if err == nil {
 			key, decodeErr := base64.StdEncoding.DecodeString(encodedKey)
 			if decodeErr == nil && len(key) == dekBytes {
@@ -207,7 +261,7 @@ func getDEK(service string) ([]byte, error) {
 
 		// Store in system Keychain
 		encodedKey = base64.StdEncoding.EncodeToString(key)
-		if setErr := keyring.Set(service, "dek", encodedKey); setErr != nil {
+		if setErr := keyringSet(service, "dek", encodedKey); setErr != nil {
 			resCh <- result{key: nil, err: NewUnavailableError("store DEK in macOS Keychain", setErr)}
 			return
 		}
@@ -267,15 +321,15 @@ func decryptData(data []byte, key []byte) (string, error) {
 }
 
 func platformGet(service, account string) (string, error) {
-	key, err := getDEK(service)
-	if err != nil {
-		return "", err
-	}
 	data, err := os.ReadFile(filepath.Join(StorageDir(service), safeFileName(account)))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil // Not found is not an error
 		}
+		return "", err
+	}
+	key, err := getDEKReadOnly(service)
+	if err != nil {
 		return "", err
 	}
 	plaintext, err := decryptData(data, key)
@@ -286,7 +340,7 @@ func platformGet(service, account string) (string, error) {
 }
 
 func platformSet(service, account, data string) error {
-	key, err := getDEK(service)
+	key, err := getOrCreateDEK(service)
 	if err != nil {
 		return err
 	}

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -18,8 +18,35 @@ package keychain
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestDefaultKeychainPathFromSecurityOutput(t *testing.T) {
+	got := defaultKeychainPathFromSecurityOutput([]byte("\"/Users/me/Library/Keychains/login.keychain-db\"\n"))
+	if got != "/Users/me/Library/Keychains/login.keychain-db" {
+		t.Fatalf("path = %q", got)
+	}
+}
+
+func TestCheckDefaultKeychainAvailableReportsMissingPath(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing.keychain-db")
+	prev := readDefaultKeychain
+	readDefaultKeychain = func() ([]byte, error) {
+		return []byte("\"" + missingPath + "\"\n"), nil
+	}
+	t.Cleanup(func() {
+		readDefaultKeychain = prev
+	})
+
+	err := checkDefaultKeychainAvailable()
+	if !IsUnavailable(err) {
+		t.Fatalf("error = %v, want unavailable", err)
+	}
+	if !strings.Contains(err.Error(), missingPath) {
+		t.Fatalf("error = %v, want missing keychain path", err)
+	}
+}
 
 // TestDisableKeychainFallback verifies that setting DWS_DISABLE_KEYCHAIN
 // routes the DEK to a local file (same scheme as Linux) and the full

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -16,10 +16,13 @@
 package keychain
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	keyringpkg "github.com/zalando/go-keyring"
 )
 
 func TestDefaultKeychainPathFromSecurityOutput(t *testing.T) {
@@ -45,6 +48,93 @@ func TestCheckDefaultKeychainAvailableReportsMissingPath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), missingPath) {
 		t.Fatalf("error = %v, want missing keychain path", err)
+	}
+}
+
+func TestGetMissingAccountDoesNotReadMacOSDEK(t *testing.T) {
+	t.Setenv(DisableKeychainEnv, "")
+
+	keychainPath := filepath.Join(t.TempDir(), "login.keychain-db")
+	if err := os.WriteFile(keychainPath, nil, 0600); err != nil {
+		t.Fatalf("WriteFile(default keychain) error = %v", err)
+	}
+
+	prevReadDefault := readDefaultKeychain
+	prevGet := keyringGet
+	prevSet := keyringSet
+	readDefaultKeychain = func() ([]byte, error) {
+		return []byte("\"" + keychainPath + "\"\n"), nil
+	}
+	keyringGet = func(service, account string) (string, error) {
+		t.Fatalf("keyring.Get(%q, %q) called for missing account", service, account)
+		return "", nil
+	}
+	keyringSet = func(service, account, value string) error {
+		t.Fatalf("keyring.Set(%q, %q) called for missing account", service, account)
+		return nil
+	}
+	t.Cleanup(func() {
+		readDefaultKeychain = prevReadDefault
+		keyringGet = prevGet
+		keyringSet = prevSet
+	})
+
+	got, err := Get("test-missing-account", "auth-token")
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if got != "" {
+		t.Fatalf("Get() = %q, want empty string", got)
+	}
+}
+
+func TestGetWithMissingMacOSDEKDoesNotCreateDEK(t *testing.T) {
+	t.Setenv(DisableKeychainEnv, "")
+
+	keychainPath := filepath.Join(t.TempDir(), "login.keychain-db")
+	if err := os.WriteFile(keychainPath, nil, 0600); err != nil {
+		t.Fatalf("WriteFile(default keychain) error = %v", err)
+	}
+
+	prevReadDefault := readDefaultKeychain
+	prevGet := keyringGet
+	prevSet := keyringSet
+	readDefaultKeychain = func() ([]byte, error) {
+		return []byte("\"" + keychainPath + "\"\n"), nil
+	}
+	keyringGet = func(service, account string) (string, error) {
+		if account != "dek" {
+			t.Fatalf("keyring.Get account = %q, want dek", account)
+		}
+		return "", keyringpkg.ErrNotFound
+	}
+	setCalls := 0
+	keyringSet = func(service, account, value string) error {
+		setCalls++
+		return errors.New("keyring.Set should not be called by Get")
+	}
+	t.Cleanup(func() {
+		readDefaultKeychain = prevReadDefault
+		keyringGet = prevGet
+		keyringSet = prevSet
+	})
+
+	service := "test-missing-dek"
+	account := "auth-token"
+	dir := StorageDir(service)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, safeFileName(account)), []byte("ciphertext"), 0600); err != nil {
+		t.Fatalf("WriteFile(ciphertext) error = %v", err)
+	}
+
+	_, err := Get(service, account)
+	if !IsDEKMissing(err) {
+		t.Fatalf("Get() error = %v, want dek missing", err)
+	}
+	if setCalls != 0 {
+		t.Fatalf("keyring.Set calls = %d, want 0", setCalls)
 	}
 }
 

--- a/internal/keychain/keychain_linux.go
+++ b/internal/keychain/keychain_linux.go
@@ -32,6 +32,10 @@ func getDEK(service string) ([]byte, error) {
 	return fileDEK(service)
 }
 
+func getDEKReadOnly(service string) ([]byte, error) {
+	return fileDEKReadOnly(service)
+}
+
 const (
 	dekBytes = 32 // DEK = Data Encryption Key (AES-256)
 	ivBytes  = 12
@@ -106,15 +110,15 @@ func decryptData(data []byte, key []byte) (string, error) {
 }
 
 func platformGet(service, account string) (string, error) {
-	key, err := getDEK(service)
-	if err != nil {
-		return "", err
-	}
 	data, err := os.ReadFile(filepath.Join(StorageDir(service), safeFileName(account)))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil // Not found is not an error
 		}
+		return "", err
+	}
+	key, err := getDEKReadOnly(service)
+	if err != nil {
 		return "", err
 	}
 	plaintext, err := decryptData(data, key)

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -19,6 +19,18 @@ import (
 	"testing"
 )
 
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "dws-keychain-test-*")
+	if err != nil {
+		panic(err)
+	}
+	_ = os.Setenv(StorageDirEnv, dir)
+	_ = os.Setenv(DisableKeychainEnv, "1")
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
 func TestKeychainBasicOperations(t *testing.T) {
 	t.Parallel()
 

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -99,6 +99,23 @@ func TestKeychainNonExistentAccount(t *testing.T) {
 	}
 }
 
+func TestGetNonExistentAccountDoesNotCreateFileDEK(t *testing.T) {
+	service := "test-service-readonly-" + t.Name()
+	account := "nonexistent-account"
+	dekPath := filepath.Join(StorageDir(service), "dek")
+
+	got, err := Get(service, account)
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if got != "" {
+		t.Fatalf("Get() = %q, want empty string", got)
+	}
+	if _, err := os.Stat(dekPath); !os.IsNotExist(err) {
+		t.Fatalf("Get() created DEK at %s; stat error = %v", dekPath, err)
+	}
+}
+
 func TestKeychainOverwrite(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- make keychain read paths side-effect free so `auth status` and diagnostics do not create a new DEK
- surface explicit `dek_missing` and `keychain_unavailable` diagnostics for auth status / doctor flows
- keep DEK creation on write paths such as token or secret persistence

## Root cause

Read-only keychain paths could fall through to DEK creation. On macOS or `DWS_DISABLE_KEYCHAIN=1` file fallback this meant commands such as `auth status` could create `keychain/dws-cli/dek` even when no login state existed, and missing DEKs were harder to diagnose.

## Validation

- `go test ./internal/keychain -count=1`
- `go test ./internal/app -count=1`
- `go build -o /tmp/dws-main-dek-pr-bin ./cmd`
- empty-config probe with `DWS_DISABLE_KEYCHAIN=1`, `DWS_KEYCHAIN_DIR`, and `DWS_CONFIG_DIR`: `auth status` returns unauthenticated and creates no `dek` file
