### PR TITLE
fix release upload of signed macOS assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Test with Race Detection
         run: go test -v -race -count=1 -timeout=5m ./cmd/... ./internal/...
 
+      - name: Test release scripts
+        run: go test -v -count=1 -timeout=5m ./test/scripts
+
   coverage:
     name: Coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,55 @@ jobs:
         env:
           DWS_PACKAGE_VERSION: ${{ github.ref_name }}
 
-      - name: Upload dws-skills.zip to release
+      # GoReleaser publishes the original archives before post-goreleaser.sh
+      # replaces the Darwin binaries with their rcodesign output. Re-upload all
+      # files changed by post-processing so GitHub, npm, and the mirrors expose
+      # the same bytes and checksums.
+      - name: Upload finalized signed assets to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" dist/dws-skills.zip --clobber
+          set -euo pipefail
+
+          assets=(
+            dist/dws-darwin-amd64.tar.gz
+            dist/dws-darwin-arm64.tar.gz
+            dist/checksums.txt
+            dist/dws-skills.zip
+          )
+
+          for asset in "${assets[@]}"; do
+            test -f "$asset"
+          done
+
+          gh release upload "$GITHUB_REF_NAME" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+          # Fail the release if GitHub still serves a pre-signing archive. Asset
+          # digests can take a moment to settle after replacement, so retry.
+          for asset in "${assets[@]}"; do
+            name="$(basename "$asset")"
+            local_digest="sha256:$(sha256sum "$asset" | awk '{print $1}')"
+            attempt=1
+            while [ "$attempt" -le 5 ]; do
+              remote_digest="$(
+                gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" \
+                  --jq ".assets[] | select(.name == \"$name\") | .digest"
+              )"
+              if [ "$remote_digest" = "$local_digest" ]; then
+                break
+              fi
+              if [ "$attempt" -eq 5 ]; then
+                echo "release asset digest mismatch for $name" >&2
+                echo "  local:  $local_digest" >&2
+                echo "  remote: ${remote_digest:-missing}" >&2
+                exit 1
+              fi
+              attempt=$((attempt + 1))
+              sleep 2
+            done
+          done
 
       - name: Sync release to China OSS mirror
         # 自动同步到国内镜像，供 install.sh 的 DWS_RELEASE_BASE 开关消费。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,48 +71,7 @@ jobs:
       - name: Upload finalized signed assets to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          assets=(
-            dist/dws-darwin-amd64.tar.gz
-            dist/dws-darwin-arm64.tar.gz
-            dist/checksums.txt
-            dist/dws-skills.zip
-          )
-
-          for asset in "${assets[@]}"; do
-            test -f "$asset"
-          done
-
-          gh release upload "$GITHUB_REF_NAME" "${assets[@]}" \
-            --repo "$GITHUB_REPOSITORY" \
-            --clobber
-
-          # Fail the release if GitHub still serves a pre-signing archive. Asset
-          # digests can take a moment to settle after replacement, so retry.
-          for asset in "${assets[@]}"; do
-            name="$(basename "$asset")"
-            local_digest="sha256:$(sha256sum "$asset" | awk '{print $1}')"
-            attempt=1
-            while [ "$attempt" -le 5 ]; do
-              remote_digest="$(
-                gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" \
-                  --jq ".assets[] | select(.name == \"$name\") | .digest"
-              )"
-              if [ "$remote_digest" = "$local_digest" ]; then
-                break
-              fi
-              if [ "$attempt" -eq 5 ]; then
-                echo "release asset digest mismatch for $name" >&2
-                echo "  local:  $local_digest" >&2
-                echo "  remote: ${remote_digest:-missing}" >&2
-                exit 1
-              fi
-              attempt=$((attempt + 1))
-              sleep 2
-            done
-          done
+        run: ./scripts/release/finalize-github-release.sh
 
       - name: Sync release to China OSS mirror
         # 自动同步到国内镜像，供 install.sh 的 DWS_RELEASE_BASE 开关消费。

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,7 +67,9 @@ release:
     # 用当前运行 CI 的仓库 owner: fork CI 发到 fork, 官方 CI 发到官方, 两边都对
     owner: "{{ .Env.GITHUB_REPOSITORY_OWNER }}"
     name: dingtalk-workspace-cli
-  draft: false
+  # Keep the release private until post-processing has replaced the Darwin
+  # archives and verified every finalized asset digest.
+  draft: true
   prerelease: auto
   name_template: "v{{.Version}}"
   mode: replace

