### PR TITLE
fix(gitee): rewrite release workflow in Gitee Go native format

### DIFF
--- a/.workflow/gitee-release.yml
+++ b/.workflow/gitee-release.yml
@@ -1,51 +1,38 @@
-name: Gitee Release
+version: '1.0'
+name: gitee-release
+displayName: 'Gitee Release'
 
-on:
+triggers:
   push:
     tags:
-      - "v*"
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Release tag to build on Gitee, e.g. v1.0.48"
-        required: false
-        type: string
+      prefix: [v]
 
-jobs:
-  release:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+stages:
+  - stage:
+      name: build-and-release
+      displayName: 'Build & Publish to Gitee Release'
+      failFast: true
+      steps:
+        - step: build@golang
+          name: build-and-publish
+          displayName: 'Build all platforms & publish'
+          inputs:
+            golangVersion: 1.25
+            commands: |
+              set -eu
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+              yum install -y zip unzip curl perl 2>/dev/null || dnf install -y zip unzip curl perl 2>/dev/null || sudo apt-get update && sudo apt-get install -y zip unzip curl perl 2>/dev/null || true
 
-      - name: Install packaging tools
-        run: |
-          set -eu
-          sudo apt-get update
-          sudo apt-get install -y zip unzip curl
+              RCS_VERSION="0.27.0"
+              curl -fsSL -o /tmp/rcodesign.tar.gz \
+                "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCS_VERSION}/apple-codesign-${RCS_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+              mkdir -p /tmp/rcodesign
+              tar -xzf /tmp/rcodesign.tar.gz -C /tmp/rcodesign --strip-components=1
+              install -m 0755 /tmp/rcodesign/rcodesign /usr/local/bin/rcodesign 2>/dev/null || \
+                { mkdir -p ~/bin && cp /tmp/rcodesign/rcodesign ~/bin/rcodesign && export PATH="$HOME/bin:$PATH"; }
+              rcodesign --version
 
-      - name: Install rcodesign
-        run: |
-          set -eu
-          RCS_VERSION="0.27.0"
-          curl -fsSL -o /tmp/rcodesign.tar.gz \
-            "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCS_VERSION}/apple-codesign-${RCS_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          mkdir -p /tmp/rcodesign
-          tar -xzf /tmp/rcodesign.tar.gz -C /tmp/rcodesign --strip-components=1
-          sudo install -m 0755 /tmp/rcodesign/rcodesign /usr/local/bin/rcodesign
-          rcodesign --version
+              export GITEE_TOKEN="${RELEASE_TOKEN}"
+              export GITEE_REPO="DingTalk-Real-AI/dingtalk-workspace-cli"
 
-      - name: Build and publish Gitee release
-        env:
-          VERSION: ${{ inputs.version || github.ref_name }}
-          GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-          GITEE_REPO: DingTalk-Real-AI/dingtalk-workspace-cli
-        run: ./scripts/release/build-and-publish-gitee.sh
+              ./scripts/release/build-and-publish-gitee.sh

--- a/scripts/dev/build-all.sh
+++ b/scripts/dev/build-all.sh
@@ -62,7 +62,11 @@ done
 # Generate checksums
 echo "==> Calculating checksums"
 cd "$DIST_DIR"
-shasum -a 256 *.tar.gz *.zip > checksums.txt
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum *.tar.gz *.zip > checksums.txt
+else
+    shasum -a 256 *.tar.gz *.zip > checksums.txt
+fi
 cd ..
 
 echo "==> Build complete! Artifacts in $DIST_DIR/"


### PR DESCRIPTION
## Summary

- Rewrite `.workflow/gitee-release.yml` from GitHub Actions syntax to Gitee Go native pipeline format (`triggers.push.tags.prefix`, `step: build@golang`, `inputs.commands`). The old file used `on:`, `jobs:`, `uses: actions/checkout@v4` etc., which Gitee Go cannot execute — so Gitee releases have been stuck at v1.0.44.
- Fix `scripts/dev/build-all.sh` to prefer `sha256sum` (coreutils) over `shasum` (Perl), matching the pattern already used in `post-goreleaser.sh` and `publish-gitee-local.sh`. CentOS (Gitee Go's `build@golang` OS) doesn't have `shasum`.

## After merging — Gitee side setup needed

1. **Enable Gitee Go**: Repo → 管理 → Gitee Go → 开启流水线
2. **Configure secret**: Pipeline settings → 添加参数 → name: `RELEASE_TOKEN`, value: (Gitee personal access token with release perms), mark as secret
3. **Verify**: Push a test tag (e.g. `v1.0.52-beta.0`) and check if the pipeline triggers and publishes

## Test plan

- [ ] Gitee Go pipeline triggers on tag push (`v*`)
- [ ] All 6 platform binaries build successfully on Gitee Go
- [ ] Darwin binaries are ad-hoc signed via `rcodesign`
- [ ] All artifacts upload to the Gitee release page
- [ ] `checksums.txt` is generated with `sha256sum` format