### PR TITLE
fix(connect): prevent agent mid-turn blocking

### DIFF
--- a/internal/helpers/connect_agent_options_test.go
+++ b/internal/helpers/connect_agent_options_test.go
@@ -167,7 +167,7 @@ func TestBuiltInAgentForwardersDefaultToPureChannelPermissions(t *testing.T) {
 		{"claudecode", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
 		{"codebuddy", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
 		{"workbuddy", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
-		{"gemini", []string{"--approval-mode=yolo"}},
+		{"gemini", []string{"--approval-mode=yolo", "--skip-trust"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.channel, func(t *testing.T) {
@@ -185,7 +185,7 @@ func TestBuiltInAgentForwardersDefaultToPureChannelPermissions(t *testing.T) {
 					t.Fatalf("%s argv missing %q: %s", tc.channel, want, got)
 				}
 			}
-			if tc.channel == "gemini" && !strings.Contains(got, "--approval-mode=yolo -p") {
+			if tc.channel == "gemini" && !strings.Contains(got, "--approval-mode=yolo --skip-trust -p") {
 				t.Fatalf("gemini approval args must precede -p prompt flag: %s", got)
 			}
 			if len(ef.streamArgv) > 0 {

--- a/internal/helpers/connect_agent_options_test.go
+++ b/internal/helpers/connect_agent_options_test.go
@@ -57,8 +57,8 @@ func TestConvSessions(t *testing.T) {
 }
 
 // TestApplyModelArg covers both shapes: replacing an existing model pin
-// (claudecode's built-in haiku) and inserting before the tail (gemini-style
-// tails that end with -p and need the prompt to stay trailing).
+// (claudecode's built-in haiku) and inserting before a prompt tail that must
+// stay trailing.
 func TestApplyModelArg(t *testing.T) {
 	replaced := applyModelArg(
 		[]string{"claude", "-p", "--model", "claude-haiku-4-5-20251001", "--strict-mcp-config"},
@@ -153,7 +153,7 @@ func TestBuiltInAgentForwardersDefaultToPureChannelPermissions(t *testing.T) {
 	t.Setenv("DWS_AGENT_CMD", "")
 	t.Setenv("DWS_CONFIG_DIR", t.TempDir())
 	stub := t.TempDir()
-	for _, name := range []string{"claude", "codebuddy", "gemini", "codex", "opencode", "qodercli"} {
+	for _, name := range []string{"claude", "codebuddy", "codex", "opencode", "qodercli"} {
 		if err := writeExecStub(stub, name); err != nil {
 			t.Fatalf("stub %s: %v", name, err)
 		}
@@ -167,7 +167,6 @@ func TestBuiltInAgentForwardersDefaultToPureChannelPermissions(t *testing.T) {
 		{"claudecode", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
 		{"codebuddy", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
 		{"workbuddy", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
-		{"gemini", []string{"--approval-mode=yolo", "--skip-trust"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.channel, func(t *testing.T) {
@@ -185,9 +184,6 @@ func TestBuiltInAgentForwardersDefaultToPureChannelPermissions(t *testing.T) {
 					t.Fatalf("%s argv missing %q: %s", tc.channel, want, got)
 				}
 			}
-			if tc.channel == "gemini" && !strings.Contains(got, "--approval-mode=yolo --skip-trust -p") {
-				t.Fatalf("gemini approval args must precede -p prompt flag: %s", got)
-			}
 			if len(ef.streamArgv) > 0 {
 				streamGot := strings.Join(ef.streamArgv, " ")
 				for _, want := range tc.want {
@@ -198,6 +194,21 @@ func TestBuiltInAgentForwardersDefaultToPureChannelPermissions(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("gemini", func(t *testing.T) {
+		t.Setenv("GEMINI_API_KEY", "test-key")
+		fwd, err := forwarderForChannel("gemini", "gemini-client", connectAgentOptions{Memory: true, Yolo: true, Model: "gemini-test"})
+		if err != nil {
+			t.Fatalf("forwarderForChannel(gemini): %v", err)
+		}
+		gf, ok := fwd.(*geminiAPIForwarder)
+		if !ok {
+			t.Fatalf("gemini forwarder = %T, want *geminiAPIForwarder", fwd)
+		}
+		if gf.model != "gemini-test" {
+			t.Fatalf("gemini model = %q, want gemini-test", gf.model)
+		}
+	})
 
 	for _, ch := range []string{"qoder", "qoderwork"} {
 		t.Run(ch, func(t *testing.T) {

--- a/internal/helpers/connect_agent_options_test.go
+++ b/internal/helpers/connect_agent_options_test.go
@@ -167,7 +167,7 @@ func TestBuiltInAgentForwardersDefaultToPureChannelPermissions(t *testing.T) {
 		{"claudecode", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
 		{"codebuddy", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
 		{"workbuddy", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
-		{"gemini", []string{"--approval-mode", "yolo", "--yolo"}},
+		{"gemini", []string{"--approval-mode=yolo"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.channel, func(t *testing.T) {
@@ -185,7 +185,7 @@ func TestBuiltInAgentForwardersDefaultToPureChannelPermissions(t *testing.T) {
 					t.Fatalf("%s argv missing %q: %s", tc.channel, want, got)
 				}
 			}
-			if tc.channel == "gemini" && !strings.Contains(got, "--approval-mode yolo --yolo -p") {
+			if tc.channel == "gemini" && !strings.Contains(got, "--approval-mode=yolo -p") {
 				t.Fatalf("gemini approval args must precede -p prompt flag: %s", got)
 			}
 			if len(ef.streamArgv) > 0 {

--- a/internal/helpers/connect_agent_options_test.go
+++ b/internal/helpers/connect_agent_options_test.go
@@ -147,6 +147,117 @@ func TestForwarderSessionAndModelWiring(t *testing.T) {
 	}
 }
 
+func TestBuiltInAgentForwardersDefaultToPureChannelPermissions(t *testing.T) {
+	clearChannelEnv(t)
+	t.Setenv("DWS_CONNECT_NO_INSTALL", "1")
+	t.Setenv("DWS_AGENT_CMD", "")
+	t.Setenv("DWS_CONFIG_DIR", t.TempDir())
+	stub := t.TempDir()
+	for _, name := range []string{"claude", "codebuddy", "gemini", "codex", "opencode", "qodercli"} {
+		if err := writeExecStub(stub, name); err != nil {
+			t.Fatalf("stub %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", stub)
+
+	cases := []struct {
+		channel string
+		want    []string
+	}{
+		{"claudecode", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
+		{"codebuddy", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
+		{"workbuddy", []string{"--permission-mode", "bypassPermissions", "--dangerously-skip-permissions"}},
+		{"gemini", []string{"--approval-mode", "yolo", "--yolo"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.channel, func(t *testing.T) {
+			fwd, err := forwarderForChannel(tc.channel, "", connectAgentOptions{Memory: true, Yolo: true})
+			if err != nil {
+				t.Fatalf("forwarderForChannel(%q): %v", tc.channel, err)
+			}
+			ef, ok := fwd.(*execForwarder)
+			if !ok {
+				t.Fatalf("%s forwarder = %T, want *execForwarder", tc.channel, fwd)
+			}
+			got := strings.Join(ef.argv, " ")
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("%s argv missing %q: %s", tc.channel, want, got)
+				}
+			}
+			if tc.channel == "gemini" && !strings.Contains(got, "--approval-mode yolo --yolo -p") {
+				t.Fatalf("gemini approval args must precede -p prompt flag: %s", got)
+			}
+			if len(ef.streamArgv) > 0 {
+				streamGot := strings.Join(ef.streamArgv, " ")
+				for _, want := range tc.want {
+					if !strings.Contains(streamGot, want) {
+						t.Fatalf("%s stream argv missing %q: %s", tc.channel, want, streamGot)
+					}
+				}
+			}
+		})
+	}
+
+	for _, ch := range []string{"qoder", "qoderwork"} {
+		t.Run(ch, func(t *testing.T) {
+			fwd, err := forwarderForChannel(ch, "client-"+ch, connectAgentOptions{Memory: true, Yolo: true})
+			if err != nil {
+				t.Fatalf("forwarderForChannel(%q): %v", ch, err)
+			}
+			qf, ok := fwd.(*qoderStreamForwarder)
+			if !ok {
+				t.Fatalf("%s forwarder = %T, want *qoderStreamForwarder", ch, fwd)
+			}
+			got := strings.Join(qf.commandArgs(), " ")
+			for _, want := range []string{"--permission-mode", "bypass_permissions", "--dangerously-skip-permissions"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("%s command args missing %q: %s", ch, want, got)
+				}
+			}
+		})
+	}
+
+	t.Run("codex", func(t *testing.T) {
+		fwd, err := forwarderForChannel("codex", "codex-client", connectAgentOptions{Memory: true, Yolo: true})
+		if err != nil {
+			t.Fatalf("forwarderForChannel(codex): %v", err)
+		}
+		cf, ok := fwd.(*codexAppServerForwarder)
+		if !ok {
+			t.Fatalf("codex forwarder = %T, want *codexAppServerForwarder", fwd)
+		}
+		params := cf.threadParams("")
+		if got := params["approvalPolicy"]; got != "never" {
+			t.Fatalf("codex approvalPolicy = %v, want never", got)
+		}
+		if got := params["sandbox"]; got != "workspace-write" {
+			t.Fatalf("codex yolo sandbox = %v, want workspace-write", got)
+		}
+	})
+
+	t.Run("opencode", func(t *testing.T) {
+		fwd, err := forwarderForChannel("opencode", "opencode-client", connectAgentOptions{Memory: true, Yolo: true})
+		if err != nil {
+			t.Fatalf("forwarderForChannel(opencode): %v", err)
+		}
+		of, ok := fwd.(*opencodeForwarder)
+		if !ok {
+			t.Fatalf("opencode forwarder = %T, want *opencodeForwarder", fwd)
+		}
+		env := of.server.commandEnv("pw")
+		if !strings.Contains(envValue(env, opencodeConfigContentEnv), `"question":false`) {
+			t.Fatalf("opencode config should disable question tool: %s", envValue(env, opencodeConfigContentEnv))
+		}
+		if !strings.Contains(envValue(env, opencodePermissionEnv), `"question":"deny"`) {
+			t.Fatalf("opencode permission should deny question: %s", envValue(env, opencodePermissionEnv))
+		}
+		if !strings.Contains(envValue(env, opencodePermissionEnv), `"bash":"allow"`) {
+			t.Fatalf("opencode permission should allow gated tools: %s", envValue(env, opencodePermissionEnv))
+		}
+	})
+}
+
 // TestRobotConnectAgentFlagsInDryRun checks the new flags surface in the
 // dry-run preview so callers can see the effective agent tuning.
 func TestRobotConnectAgentFlagsInDryRun(t *testing.T) {

--- a/internal/helpers/connect_at_poll.go
+++ b/internal/helpers/connect_at_poll.go
@@ -144,11 +144,27 @@ func (p *atMentionPoller) handleMessage(ctx context.Context, msg atMentionMessag
 		convID = msg.SenderStaffID
 	}
 
-	p.queue.run(convID, func() {
+	turn := connectQueuedTurn{
+		convID:           convID,
+		text:             text,
+		msgID:            msg.MsgID,
+		senderStaffID:    strings.TrimSpace(msg.SenderStaffID),
+		conversationID:   strings.TrimSpace(msg.OpenConversationID),
+		conversationType: strings.TrimSpace(msg.ConversationType),
+	}
+	p.queue.submit(turn, func(turns []connectQueuedTurn) {
+		turn := mergeConnectQueuedTurns(turns)
+		if len(turns) > 1 {
+			fmt.Fprintf(os.Stderr, "[connect][at-poll] 合并 %d 条待处理 @消息 (convId=%s, latestMsgId=%s)\n", len(turns), turn.convID, turn.msgID)
+		}
+		text := turn.text
+		convID := turn.convID
+		senderStaffID := turn.senderStaffID
+		openConversationID := turn.conversationID
 		if p.extras.gate.enabled() {
-			if ok, reason := p.extras.gate.allow(msg.SenderStaffID, "2", msg.OpenConversationID); !ok {
+			if ok, reason := p.extras.gate.allow(senderStaffID, "2", openConversationID); !ok {
 				fmt.Fprintf(os.Stderr, "[connect][at-poll] 已拦截消息（%s）: staffId=%s convId=%s\n",
-					reason, msg.SenderStaffID, msg.OpenConversationID)
+					reason, senderStaffID, openConversationID)
 				return
 			}
 		}
@@ -180,8 +196,8 @@ func (p *atMentionPoller) handleMessage(ctx context.Context, msg atMentionMessag
 			p.health.onReply()
 		}
 
-		if reply != "" && msg.OpenConversationID != "" {
-			if serr := p.sendGroupReply(ctx, msg.OpenConversationID, reply); serr != nil {
+		if reply != "" && openConversationID != "" {
+			if serr := p.sendGroupReply(ctx, openConversationID, reply); serr != nil {
 				fmt.Fprintf(os.Stderr, "[connect][at-poll] 群回复发送失败: %v\n", serr)
 			}
 		}

--- a/internal/helpers/connect_codex_appserver_test.go
+++ b/internal/helpers/connect_codex_appserver_test.go
@@ -107,14 +107,13 @@ while IFS= read -r line; do
     *\"method\":\"initialize\"*) printf '%s\n' '{"id":1,"result":{}}' ;;
     *\"method\":\"thread/start\"*) printf '%s\n' '{"id":2,"result":{"thread":{"id":"thr_stub"}}}' ;;
     *\"method\":\"thread/resume\"*) printf '%s\n' '{"id":2,"result":{"thread":{"id":"thr_stub"}}}' ;;
-    *\"method\":\"turn/start\"*)
-      printf '%s\n' '{"method":"item/agentMessage/delta","params":{"threadId":"thr_stub","turnId":"turn_stub","itemId":"item_1","delta":"你"}}'
-      printf '%s\n' '{"method":"item/agentMessage/delta","params":{"threadId":"thr_stub","turnId":"turn_stub","itemId":"item_1","delta":"好"}}'
-      printf '%s\n' '{"method":"turn/completed","params":{"threadId":"thr_stub","turn":{"id":"turn_stub","status":"completed","items":[{"id":"item_1","type":"agentMessage","text":"你好"}]}}}'
-      exit 0
-      ;;
-  esac
-done
+	    *\"method\":\"turn/start\"*)
+	      printf '%s\n' '{"method":"item/agentMessage/delta","params":{"threadId":"thr_stub","turnId":"turn_stub","itemId":"item_1","delta":"你"}}'
+	      printf '%s\n' '{"method":"item/agentMessage/delta","params":{"threadId":"thr_stub","turnId":"turn_stub","itemId":"item_1","delta":"好"}}'
+	      printf '%s\n' '{"method":"turn/completed","params":{"threadId":"thr_stub","turn":{"id":"turn_stub","status":"completed","items":[{"id":"item_1","type":"agentMessage","text":"你好"}]}}}'
+	      ;;
+	  esac
+	done
 `)
 	fwd := &codexAppServerForwarder{
 		bin:      codex,

--- a/internal/helpers/connect_exec_forwarder_test.go
+++ b/internal/helpers/connect_exec_forwarder_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExecForwarderRetriesMissingSessionOnce(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "agent")
+	logPath := filepath.Join(dir, "calls.log")
+	if err := os.WriteFile(bin, []byte(`#!/bin/sh
+echo "$@" >> "$DWS_STALE_LOG"
+case " $* " in
+  *" --resume "*)
+    echo "No conversation found with session ID: stale" >&2
+    exit 1
+    ;;
+esac
+echo fresh-ok
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions := newConvSessions("")
+	if got := sessions.args("conv-1"); len(got) != 2 || got[0] != "--session-id" {
+		t.Fatalf("seed session args = %v, want --session-id", got)
+	}
+	f := &execForwarder{
+		name:     "claudecode",
+		argv:     []string{bin, "-p"},
+		env:      []string{"DWS_STALE_LOG=" + logPath},
+		timeout:  5 * time.Second,
+		sessions: sessions,
+	}
+
+	reply, err := f.forward(context.Background(), "conv-1", "hello")
+	if err != nil {
+		t.Fatalf("forward: %v", err)
+	}
+	if reply != "fresh-ok" {
+		t.Fatalf("reply = %q, want fresh-ok", reply)
+	}
+	calls := readCallLog(t, logPath)
+	if len(calls) != 2 {
+		t.Fatalf("calls = %v, want stale resume then fresh session", calls)
+	}
+	if !strings.Contains(calls[0], "--resume") || !strings.Contains(calls[1], "--session-id") {
+		t.Fatalf("calls = %v, want --resume then --session-id", calls)
+	}
+}
+
+func TestExecForwarderStreamRetriesMissingSessionOnce(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "agent-stream")
+	logPath := filepath.Join(dir, "calls.log")
+	if err := os.WriteFile(bin, []byte(`#!/bin/sh
+echo "$@" >> "$DWS_STALE_LOG"
+case " $* " in
+  *" --resume "*)
+    echo "session not found: stale" >&2
+    exit 1
+    ;;
+esac
+printf '%s\n' '{"type":"result","result":"fresh-stream-ok"}'
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions := newConvSessions("")
+	_ = sessions.args("conv-1")
+	f := &execForwarder{
+		name:       "claudecode",
+		argv:       []string{bin, "-p"},
+		streamArgv: []string{bin, "--output-format", "stream-json"},
+		env:        []string{"DWS_STALE_LOG=" + logPath},
+		parser:     "cc",
+		timeout:    5 * time.Second,
+		sessions:   sessions,
+	}
+
+	reply, err := f.forwardStream(context.Background(), "conv-1", "hello", func(string) {})
+	if err != nil {
+		t.Fatalf("forwardStream: %v", err)
+	}
+	if reply != "fresh-stream-ok" {
+		t.Fatalf("reply = %q, want fresh-stream-ok", reply)
+	}
+	calls := readCallLog(t, logPath)
+	if len(calls) != 2 {
+		t.Fatalf("calls = %v, want stale resume then fresh session", calls)
+	}
+	if !strings.Contains(calls[0], "--resume") || !strings.Contains(calls[1], "--session-id") {
+		t.Fatalf("calls = %v, want --resume then --session-id", calls)
+	}
+}
+
+func TestExecForwarderDoesNotRetryNonSessionErrors(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "agent")
+	logPath := filepath.Join(dir, "calls.log")
+	if err := os.WriteFile(bin, []byte(`#!/bin/sh
+echo "$@" >> "$DWS_STALE_LOG"
+echo "plain failure" >&2
+exit 1
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions := newConvSessions("")
+	_ = sessions.args("conv-1")
+	f := &execForwarder{
+		name:     "claudecode",
+		argv:     []string{bin, "-p"},
+		env:      []string{"DWS_STALE_LOG=" + logPath},
+		timeout:  5 * time.Second,
+		sessions: sessions,
+	}
+
+	if _, err := f.forward(context.Background(), "conv-1", "hello"); err == nil {
+		t.Fatal("forward error = nil, want error")
+	}
+	calls := readCallLog(t, logPath)
+	if len(calls) != 1 {
+		t.Fatalf("calls = %v, want one non-session failure without retry", calls)
+	}
+	if !strings.Contains(calls[0], "--resume") {
+		t.Fatalf("call = %q, want stale --resume attempt", calls[0])
+	}
+}
+
+func readCallLog(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var calls []string
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.TrimSpace(line) != "" {
+			calls = append(calls, line)
+		}
+	}
+	return calls
+}

--- a/internal/helpers/connect_gemini_api.go
+++ b/internal/helpers/connect_gemini_api.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+)
+
+const (
+	defaultGeminiAPIBaseURL = "https://generativelanguage.googleapis.com/v1beta"
+	defaultGeminiModel      = "gemini-2.5-flash"
+)
+
+type geminiAPIForwarder struct {
+	model      string
+	apiKey     string
+	baseURL    string
+	timeout    time.Duration
+	httpClient *http.Client
+}
+
+func newGeminiAPIForwarder(timeout time.Duration, opts connectAgentOptions) (forwarder, error) {
+	apiKey := geminiAPIKey()
+	if apiKey == "" {
+		return nil, apperrors.NewValidation("gemini 渠道现在走 Gemini API；请设置 GEMINI_API_KEY（或 GOOGLE_API_KEY），模型可用 --agent-model 指定，Gemini-compatible 代理可设置 GEMINI_API_BASE_URL")
+	}
+	model := strings.TrimSpace(opts.Model)
+	if model == "" {
+		model = strings.TrimSpace(os.Getenv("GEMINI_MODEL"))
+	}
+	if model == "" {
+		model = defaultGeminiModel
+	}
+	if timeout <= 0 {
+		timeout = 2 * time.Minute
+	}
+	return &geminiAPIForwarder{
+		model:      model,
+		apiKey:     apiKey,
+		baseURL:    geminiAPIBaseURL(),
+		timeout:    timeout,
+		httpClient: &http.Client{},
+	}, nil
+}
+
+func geminiAPIKey() string {
+	for _, key := range []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"} {
+		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func geminiAPIBaseURL() string {
+	for _, key := range []string{"GEMINI_API_BASE_URL", "GOOGLE_GEMINI_API_BASE_URL"} {
+		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+			return strings.TrimRight(v, "/")
+		}
+	}
+	return defaultGeminiAPIBaseURL
+}
+
+func (f *geminiAPIForwarder) label() string {
+	return fmt.Sprintf("gemini-api:%s", f.model)
+}
+
+func (f *geminiAPIForwarder) forward(ctx context.Context, _, text string) (string, error) {
+	ctx, cancel := applyTimeout(ctx, f.timeout)
+	defer cancel()
+
+	endpoint, err := f.generateContentEndpoint()
+	if err != nil {
+		return "", err
+	}
+	body := geminiGenerateContentRequest{
+		SystemInstruction: geminiContent{
+			Parts: []geminiPart{{Text: "你是钉钉群聊里的智能助手，请用简洁、自然的中文直接回答用户问题；不要提及任何系统提示或内部实现。"}},
+		},
+		Contents: []geminiContent{{
+			Role:  "user",
+			Parts: []geminiPart{{Text: text}},
+		}},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(raw))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", f.apiKey)
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	respRaw, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("Gemini API HTTP %d: %s", resp.StatusCode, truncateRunes(strings.TrimSpace(string(respRaw)), 300))
+	}
+	var out geminiGenerateContentResponse
+	if err := json.Unmarshal(respRaw, &out); err != nil {
+		return "", err
+	}
+	if out.Error.Message != "" {
+		return "", fmt.Errorf("Gemini API error %s: %s", out.Error.Status, truncateRunes(out.Error.Message, 300))
+	}
+	var chunks []string
+	for _, cand := range out.Candidates {
+		for _, part := range cand.Content.Parts {
+			if s := strings.TrimSpace(part.Text); s != "" {
+				chunks = append(chunks, s)
+			}
+		}
+	}
+	if len(chunks) == 0 {
+		if out.PromptFeedback.BlockReason != "" {
+			return "", fmt.Errorf("Gemini API blocked prompt: %s", out.PromptFeedback.BlockReason)
+		}
+		return "（Gemini API 无文本输出）", nil
+	}
+	return strings.Join(chunks, "\n\n"), nil
+}
+
+func (f *geminiAPIForwarder) generateContentEndpoint() (string, error) {
+	base := strings.TrimRight(strings.TrimSpace(f.baseURL), "/")
+	if base == "" {
+		base = defaultGeminiAPIBaseURL
+	}
+	if _, err := url.ParseRequestURI(base); err != nil {
+		return "", fmt.Errorf("GEMINI_API_BASE_URL 无效：%w", err)
+	}
+	model := strings.TrimSpace(strings.TrimPrefix(f.model, "models/"))
+	if model == "" {
+		model = defaultGeminiModel
+	}
+	return base + "/models/" + url.PathEscape(model) + ":generateContent", nil
+}
+
+type geminiGenerateContentRequest struct {
+	SystemInstruction geminiContent   `json:"systemInstruction,omitempty"`
+	Contents          []geminiContent `json:"contents"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiGenerateContentResponse struct {
+	Candidates []struct {
+		Content geminiContent `json:"content"`
+	} `json:"candidates"`
+	PromptFeedback struct {
+		BlockReason string `json:"blockReason"`
+	} `json:"promptFeedback"`
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}

--- a/internal/helpers/connect_gemini_api_test.go
+++ b/internal/helpers/connect_gemini_api_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGeminiChannelUsesAPIWithoutLocalCLI(t *testing.T) {
+	clearChannelEnv(t)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("GEMINI_API_KEY", "test-key")
+	t.Setenv("GEMINI_API_BASE_URL", "https://gemini-proxy.example/v1beta")
+
+	fwd, err := forwarderForChannel("gemini", "", connectAgentOptions{Model: "gemini-test"})
+	if err != nil {
+		t.Fatalf("forwarderForChannel(gemini): %v", err)
+	}
+	gf, ok := fwd.(*geminiAPIForwarder)
+	if !ok {
+		t.Fatalf("gemini forwarder = %T, want *geminiAPIForwarder", fwd)
+	}
+	if gf.model != "gemini-test" {
+		t.Fatalf("model = %q, want gemini-test", gf.model)
+	}
+	if gf.baseURL != "https://gemini-proxy.example/v1beta" {
+		t.Fatalf("baseURL = %q", gf.baseURL)
+	}
+}
+
+func TestGeminiAPIForwarderForward(t *testing.T) {
+	clearChannelEnv(t)
+	var gotPath, gotKey, gotText string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotKey = r.Header.Get("x-goog-api-key")
+		var req geminiGenerateContentRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		if len(req.Contents) > 0 && len(req.Contents[0].Parts) > 0 {
+			gotText = req.Contents[0].Parts[0].Text
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"gemini-api-ok"}]}}]}`))
+	}))
+	defer ts.Close()
+	t.Setenv("GEMINI_API_KEY", "test-key")
+	t.Setenv("GEMINI_API_BASE_URL", ts.URL)
+
+	fwd, err := forwarderForChannel("gemini", "", connectAgentOptions{Model: "models/gemini-test"})
+	if err != nil {
+		t.Fatalf("forwarderForChannel(gemini): %v", err)
+	}
+	reply, err := fwd.forward(context.Background(), "conv-1", "你好")
+	if err != nil {
+		t.Fatalf("forward: %v", err)
+	}
+	if reply != "gemini-api-ok" {
+		t.Fatalf("reply = %q, want gemini-api-ok", reply)
+	}
+	if gotPath != "/models/gemini-test:generateContent" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotKey != "test-key" {
+		t.Fatalf("x-goog-api-key = %q", gotKey)
+	}
+	if gotText != "你好" {
+		t.Fatalf("prompt text = %q", gotText)
+	}
+}
+
+func TestGeminiChannelRequiresAPIKey(t *testing.T) {
+	clearChannelEnv(t)
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	_, err := forwarderForChannel("gemini", "", connectAgentOptions{})
+	if err == nil || !strings.Contains(err.Error(), "GEMINI_API_KEY") {
+		t.Fatalf("err = %v, want GEMINI_API_KEY validation", err)
+	}
+}
+
+func TestGeminiCLIStatusUsesAPIKey(t *testing.T) {
+	clearChannelEnv(t)
+	t.Setenv("GEMINI_API_KEY", "")
+	t.Setenv("GOOGLE_API_KEY", "")
+	if got := connectCliStatus("gemini")["installed"]; got != false {
+		t.Fatalf("installed without key = %v, want false", got)
+	}
+	t.Setenv("GOOGLE_API_KEY", "google-key")
+	if got := connectCliStatus("gemini")["installed"]; got != true {
+		t.Fatalf("installed with key = %v, want true", got)
+	}
+	if got := connectCliStatus("gemini")["autoInstall"]; got != false {
+		t.Fatalf("autoInstall = %v, want false", got)
+	}
+}

--- a/internal/helpers/connect_opencode.go
+++ b/internal/helpers/connect_opencode.go
@@ -40,6 +40,8 @@ const (
 	opencodeNoTextReply        = "（本地 agent 无文本输出）"
 	opencodeServerStartupWait  = 20 * time.Second
 	opencodeServerPollInterval = 150 * time.Millisecond
+	opencodeConfigContentEnv   = "OPENCODE_CONFIG_CONTENT"
+	opencodePermissionEnv      = "OPENCODE_PERMISSION"
 	// opencodeHealthProbeTimeout bounds a single /global/health probe so startup
 	// detection stays snappy even though the shared http.Client has no overall
 	// deadline (message turns rely on the per-turn ctx instead).
@@ -240,14 +242,7 @@ func (s *opencodeServer) ensure(ctx context.Context) (*opencodeHTTPClient, error
 	if s.workDir != "" {
 		cmd.Dir = s.workDir
 	}
-	cmd.Env = append(os.Environ(), s.env...)
-	cmd.Env = append(cmd.Env,
-		"OPENCODE_SERVER_USERNAME="+opencodeServerUsername,
-		"OPENCODE_SERVER_PASSWORD="+password,
-	)
-	if !s.yolo {
-		cmd.Env = append(cmd.Env, `OPENCODE_PERMISSION={"bash":"ask","edit":"ask","write":"ask"}`)
-	}
+	cmd.Env = s.commandEnv(password)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
@@ -267,6 +262,97 @@ func (s *opencodeServer) ensure(ctx context.Context) (*opencodeHTTPClient, error
 		return nil, err
 	}
 	return client, nil
+}
+
+func (s *opencodeServer) commandEnv(password string) []string {
+	env := append([]string{}, os.Environ()...)
+	env = append(env, s.env...)
+	env = upsertEnv(env, "OPENCODE_SERVER_USERNAME", opencodeServerUsername)
+	env = upsertEnv(env, "OPENCODE_SERVER_PASSWORD", password)
+	config := opencodeNonInteractiveConfig(envValue(env, opencodeConfigContentEnv))
+	env = upsertEnv(env, opencodeConfigContentEnv, config)
+	env = upsertEnv(env, opencodePermissionEnv, opencodeNonInteractivePermission())
+	return env
+}
+
+func opencodeNonInteractiveConfig(existing string) string {
+	cfg := map[string]any{}
+	if strings.TrimSpace(existing) != "" {
+		_ = json.Unmarshal([]byte(existing), &cfg)
+	}
+	tools, _ := cfg["tools"].(map[string]any)
+	if tools == nil {
+		tools = map[string]any{}
+	}
+	tools["question"] = false
+	cfg["tools"] = tools
+
+	permission, _ := cfg["permission"].(map[string]any)
+	if permission == nil {
+		permission = map[string]any{}
+	}
+	for k, v := range opencodeNonInteractivePermissionMap() {
+		permission[k] = v
+	}
+	cfg["permission"] = permission
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		return `{"tools":{"question":false},"permission":{"*":"allow","read":"allow","edit":"allow","write":"allow","patch":"allow","apply_patch":"allow","glob":"allow","grep":"allow","bash":"allow","task":"allow","skill":"allow","lsp":"allow","webfetch":"allow","websearch":"allow","question":"deny","external_directory":"allow","doom_loop":"allow"}}`
+	}
+	return string(data)
+}
+
+func opencodeNonInteractivePermission() string {
+	data, err := json.Marshal(opencodeNonInteractivePermissionMap())
+	if err != nil {
+		return `{"*":"allow","read":"allow","edit":"allow","write":"allow","patch":"allow","apply_patch":"allow","glob":"allow","grep":"allow","bash":"allow","task":"allow","skill":"allow","lsp":"allow","webfetch":"allow","websearch":"allow","question":"deny","external_directory":"allow","doom_loop":"allow"}`
+	}
+	return string(data)
+}
+
+func opencodeNonInteractivePermissionMap() map[string]string {
+	return map[string]string{
+		"*":                  "allow",
+		"read":               "allow",
+		"edit":               "allow",
+		"write":              "allow",
+		"patch":              "allow",
+		"apply_patch":        "allow",
+		"glob":               "allow",
+		"grep":               "allow",
+		"bash":               "allow",
+		"task":               "allow",
+		"skill":              "allow",
+		"lsp":                "allow",
+		"webfetch":           "allow",
+		"websearch":          "allow",
+		"question":           "deny",
+		"external_directory": "allow",
+		"doom_loop":          "allow",
+	}
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix)
+		}
+	}
+	return ""
+}
+
+func upsertEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env)+1)
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			continue
+		}
+		out = append(out, item)
+	}
+	return append(out, prefix+value)
 }
 
 func (s *opencodeServer) waitHealthy(ctx context.Context, client *opencodeHTTPClient) error {

--- a/internal/helpers/connect_opencode_test.go
+++ b/internal/helpers/connect_opencode_test.go
@@ -261,6 +261,53 @@ func TestNewOpencodeServerHasNoClientTimeout(t *testing.T) {
 	}
 }
 
+func TestOpencodeServerEnvDisablesInteractiveGates(t *testing.T) {
+	s := newOpencodeServer("opencode", []string{
+		`OPENCODE_CONFIG_CONTENT={"provider":{"x":true},"tools":{"read":true},"permission":{"bash":"ask","edit":"ask","write":"ask","question":"ask"}}`,
+		`OPENCODE_PERMISSION={"bash":"ask"}`,
+	}, "", false)
+
+	env := s.commandEnv("pw")
+	if got := envValue(env, "OPENCODE_SERVER_USERNAME"); got != opencodeServerUsername {
+		t.Fatalf("server username = %q, want %q", got, opencodeServerUsername)
+	}
+	if got := envValue(env, "OPENCODE_SERVER_PASSWORD"); got != "pw" {
+		t.Fatalf("server password = %q, want pw", got)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(envValue(env, opencodeConfigContentEnv)), &cfg); err != nil {
+		t.Fatalf("decode OPENCODE_CONFIG_CONTENT: %v", err)
+	}
+	if _, ok := cfg["provider"].(map[string]any)["x"]; !ok {
+		t.Fatalf("existing config fields were not preserved: %#v", cfg)
+	}
+	tools := cfg["tools"].(map[string]any)
+	if got := tools["question"]; got != false {
+		t.Fatalf("tools.question = %#v, want false", got)
+	}
+	permission := cfg["permission"].(map[string]any)
+	for _, key := range []string{"bash", "edit", "write", "external_directory", "doom_loop"} {
+		if got := permission[key]; got != "allow" {
+			t.Fatalf("permission.%s = %#v, want allow", key, got)
+		}
+	}
+	if got := permission["question"]; got != "deny" {
+		t.Fatalf("permission.question = %#v, want deny", got)
+	}
+
+	var envPermission map[string]string
+	if err := json.Unmarshal([]byte(envValue(env, opencodePermissionEnv)), &envPermission); err != nil {
+		t.Fatalf("decode OPENCODE_PERMISSION: %v", err)
+	}
+	if got := envPermission["bash"]; got != "allow" {
+		t.Fatalf("OPENCODE_PERMISSION.bash = %q, want allow", got)
+	}
+	if got := envPermission["question"]; got != "deny" {
+		t.Fatalf("OPENCODE_PERMISSION.question = %q, want deny", got)
+	}
+}
+
 // TestOpencodeForwarderMessageGovernedByTurnCtx verifies a slow reply is not
 // cut by a fixed client timeout (the old 30s bug) and that the per-turn ctx is
 // the real governor instead.

--- a/internal/helpers/connect_qoder_stream.go
+++ b/internal/helpers/connect_qoder_stream.go
@@ -164,7 +164,7 @@ func (f *qoderStreamForwarder) commandArgs() []string {
 		"--input-format", "stream-json",
 	}
 	if f.yolo {
-		args = append(args, "--dangerously-skip-permissions")
+		args = append(args, "--permission-mode", "bypass_permissions", "--dangerously-skip-permissions")
 	} else {
 		args = append(args,
 			"--system-prompt", "",
@@ -334,6 +334,11 @@ func (f *qoderStreamForwarder) handleControlRequestLocked(line string) bool {
 	if json.Unmarshal([]byte(line), &ev) != nil || ev.Type != "control_request" || ev.RequestID == "" {
 		return false
 	}
+	subtype, _ := ev.Request["subtype"].(string)
+	if subtype == "" {
+		subtype, _ = ev.Request["type"].(string)
+	}
+	fmt.Fprintf(os.Stderr, "[connect][qoder] 自动拒绝/跳过未桥接的 control_request subtype=%q requestId=%s\n", subtype, ev.RequestID)
 	response := map[string]any{
 		"type": "control_response",
 		"response": map[string]any{

--- a/internal/helpers/connect_qoder_stream_test.go
+++ b/internal/helpers/connect_qoder_stream_test.go
@@ -14,7 +14,9 @@
 package helpers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -122,6 +124,39 @@ func TestQoderForwarderKeepsStreamJSONProcessAlive(t *testing.T) {
 	}
 	if !strings.Contains(lines[0], "--input-format") || !strings.Contains(lines[0], "stream-json") {
 		t.Fatalf("qodercli should start in stream-json input mode, log:\n%s", raw)
+	}
+}
+
+type qoderTestWriteCloser struct {
+	bytes.Buffer
+}
+
+func (w *qoderTestWriteCloser) Close() error { return nil }
+
+func TestQoderControlRequestReturnsImmediately(t *testing.T) {
+	stdin := &qoderTestWriteCloser{}
+	f := &qoderStreamForwarder{name: "qoder", stdin: stdin}
+
+	if !f.handleControlRequestLocked(`{"type":"control_request","request_id":"req-1","request":{"type":"permission","subtype":"permission","tool":"bash"}}`) {
+		t.Fatal("control_request was not handled")
+	}
+
+	var got struct {
+		Type     string `json:"type"`
+		Response struct {
+			Subtype   string `json:"subtype"`
+			RequestID string `json:"request_id"`
+			Code      string `json:"code"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(stdin.Bytes()), &got); err != nil {
+		t.Fatalf("decode response: %v; raw=%q", err, stdin.String())
+	}
+	if got.Type != "control_response" || got.Response.RequestID != "req-1" {
+		t.Fatalf("response identity mismatch: %#v", got)
+	}
+	if got.Response.Subtype != "error" || got.Response.Code != "unsupported_control_request" {
+		t.Fatalf("response should explicitly unblock with unsupported error: %#v", got.Response)
 	}
 }
 

--- a/internal/helpers/connect_queue.go
+++ b/internal/helpers/connect_queue.go
@@ -15,42 +15,79 @@ package helpers
 
 import "sync"
 
-// convQueue serialises message handling per conversation: same-chat messages
-// run in arrival order — a Q&A follow-up ("还是不行") must see the previous
-// turn's session state, and two parallel agent CLIs racing on one --resume
-// session corrupt the transcript. Different conversations stay parallel.
-// Ported from the hermes gateway's per-session promise chain
-// (gateway/run.py session queues).
+// convQueue serialises agent turns per conversation while coalescing bursts.
+// Same-chat agent calls must never run in parallel — two turns racing on one
+// session corrupt the transcript. But a pure FIFO is also bad UX: if a user
+// keeps sending clarifications while a long turn is running, the bot should not
+// spend the next several minutes answering stale intermediate prompts. Instead,
+// messages arriving during the active turn accumulate in one pending batch; when
+// the active turn finishes, that whole batch is processed as a single follow-up.
+// Different conversations still run in parallel.
 type convQueue struct {
-	mu    sync.Mutex
-	tails map[string]chan struct{}
+	mu     sync.Mutex
+	states map[string]*convQueueState
+}
+
+type convQueueState struct {
+	running bool
+	pending []connectQueuedTurn
+	process func([]connectQueuedTurn)
 }
 
 func newConvQueue() *convQueue {
-	return &convQueue{tails: map[string]chan struct{}{}}
+	return &convQueue{states: map[string]*convQueueState{}}
 }
 
-// run schedules fn after the conversation's previous task and returns
-// immediately (the Stream callback must ack fast). The chain entry is removed
-// once the queue for that conversation drains, so idle chats hold no memory.
-func (q *convQueue) run(convID string, fn func()) {
+// submit schedules turn handling and returns immediately (the Stream callback
+// must ack fast). If the conversation is already running, the turn is appended
+// to that conversation's pending batch instead of creating another queued worker.
+func (q *convQueue) submit(turn connectQueuedTurn, process func([]connectQueuedTurn)) {
+	convID := turn.convID
 	q.mu.Lock()
-	prev := q.tails[convID]
-	done := make(chan struct{})
-	q.tails[convID] = done
-	q.mu.Unlock()
-	go func() {
-		defer func() {
-			close(done)
-			q.mu.Lock()
-			if q.tails[convID] == done {
-				delete(q.tails, convID)
-			}
-			q.mu.Unlock()
-		}()
-		if prev != nil {
-			<-prev
+	st := q.states[convID]
+	if st == nil {
+		st = &convQueueState{}
+		q.states[convID] = st
+	}
+	if st.running {
+		st.pending = append(st.pending, turn)
+		if process != nil {
+			st.process = process
 		}
-		fn()
-	}()
+		q.mu.Unlock()
+		return
+	}
+	st.running = true
+	st.process = process
+	q.mu.Unlock()
+	go q.drain(convID, []connectQueuedTurn{turn})
+}
+
+func (q *convQueue) drain(convID string, batch []connectQueuedTurn) {
+	for {
+		process := q.processFor(convID)
+		if process != nil {
+			process(batch)
+		}
+
+		q.mu.Lock()
+		st := q.states[convID]
+		if st == nil || len(st.pending) == 0 {
+			delete(q.states, convID)
+			q.mu.Unlock()
+			return
+		}
+		batch = append([]connectQueuedTurn(nil), st.pending...)
+		st.pending = nil
+		q.mu.Unlock()
+	}
+}
+
+func (q *convQueue) processFor(convID string) func([]connectQueuedTurn) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if st := q.states[convID]; st != nil {
+		return st.process
+	}
+	return nil
 }

--- a/internal/helpers/connect_queue_test.go
+++ b/internal/helpers/connect_queue_test.go
@@ -14,36 +14,44 @@
 package helpers
 
 import (
+	"reflect"
 	"sync"
 	"testing"
 	"time"
 )
 
-// TestConvQueueSerialSameConversation: tasks of one conversation run in
-// arrival order even when earlier tasks are slow.
-func TestConvQueueSerialSameConversation(t *testing.T) {
+// TestConvQueueCoalescesSameConversationBurst: while one conversation is
+// running, later messages are batched into one follow-up turn instead of forming
+// a long FIFO of stale prompts.
+func TestConvQueueCoalescesSameConversationBurst(t *testing.T) {
 	q := newConvQueue()
-	var mu sync.Mutex
-	var order []int
-	var wg sync.WaitGroup
-	for i := 1; i <= 5; i++ {
-		i := i
-		wg.Add(1)
-		q.run("conv-1", func() {
-			defer wg.Done()
-			if i == 1 {
-				time.Sleep(50 * time.Millisecond) // slow head must not be overtaken
-			}
-			mu.Lock()
-			order = append(order, i)
-			mu.Unlock()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	batches := make(chan []string, 2)
+	var once sync.Once
+	process := func(batch []connectQueuedTurn) {
+		var got []string
+		for _, turn := range batch {
+			got = append(got, turn.text)
+		}
+		batches <- got
+		once.Do(func() {
+			close(started)
+			<-release
 		})
 	}
-	wg.Wait()
-	for i, v := range order {
-		if v != i+1 {
-			t.Fatalf("order = %v, want 1..5 in sequence", order)
-		}
+
+	q.submit(connectQueuedTurn{convID: "conv-1", text: "first"}, process)
+	<-started
+	q.submit(connectQueuedTurn{convID: "conv-1", text: "second"}, process)
+	q.submit(connectQueuedTurn{convID: "conv-1", text: "third"}, process)
+	close(release)
+
+	if got := <-batches; !reflect.DeepEqual(got, []string{"first"}) {
+		t.Fatalf("first batch = %v, want [first]", got)
+	}
+	if got := <-batches; !reflect.DeepEqual(got, []string{"second", "third"}) {
+		t.Fatalf("pending batch = %v, want [second third]", got)
 	}
 }
 
@@ -53,14 +61,14 @@ func TestConvQueueParallelAcrossConversations(t *testing.T) {
 	q := newConvQueue()
 	slowRelease := make(chan struct{})
 	slowStarted := make(chan struct{})
-	q.run("conv-slow", func() {
+	q.submit(connectQueuedTurn{convID: "conv-slow", text: "slow"}, func([]connectQueuedTurn) {
 		close(slowStarted)
 		<-slowRelease
 	})
 	<-slowStarted
 
 	fastDone := make(chan struct{})
-	q.run("conv-fast", func() { close(fastDone) })
+	q.submit(connectQueuedTurn{convID: "conv-fast", text: "fast"}, func([]connectQueuedTurn) { close(fastDone) })
 	select {
 	case <-fastDone:
 	case <-time.After(2 * time.Second):
@@ -75,12 +83,12 @@ func TestConvQueueDrainsEntries(t *testing.T) {
 	q := newConvQueue()
 	var wg sync.WaitGroup
 	wg.Add(1)
-	q.run("conv-1", func() { wg.Done() })
+	q.submit(connectQueuedTurn{convID: "conv-1", text: "done"}, func([]connectQueuedTurn) { wg.Done() })
 	wg.Wait()
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		q.mu.Lock()
-		n := len(q.tails)
+		n := len(q.states)
 		q.mu.Unlock()
 		if n == 0 {
 			return

--- a/internal/helpers/connect_stream.go
+++ b/internal/helpers/connect_stream.go
@@ -850,14 +850,14 @@ func forwarderForChannel(channel, clientID string, opts connectAgentOptions) (fo
 	if !overridden && opts.Yolo {
 		switch channel {
 		case "claudecode", "codebuddy", "workbuddy":
-			argv = append(argv, "--dangerously-skip-permissions")
+			argv = append(argv, "--permission-mode", "bypassPermissions", "--dangerously-skip-permissions")
 			if len(streamArgv) > 0 {
-				streamArgv = append(streamArgv, "--dangerously-skip-permissions")
+				streamArgv = append(streamArgv, "--permission-mode", "bypassPermissions", "--dangerously-skip-permissions")
 			}
 		case "gemini":
-			argv = append(argv, "--yolo")
+			argv = insertBeforeArg(argv, "-p", "--approval-mode", "yolo", "--yolo")
 			if len(streamArgv) > 0 {
-				streamArgv = append(streamArgv, "--yolo")
+				streamArgv = insertBeforeArg(streamArgv, "-p", "--approval-mode", "yolo", "--yolo")
 			}
 		}
 	}
@@ -881,6 +881,18 @@ func applyModelArg(argv []string, flag, model string) []string {
 		}
 	}
 	return append(out[:1:1], append([]string{flag, model}, out[1:]...)...)
+}
+
+func insertBeforeArg(argv []string, marker string, values ...string) []string {
+	for i := 1; i < len(argv); i++ {
+		if argv[i] == marker {
+			out := append([]string(nil), argv[:i]...)
+			out = append(out, values...)
+			return append(out, argv[i:]...)
+		}
+	}
+	out := append([]string(nil), argv...)
+	return append(out, values...)
 }
 
 // msgDedup tracks recently-seen MsgIds so a redelivered message is not

--- a/internal/helpers/connect_stream.go
+++ b/internal/helpers/connect_stream.go
@@ -935,6 +935,80 @@ type connectExtras struct {
 	persona string
 }
 
+type connectQueuedTurn struct {
+	convID           string
+	text             string
+	picCode          string
+	fileInfo         fileInboundInfo
+	webhook          string
+	msgID            string
+	msgType          string
+	senderStaffID    string
+	conversationID   string
+	conversationType string
+	callbackData     chatbot.BotCallbackDataModel
+}
+
+func mergeConnectQueuedTurns(turns []connectQueuedTurn) connectQueuedTurn {
+	if len(turns) == 0 {
+		return connectQueuedTurn{}
+	}
+	if len(turns) == 1 {
+		return turns[0]
+	}
+	for i := len(turns) - 1; i >= 0; i-- {
+		if connectTurnShouldStayStandalone(turns[i]) {
+			return turns[i]
+		}
+	}
+	merged := turns[len(turns)-1]
+	lines := make([]string, 0, len(turns)+1)
+	lines = append(lines, "用户在上一轮处理期间连续发送了以下消息，请把它们作为同一个最新请求一起处理：")
+	for i, turn := range turns {
+		lines = append(lines, fmt.Sprintf("%d. %s", i+1, connectTurnSummary(turn)))
+	}
+	merged.text = strings.Join(lines, "\n")
+	if merged.picCode == "" && !merged.fileInfo.hasActionable() {
+		for i := len(turns) - 1; i >= 0; i-- {
+			if turns[i].picCode != "" {
+				merged.picCode = turns[i].picCode
+				break
+			}
+			if turns[i].fileInfo.hasActionable() {
+				merged.fileInfo = turns[i].fileInfo
+				break
+			}
+		}
+	}
+	return merged
+}
+
+func connectTurnShouldStayStandalone(turn connectQueuedTurn) bool {
+	if _, ok := parseConnectControlCommand(turn.text); ok {
+		return true
+	}
+	if _, ok := parseDecisionWord(turn.text); ok {
+		return true
+	}
+	return isRetryWord(turn.text)
+}
+
+func connectTurnSummary(turn connectQueuedTurn) string {
+	if text := strings.TrimSpace(turn.text); text != "" {
+		return text
+	}
+	if turn.picCode != "" {
+		return "[图片]"
+	}
+	if turn.fileInfo.hasActionable() {
+		if name := strings.TrimSpace(turn.fileInfo.FileName); name != "" {
+			return "[文件: " + name + "]"
+		}
+		return "[文件]"
+	}
+	return "[空消息]"
+}
+
 func runStreamConnector(ctx context.Context, channel, clientID, clientSecret string, fwd forwarder, cardCli *aiCardClient, extras *connectExtras) error {
 	if extras == nil {
 		extras = &connectExtras{}
@@ -1072,11 +1146,36 @@ func runStreamConnector(ctx context.Context, channel, clientID, clientSecret str
 		if convID == "" {
 			convID = strings.TrimSpace(data.SenderStaffId)
 		}
-		callbackData := data
 		msgID := strings.TrimSpace(data.MsgId)
-		// Same-conversation messages run in arrival order (follow-ups need the
-		// previous turn's session state); different conversations in parallel.
-		queue.run(convID, func() {
+		turn := connectQueuedTurn{
+			convID:           convID,
+			text:             text,
+			picCode:          picCode,
+			fileInfo:         fileInfo,
+			webhook:          webhook,
+			msgID:            msgID,
+			msgType:          msgtype,
+			senderStaffID:    strings.TrimSpace(data.SenderStaffId),
+			conversationID:   strings.TrimSpace(data.ConversationId),
+			conversationType: strings.TrimSpace(data.ConversationType),
+			callbackData:     *data,
+		}
+		// Same-conversation agent calls never run in parallel; messages received
+		// while a turn is running are merged into one pending follow-up instead
+		// of forming an unbounded stale FIFO.
+		queue.submit(turn, func(turns []connectQueuedTurn) {
+			turn := mergeConnectQueuedTurns(turns)
+			if len(turns) > 1 {
+				fmt.Fprintf(os.Stderr, "[connect] 合并 %d 条待处理消息 (convId=%s, latestMsgId=%s)\n", len(turns), turn.convID, turn.msgID)
+			}
+			text := turn.text
+			picCode := turn.picCode
+			fileInfo := turn.fileInfo
+			webhook := turn.webhook
+			convID := turn.convID
+			msgID := turn.msgID
+			msgtype := turn.msgType
+			callbackData := &turn.callbackData
 			// Digital-twin text approval: if this is the OWNER replying
 			// 「同意」/「拒绝」 (in their 1:1 chat with the bot) to the pending
 			// request, route it to the gate (decide → execute/decline, with

--- a/internal/helpers/connect_stream.go
+++ b/internal/helpers/connect_stream.go
@@ -855,9 +855,9 @@ func forwarderForChannel(channel, clientID string, opts connectAgentOptions) (fo
 				streamArgv = append(streamArgv, "--permission-mode", "bypassPermissions", "--dangerously-skip-permissions")
 			}
 		case "gemini":
-			argv = insertBeforeArg(argv, "-p", "--approval-mode=yolo")
+			argv = insertBeforeArg(argv, "-p", "--approval-mode=yolo", "--skip-trust")
 			if len(streamArgv) > 0 {
-				streamArgv = insertBeforeArg(streamArgv, "-p", "--approval-mode=yolo")
+				streamArgv = insertBeforeArg(streamArgv, "-p", "--approval-mode=yolo", "--skip-trust")
 			}
 		}
 	}

--- a/internal/helpers/connect_stream.go
+++ b/internal/helpers/connect_stream.go
@@ -250,19 +250,24 @@ func (f *execForwarder) label() string {
 	return fmt.Sprintf("exec:%s (%s, %s)", f.name, f.argv[0], memo)
 }
 
-func (f *execForwarder) forward(ctx context.Context, convID, text string) (string, error) {
-	ctx, cancel := applyTimeout(ctx, f.timeout)
-	defer cancel()
+func (f *execForwarder) hasSession(convID string) bool {
+	return f.sessions != nil && strings.TrimSpace(convID) != ""
+}
+
+func (f *execForwarder) commandArgs(argv []string, convID, text string) []string {
 	// Session args go right after the binary, before the spec tail — some specs
 	// (qoder) end the tail with `-p` so the prompt must stay the trailing
 	// positional argument.
 	var args []string
-	if f.sessions != nil && strings.TrimSpace(convID) != "" {
+	if f.hasSession(convID) {
 		args = append(args, f.sessions.args(convID)...)
 	}
-	args = append(args, f.argv[1:]...)
+	args = append(args, argv[1:]...)
 	args = append(args, text)
-	cmd := exec.CommandContext(ctx, f.argv[0], args...)
+	return args
+}
+
+func (f *execForwarder) configureCommand(cmd *exec.Cmd) {
 	// Run the agent CLI from a clean, empty directory rather than inheriting the
 	// connector's CWD (often $HOME). Some agents scan the working tree / nearby
 	// config on startup — e.g. `claude -p` takes ~29s from a large $HOME but ~4s
@@ -278,37 +283,60 @@ func (f *execForwarder) forward(ctx context.Context, convID, text string) (strin
 	if len(f.env) > 0 {
 		cmd.Env = append(os.Environ(), f.env...)
 	}
-	out, err := cmd.Output()
-	s := strings.TrimSpace(string(out))
-	// Guard against a backend error being mistaken for the answer: some agent
-	// CLIs (claude) print "API Error: 4xx ..." to stdout and still exit 0, so a
-	// non-empty stdout is not proof of a real reply. If stdout is a bare backend
-	// error, return an actionable hint instead of forwarding the raw error into
-	// the chat (issue #14: a custom-provider 422 was echoed to the group).
-	if s != "" && !agentReplyIsError(s) {
-		return brandReply(f.name, s), nil
-	}
-	if s != "" && agentReplyIsError(s) {
-		if f.sessions != nil && strings.TrimSpace(convID) != "" {
-			f.sessions.reset(convID)
+}
+
+func (f *execForwarder) forward(ctx context.Context, convID, text string) (string, error) {
+	ctx, cancel := applyTimeout(ctx, f.timeout)
+	defer cancel()
+
+	run := func() (string, string, error) {
+		args := f.commandArgs(f.argv, convID, text)
+		cmd := exec.CommandContext(ctx, f.argv[0], args...)
+		f.configureCommand(cmd)
+		out, err := cmd.Output()
+		s := strings.TrimSpace(string(out))
+		// Guard against a backend error being mistaken for the answer: some agent
+		// CLIs (claude) print "API Error: 4xx ..." to stdout and still exit 0, so a
+		// non-empty stdout is not proof of a real reply. If stdout is a bare backend
+		// error, return an actionable hint instead of forwarding the raw error into
+		// the chat (issue #14: a custom-provider 422 was echoed to the group).
+		if s != "" && !agentReplyIsError(s) {
+			return brandReply(f.name, s), "", nil
 		}
-		return agentBackendErrorReply(s), nil
+		if s != "" && agentReplyIsError(s) {
+			if f.hasSession(convID) {
+				f.sessions.reset(convID)
+			}
+			return agentBackendErrorReply(s), "", nil
+		}
+		if err != nil {
+			msg := execErrorMessage(err)
+			return "", msg, err
+		}
+		return "（本地 agent 无文本输出）", "", nil
 	}
-	if err != nil {
+
+	reply, msg, err := run()
+	if err == nil {
+		return reply, nil
+	}
+
+	if f.hasSession(convID) && agentSessionMissingError(msg) {
+		f.sessions.reset(convID)
+		reply, msg, err = run()
+		if err == nil {
+			return reply, nil
+		}
+	}
+
+	if f.hasSession(convID) {
 		// Self-heal session state: if this conversation's session is broken
 		// (e.g. --resume of a session that was never created or got cleaned),
 		// drop the mapping so the next message starts a fresh session instead
 		// of failing forever.
-		if f.sessions != nil && strings.TrimSpace(convID) != "" {
-			f.sessions.reset(convID)
-		}
-		msg := err.Error()
-		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
-			msg = strings.TrimSpace(string(ee.Stderr))
-		}
-		return "", fmt.Errorf("本地 %s agent 调用失败：%s", f.name, truncateRunes(msg, 300))
+		f.sessions.reset(convID)
 	}
-	return "（本地 agent 无文本输出）", nil
+	return "", fmt.Errorf("本地 %s agent 调用失败：%s", f.name, truncateRunes(msg, 300))
 }
 
 // convSessions maps a DingTalk conversation to a stable agent session ID, so a
@@ -415,6 +443,17 @@ func brandReply(channel, reply string) string {
 	return qoderworkIdentityRe.ReplaceAllString(reply, "我是 QoderWork 助手，钉钉群里的智能助手。")
 }
 
+func execErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+		msg = strings.TrimSpace(string(ee.Stderr))
+	}
+	return msg
+}
+
 // agentReplyIsError reports whether an agent's stdout is a bare backend error
 // rather than a real answer. Claude Code prints provider failures as
 // "API Error: <status> ..." on stdout and may still exit 0, so the connector
@@ -422,6 +461,16 @@ func brandReply(channel, reply string) string {
 // leading marker; a legitimate reply never starts with "API Error:".
 func agentReplyIsError(s string) bool {
 	return strings.HasPrefix(strings.TrimSpace(s), "API Error:")
+}
+
+// agentSessionMissingError recognizes stale addressable sessions. Agent CLIs
+// differ in wording, but the operational meaning is the same: the connector's
+// persisted session id points at a conversation the CLI can no longer resume.
+func agentSessionMissingError(msg string) bool {
+	lower := strings.ToLower(strings.TrimSpace(msg))
+	return strings.Contains(lower, "no conversation found with session id") ||
+		strings.Contains(lower, "conversation not found") ||
+		strings.Contains(lower, "session not found")
 }
 
 // agentBackendErrorReply turns a bare backend error into a short, actionable

--- a/internal/helpers/connect_stream.go
+++ b/internal/helpers/connect_stream.go
@@ -855,9 +855,9 @@ func forwarderForChannel(channel, clientID string, opts connectAgentOptions) (fo
 				streamArgv = append(streamArgv, "--permission-mode", "bypassPermissions", "--dangerously-skip-permissions")
 			}
 		case "gemini":
-			argv = insertBeforeArg(argv, "-p", "--approval-mode", "yolo", "--yolo")
+			argv = insertBeforeArg(argv, "-p", "--approval-mode=yolo")
 			if len(streamArgv) > 0 {
-				streamArgv = insertBeforeArg(streamArgv, "-p", "--approval-mode", "yolo", "--yolo")
+				streamArgv = insertBeforeArg(streamArgv, "-p", "--approval-mode=yolo")
 			}
 		}
 	}

--- a/internal/helpers/connect_stream.go
+++ b/internal/helpers/connect_stream.go
@@ -637,10 +637,11 @@ func claudeUserSettingsEnv() []string {
 	return out
 }
 
-// agentSpecs is the registry of local-agent channels. Most forward to a local
+// agentSpecs is the registry of agent channels. Most forward to a local
 // headless CLI (one-shot per message, 24/7, no interactive session). Codex uses
-// the local CLI binary only to host app-server. Exact headless flags for
-// non-Codex channels can be overridden per run with DWS_AGENT_CMD.
+// the local CLI binary only to host app-server; Gemini uses its HTTP API.
+// Exact headless flags for CLI channels can be overridden per run with
+// DWS_AGENT_CMD.
 //
 // Install policy: npm/pipx (package managers) are auto-installed; curl|bash
 // remote-script installs and desktop apps are hint-only (we do not silently pipe
@@ -657,9 +658,8 @@ var agentSpecs = map[string]agentSpec{
 	"codex": {app: "OpenAI Codex CLI", bins: []string{"codex"},
 		install: []string{"npm", "i", "-g", "@openai/codex"}, hint: "npm i -g @openai/codex",
 		modelFlag: "-m"},
-	"gemini": {app: "Gemini CLI", bins: []string{"gemini"}, argvTail: []string{"-p"},
-		install: []string{"npm", "i", "-g", "@google/gemini-cli"}, hint: "npm i -g @google/gemini-cli",
-		modelFlag: "-m"},
+	"gemini": {app: "Gemini API",
+		hint: "设置 GEMINI_API_KEY（或 GOOGLE_API_KEY）；模型可用 --agent-model 指定；Gemini-compatible 代理可设置 GEMINI_API_BASE_URL"},
 	// opencode is resolved here only to find the local binary. The forwarder
 	// uses `opencode serve --pure` plus HTTP session/message APIs instead of
 	// parsing `opencode run` stdout.
@@ -768,6 +768,17 @@ func connectCliStatus(channel string) map[string]any {
 			status["command"] = command
 		}
 		return status
+	case "gemini":
+		status := map[string]any{
+			"required":    "GEMINI_API_KEY or GOOGLE_API_KEY",
+			"installed":   geminiAPIKey() != "",
+			"autoInstall": false,
+			"installHint": "设置 GEMINI_API_KEY（或 GOOGLE_API_KEY）；模型可用 --agent-model 指定；Gemini-compatible 代理可设置 GEMINI_API_BASE_URL",
+		}
+		if base := strings.TrimSpace(geminiAPIBaseURL()); base != "" {
+			status["baseURL"] = base
+		}
+		return status
 	}
 	spec, ok := agentSpecs[channel]
 	if !ok {
@@ -834,6 +845,10 @@ func forwarderForChannel(channel, clientID string, opts connectAgentOptions) (fo
 	if !ok {
 		return nil, apperrors.NewValidation(fmt.Sprintf("渠道 %q 不是 stream-bridge 渠道，无 forwarder", channel))
 	}
+	overridden := strings.TrimSpace(os.Getenv("DWS_AGENT_CMD")) != "" && channel != "codex"
+	if channel == "gemini" && !overridden {
+		return newGeminiAPIForwarder(timeout, opts)
+	}
 	// Resolve the agent CLI (PATH → app bundle → auto-install → guidance) and
 	// preflight here so a missing dependency errors at connect time.
 	argv, env, err := resolveExecAgent(channel)
@@ -844,7 +859,6 @@ func forwarderForChannel(channel, clientID string, opts connectAgentOptions) (fo
 	// model or session flags we cannot know are valid for it. Codex ignores the
 	// override because its channel is app-server only; custom commands belong on
 	// --channel custom.
-	overridden := strings.TrimSpace(os.Getenv("DWS_AGENT_CMD")) != "" && channel != "codex"
 	userPickedModel := opts.Model != "" || strings.TrimSpace(os.Getenv("DWS_AGENT_MODEL")) != ""
 	if !overridden && opts.Model != "" {
 		if spec.modelFlag == "" {
@@ -902,11 +916,6 @@ func forwarderForChannel(channel, clientID string, opts connectAgentOptions) (fo
 			argv = append(argv, "--permission-mode", "bypassPermissions", "--dangerously-skip-permissions")
 			if len(streamArgv) > 0 {
 				streamArgv = append(streamArgv, "--permission-mode", "bypassPermissions", "--dangerously-skip-permissions")
-			}
-		case "gemini":
-			argv = insertBeforeArg(argv, "-p", "--approval-mode=yolo", "--skip-trust")
-			if len(streamArgv) > 0 {
-				streamArgv = insertBeforeArg(streamArgv, "-p", "--approval-mode=yolo", "--skip-trust")
 			}
 		}
 	}

--- a/internal/helpers/connect_stream_test.go
+++ b/internal/helpers/connect_stream_test.go
@@ -162,3 +162,31 @@ func TestEnvDurationMS(t *testing.T) {
 		t.Fatalf("invalid env falls back to default = %v, want %v", got, def)
 	}
 }
+
+func TestMergeConnectQueuedTurnsBuildsSinglePrompt(t *testing.T) {
+	merged := mergeConnectQueuedTurns([]connectQueuedTurn{
+		{convID: "conv-1", text: "第一条", msgID: "m1"},
+		{convID: "conv-1", text: "补充：按今天的数据", msgID: "m2"},
+		{convID: "conv-1", text: "最后改成周报口径", msgID: "m3"},
+	})
+	if merged.msgID != "m3" {
+		t.Fatalf("merged msgID = %q, want latest m3", merged.msgID)
+	}
+	for _, want := range []string{"连续发送", "1. 第一条", "2. 补充：按今天的数据", "3. 最后改成周报口径"} {
+		if !strings.Contains(merged.text, want) {
+			t.Fatalf("merged prompt missing %q:\n%s", want, merged.text)
+		}
+	}
+}
+
+func TestMergeConnectQueuedTurnsKeepsControlMessagesStandalone(t *testing.T) {
+	for _, text := range []string{"/clear", "同意", "拒绝", "重试"} {
+		merged := mergeConnectQueuedTurns([]connectQueuedTurn{
+			{convID: "conv-1", text: "先查一下", msgID: "m1"},
+			{convID: "conv-1", text: text, msgID: "m2"},
+		})
+		if merged.text != text || merged.msgID != "m2" {
+			t.Fatalf("control %q merged to (%q,%q), want standalone latest", text, merged.text, merged.msgID)
+		}
+	}
+}

--- a/internal/helpers/connect_streaming.go
+++ b/internal/helpers/connect_streaming.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 )
@@ -53,76 +52,79 @@ func (f *execForwarder) forwardStream(ctx context.Context, convID, text string, 
 	ctx, cancel := applyTimeout(ctx, f.timeout)
 	defer cancel()
 
-	var args []string
-	if f.sessions != nil && strings.TrimSpace(convID) != "" {
-		args = append(args, f.sessions.args(convID)...)
-	}
-	args = append(args, f.streamArgv[1:]...)
-	args = append(args, text)
-	cmd := exec.CommandContext(ctx, f.streamArgv[0], args...)
-	if f.workDir != "" {
-		cmd.Dir = f.workDir
-	} else {
-		cmd.Dir = connectWorkDir()
-	}
-	if len(f.env) > 0 {
-		cmd.Env = append(os.Environ(), f.env...)
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return "", err
-	}
-	var stderrBuf strings.Builder
-	cmd.Stderr = &stderrBuf
-	if err := cmd.Start(); err != nil {
-		return "", err
+	run := func() (string, string, error) {
+		args := f.commandArgs(f.streamArgv, convID, text)
+		cmd := exec.CommandContext(ctx, f.streamArgv[0], args...)
+		f.configureCommand(cmd)
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return "", err.Error(), err
+		}
+		var stderrBuf strings.Builder
+		cmd.Stderr = &stderrBuf
+		if err := cmd.Start(); err != nil {
+			return "", err.Error(), err
+		}
+
+		var acc strings.Builder // accumulated visible text ("cc" deltas / "qoder" turns)
+		finalText := ""
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" || !strings.HasPrefix(line, "{") {
+				continue
+			}
+			delta, final := parseStreamLine(f.parser, line)
+			if delta != "" {
+				acc.WriteString(delta)
+				onDelta(brandReply(f.name, acc.String()))
+			}
+			if final != "" {
+				finalText = final
+			}
+		}
+		waitErr := cmd.Wait()
+
+		if finalText == "" {
+			finalText = strings.TrimSpace(acc.String())
+		}
+		// A bare backend error (e.g. claude's "API Error: 4xx ...") must not be
+		// forwarded as the answer (issue #14): return an actionable hint instead.
+		if agentReplyIsError(finalText) {
+			if f.hasSession(convID) {
+				f.sessions.reset(convID)
+			}
+			return agentBackendErrorReply(finalText), "", nil
+		}
+		if finalText != "" {
+			return brandReply(f.name, finalText), "", nil
+		}
+		if waitErr != nil {
+			msg := waitErr.Error()
+			if s := strings.TrimSpace(stderrBuf.String()); s != "" {
+				msg = s
+			}
+			return "", msg, waitErr
+		}
+		return "（本地 agent 无文本输出）", "", nil
 	}
 
-	var acc strings.Builder // accumulated visible text ("cc" deltas / "qoder" turns)
-	finalText := ""
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || !strings.HasPrefix(line, "{") {
-			continue
-		}
-		delta, final := parseStreamLine(f.parser, line)
-		if delta != "" {
-			acc.WriteString(delta)
-			onDelta(brandReply(f.name, acc.String()))
-		}
-		if final != "" {
-			finalText = final
+	reply, msg, err := run()
+	if err == nil {
+		return reply, nil
+	}
+	if f.hasSession(convID) && agentSessionMissingError(msg) {
+		f.sessions.reset(convID)
+		reply, msg, err = run()
+		if err == nil {
+			return reply, nil
 		}
 	}
-	waitErr := cmd.Wait()
-
-	if finalText == "" {
-		finalText = strings.TrimSpace(acc.String())
-	}
-	// A bare backend error (e.g. claude's "API Error: 4xx ...") must not be
-	// forwarded as the answer (issue #14): return an actionable hint instead.
-	if agentReplyIsError(finalText) {
-		if f.sessions != nil && strings.TrimSpace(convID) != "" {
-			f.sessions.reset(convID)
-		}
-		return agentBackendErrorReply(finalText), nil
-	}
-	if finalText != "" {
-		return brandReply(f.name, finalText), nil
-	}
-	if f.sessions != nil && strings.TrimSpace(convID) != "" {
+	if f.hasSession(convID) {
 		f.sessions.reset(convID)
 	}
-	if waitErr != nil {
-		msg := waitErr.Error()
-		if s := strings.TrimSpace(stderrBuf.String()); s != "" {
-			msg = s
-		}
-		return "", fmt.Errorf("本地 %s agent 调用失败：%s", f.name, truncateRunes(msg, 300))
-	}
-	return "（本地 agent 无文本输出）", nil
+	return "", fmt.Errorf("本地 %s agent 调用失败：%s", f.name, truncateRunes(msg, 300))
 }
 
 // parseStreamLine extracts (visible-text delta, final text) from one JSONL

--- a/internal/helpers/devapp_connect.go
+++ b/internal/helpers/devapp_connect.go
@@ -583,7 +583,7 @@ func newDevAppRobotConnectCommand(runner executor.Runner) *cobra.Command {
 	cmd.Flags().String("robot-client-id", "", "现成机器人 clientId（AppKey）")
 	cmd.Flags().String("robot-client-secret", "", "现成机器人 clientSecret（AppSecret）")
 	cmd.Flags().String("unified-app-id", "", "统一应用 ID：复用 dev app credentials get 自动取凭证（替代手填 robot-client-id/secret）")
-	cmd.Flags().String("agent-model", "", "覆盖本地 agent 模型（如 claude 的 sonnet/opus；默认用渠道内置模型，求快）；env: DWS_AGENT_MODEL")
+	cmd.Flags().String("agent-model", "", "覆盖 agent 模型（如 claude 的 sonnet/opus、gemini-2.5-pro；默认用渠道内置模型，求快）；env: DWS_AGENT_MODEL")
 	cmd.Flags().String("agent-workdir", "", "本地 agent 的运行目录（放知识文件可给机器人上下文；默认空白临时目录，求快）；env: DWS_AGENT_WORKDIR")
 	cmd.Flags().Bool("agent-memory", true, "按会话续聊：同一群/单聊共享 agent 会话上下文（codex/opencode/qoder/qoderwork/claudecode/codebuddy/workbuddy 支持；--agent-memory=false 关闭）")
 	cmd.Flags().Int("agent-timeout", 0, "每次 agent 调用的超时时间（秒），0=不限制（默认）；env: DWS_AGENT_TIMEOUT_MS（毫秒）")
@@ -751,7 +751,7 @@ func resolveAgentYoloMode(cmd *cobra.Command) (bool, error) {
 // connectAgentOptionsPayload renders the effective agent tuning for the
 // dry-run preview, including whether session memory actually applies to the
 // chosen channel (Codex uses app-server threads, opencode uses opencode serve
-// sessions, CLI session channels use --session-id/--resume, and gemini stays
+// sessions, CLI session channels use --session-id/--resume, and Gemini API stays
 // stateless today).
 func connectAgentOptionsPayload(channel string, opts connectAgentOptions) map[string]any {
 	spec, ok := agentSpecs[channel]

--- a/internal/helpers/devapp_connect_test.go
+++ b/internal/helpers/devapp_connect_test.go
@@ -29,6 +29,8 @@ func clearChannelEnv(t *testing.T) {
 		"DWS_CONNECT_CMD", "DWS_AGENT_CMD",
 		"WORKBUDDY_CONFIG_DIR", "WORKBUDDY_APP_NAME", "CLAUDECODE",
 		"DWS_AGENT_PERMISSION_MODE", "DWS_AGENT_APPROVAL_MODE",
+		"GEMINI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_BASE_URL",
+		"GOOGLE_GEMINI_API_BASE_URL", "GEMINI_MODEL",
 	} {
 		t.Setenv(k, "")
 	}
@@ -264,7 +266,7 @@ func TestAgentSpecsCoverMainstreamAgents(t *testing.T) {
 			t.Errorf("agentSpecs missing channel %q", ch)
 			continue
 		}
-		if len(spec.bins) == 0 {
+		if ch != "gemini" && len(spec.bins) == 0 {
 			t.Errorf("channel %q has no bins", ch)
 		}
 		if spec.hint == "" {


### PR DESCRIPTION
## Summary

- Disable/avoid agent mid-turn blocking in `dev connect` pure-channel forwarding: opencode question/permission pauses are bypassed, built-in agent permission modes default to non-interactive/yolo where applicable, and unbridged qoder control requests are auto-handled instead of hanging.
- Coalesce rapid user messages while an agent turn is active so follow-up DingTalk messages are batched into the next turn instead of piling up as a long FIFO.
- Harden default-memory agent sessions by retrying once with a fresh session when a stale local session id is reported.
- Move the `gemini` channel off the local Gemini CLI and onto the Gemini `generateContent` API (`GEMINI_API_KEY` / `GOOGLE_API_KEY`, optional `GEMINI_API_BASE_URL`, `--agent-model` support), so the channel no longer depends on a local `gemini` command.

## Verification

- [x] `go test -race -count=1 -timeout=5m ./internal/helpers`
- [x] `go test -count=1 $(go list ./... | grep -v '/test/scripts$')`
- [x] GitHub CI: Lint, Test, Coverage, Policy Check, Edition Contract Tests, Multi Profile E2E all passing on the fork branch
- [x] Real DingTalk robot verification for opencode, codex, qoder, qoderwork, claudecode, codebuddy, workbuddy
- [x] Real DingTalk robot verification for gemini API channel with `PATH` excluding `gemini` CLI and a fake Gemini-compatible endpoint
- [x] Queue/coalescing verification with a slow active turn plus rapid follow-up messages

## Notes

- `test/scripts` was not included in the local all-package command because this workstation's post-goreleaser tests require valid release archive fixtures; the corresponding GitHub CI checks passed.
- The `gemini` channel supports Gemini API-compatible endpoints via `GEMINI_API_BASE_URL`; arbitrary OpenAI-compatible third-party models should be handled by a separate channel rather than overloading Gemini protocol semantics.