--- a/scripts/release/finalize-github-release.sh
+++ b/scripts/release/finalize-github-release.sh
@@ -61,7 +61,7 @@ for asset in "$@"; do
   attempt=1
   while [ "$attempt" -le "$DIGEST_ATTEMPTS" ]; do
     remote_digest="$(
-      gh api "repos/$REPOSITORY/releases/tags/$TAG" \
+      gh release view "$TAG" --repo "$REPOSITORY" --json assets \
         --jq ".assets[] | select(.name == \"$name\") | .digest"
     )"
     if [ "$remote_digest" = "$local_digest" ]; then

--- a/scripts/release/finalize-github-release.sh
+++ b/scripts/release/finalize-github-release.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -eu
+
+# Replace GoReleaser's original assets with post-processed artifacts, verify
+# that GitHub serves exactly those bytes, and only then make the Draft public.
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+DIST_DIR="${DWS_PACKAGE_DIST_DIR:-$ROOT/dist}"
+TAG="${GITHUB_REF_NAME:?GITHUB_REF_NAME is required}"
+REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+PUBLISH_RELEASE="${DWS_PUBLISH_RELEASE:-true}"
+DIGEST_ATTEMPTS="${DWS_RELEASE_DIGEST_ATTEMPTS:-5}"
+DIGEST_RETRY_DELAY="${DWS_RELEASE_DIGEST_RETRY_DELAY:-2}"
+
+err() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+sha256_file() {
+  target="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$target" | awk '{print $1}'
+    return
+  fi
+  shasum -a 256 "$target" | awk '{print $1}'
+}
+
+case "$PUBLISH_RELEASE" in
+  1|true|yes) publish_release=1 ;;
+  0|false|no) publish_release=0 ;;
+  *) err "invalid DWS_PUBLISH_RELEASE value: $PUBLISH_RELEASE" ;;
+esac
+
+case "$DIGEST_ATTEMPTS" in
+  ''|*[!0-9]*) err "DWS_RELEASE_DIGEST_ATTEMPTS must be a positive integer" ;;
+  0) err "DWS_RELEASE_DIGEST_ATTEMPTS must be greater than zero" ;;
+esac
+
+command -v gh >/dev/null 2>&1 || err "gh is required"
+
+set -- \
+  "$DIST_DIR/dws-darwin-amd64.tar.gz" \
+  "$DIST_DIR/dws-darwin-arm64.tar.gz" \
+  "$DIST_DIR/checksums.txt" \
+  "$DIST_DIR/dws-skills.zip"
+
+for asset in "$@"; do
+  [ -f "$asset" ] || err "finalized release asset missing: $asset"
+done
+
+gh release upload "$TAG" "$@" \
+  --repo "$REPOSITORY" \
+  --clobber
+
+# Fail before publication if GitHub still serves a pre-signing archive. Asset
+# digests can take a moment to settle after replacement, so retry.
+for asset in "$@"; do
+  name="$(basename "$asset")"
+  local_digest="sha256:$(sha256_file "$asset")"
+  attempt=1
+  while [ "$attempt" -le "$DIGEST_ATTEMPTS" ]; do
+    remote_digest="$(
+      gh api "repos/$REPOSITORY/releases/tags/$TAG" \
+        --jq ".assets[] | select(.name == \"$name\") | .digest"
+    )"
+    if [ "$remote_digest" = "$local_digest" ]; then
+      break
+    fi
+    if [ "$attempt" -eq "$DIGEST_ATTEMPTS" ]; then
+      printf 'release asset digest mismatch for %s\n' "$name" >&2
+      printf '  local:  %s\n' "$local_digest" >&2
+      printf '  remote: %s\n' "${remote_digest:-missing}" >&2
+      exit 1
+    fi
+    attempt=$((attempt + 1))
+    sleep "$DIGEST_RETRY_DELAY"
+  done
+done
+
+if [ "$publish_release" -eq 1 ]; then
+  gh release edit "$TAG" --repo "$REPOSITORY" --draft=false
+else
+  printf 'finalized assets verified; keeping release %s as Draft\n' "$TAG"
+fi

