### PR TITLE
fix: default pat chmod grants to permanent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+### Changed
+
+- **`dws pat chmod` defaults to permanent grants** (#584) — running `dws pat chmod <scope>` without `--grant-type` now requests a `permanent` grant instead of `session`, aligning the direct CLI path with the recommend-authorization helper. Session grants remain available by passing `--grant-type session --session-id <id>`.
+
 ## [1.0.50] - 2026-07-08
 
 This release fixes a long-standing gap where the global `--jq` / `--fields` output filters were silently ignored on product commands, lands a JSON-mode output path for the sheet batch-style command, and aligns the bundled skill surface with the real command semantics uncovered by the round-2 real-machine QA sweep.

--- a/internal/pat/chmod.go
+++ b/internal/pat/chmod.go
@@ -248,8 +248,8 @@ scope 格式: <product>.<entity>:<permission>
 
 grantType 规则:
   once       一次性，执行一次后自动失效
-  session    当前会话有效（默认），需要 --session-id
-  permanent  永久有效
+  session    当前会话有效，需要 --session-id
+  permanent  永久有效（默认）
 
 批量授权:
   dws pat chmod 支持一次传多个 scope 直接批量授予。
@@ -275,9 +275,9 @@ agentCode 配置:
   dws pat chmod chat.message:list --grant-type once
   dws pat chmod aitable.record:query aitable.record:create --grant-type permanent --yes
   dws pat chmod --product calendar --product aitable --grant-type once --dry-run --format json
-  dws pat chmod --products calendar,aitable --grant-type session --session-id session-xxx --yes
+  dws pat chmod --products calendar,aitable --grant-type permanent --yes
   dws pat chmod --domain calendar --domain chat --grant-type once --yes
-  dws pat chmod --recommend --grant-type session --session-id session-xxx --yes`,
+  dws pat chmod --recommend --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flagVal, _ := cmd.Flags().GetString("agentCode")
 			agentCode, err := resolveAgentCode(flagVal)
@@ -404,7 +404,7 @@ agentCode 配置:
 
 	chmodCmd.Flags().String("agentCode", "",
 		"Agent 唯一标识（可选；也可通过 env DINGTALK_DWS_AGENTCODE 注入，flag 优先；未传则由服务端默认兜底）")
-	chmodCmd.Flags().String("grant-type", "session", "授权策略: once|session|permanent")
+	chmodCmd.Flags().String("grant-type", grantTypePermanent, "授权策略: once|session|permanent")
 	chmodCmd.Flags().String("session-id", "", "会话标识（session 模式下必填）")
 	chmodCmd.Flags().StringArrayVar(&productFlags, "product", nil, "产品编码，可重复；与 --products 等价；执行批量授权需 --yes")
 	chmodCmd.Flags().StringSliceVar(&productsFlag, "products", nil, "产品编码列表，逗号分隔；执行批量授权需 --yes")

--- a/internal/pat/chmod_test.go
+++ b/internal/pat/chmod_test.go
@@ -382,7 +382,7 @@ func TestPATHelpDocumentsBatchAuthorization(t *testing.T) {
 		"由服务端默认兜底",
 		"aitable.record:query aitable.record:create --grant-type permanent --yes",
 		"dws pat chmod --products calendar,aitable",
-		"dws pat chmod --recommend --grant-type session",
+		"dws pat chmod --recommend --yes",
 	} {
 		if !strings.Contains(chmodHelp, want) {
 			t.Fatalf("pat chmod help missing %q\nhelp:\n%s", want, chmodHelp)
@@ -486,6 +486,7 @@ func TestChmod_productsSessionModePassesIdentityArgsAndCompatEnv(t *testing.T) {
 		`{"success":true,"data":{"grantedScopes":["calendar.event:read"]}}`,
 	}}
 	cmd := newChmodCommand(fake)
+	_ = cmd.Flags().Set("grant-type", "session")
 	_ = cmd.Flags().Set("products", "calendar")
 	_ = cmd.Flags().Set("session-id", "session-123")
 	setBatchYesForTest(t, cmd)
@@ -851,7 +852,7 @@ func TestChmod_grantTypeAndSessionParameterMatrix(t *testing.T) {
 	}
 }
 
-func TestChmod_productsDryRunUsesSessionIDFromEnv(t *testing.T) {
+func TestChmod_productsSessionDryRunUsesSessionIDFromEnv(t *testing.T) {
 	t.Setenv(agentCodeEnv, "qoderwork")
 	t.Setenv(sessionIDEnvDWS, "env-session-123")
 	fake := &sequenceToolCaller{
@@ -861,6 +862,7 @@ func TestChmod_productsDryRunUsesSessionIDFromEnv(t *testing.T) {
 		},
 	}
 	cmd := newChmodCommand(fake)
+	_ = cmd.Flags().Set("grant-type", "session")
 	_ = cmd.Flags().Set("products", "calendar")
 
 	if err := cmd.RunE(cmd, nil); err != nil {
@@ -1064,6 +1066,7 @@ func TestChmod_sessionModeUsesDingtalkSessionEnv(t *testing.T) {
 
 	fake := &fakeToolCaller{resultOK: true}
 	cmd := buildChmod(t, fake)
+	_ = cmd.Flags().Set("grant-type", "session")
 
 	if err := cmd.RunE(cmd, []string{"aitable.record:read"}); err != nil {
 		t.Fatalf("chmod RunE error = %v", err)
@@ -1089,6 +1092,7 @@ func TestChmod_explicitSessionIDOverridesStaleDingtalkSessionEnv(t *testing.T) {
 
 	fake := &fakeToolCaller{resultOK: true}
 	cmd := buildChmod(t, fake)
+	_ = cmd.Flags().Set("grant-type", "session")
 	_ = cmd.Flags().Set("session-id", "flag-session")
 
 	if err := cmd.RunE(cmd, []string{"aitable.record:read"}); err != nil {
@@ -1116,7 +1120,6 @@ func TestChmod_recommendFlagPlansThenGrantsWithoutPositionalScopes(t *testing.T)
 		`{"success":true,"data":{"grantedScopes":["recommended.scope:read"]}}`,
 	}}
 	cmd := newChmodCommand(fake)
-	_ = cmd.Flags().Set("grant-type", "once")
 	_ = cmd.Flags().Set("recommend", "true")
 	setBatchYesForTest(t, cmd)
 
@@ -1133,8 +1136,14 @@ func TestChmod_recommendFlagPlansThenGrantsWithoutPositionalScopes(t *testing.T)
 	if got := fake.calls[0].args["recommend"]; got != true {
 		t.Fatalf("recommend = %#v, want true", got)
 	}
+	if got := fake.calls[0].args["grantType"]; got != grantTypePermanent {
+		t.Fatalf("plan grantType = %#v, want %q", got, grantTypePermanent)
+	}
 	if fake.calls[1].tool != patBatchGrantToolName {
 		t.Fatalf("second tool = %q, want %q", fake.calls[1].tool, patBatchGrantToolName)
+	}
+	if got := fake.calls[1].args["grantType"]; got != grantTypePermanent {
+		t.Fatalf("grant grantType = %#v, want %q", got, grantTypePermanent)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change `dws pat chmod` default `--grant-type` from `session` to `permanent`.
- Update help/examples so `--recommend` no longer advertises session as the default.
- Keep session-mode tests explicit and assert the recommend flow uses permanent by default.

## Why
`dws pat chmod --recommend` previously failed during client-side validation with `--session-id is required` because the implicit grant type was `session`. These recommendation-style commands should default to permanent authorization.

## Validation
- `go test ./internal/pat`
- `go test ./internal/pat ./test/unit`
- `go run ./cmd/main.go pat chmod --help`
- `go run ./cmd/main.go --mock --dry-run pat chmod --recommend --format json`
- `git diff --check`