--- a/scripts/release/post-goreleaser.sh
+++ b/scripts/release/post-goreleaser.sh
@@ -272,10 +272,9 @@ sign_darwin_archives() {
 }
 
 write_checksums() {
-  checksum_path="$DIST_DIR/checksums.txt"
-  # Append skills zip checksum to goreleaser's checksums file
+  # Keep this idempotent: workflow retries must not leave duplicate entries.
   if [ -f "$DIST_DIR/dws-skills.zip" ]; then
-    printf '%s  %s\n' "$(sha256_file "$DIST_DIR/dws-skills.zip")" "dws-skills.zip" >> "$checksum_path"
+    update_checksum_entry "dws-skills.zip" "$(sha256_file "$DIST_DIR/dws-skills.zip")"
   fi
 }
 

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -1,6 +1,8 @@
 package scripts_test
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,9 +30,41 @@ var expectedPackagedSkillTargets = []string{
 	".hermes/skills/dws",
 }
 
-// seedDistArtifacts creates fake goreleaser output archives (empty tar.gz/zip
-// files) and a checksums.txt stub so that post-goreleaser.sh can run without
-// an actual goreleaser build.
+func writeDarwinArchive(t *testing.T, path string) {
+	t.Helper()
+
+	archive, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Create(%s) error = %v", path, err)
+	}
+	gzipWriter := gzip.NewWriter(archive)
+	tarWriter := tar.NewWriter(gzipWriter)
+	binary := []byte("#!/bin/sh\nexit 0\n")
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name: "dws",
+		Mode: 0o755,
+		Size: int64(len(binary)),
+	}); err != nil {
+		t.Fatalf("WriteHeader(%s) error = %v", path, err)
+	}
+	if _, err := tarWriter.Write(binary); err != nil {
+		t.Fatalf("Write(%s) error = %v", path, err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("tar Close(%s) error = %v", path, err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("gzip Close(%s) error = %v", path, err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatalf("Close(%s) error = %v", path, err)
+	}
+}
+
+// seedDistArtifacts creates minimal goreleaser output archives and a
+// checksums.txt stub so post-goreleaser.sh can run without a real build.
+// Darwin archives must be valid tar.gz files because the packaging script
+// extracts and signs their dws binaries.
 func seedDistArtifacts(t *testing.T, distDir string, targets []string) {
 	t.Helper()
 	if err := os.MkdirAll(distDir, 0o755); err != nil {
@@ -39,6 +73,10 @@ func seedDistArtifacts(t *testing.T, distDir string, targets []string) {
 
 	for _, target := range targets {
 		p := filepath.Join(distDir, target)
+		if strings.HasPrefix(target, "dws-darwin-") && strings.HasSuffix(target, ".tar.gz") {
+			writeDarwinArchive(t, p)
+			continue
+		}
 		if err := os.WriteFile(p, []byte("fake-archive"), 0o644); err != nil {
 			t.Fatalf("WriteFile(%s) error = %v", p, err)
 		}
@@ -53,6 +91,23 @@ func seedDistArtifacts(t *testing.T, distDir string, targets []string) {
 	if err := os.WriteFile(checksums, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile(%s) error = %v", checksums, err)
 	}
+}
+
+func postGoreleaserEnv(t *testing.T, distDir, releaseBaseURL string) []string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	fakeCodesign := filepath.Join(binDir, "codesign")
+	if err := os.WriteFile(fakeCodesign, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake codesign) error = %v", err)
+	}
+
+	return append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DWS_PACKAGE_VERSION=v0.0.0-test",
+		"DWS_PACKAGE_DIST_DIR="+distDir,
+		"DWS_RELEASE_BASE_URL="+releaseBaseURL,
+	)
 }
 
 func TestPostGoreleaserBuildsExpectedArtifacts(t *testing.T) {
@@ -77,10 +132,7 @@ func TestPostGoreleaserBuildsExpectedArtifacts(t *testing.T) {
 	seedDistArtifacts(t, distDir, []string{archiveName})
 
 	cmd := exec.Command("sh", scriptPath)
-	cmd.Env = append(os.Environ(),
-		"DWS_PACKAGE_DIST_DIR="+distDir,
-		"DWS_RELEASE_BASE_URL=https://downloads.example.com/dws/releases/v1.2.3",
-	)
+	cmd.Env = postGoreleaserEnv(t, distDir, "https://downloads.example.com/dws/releases/v1.2.3")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("post-goreleaser.sh error = %v\noutput:\n%s", err, string(output))
@@ -199,10 +251,7 @@ func TestPostGoreleaserAllPlatformNpmAssets(t *testing.T) {
 	seedDistArtifacts(t, distDir, allArchives)
 
 	cmd := exec.Command("sh", scriptPath)
-	cmd.Env = append(os.Environ(),
-		"DWS_PACKAGE_DIST_DIR="+distDir,
-		"DWS_RELEASE_BASE_URL=https://downloads.example.com/dws/releases/v9.9.9",
-	)
+	cmd.Env = postGoreleaserEnv(t, distDir, "https://downloads.example.com/dws/releases/v9.9.9")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("post-goreleaser.sh error = %v\noutput:\n%s", err, string(output))
@@ -279,10 +328,7 @@ func TestPostGoreleaserSkillsZipLayout(t *testing.T) {
 	seedDistArtifacts(t, distDir, []string{archiveName})
 
 	cmd := exec.Command("sh", scriptPath)
-	cmd.Env = append(os.Environ(),
-		"DWS_PACKAGE_DIST_DIR="+distDir,
-		"DWS_RELEASE_BASE_URL=https://downloads.example.com/dws/releases/v0.0.0",
-	)
+	cmd.Env = postGoreleaserEnv(t, distDir, "https://downloads.example.com/dws/releases/v0.0.0")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("post-goreleaser.sh error = %v\noutput:\n%s", err, string(output))

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -350,17 +350,133 @@ func TestReleaseWorkflowUploadsPostProcessedDarwinAssets(t *testing.T) {
 		t.Fatalf("finalized asset upload must run after post-goreleaser.sh")
 	}
 
+	if !strings.Contains(workflow[upload:], "./scripts/release/finalize-github-release.sh") {
+		t.Fatal("release workflow must delegate atomic finalization to finalize-github-release.sh")
+	}
+
+	finalizePath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "release", "finalize-github-release.sh"))
+	if err != nil {
+		t.Fatalf("Abs(finalize-github-release.sh) error = %v", err)
+	}
+	finalizeData, err := os.ReadFile(finalizePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", finalizePath, err)
+	}
+	finalize := string(finalizeData)
+
 	for _, required := range []string{
-		"dist/dws-darwin-amd64.tar.gz",
-		"dist/dws-darwin-arm64.tar.gz",
-		"dist/checksums.txt",
-		"dist/dws-skills.zip",
+		"dws-darwin-amd64.tar.gz",
+		"dws-darwin-arm64.tar.gz",
+		"checksums.txt",
+		"dws-skills.zip",
 		"gh release upload",
 		"--clobber",
 		"release asset digest mismatch",
 	} {
-		if !strings.Contains(workflow[upload:], required) {
+		if !strings.Contains(finalize, required) {
 			t.Errorf("finalized asset upload is missing %q", required)
 		}
+	}
+}
+
+func TestReleaseStaysDraftUntilFinalizedAssetDigestsMatch(t *testing.T) {
+	t.Parallel()
+
+	goreleaserPath, err := filepath.Abs(filepath.Join("..", "..", ".goreleaser.yaml"))
+	if err != nil {
+		t.Fatalf("Abs(.goreleaser.yaml) error = %v", err)
+	}
+	goreleaserData, err := os.ReadFile(goreleaserPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", goreleaserPath, err)
+	}
+	if !strings.Contains(string(goreleaserData), "draft: true") {
+		t.Fatal("GoReleaser must keep the release as Draft during post-processing")
+	}
+
+	finalizePath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "release", "finalize-github-release.sh"))
+	if err != nil {
+		t.Fatalf("Abs(finalize-github-release.sh) error = %v", err)
+	}
+	finalizeData, err := os.ReadFile(finalizePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", finalizePath, err)
+	}
+	finalize := string(finalizeData)
+
+	upload := strings.Index(finalize, "gh release upload")
+	digestFailure := strings.Index(finalize, "release asset digest mismatch")
+	publish := strings.Index(finalize, "gh release edit")
+	if upload == -1 || digestFailure == -1 || publish == -1 || !(upload < digestFailure && digestFailure < publish) {
+		t.Fatal("Draft publication must happen after finalized asset upload and digest verification")
+	}
+}
+
+func TestFinalizeGitHubReleaseDoesNotPublishAfterUploadFailure(t *testing.T) {
+	t.Parallel()
+
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "release", "finalize-github-release.sh"))
+	if err != nil {
+		t.Fatalf("Abs(finalize-github-release.sh) error = %v", err)
+	}
+
+	root := t.TempDir()
+	distDir := filepath.Join(root, "dist")
+	if err := os.MkdirAll(distDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", distDir, err)
+	}
+	for _, name := range []string{
+		"dws-darwin-amd64.tar.gz",
+		"dws-darwin-arm64.tar.gz",
+		"checksums.txt",
+		"dws-skills.zip",
+	} {
+		if err := os.WriteFile(filepath.Join(distDir, name), []byte("finalized"), 0o644); err != nil {
+			t.Fatalf("WriteFile(%s) error = %v", name, err)
+		}
+	}
+
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", binDir, err)
+	}
+	logPath := filepath.Join(root, "gh.log")
+	fakeGH := `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GH_LOG"
+if [ "$1" = "release" ] && [ "$2" = "upload" ]; then
+  exit 42
+fi
+if [ "$1" = "release" ] && [ "$2" = "edit" ]; then
+  exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(binDir, "gh"), []byte(fakeGH), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake gh) error = %v", err)
+	}
+
+	cmd := exec.Command("sh", scriptPath)
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_GH_LOG="+logPath,
+		"GITHUB_REF_NAME=v-test",
+		"GITHUB_REPOSITORY=example/dws",
+		"DWS_PACKAGE_DIST_DIR="+distDir,
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("finalize-github-release.sh unexpectedly succeeded after upload failure:\n%s", output)
+	}
+
+	logData, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile(%s) error = %v", logPath, readErr)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "release upload") {
+		t.Fatalf("fake gh did not observe release upload:\n%s", logText)
+	}
+	if strings.Contains(logText, "release edit") {
+		t.Fatalf("Draft release was published after upload failure:\n%s", logText)
 	}
 }

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -330,3 +330,37 @@ func TestPostGoreleaserSkillsZipLayout(t *testing.T) {
 		t.Fatalf("multi/ does not contain any dingtalk-* skill: %v", multiEntries)
 	}
 }
+
+func TestReleaseWorkflowUploadsPostProcessedDarwinAssets(t *testing.T) {
+	t.Parallel()
+
+	workflowPath, err := filepath.Abs(filepath.Join("..", "..", ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatalf("Abs(release.yml) error = %v", err)
+	}
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", workflowPath, err)
+	}
+	workflow := string(data)
+
+	postProcess := strings.Index(workflow, "./scripts/release/post-goreleaser.sh")
+	upload := strings.Index(workflow, "Upload finalized signed assets to release")
+	if postProcess == -1 || upload == -1 || upload < postProcess {
+		t.Fatalf("finalized asset upload must run after post-goreleaser.sh")
+	}
+
+	for _, required := range []string{
+		"dist/dws-darwin-amd64.tar.gz",
+		"dist/dws-darwin-arm64.tar.gz",
+		"dist/checksums.txt",
+		"dist/dws-skills.zip",
+		"gh release upload",
+		"--clobber",
+		"release asset digest mismatch",
+	} {
+		if !strings.Contains(workflow[upload:], required) {
+			t.Errorf("finalized asset upload is missing %q", required)
+		}
+	}
+}

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -370,6 +370,7 @@ func TestReleaseWorkflowUploadsPostProcessedDarwinAssets(t *testing.T) {
 		"checksums.txt",
 		"dws-skills.zip",
 		"gh release upload",
+		"gh release view",
 		"--clobber",
 		"release asset digest mismatch",
 	} {


### PR DESCRIPTION
## Summary

- re-upload the post-processed Darwin archives, `checksums.txt`, and skills archive after ad-hoc signing
- verify every replaced GitHub Release asset digest against the finalized local artifact
- make the skills checksum update idempotent and add a regression test for the release ordering

## Root cause

GoReleaser published the original archives before `post-goreleaser.sh` ran `rcodesign`. The signed Darwin archives and rewritten checksums were packaged into npm, but only `dws-skills.zip` was uploaded afterward. As a result, GitHub Releases and npm exposed different macOS binaries.

## Impact

GitHub Releases, npm packages, and downstream mirrors will now consume the same signed macOS artifacts. A digest mismatch fails the release instead of silently publishing the pre-signing archive.

## Validation

- parsed `.github/workflows/release.yml` successfully
- validated the finalized-asset upload Bash block with `bash -n`
- `git diff --check`
- `GOCACHE=/tmp/dws-go-build-cache go test ./test/scripts -run TestReleaseWorkflowUploadsPostProcessedDarwinAssets -count=1`

The full `test/scripts` package still has pre-existing failures: release-package tests seed invalid fake tar archives that the signing step cannot extract, and installer tests attempt to write outside the sandboxed test home.
