### PR TITLE
feat(event): AI-subprocess contract and cobra-synthesized schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+### Changed
+
+- **`event consume` AI-subprocess contract** — aligns personal event streaming with the contract an orchestrator can drive without guessing: a fixed stderr ready line `[event] ready event_key=<key> bus_pid=<pid>` (block on it, don't `sleep`); a final `[event] exited — received N event(s) in Xs (reason: limit|timeout|signal|bus_shutdown)` line with exit code 0 on controlled exit and non-zero (no `exited` line) on failure; stdin-EOF as a graceful shutdown signal, armed only for a parent-controlled pipe stdin on an unbounded run (an interactive TTY and `< /dev/null` never trigger it), with a self-explaining diagnostic when it fires; and ownership-based subscription cleanup — a subscription this run created is unsubscribed on any clean exit while a `--subscribe-id`-reused one is left intact (`--ephemeral` still forces cleanup), so `kill -9` is the only way to leak a server-side subscription. Skill docs (mono + `dingtalk-event`) document the contract; design notes in `docs/event-subprocess-contract.md`.
+
 ### Added
 
+- **`dws schema` for registered local commands** — `dws schema "event consume"` (or `event.consume`) now returns a machine-readable input schema synthesized from the command's cobra flags, in the same flat shape helper subtrees emit: `{description, path, source, parameters{<flag>:{type, required, description, default?}}}` plus an `arguments` array for positional inputs, with `source: "cobra"` distinguishing flag-synthesized schema from MCP-fetched (`mcp:<server>`). Intermediate nodes (`dws schema event`) list their subcommands. The mechanism is a reusable registry (`cobraSchemaRoots`); `event` is the first consumer and more command trees can opt in without further wiring. Inherited global flags and hidden internal flags are excluded so the schema describes just that command.
 - **Safe macOS Keychain → file-DEK migration** — `dws auth migrate-keychain --to file-dek` preflights every legacy/profile auth entry before rewriting, ignores unrelated application secrets, supports side-effect-free `--dry-run`, requires explicit `--yes`, and lets sandboxed and normal processes share an existing login without exposing tokens.
 
 ### Fixed

--- a/docs/event-subprocess-contract.md
+++ b/docs/event-subprocess-contract.md
@@ -1,0 +1,115 @@
+# Event consume — AI subprocess contract
+
+Aligns `dws event consume` with the "AI subprocess contract" that
+`lark-cli event consume` exposes, so any orchestrator (Claude Code's
+Monitor, a bash bridge, systemd, an agent plugin) can drive it with zero
+ambiguity: know when it is ready, stop it cleanly, and machine-read why it
+exited.
+
+Scope of this branch: the four **contract** items below. Reconnect
+resilience (keeping the stream alive across a transient upstream drop) is
+tracked separately and intentionally out of scope here.
+
+## Baseline (already present, no work)
+
+- `--max-events N` — stop after N events (exit 0).
+- `--duration D` — wall-clock budget (exit 0). Kept as `--duration`, NOT
+  aliased to `--timeout`: the global `--timeout` is the HTTP request
+  timeout (int seconds) and would collide (different type and meaning).
+  Docs note the lark-cli name difference.
+- Bus idle-shutdown fires only with **zero** consumers, so a connected
+  consumer is never idle-killed.
+- SIGINT/SIGTERM already cancel the run context and return cleanly.
+
+## Improvements
+
+### 1. Ready marker (standardized)
+
+On connect, emit a fixed stderr line **before** any stdout event:
+
+```
+[event] ready event_key=<key> bus_pid=<pid>
+```
+
+Parents block on stderr until this line, then read stdout. Suppressed
+under `--quiet`. Replaces the ad-hoc `connected bus pid=...` line (which
+omits `event_key`).
+
+**Verification**
+- T1a: stderr contains a line matching `^\[event\] ready event_key=<key>`.
+- T1b: that line appears before the first stdout event (ordering).
+- T1c: with `--quiet`, the line is absent.
+
+### 2. stdin EOF = graceful exit
+
+`consume` watches stdin; closing stdin is a shutdown signal (wired for AI
+subprocess callers). To stay resident, feed a never-EOF stdin
+(`< <(tail -f /dev/null)`) or run bounded (`--max-events` / `--duration`).
+
+**Verification**
+- T2a: `printf '' | dws event consume <key>` exits ≤2s, code 0, final
+  line `reason: signal` (stdin-eof classified as signal).
+- T2b: `dws event consume <key> < <(tail -f /dev/null)` still alive after
+  5s, connection intact.
+- T2c (unit): a controllable stdin reader hitting EOF makes Run return nil
+  via the cleanup path.
+
+### 3. Exit reason contract + exit codes
+
+On exit, final stderr line:
+
+```
+[event] exited — received N event(s) in Xs (reason: <limit|timeout|signal|bus_shutdown>)
+```
+
+Exit codes: controlled exit (limit/timeout/signal/stdin-eof) = 0; startup
+or runtime failure (permissions, network, params) = non-zero, with no
+`exited` line and an `Error:` line instead.
+
+**Verification**
+- T3a: `--max-events 1` + 1 event → exit 0, reason=`limit`, N=1.
+- T3b: `--duration 2s`, no events → exit 0, reason=`timeout`.
+- T3c: SIGTERM mid-run → exit 0, reason=`signal`.
+- T3d: bad params / permission failure → exit≠0, no `exited` line, has `Error:`.
+- Unit tests assert (reason string, exit code) for each path.
+
+### 4. Cleanup on exit (no `kill -9`)
+
+Ownership-based, matching lark-cli:
+- If this run **created** the subscription (no `--subscribe-id`), a clean
+  exit (SIGTERM / SIGINT / stdin-EOF / limit / timeout) **unsubscribes**
+  it server-side and sends Bye.
+- If `--subscribe-id` was passed (reusing an existing subscription), the
+  subscription is **left intact** — the caller owns its lifecycle.
+- `--ephemeral` remains as an explicit "always unsubscribe" override.
+- Help/docs warn: avoid `kill -9` (skips the unsubscribe → leaked
+  server-side subscription: "subscription already exists" on restart,
+  duplicate delivery). Prefer SIGTERM or closing stdin.
+
+**Verification**
+- T4a: start consume (self-created subscription), record subscribe_id;
+  SIGTERM; afterwards `dws event status` no longer lists that subscribe_id
+  and the server-side subscription is gone.
+- T4b: start consume with `--subscribe-id <existing>`; SIGTERM; the
+  subscription is still present (reuse case preserved).
+- T4c (control): `kill -9` leaves subscribe_id lingering (documented risk;
+  we only guarantee SIGTERM is clean, we do not fix kill -9 itself).
+
+## Out of scope (next branch)
+
+**Reconnect resilience** — today `personal source` retries only
+`retryable` errors (1–30s backoff); a non-retryable error tears the bus
+down and takes consume with it (the likely cause of the observed silent
+drop). Making more drops retryable, keeping the bus alive across a
+reconnect, and emitting `reason: source_lost` only after exhausting the
+budget — tracked on its own branch, since it needs error-classification
+judgement and real flaky-network testing, and would otherwise couple clean
+contract work with resilience work.
+
+## Test surface
+
+- Unit: extend `internal/event/consume/*_test.go` with fake bus conn /
+  stdin / stderr sink for T1c, T2c, T3 (all paths), T4 ownership branch.
+- Integration/e2e: `--foreground` + mock source (or a short real run) for
+  T1a/b, T2a/b, T3a–d, T4a/b/c — assert the stderr contract lines and exit
+  codes.

--- a/internal/app/event_command.go
+++ b/internal/app/event_command.go
@@ -101,7 +101,9 @@ func newEventConsumeCommand() *cobra.Command {
   raw             仅 SDK 原始 payload，无外层封装
   compact         扁平化 + 解析嵌套 + 抽取语义字段（Agent 友好）
 
-默认使用当前 OAuth 登录态自动创建/复用个人订阅并建立个人长连接。
+默认使用当前 OAuth 登录态自动创建/复用个人订阅并建立个人长连接；非默认组织加
+--profile。连上后 stderr 打就绪行 [event] ready，等它出现再读 stdout；停机用
+SIGTERM、关 stdin，或 dws event stop <subscribe_id>，不要 kill -9。
 --event-types/--filter 只影响本地 bus → consume 这一段投递；普通个人事件消费
 通常不需要设置。`,
 		Args:              cobra.MaximumNArgs(1),
@@ -214,6 +216,11 @@ func newEventConsumeCommand() *cobra.Command {
 				DryRun:         dryRun,
 				SpawnExtraArgs: streamOpts.spawnArgs(),
 			}
+			// Arm the stdin-EOF shutdown watcher only for a pipe-style,
+			// unbounded run (see shouldWatchStdinEOF).
+			if shouldWatchStdinEOF(maxEvents, duration) {
+				cfg.Stdin = c.InOrStdin()
+			}
 
 			// Step 5: validation (flag-only rules).
 			if err := consume.ValidateConfig(cfg); err != nil {
@@ -260,7 +267,7 @@ func newEventConsumeCommand() *cobra.Command {
 	f.BoolVar(&dryRun, "dry-run", false,
 		"仅打印解析后的配置，不连接 bus / 云端")
 	f.BoolVar(&foreground, "foreground", false,
-		"不 fork daemon，当前进程跑 bus (systemd/k8s/launchd 友好)")
+		"当前进程直接跑 bus 服务、不 fork、不打印事件（给 systemd/k8s 托管用）；读事件不要用它")
 	f.StringVar(&personalOpts.SubscribeID, "subscribe-id", "",
 		"个人事件订阅 ID；传入后复用已有订阅")
 	f.StringVar(&personalOpts.Rule, "rule", "",
@@ -274,7 +281,10 @@ func newEventConsumeCommand() *cobra.Command {
 	f.DurationVar(&personalOpts.TTL, "ttl", 0,
 		"个人订阅 TTL (Go duration，如 24h；0 表示不过期)")
 	f.BoolVar(&personalOpts.Ephemeral, "ephemeral", false,
-		"consume 退出时自动取消个人订阅")
+		"强制退出时取消个人订阅。默认已按归属清理：本次新建的订阅退出即取消，"+
+			"用 --subscribe-id 复用的订阅保留。优雅停可用 SIGTERM、关闭 stdin，"+
+			"或从外部 dws event stop <subscribe_id>（会一并退订）；"+
+			"请勿 kill -9（会跳过退订、泄漏服务端订阅）")
 	f.StringVar(&personalOpts.UserID, "user", "",
 		"个人单聊对端 userId")
 	f.StringVar(&personalOpts.GroupID, "group", "",
@@ -457,7 +467,13 @@ func newEventBusCommand() *cobra.Command {
 			readyPipe := busctl.ReadyFDFromEnv()
 			failEarly := func(err error) error {
 				if readyPipe != nil {
+					// 'E' signals failure; the trailing text lets the parent
+					// (busctl.waitReady) surface the real startup error to the
+					// user instead of an opaque "startup failure on ready pipe".
 					_, _ = readyPipe.Write([]byte{'E'})
+					if err != nil {
+						_, _ = io.WriteString(readyPipe, err.Error())
+					}
 					_ = readyPipe.Close()
 				}
 				return err
@@ -1091,6 +1107,26 @@ func firstArg(args []string) string {
 		return ""
 	}
 	return args[0]
+}
+
+// shouldWatchStdinEOF gates the stdin-EOF shutdown watcher (AI-subprocess
+// contract). It arms only for a parent-controlled, pipe-style stdin on an
+// unbounded run:
+//   - bounded runs (--max-events / --duration) already have their own
+//     lifecycle, so stdin is irrelevant;
+//   - char devices (an interactive TTY, or /dev/null) are excluded, so a
+//     terminal Ctrl-D and the common `< /dev/null` launch do NOT trigger a
+//     surprise shutdown. Only a pipe / regular file — an stdin a parent
+//     holds and can close to stop us — arms the watcher.
+func shouldWatchStdinEOF(maxEvents int, duration time.Duration) bool {
+	if maxEvents > 0 || duration > 0 {
+		return false
+	}
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice == 0
 }
 
 // eventTypesWithDefault picks the catch-all list from registry when the

--- a/internal/app/event_personal_command.go
+++ b/internal/app/event_personal_command.go
@@ -204,6 +204,7 @@ func runPersonalEventConsume(c *cobra.Command, opts personalConsumeOptions) erro
 			Compact:        opts.Common.Compact,
 			MaxEvents:      opts.Common.MaxEvents,
 			Duration:       opts.Common.Duration,
+			EventKey:       opts.EventKey,
 			Format:         normalised,
 			OutputDir:      opts.Common.OutputDir,
 			Routes:         routes,
@@ -239,7 +240,14 @@ func runPersonalEventConsume(c *cobra.Command, opts personalConsumeOptions) erro
 		_ = client.DeleteSubscription(context.Background(), sub.SubscribeID)
 		_ = personal.RemoveRunStates(workDir, []string{sub.SubscribeID})
 	}
-	if opts.Ephemeral {
+	// Ownership-based cleanup (AI-subprocess contract, aligned with
+	// lark-cli): a subscription this run CREATED is unsubscribed on exit
+	// (any exit — SIGTERM / stdin-EOF / limit / timeout / error), so nothing
+	// leaks server-side. A subscription REUSED via --subscribe-id is left
+	// intact — the caller owns its lifecycle. --ephemeral forces cleanup
+	// either way.
+	selfCreated := strings.TrimSpace(opts.SubscribeID) == ""
+	if opts.Ephemeral || selfCreated {
 		defer cleanup()
 	}
 
@@ -251,6 +259,7 @@ func runPersonalEventConsume(c *cobra.Command, opts personalConsumeOptions) erro
 		Compact:        opts.Common.Compact,
 		MaxEvents:      opts.Common.MaxEvents,
 		Duration:       opts.Common.Duration,
+		EventKey:       eventKey,
 		Format:         normalised,
 		OutputDir:      opts.Common.OutputDir,
 		Routes:         routes,
@@ -259,6 +268,11 @@ func runPersonalEventConsume(c *cobra.Command, opts personalConsumeOptions) erro
 		Quiet:          opts.Common.Quiet,
 		Foreground:     opts.Common.Foreground,
 		Force:          opts.Common.Force,
+	}
+	// Arm the stdin-EOF shutdown watcher only for a pipe-style, unbounded
+	// run (see shouldWatchStdinEOF).
+	if shouldWatchStdinEOF(opts.Common.MaxEvents, opts.Common.Duration) {
+		cfg.Stdin = c.InOrStdin()
 	}
 	applyPersonalConsumeFilters(&cfg, opts, sub.SubscribeID, eventKey)
 	if opts.DebugRawEvents && !opts.Common.Quiet {
@@ -755,6 +769,16 @@ func personalBusSpawnArgs(identity personal.Identity, ticketMode, ticketURL stri
 	args := []string{
 		"--source-kind", string(dwsevent.SourceKindPersonalStream),
 		"--stream-source-id", identity.SourceID,
+	}
+	// Forward the organization so the detached _bus child resolves
+	// credentials for the SAME profile the parent used. Without this the
+	// child falls back to the default profile's token slot and fails to
+	// authenticate the personal stream for a non-default `--profile`
+	// (symptom: "bus child reported startup failure on ready pipe", no
+	// bus.log). --profile accepts a corpId; the root pre-parses it into the
+	// runtime profile before the _bus handler resolves the identity.
+	if cid := strings.TrimSpace(identity.CorpID); cid != "" {
+		args = append(args, "--profile", cid)
 	}
 	if strings.TrimSpace(ticketMode) != "" {
 		args = append(args, "--stream-ticket-mode", ticketMode)

--- a/internal/app/event_stdin_gate_test.go
+++ b/internal/app/event_stdin_gate_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/event/personal"
+)
+
+// A bounded run never arms the stdin-EOF watcher, regardless of stdin
+// shape: --max-events / --duration are the lifecycle control.
+func TestShouldWatchStdinEOF_BoundedIsNeverArmed(t *testing.T) {
+	if shouldWatchStdinEOF(1, 0) {
+		t.Error("--max-events set should not arm stdin watcher")
+	}
+	if shouldWatchStdinEOF(0, 5*time.Second) {
+		t.Error("--duration set should not arm stdin watcher")
+	}
+	if shouldWatchStdinEOF(3, 2*time.Second) {
+		t.Error("both bounds set should not arm stdin watcher")
+	}
+}
+
+// Regression: the detached _bus child must receive --profile so it resolves
+// credentials for the same organization as the parent. Missing it made a
+// non-default `--profile` consume fail with "bus child reported startup
+// failure on ready pipe" (no bus.log).
+func TestPersonalBusSpawnArgs_ForwardsProfile(t *testing.T) {
+	args := personalBusSpawnArgs(personal.Identity{
+		CorpID:   "dinga626d60c1128d449",
+		SourceID: "open",
+	}, "", "")
+	found := false
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--profile" && args[i+1] == "dinga626d60c1128d449" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("spawn args must forward --profile <corpId>; got %v", args)
+	}
+
+	// No CorpID → no --profile appended (avoid an empty flag value).
+	bare := personalBusSpawnArgs(personal.Identity{SourceID: "open"}, "", "")
+	for _, a := range bare {
+		if a == "--profile" {
+			t.Errorf("must not append --profile when CorpID is empty; got %v", bare)
+		}
+	}
+}

--- a/internal/cli/canonical.go
+++ b/internal/cli/canonical.go
@@ -75,7 +75,10 @@ func NewSchemaCommand(_ CatalogLoader, helperTools HelperToolFetcher) *cobra.Com
 		Short: "查看有限的本地 Schema（静态端点模式）",
 		Long: `查看有限的本地 Schema 元数据。
 
-服务发现和动态 schema 已下线。静态端点模式下，仅支持 helper-only 子树的 schema 查询；普通产品命令和 flag 以当前二进制的 --help 为准。`,
+服务发现和动态 schema 已下线。静态端点模式下，schema 覆盖两类命令：
+  1. helper-only 子树（如 dev）：CONTENT 从其绑定的 MCP 服务实时取，source 为 mcp:<server>；
+  2. 登记的本地命令（如 event）：从二进制注册的 cobra flag 合成，source 为 cobra。
+其余普通产品命令和 flag 仍以当前二进制的 --help 为准。`,
 		Args:              cobra.MaximumNArgs(1),
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -88,9 +91,22 @@ func NewSchemaCommand(_ CatalogLoader, helperTools HelperToolFetcher) *cobra.Com
 				args = []string{cliPath}
 			}
 
-			// Helper-only subtrees support.
+			// Helper-only subtrees: schema CONTENT fetched live from the MCP server.
 			if len(args) > 0 && helperTools != nil {
 				payload, ok, err := renderHelperSchema(cmd.Context(), cmd.Root(), args[0], helperTools)
+				if err != nil {
+					return err
+				}
+				if ok {
+					data, _ := json.MarshalIndent(payload, "", "  ")
+					fmt.Fprintln(cmd.OutOrStdout(), string(data))
+					return nil
+				}
+			}
+
+			// Registered local subtrees (event, …): schema synthesized from cobra flags.
+			if len(args) > 0 {
+				payload, ok, err := renderCobraSchema(cmd.Root(), args[0])
 				if err != nil {
 					return err
 				}

--- a/internal/cli/cobra_schema.go
+++ b/internal/cli/cobra_schema.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// cobraSchemaRoots are top-level command names whose subtrees answer `dws schema`
+// by SYNTHESIZING the machine-readable input schema from their cobra flags. This
+// is the local-command counterpart to helperSchemaRoots: helper subtrees (dev)
+// fetch CONTENT live from an MCP server, whereas these commands have no MCP
+// backing so the schema is built from the flags the binary actually registered.
+//
+// The output shape is the same flat object helper leaves emit — {description,
+// path, source, parameters{<flag>:{type,description,required,default?}}} — so an
+// agent gets one consistent schema format no matter the source; `source` is
+// "cobra" to mark it synthesized from flags (vs "mcp:<server>"). event is the
+// first consumer; register more command trees here as they adopt the contract.
+var cobraSchemaRoots = map[string]bool{"event": true}
+
+// renderCobraSchema builds the `dws schema` payload for command subtrees listed
+// in cobraSchemaRoots. Mirrors renderHelperSchema's routing: returns
+// (payload, true) when the path targets a registered subtree so the caller
+// skips the static-mode fallback; (nil, false) otherwise.
+//
+// A runnable leaf renders the flat parameter object synthesized from its flags
+// (plus positional arguments parsed from its Use line). A group/root renders the
+// same browse listing helper groups use.
+func renderCobraSchema(root *cobra.Command, rawPath string) (map[string]any, bool, error) {
+	if root == nil {
+		return nil, false, nil
+	}
+	tokens := splitSchemaPathTokens(rawPath)
+	if len(tokens) == 0 || !cobraSchemaRoots[tokens[0]] {
+		return nil, false, nil
+	}
+
+	target, rest, err := root.Find(tokens)
+	if err != nil || target == nil {
+		target = root
+		rest = tokens[1:]
+	}
+	// Any non-flag leftover token means an unknown subcommand — surface it with
+	// the closest group's children, same as renderHelperSchema.
+	if unknown := firstNonFlag(rest); unknown != "" {
+		return map[string]any{
+			"path":      rawPath,
+			"error":     "unknown subcommand \"" + unknown + "\" under \"" + helperCommandPath(target) + "\"",
+			"available": helperSubcommands(target),
+		}, true, nil
+	}
+
+	if target.Runnable() && !target.HasAvailableSubCommands() {
+		return cobraLeafSchema(target), true, nil
+	}
+	return map[string]any{
+		"path":     helperCommandPath(target),
+		"commands": helperSubcommands(target),
+	}, true, nil
+}
+
+// cobraLeafSchema renders one runnable command as the flat schema object,
+// synthesizing parameters from its flags and (when present) positional
+// arguments from its Use line.
+func cobraLeafSchema(cmd *cobra.Command) map[string]any {
+	out := map[string]any{
+		"description": strings.TrimSpace(cmd.Short),
+		"path":        helperCommandPath(cmd),
+		"source":      "cobra",
+		"parameters":  cobraFlatParameters(cmd),
+	}
+	if args := cobraPositionalArgs(cmd); len(args) > 0 {
+		out["arguments"] = args
+	}
+	return out
+}
+
+// cobraFlatParameters projects a command's LOCAL flags into the flat
+// per-parameter object. Local (non-inherited) flags are the command-specific
+// inputs; global persistent flags inherited from the root (--profile, --verbose,
+// --jq, …) are intentionally excluded so the schema describes THIS command, not
+// the whole CLI. Hidden internal flags are skipped. Each entry is
+// {type, description, required, default?} with type mapped to a JSON-type
+// string, required read from cobra's required-flag annotation, and default only
+// when the flag has a meaningful (non-zero) default.
+func cobraFlatParameters(cmd *cobra.Command) map[string]any {
+	params := map[string]any{}
+	cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		entry := map[string]any{
+			"type":        pflagJSONType(f),
+			"description": strings.TrimSpace(f.Usage),
+			"required":    flagIsRequired(f),
+		}
+		if def, ok := meaningfulDefault(f); ok {
+			entry["default"] = def
+		}
+		params[f.Name] = entry
+	})
+	return params
+}
+
+// cobraPositionalArgs parses a command's Use line into structured positional
+// arguments. Cobra has no typed metadata for positionals, so the Use string
+// ("consume [event_key]", "stop [subscribe_id]") is the source of truth:
+// tokens after the command name are positional slots. <name> is required,
+// [name] is optional, a trailing "..." marks it variadic. Returns nil when the
+// command declares no positionals (e.g. flag-only commands), so the leaf object
+// simply omits the "arguments" field.
+func cobraPositionalArgs(cmd *cobra.Command) []map[string]any {
+	fields := strings.Fields(cmd.Use)
+	if len(fields) <= 1 {
+		return nil
+	}
+	out := []map[string]any{}
+	for _, tok := range fields[1:] {
+		variadic := strings.Contains(tok, "...")
+		required := strings.HasPrefix(tok, "<")
+		name := strings.Trim(tok, "[]<>.")
+		if name == "" {
+			continue
+		}
+		arg := map[string]any{
+			"name":     name,
+			"required": required,
+		}
+		if variadic {
+			arg["variadic"] = true
+		}
+		out = append(out, arg)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// pflagJSONType maps a pflag value type to a JSON-type string. Duration is
+// expressed as "string" because it is entered as a CLI string ("10m"); slice
+// and array types collapse to "array"; the numeric families collapse to
+// "integer"/"number". Unknown types default to "string" so the contract is
+// always populated.
+func pflagJSONType(f *pflag.Flag) string {
+	switch f.Value.Type() {
+	case "bool":
+		return "boolean"
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64", "count":
+		return "integer"
+	case "float32", "float64":
+		return "number"
+	case "stringSlice", "stringArray", "intSlice", "int32Slice", "int64Slice",
+		"uintSlice", "float32Slice", "float64Slice", "boolSlice", "durationSlice":
+		return "array"
+	default:
+		// string, duration, ip, and any custom Value type read as a string.
+		return "string"
+	}
+}
+
+// flagIsRequired reports whether cobra.MarkFlagRequired was applied to the flag
+// (it records the requirement in the flag's annotations under
+// cobra.BashCompOneRequiredFlag). Event's conditionally-required inputs
+// (--user / --group depend on the event key) are enforced at runtime, not via
+// this annotation, so they read as required:false here — the dependency is
+// documented in the command help, not the flag metadata.
+func flagIsRequired(f *pflag.Flag) bool {
+	if f.Annotations == nil {
+		return false
+	}
+	vals, ok := f.Annotations[cobra.BashCompOneRequiredFlag]
+	return ok && len(vals) == 1 && vals[0] == "true"
+}
+
+// meaningfulDefault returns a flag's default only when it is a real value, not
+// the zero/unset sentinel ("", "0", "0s", "false", "[]"). A zero default means
+// "no default — the value comes from you", so omitting it matches how the helper
+// renderer omits absent MCP defaults and keeps the schema free of noise.
+func meaningfulDefault(f *pflag.Flag) (string, bool) {
+	def := strings.TrimSpace(f.DefValue)
+	switch def {
+	case "", "0", "0s", "false", "[]", "{}":
+		return "", false
+	default:
+		return def, true
+	}
+}

--- a/internal/cli/cobra_schema_test.go
+++ b/internal/cli/cobra_schema_test.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// buildEventTestTree mirrors the shape of the real `dws event` subtree closely
+// enough to exercise the cobra-flag schema renderer: a group with a runnable
+// leaf that carries a positional arg, typed flags (string/int/duration/bool),
+// a required flag, a hidden internal flag, and a defaulted flag.
+func buildEventTestTree() *cobra.Command {
+	root := &cobra.Command{Use: "dws"}
+	// A global persistent flag inherited by every command — must NOT appear in a
+	// command's synthesized parameters (it describes the CLI, not the command).
+	root.PersistentFlags().String("profile", "", "组织 profile")
+
+	consume := &cobra.Command{
+		Use:   "consume [event_key]",
+		Short: "订阅事件流并输出到 stdout",
+		Args:  cobra.MaximumNArgs(1),
+		Run:   func(*cobra.Command, []string) {},
+	}
+	f := consume.Flags()
+	f.StringP("format", "f", "ndjson", "输出格式")
+	f.String("user", "", "单聊对端 userId")
+	f.String("group", "", "群 openConversationId")
+	f.Int("max-events", 0, "收到 N 条后退出")
+	f.Duration("duration", 0, "运行时长上限")
+	f.Bool("ephemeral", false, "退出时强制退订")
+	f.String("subscribe-id", "", "复用已有订阅")
+	f.String("client-id", "", "内部：覆盖凭证解析")
+	_ = f.MarkHidden("client-id")
+	// A flag marked required via cobra — must read required:true.
+	f.String("token", "", "必填令牌")
+	_ = consume.MarkFlagRequired("token")
+
+	stop := &cobra.Command{
+		Use:   "stop [subscribe_id]",
+		Short: "取消订阅",
+		Run:   func(*cobra.Command, []string) {},
+	}
+	stop.Flags().Bool("all", false, "取消全部")
+
+	event := &cobra.Command{Use: "event", Short: "个人消息事件"}
+	// A hidden internal subcommand — must not appear in the browse listing.
+	bus := &cobra.Command{Use: "_bus", Short: "内部 bus", Hidden: true, Run: func(*cobra.Command, []string) {}}
+	event.AddCommand(consume, stop, bus)
+
+	root.AddCommand(event)
+	return root
+}
+
+func TestRenderCobraSchema_LeafFlatShape(t *testing.T) {
+	root := buildEventTestTree()
+
+	payload, ok, err := renderCobraSchema(root, "event consume")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected cobra renderer to claim the event path")
+	}
+
+	if payload["description"] != "订阅事件流并输出到 stdout" {
+		t.Fatalf("description = %v", payload["description"])
+	}
+	if payload["path"] != "event consume" {
+		t.Fatalf("path = %v", payload["path"])
+	}
+	if payload["source"] != "cobra" {
+		t.Fatalf("source = %v, want cobra", payload["source"])
+	}
+
+	params, _ := payload["parameters"].(map[string]any)
+	if params == nil {
+		t.Fatalf("no parameters: %#v", payload)
+	}
+
+	// Inherited global flag must be excluded.
+	if _, present := params["profile"]; present {
+		t.Fatal("inherited --profile must not appear in a command's parameters")
+	}
+	// Hidden internal flag must be excluded.
+	if _, present := params["client-id"]; present {
+		t.Fatal("hidden --client-id must not appear")
+	}
+
+	// Type mapping.
+	if got := paramField(t, params, "user", "type"); got != "string" {
+		t.Errorf("user type = %v, want string", got)
+	}
+	if got := paramField(t, params, "max-events", "type"); got != "integer" {
+		t.Errorf("max-events type = %v, want integer", got)
+	}
+	if got := paramField(t, params, "duration", "type"); got != "string" {
+		t.Errorf("duration type = %v, want string (CLI string like 10m)", got)
+	}
+	if got := paramField(t, params, "ephemeral", "type"); got != "boolean" {
+		t.Errorf("ephemeral type = %v, want boolean", got)
+	}
+
+	// Meaningful default is surfaced; zero defaults are omitted.
+	if got := paramField(t, params, "format", "default"); got != "ndjson" {
+		t.Errorf("format default = %v, want ndjson", got)
+	}
+	if _, hasDefault := params["max-events"].(map[string]any)["default"]; hasDefault {
+		t.Error("max-events has a zero default (0) — must be omitted")
+	}
+	if _, hasDefault := params["ephemeral"].(map[string]any)["default"]; hasDefault {
+		t.Error("ephemeral has a zero default (false) — must be omitted")
+	}
+	if _, hasDefault := params["duration"].(map[string]any)["default"]; hasDefault {
+		t.Error("duration has a zero default (0s) — must be omitted")
+	}
+
+	// Required annotation is honored; unmarked flags read required:false.
+	if got := paramField(t, params, "token", "required"); got != true {
+		t.Errorf("token required = %v, want true", got)
+	}
+	if got := paramField(t, params, "user", "required"); got != false {
+		t.Errorf("user required = %v, want false", got)
+	}
+}
+
+func TestRenderCobraSchema_PositionalArguments(t *testing.T) {
+	root := buildEventTestTree()
+
+	payload, _, err := renderCobraSchema(root, "event.consume")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	args, _ := payload["arguments"].([]map[string]any)
+	if len(args) != 1 {
+		t.Fatalf("arguments = %#v, want 1 positional", payload["arguments"])
+	}
+	if args[0]["name"] != "event_key" {
+		t.Errorf("arg name = %v, want event_key", args[0]["name"])
+	}
+	// [event_key] is optional syntax → required:false.
+	if args[0]["required"] != false {
+		t.Errorf("arg required = %v, want false", args[0]["required"])
+	}
+}
+
+func TestRenderCobraSchema_DotAndSpacePathEquivalent(t *testing.T) {
+	root := buildEventTestTree()
+	dotted, _, _ := renderCobraSchema(root, "event.consume")
+	spaced, _, _ := renderCobraSchema(root, "event consume")
+	if dotted["path"] != spaced["path"] || dotted["path"] != "event consume" {
+		t.Fatalf("dot/space forms diverged: %v vs %v", dotted["path"], spaced["path"])
+	}
+}
+
+func TestRenderCobraSchema_GroupBrowse(t *testing.T) {
+	root := buildEventTestTree()
+
+	payload, ok, err := renderCobraSchema(root, "event")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claim")
+	}
+	cmds, _ := payload["commands"].([]map[string]any)
+	// consume + stop; hidden _bus excluded.
+	if len(cmds) != 2 {
+		t.Fatalf("commands = %#v, want 2 (hidden _bus excluded)", cmds)
+	}
+	for _, c := range cmds {
+		if c["cli_path"] == "event _bus" {
+			t.Fatal("hidden _bus must not be listed")
+		}
+	}
+}
+
+func TestRenderCobraSchema_UnknownSubcommand(t *testing.T) {
+	root := buildEventTestTree()
+	payload, ok, err := renderCobraSchema(root, "event nope")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected claim")
+	}
+	if payload["error"] == nil {
+		t.Fatalf("expected unknown-subcommand error, got %#v", payload)
+	}
+	if avail, _ := payload["available"].([]map[string]any); len(avail) == 0 {
+		t.Fatal("expected available subcommands listed")
+	}
+}
+
+func TestRenderCobraSchema_NonRegisteredPathDeclined(t *testing.T) {
+	root := buildEventTestTree()
+	if _, ok, _ := renderCobraSchema(root, "dev app create"); ok {
+		t.Fatal("non-registered path must not be claimed by the cobra renderer")
+	}
+	if _, ok, _ := renderCobraSchema(root, "ding.message.send"); ok {
+		t.Fatal("non-registered path must not be claimed")
+	}
+}
+
+// paramField fetches params[<name>][<field>], failing the test if the param is
+// absent.
+func paramField(t *testing.T, params map[string]any, name, field string) any {
+	t.Helper()
+	p, _ := params[name].(map[string]any)
+	if p == nil {
+		t.Fatalf("missing param %q in %#v", name, params)
+	}
+	return p[field]
+}

--- a/internal/event/busctl/spawn.go
+++ b/internal/event/busctl/spawn.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -136,11 +137,15 @@ func Spawn(cfg SpawnConfig) (pid int, err error) {
 	return pid, nil
 }
 
-// waitReady reads exactly one byte from pr ('R' or 'E') within ReadyTimeout.
-// pr is closed by the caller on return.
+// waitReady reads the child's ready signal within ReadyTimeout. The first
+// byte is 'R' (ready) or 'E' (error); on 'E' the child may write its real
+// error text after the byte and close the pipe, which we surface so the
+// caller sees WHY the bus failed to start (instead of an opaque
+// ErrSpawnFailed). pr is closed by the caller on return.
 func waitReady(pr *os.File) error {
 	type result struct {
 		b   byte
+		msg string
 		err error
 	}
 	done := make(chan result, 1)
@@ -153,6 +158,13 @@ func waitReady(pr *os.File) error {
 		}
 		if n != 1 {
 			done <- result{err: io.ErrUnexpectedEOF}
+			return
+		}
+		if buf[0] == 'E' {
+			// Failure: read the trailing error text (bounded), which the
+			// child writes right after 'E' before closing.
+			rest, _ := io.ReadAll(io.LimitReader(pr, 4096))
+			done <- result{b: 'E', msg: strings.TrimSpace(string(rest))}
 			return
 		}
 		done <- result{b: buf[0]}
@@ -169,6 +181,9 @@ func waitReady(pr *os.File) error {
 		case 'R':
 			return nil
 		case 'E':
+			if res.msg != "" {
+				return fmt.Errorf("%w: %s", ErrSpawnFailed, res.msg)
+			}
 			return ErrSpawnFailed
 		default:
 			return fmt.Errorf("busctl: unexpected ready byte %q", res.b)

--- a/internal/event/busctl/spawn_test.go
+++ b/internal/event/busctl/spawn_test.go
@@ -15,9 +15,11 @@ package busctl
 
 import (
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -244,5 +246,47 @@ func TestReadyFDFromEnv_LowFDRejected(t *testing.T) {
 	t.Setenv(ReadyFDEnv, "1")
 	if f := ReadyFDFromEnv(); f != nil {
 		t.Errorf("ReadyFDFromEnv should reject stdio fds, got %v", f)
+	}
+}
+
+// waitReady must surface the child's real startup error (written after the
+// 'E' byte) so consume shows WHY the bus failed, not an opaque message.
+func TestWaitReady_FailureSurfacesChildError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses Unix pipe")
+	}
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pr.Close()
+	const reason = "newPersonalStreamSource: token expired for corp dinga626"
+	go func() {
+		_, _ = pw.Write([]byte{'E'})
+		_, _ = io.WriteString(pw, reason)
+		_ = pw.Close()
+	}()
+	err = waitReady(pr)
+	if !errors.Is(err, ErrSpawnFailed) {
+		t.Fatalf("want ErrSpawnFailed, got %v", err)
+	}
+	if !strings.Contains(err.Error(), reason) {
+		t.Errorf("error must surface the child's real reason; got: %v", err)
+	}
+}
+
+// A bare 'E' (no trailing text) still reports ErrSpawnFailed.
+func TestWaitReady_BareFailureByte(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses Unix pipe")
+	}
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pr.Close()
+	go func() { _, _ = pw.Write([]byte{'E'}); _ = pw.Close() }()
+	if err := waitReady(pr); !errors.Is(err, ErrSpawnFailed) {
+		t.Fatalf("want ErrSpawnFailed, got %v", err)
 	}
 }

--- a/internal/event/consume/run.go
+++ b/internal/event/consume/run.go
@@ -55,6 +55,11 @@ type Config struct {
 	// MaxEvents: stop after receiving this many events. 0 = no limit.
 	MaxEvents int
 
+	// EventKey is the single event key being consumed. Used only for the
+	// AI-subprocess contract stderr lines (`[event] ready event_key=...`).
+	// Empty → the key is omitted from the marker.
+	EventKey string
+
 	// Duration: wall-clock budget for the consume run. After this elapses,
 	// Run returns nil (clean exit, exit code 0). Zero = no limit.
 	//
@@ -90,6 +95,18 @@ type Config struct {
 	OutputDir string
 	// Routes are pre-parsed --route specs. Empty = no routing.
 	Routes []Route
+
+	// Stdin, when non-nil, is watched for EOF: closing stdin triggers a
+	// graceful shutdown (reason: signal). This wires the AI-subprocess
+	// contract — a parent closes stdin to stop the consumer. The cobra
+	// layer passes os.Stdin; tests inject a controllable reader. nil →
+	// stdin is not watched (backward-compatible default for callers that
+	// do not opt in).
+	//
+	// Note: `< /dev/null` EOFs immediately and exits at once. To stay
+	// resident feed a never-EOF stdin (`< <(tail -f /dev/null)`) or run
+	// bounded (--max-events / --duration).
+	Stdin io.Reader
 
 	// Stdout sink; nil → os.Stdout. Injected for tests.
 	Stdout io.Writer
@@ -132,14 +149,29 @@ func Run(ctx context.Context, cfg Config) error {
 		return nil
 	}
 
+	// Distinguish the exit cause for the contract's `exited` line:
+	//   duration deadline    → timeout
+	//   parentCtx cancelled  → signal (SIGTERM/SIGINT)
+	//   runCtx-only cancelled → signal (stdin EOF)
+	parentCtx := ctx
+
 	// --duration: layer a deadline on top of caller-provided ctx. Run
 	// returns nil on deadline (clean exit) rather than surfacing the
 	// context.DeadlineExceeded as an error to the user.
+	var timeoutCtx context.Context
 	if cfg.Duration > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, cfg.Duration)
+		timeoutCtx, cancel = context.WithTimeout(ctx, cfg.Duration)
 		defer cancel()
+		ctx = timeoutCtx
 	}
+
+	// runCtx lets the stdin watcher and the read loop share one cancel
+	// without disturbing the timeout/parent contexts (so we can still tell
+	// stdin-EOF from a real signal from a duration deadline).
+	runCtx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+	ctx = runCtx
 
 	pipeline, err := BuildPipeline(cfg.Format, cfg.OutputDir, cfg.Routes, cfg.Stdout)
 	if err != nil {
@@ -184,19 +216,57 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("consume: unexpected first frame type %q", ack.Type)
 	}
 	if !cfg.Quiet {
-		fmt.Fprintf(cfg.Stderr,
-			"connected bus pid=%d source=%s state=%s idle_timeout=%ds\n",
-			ack.BusPID, ack.StateSource, ack.SourceState, ack.IdleTimeoutSecs)
+		// Contract: a fixed ready line on stderr BEFORE any stdout event.
+		// Parents block on stderr until this appears, then read stdout.
+		if cfg.EventKey != "" {
+			fmt.Fprintf(cfg.Stderr, "[event] ready event_key=%s bus_pid=%d\n", cfg.EventKey, ack.BusPID)
+		} else {
+			fmt.Fprintf(cfg.Stderr, "[event] ready bus_pid=%d\n", ack.BusPID)
+		}
+		// Secondary diagnostic line (source/state/idle); not part of the
+		// ready contract.
+		fmt.Fprintf(cfg.Stderr, "[event] bus source=%s state=%s idle_timeout=%ds\n",
+			ack.StateSource, ack.SourceState, ack.IdleTimeoutSecs)
 	}
 
+	// Watch stdin for EOF → graceful shutdown (AI-subprocess contract).
+	// The cobra layer only sets Stdin when the watcher should arm (a
+	// pipe-style, unbounded run); tests inject it directly.
+	if cfg.Stdin != nil {
+		go watchStdinEOF(runCtx, cfg.Stdin, cfg.Stderr, cancelRun)
+	}
+
+	// Exit-reason contract: on a graceful exit emit a final stderr line
+	//   [event] exited — received N event(s) in Xs (reason: <r>)
+	// Error returns leave reason empty → no `exited` line (an `Error:` line
+	// is printed by the cobra layer instead).
 	received := 0
+	start := time.Now()
+	reason := ""
+	defer func() {
+		if !cfg.Quiet && reason != "" {
+			fmt.Fprintf(cfg.Stderr, "[event] exited — received %d event(s) in %s (reason: %s)\n",
+				received, time.Since(start).Round(time.Millisecond), reason)
+		}
+	}()
+
+	// classifyCancel maps a context-cancelled exit to a contract reason.
+	classifyCancel := func() string {
+		if timeoutCtx != nil && errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) && parentCtx.Err() == nil {
+			return "timeout"
+		}
+		return "signal"
+	}
+
 	for {
 		raw, err := r.Read()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return nil // peer closed cleanly
+				reason = "bus_shutdown" // peer closed cleanly
+				return nil
 			}
 			if isCtxCancelled(ctx) {
+				reason = classifyCancel()
 				return nil
 			}
 			return fmt.Errorf("consume: read frame: %w", err)
@@ -219,6 +289,7 @@ func Run(ctx context.Context, cfg Config) error {
 						Type:   transport.FrameTypeBye,
 						Reason: "client_done",
 					})
+					reason = "signal"
 					return nil
 				}
 				return fmt.Errorf("consume: deliver event: %w", err)
@@ -229,14 +300,16 @@ func Run(ctx context.Context, cfg Config) error {
 					Type:   transport.FrameTypeBye,
 					Reason: "client_done",
 				})
+				reason = "limit"
 				return nil
 			}
 		case transport.FrameTypeBye:
 			var bye transport.Bye
 			_ = json.Unmarshal(raw, &bye)
 			if !cfg.Quiet {
-				fmt.Fprintf(cfg.Stderr, "bus closing: %s\n", bye.Reason)
+				fmt.Fprintf(cfg.Stderr, "[event] bus closing: %s\n", bye.Reason)
 			}
+			reason = "bus_shutdown"
 			return nil
 		case transport.FrameTypeSourceState:
 			if !cfg.Quiet {
@@ -267,5 +340,37 @@ func isCtxCancelled(ctx context.Context) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// watchStdinEOF reads and discards stdin until EOF (or any read error),
+// then prints a self-explaining diagnostic and calls onEOF to trigger a
+// graceful shutdown. This implements the AI-subprocess contract: a parent
+// closes the child's stdin to stop it. It returns early if ctx is
+// cancelled first (the run ended for another reason), so it does not fire
+// a spurious shutdown. errOut is io.Discard under --quiet.
+func watchStdinEOF(ctx context.Context, r io.Reader, errOut io.Writer, onEOF func()) {
+	buf := make([]byte, 512)
+	for {
+		if _, err := r.Read(buf); err != nil {
+			select {
+			case <-ctx.Done():
+				// Run already ending; do not attribute this to stdin.
+			default:
+				fmt.Fprintln(errOut, "[event] stdin closed — shutting down. "+
+					"consume treats stdin EOF as an exit signal (wired for AI subprocess callers). "+
+					"To keep running: pass --max-events/--duration for a bounded run, "+
+					"keep stdin open (`< <(tail -f /dev/null)` in a script), "+
+					"or stop via SIGTERM instead of closing stdin.")
+				onEOF()
+			}
+			return
+		}
+		// Discard any data and keep reading until EOF.
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 	}
 }

--- a/internal/event/consume/run_test.go
+++ b/internal/event/consume/run_test.go
@@ -163,9 +163,9 @@ func TestRun_StdoutNDJSON(t *testing.T) {
 		}
 	}
 
-	// Stderr should have the connected-to-bus banner.
-	if !strings.Contains(stderr.String(), "connected bus pid=") {
-		t.Errorf("stderr missing connected banner:\n%s", stderr.String())
+	// Stderr should carry the standardized ready marker.
+	if !strings.Contains(stderr.String(), "[event] ready ") {
+		t.Errorf("stderr missing ready marker:\n%s", stderr.String())
 	}
 }
 
@@ -307,5 +307,158 @@ func TestRun_MultipleConsumersOneBus(t *testing.T) {
 		if len(lines) != 2 {
 			t.Errorf("consumer %d: got %d lines, want 2:\n%s", i, len(lines), buf.String())
 		}
+	}
+}
+
+// --- AI subprocess contract tests (event-subprocess-contract.md) ---
+
+// T1a/T1b: the ready marker carries event_key and precedes the first
+// stdout event.
+func TestRun_ReadyMarkerContract(t *testing.T) {
+	skipOnWindows(t)
+	dir, sock, cancel, runDone, trigger := bringUpBus(t, []dwsevent.RawEvent{
+		{EventID: "1", EventType: "im.message.receive_v1", Data: `{}`},
+	})
+	defer func() { cancel(); <-runDone }()
+	go func() { time.Sleep(150 * time.Millisecond); close(trigger) }()
+
+	var stdout, stderr bytes.Buffer
+	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cc()
+	if err := Run(ctx, Config{
+		WorkDir: dir, IPCEndpoint: sock, ClientID: "ding_test",
+		Stdout: &stdout, Stderr: &stderr,
+		EventKey: "im.message.receive_v1", MaxEvents: 1,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// T1a: ready line with event_key.
+	if !strings.Contains(stderr.String(), "[event] ready event_key=im.message.receive_v1") {
+		t.Errorf("missing ready marker with event_key:\n%s", stderr.String())
+	}
+	// T1b: ready is on stderr, the event is on stdout — the ready line is
+	// emitted before Deliver writes the first stdout line. Assert stdout
+	// got exactly the event and stderr got ready before exited.
+	rIdx := strings.Index(stderr.String(), "[event] ready")
+	xIdx := strings.Index(stderr.String(), "[event] exited")
+	if rIdx < 0 || xIdx < 0 || rIdx > xIdx {
+		t.Errorf("ready must precede exited:\n%s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "im.message.receive_v1") {
+		t.Errorf("stdout missing the event:\n%s", stdout.String())
+	}
+}
+
+// T3a: --max-events exit → reason=limit.
+func TestRun_ExitReasonLimit(t *testing.T) {
+	skipOnWindows(t)
+	dir, sock, cancel, runDone, trigger := bringUpBus(t, []dwsevent.RawEvent{
+		{EventID: "1", EventType: "im.message.receive_v1", Data: `{}`},
+	})
+	defer func() { cancel(); <-runDone }()
+	go func() { time.Sleep(150 * time.Millisecond); close(trigger) }()
+
+	var stdout, stderr bytes.Buffer
+	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cc()
+	if err := Run(ctx, Config{
+		WorkDir: dir, IPCEndpoint: sock, ClientID: "ding_test",
+		Stdout: &stdout, Stderr: &stderr, MaxEvents: 1,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "reason: limit") {
+		t.Errorf("expected reason: limit:\n%s", stderr.String())
+	}
+}
+
+// T3b: --duration deadline with no events → reason=timeout, exit clean.
+func TestRun_ExitReasonTimeout(t *testing.T) {
+	skipOnWindows(t)
+	// Bring up bus but never trigger emission → consume blocks until the
+	// duration deadline fires.
+	dir, sock, cancel, runDone, _ := bringUpBus(t, nil)
+	defer func() { cancel(); <-runDone }()
+
+	var stdout, stderr bytes.Buffer
+	ctx, cc := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cc()
+	if err := Run(ctx, Config{
+		WorkDir: dir, IPCEndpoint: sock, ClientID: "ding_test",
+		Stdout: &stdout, Stderr: &stderr, Duration: 300 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("Run should exit clean on duration: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "reason: timeout") {
+		t.Errorf("expected reason: timeout:\n%s", stderr.String())
+	}
+}
+
+// T3c: parent ctx cancel (signal) → reason=signal.
+func TestRun_ExitReasonSignal(t *testing.T) {
+	skipOnWindows(t)
+	dir, sock, cancel, runDone, _ := bringUpBus(t, nil)
+	defer func() { cancel(); <-runDone }()
+
+	var stdout, stderr bytes.Buffer
+	ctx, cc := context.WithCancel(context.Background())
+	go func() { time.Sleep(250 * time.Millisecond); cc() }()
+	if err := Run(ctx, Config{
+		WorkDir: dir, IPCEndpoint: sock, ClientID: "ding_test",
+		Stdout: &stdout, Stderr: &stderr,
+	}); err != nil {
+		t.Fatalf("Run should exit clean on signal: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "reason: signal") {
+		t.Errorf("expected reason: signal:\n%s", stderr.String())
+	}
+}
+
+// T2c: closing stdin triggers a graceful shutdown (reason=signal), with no
+// --max-events / --duration set.
+func TestRun_StdinEOFShutsDown(t *testing.T) {
+	skipOnWindows(t)
+	dir, sock, cancel, runDone, _ := bringUpBus(t, nil)
+	defer func() { cancel(); <-runDone }()
+
+	pr, pw := io.Pipe()
+	go func() { time.Sleep(250 * time.Millisecond); _ = pw.Close() }() // EOF
+
+	var stdout, stderr bytes.Buffer
+	ctx, cc := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cc()
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, Config{
+			WorkDir: dir, IPCEndpoint: sock, ClientID: "ding_test",
+			Stdout: &stdout, Stderr: &stderr, Stdin: pr,
+		})
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run should exit clean on stdin EOF: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not exit after stdin EOF")
+	}
+	if !strings.Contains(stderr.String(), "reason: signal") {
+		t.Errorf("expected reason: signal on stdin EOF:\n%s", stderr.String())
+	}
+}
+
+// T3d: a startup failure returns non-nil and emits NO `exited` line (the
+// cobra layer prints an Error: line instead).
+func TestRun_FailureHasNoExitedLine(t *testing.T) {
+	skipOnWindows(t)
+	var stderr bytes.Buffer
+	// Missing WorkDir/IPCEndpoint/ClientID → immediate config error, before
+	// the exit-reason machinery is armed.
+	err := Run(context.Background(), Config{Stderr: &stderr})
+	if err == nil {
+		t.Fatal("expected error for missing required config")
+	}
+	if strings.Contains(stderr.String(), "[event] exited") {
+		t.Errorf("failure must not print an exited line:\n%s", stderr.String())
 	}
 }

--- a/skills/mono/SKILL.md
+++ b/skills/mono/SKILL.md
@@ -132,18 +132,22 @@ Step 3 → 加 --yes 执行命令
 dws <command-path> --help
 # 例：dws calendar event list --help
 
-# helper-only schema 查询（如 dev.*），普通产品命令不要依赖 schema 推断参数
+# 结构化 schema 查询：helper-only 子树（dev.*，source=mcp:<server>）
 dws schema "dev app create"
+# 登记的本地命令子树（event.*，source=cobra，从二进制 flag 合成）
+dws schema "event consume"     # 叶子：parameters{<flag>:{type,required,description,default?}} + arguments[位置参数]
+dws schema event               # 中间节点：列子命令
+# 其余普通产品命令不走 schema，直接看 --help。
 # 注：--jq 对 schema 输出无效（不过滤，仍返回完整对象）；schema 结构里必填标在
 # .parameters.<字段>.required，没有 .tool 键。要看必填字段自行读 .parameters 即可。
 ```
 
 **何时用哪条路径：**
 - 只需看某个命令怎么调用 → `dws <cmd> --help`
-- 构造 `--params` / `--json` 时不确定字段类型、必填、别名 → 先看 `dws <cmd> --help`，helper-only 命令再看 `dws schema`
+- 构造 `--params` / `--json` 时不确定字段类型、必填、别名 → 先看 `dws <cmd> --help`，helper-only（dev.*）和登记的本地命令（event.*）可看 `dws schema` 取机读结构
 - 参考文档和 `--help` 冲突时 → **以 `--help` 为准**，文档视为过期
 
-`dws schema` 在静态端点模式下只保留 helper-only 子树；普通产品命令和 flag 不再通过远程 schema 动态发现。写/删操作须先向用户确认再加 `--yes`。
+`dws schema` 覆盖两类命令：helper-only 子树（dev，CONTENT 从 MCP 实时取）和登记的本地命令（event，从 cobra flag 合成、source=cobra）；其余普通产品命令和 flag 以 `--help` 为准。写/删操作须先向用户确认再加 `--yes`。
 
 ## 错误处理
 1. 遇到错误，加 `--verbose` 重试一次

--- a/skills/mono/references/products/event.md
+++ b/skills/mono/references/products/event.md
@@ -1,92 +1,101 @@
 # dws event — 个人消息事件
 
-通过个人 Stream 长连接监听当前用户收到的钉钉消息事件，NDJSON 输出到 stdout，用于驱动事件触发的 Agent。实时监听、自动回复、订阅事件都必须使用 `dws event consume`，不要写脚本轮询消息历史。
+监听当前用户收到的钉钉消息事件，NDJSON 输出到 stdout。实时监听 / 自动回复 / 订阅一律用 `dws event consume`，不要轮询消息历史。
+
+## 运行方式
+
+- bus 后台进程持有对钉钉的个人 Stream 长连；consume 从 bus 读事件、按 NDJSON 打到 stdout。consume 只读，不发消息（回复用 `dws chat message send`）。
+- 没有 bus 时 consume 自动拉起；通常只跑 consume。
+- 一个组织一个 bus，互不干扰、可同时跑；同组织内多个 consume 共享一个 bus。
+- 非默认组织加全局 `--profile <corpId 或 profile 名>`；漏传会退回默认 profile 而失败。
 
 ## Core commands
 
 | Command | Purpose |
 |---|---|
-| `dws event schema <event_key>` | 查看事件参数和输出字段 schema，默认 JSON |
-| `dws event consume <event_key> [flags]` | 阻塞消费；事件写到 stdout，推荐 `-f ndjson` |
-| `dws event status --event <event_key>` | 查看个人订阅、personal bus 和本地 consume |
-| `dws event stop <subscribe_id>` | 取消个人订阅并停止对应本地消费 |
-| `dws event stop --all` | 清理当前身份下本地记录的全部个人订阅 |
+| `dws event schema <event_key>` | 查看事件参数和输出字段 schema |
+| `dws event consume <event_key> [flags]` | 阻塞消费，事件写到 stdout，用 `-f ndjson` |
+| `dws event status --event <event_key>` | 查看个人订阅、bus、本地 consume |
+| `dws event stop <subscribe_id>` | 取消订阅并停止对应本地消费 |
+| `dws event stop --all` | 清理当前身份下全部个人订阅 |
+
+注意区分两个 schema：`dws event schema <event_key>` 查事件的输出字段；`dws schema "event consume"` 查 consume 命令自身的入参（机读结构，source=cobra，含 parameters + 位置参数）。
 
 ## Event catalog
 
 | 事件码 | 场景 | 必填参数 |
 |---|---|---|
 | `user_im_message_receive_at` | 当前用户被 @ 的消息 | 无 |
-| `user_im_message_receive_o2o` | 当前用户与指定用户的单聊消息 | `--user` |
-| `user_im_message_receive_group` | 当前用户所在指定群聊/会话的消息 | `--group` |
+| `user_im_message_receive_o2o` | 与指定用户的单聊消息 | `--user` |
+| `user_im_message_receive_group` | 指定群聊 / 会话的消息 | `--group` |
 
-只承认上表 3 个事件码。默认身份就是当前用户，不要额外加身份切换 flag。
+只承认这 3 个事件码。默认身份即当前用户，不加身份切换 flag。
 
 ## Intent mapping
 
 | 用户说 | 下一步 |
 |---|---|
-| "监听有人 @ 我的消息" | `event consume`，事件码 `user_im_message_receive_at`，参数 `-f ndjson` |
-| "监听我和 userId 507971 的单聊消息" | `event consume`，事件码 `user_im_message_receive_o2o`，参数 `--user 507971 -f ndjson` |
-| "监听 XX 群消息" | 先 `dws chat search --query "XX" --format json`，确认后 consume group |
-| "监听并自动回复某人的单聊消息" | 先解析对端 userId，再启动 o2o consume；不要写轮询脚本 |
-| "查看个人消息事件 schema" | `dws event schema <event_key>` |
-| "看个人事件订阅状态" | `dws event status --event <event_key>` |
-| "停止这个个人事件订阅" | `dws event stop <subscribe_id>` |
+| 监听有人 @ 我 | consume `user_im_message_receive_at` |
+| 监听我和某用户的单聊 | 解析对端 userId，consume `user_im_message_receive_o2o --user <id>` |
+| 监听某群 | 先 `dws chat search --query "<群名>"` 拿 openConversationId，再 consume group |
+| 监听并自动回复某人单聊 | 解析对端 userId，启动 o2o consume；回复用 `dws chat message send` |
+| 查看事件 schema | `dws event schema <event_key>` |
+| 看订阅状态 | `dws event status --event <event_key>` |
+| 停止订阅 | `dws event stop <subscribe_id>` |
 
-多候选必须让用户确认。缺少必填 ID 且无法解析时先追问，不要猜测。
+多候选让用户确认。缺必填 ID 且解析不出先追问，不要猜。
 
 ## Call flow
 
-1. 从用户意图选择事件码；人名或群名先解析成必填 ID。
-2. 需要了解字段时运行 `dws event schema <event_key>`，读取 `jq_root_path` 和 `schema.properties`。
-3. 启动 `dws event consume <event_key> ... -f ndjson`，等待 stderr 出现 `connected bus pid=...` 后开始读 stdout。
-4. stdout 每行是一个事件 JSON；业务字段在 `data` JSON 字符串内，按 `jq_root_path` 解析。
-5. 需要确认监听状态时运行 `dws event status --event <event_key>`，查看 `Subscriptions` 和 `Consumers`。
-6. 任务完成后用 `dws event stop <subscribe_id>` 取消订阅；临时测试可以在 consume 上加 `--max-events` 或 `--duration`。
+1. 按意图选事件码；人名 / 群名先解析成必填 ID。
+2. 需要字段时 `dws event schema <event_key>`，读 `jq_root_path` 和 `schema.properties`。
+3. 启动 `dws event consume <event_key> ... -f ndjson`，等 stderr 出现 `[event] ready event_key=<key> ...` 再读 stdout，不要 sleep。
+4. stdout 每行一个事件 JSON；`data` 字段是 JSON 字符串，按 `jq_root_path` 再 parse。
+5. `dws event status --event <event_key>` 看 Subscriptions / Consumers。
+6. `dws event stop <subscribe_id>` 取消订阅；自测可加 `--max-events` / `--duration` 自动退出。
 
-## Common commands
+## Commands
 
 ```bash
-dws event schema user_im_message_receive_at
 dws event schema user_im_message_receive_o2o
-dws event schema user_im_message_receive_group
-```
 
-```bash
 dws event consume user_im_message_receive_at -f ndjson
-```
+dws event consume user_im_message_receive_o2o --user 507971 -f ndjson
+dws event consume user_im_message_receive_group --group <openConversationId> -f ndjson
 
-```bash
-dws event consume user_im_message_receive_o2o \
-  --user 507971 \
-  -f ndjson
-```
-
-```bash
-dws event consume user_im_message_receive_group \
-  --group <openConversationId> \
-  -f ndjson
-```
-
-```bash
-dws event status --event user_im_message_receive_at
 dws event status --event user_im_message_receive_o2o
-dws event status --event user_im_message_receive_group
 dws event stop <subscribe_id>
+dws event stop --all
 ```
 
-`status` 的 `Consumers` 表展示本地 consume 的 PID、事件码、`subscribe_id` 和 received/dropped 计数，可用于确认监听是否仍在 personal bus 上。
+## Subprocess contract
 
-裸 `dws event stop` 不会取消订阅；批量清理必须显式使用 `dws event stop --all`。Ctrl+C、`--duration`、`--max-events` 只结束本地前台消费进程，不等价于取消服务端订阅。
+- 就绪：连上后 stderr 打 `[event] ready event_key=<key> bus_pid=<pid>`，父进程等这行再读 stdout。不要 `--quiet`（会抑制它）。
+- 退出：末行 `[event] exited — received N event(s) in Xs (reason: limit|timeout|signal|bus_shutdown)`；受控退出码 0，失败非 0 且无 exited 行、有 Error 行。
+- stdin 关闭 = 停机：仅当 stdin 是管道且未设 `--max-events/--duration` 时生效；交互终端和 `< /dev/null` 不触发。用管道 stdin 又要常驻就喂 `< <(tail -f /dev/null)`。
+- 订阅清理：本次新建的订阅任意退出即自动退订；`--subscribe-id` 复用的保留；`--ephemeral` 强制退订。优雅停用 SIGTERM、关 stdin，或外部 `dws event stop <subscribe_id>`。不要 `kill -9`（跳过退订、泄漏服务端订阅）。
+- 一 consume 一 event_key；监听 N 个就起 N 个 consume，共用一个 bus。
 
 ## Output parsing
 
-- 推荐 `-f ndjson`：一行一个事件 JSON，适合 Agent 管道读取。
-- 人工取样可用 `-f json --max-events 1`。
-- `data` 是服务端业务 payload 的 JSON 字符串；读取消息内容前按 schema 的 `jq_root_path` 再解析一次。
-- 当前消息正文在 `payload.body.content`，发送人展示名在 `payload.body.sender`，会话 ID 在 `payload.body.openConversationId`。
-- `--debug-raw-events` 仅用于服务端联调，正常消费不要使用。
+- 用 `-f ndjson`，一行一个事件 JSON。抓样本用 `-f json --max-events 1`。
+- 两层解析：外层事件 JSON 的 `data` 字段是 JSON 字符串，`fromjson` 后取 `payload.body.content`（正文）/ `payload.body.sender`（发送人）/ `payload.body.openConversationId`（会话）。样例：
+
+```json
+{"type":"event","event_type":"user_im_message_receive_group",
+ "data":"{\"payload\":{\"body\":{\"sender\":\"张三\",\"content\":\"你好\",\"openConversationId\":\"cid...==\"}},\"subject\":{\"isSelfLoop\":false}}"}
+```
+
+- 自己发的消息不作为事件回来（`isSelfLoop` 过滤）：边听边回不成环；自发验证会看到 0 事件，测投递用别人 / 机器人发。
+- `--jq <表达式>` 把过滤 / 投影下推到 consume，减少输出。
+- `--debug-raw-events` 仅联调用。
+
+## Troubleshooting
+
+- consume 报 bus 启动失败：报错已带子进程真实原因。多为登录问题，`dws --profile <x> auth status` 看登录态（非默认组织带对 `--profile`），过期就 `auth login` 重登。
+- 本地日志：`~/.dws/events/<edition>/personal_stream/<hash>/bus.log`（`edition` 一般 `open`，`hash` 见 `dws event status` 的 Workdir）；极早期失败可能无日志，以 consume 报错为准。
+- 有残留 / 连不上：`dws event status` 查 stale，`dws event stop --all` 清理重试。
+- 挂住无输出：多是误加 `--foreground`（跑 bus、不打印事件），去掉。
 
 ## Full reference
 

--- a/skills/multi/dingtalk-event/SKILL.md
+++ b/skills/multi/dingtalk-event/SKILL.md
@@ -7,6 +7,13 @@ description: 钉钉个人消息事件长连接监听、订阅与消费，输出 
 
 只使用 `dws event consume` 建立个人消息事件长连接。用户要求实时监听、订阅、自动回复或驱动 Agent 时，不要写轮询脚本，不要用消息历史查询模拟事件。
 
+## 运行方式
+
+- bus 后台进程持有对钉钉的个人 Stream 长连；consume 从 bus 读事件、按 NDJSON 打到 stdout。consume 只读，不发消息（回复用 `dws chat message send`）。
+- 没有 bus 时 consume 自动拉起；通常只跑 consume。
+- 一个组织一个 bus，可同时跑；同组织内多个 consume 共享一个 bus。
+- 非默认组织加全局 `--profile <corpId 或 profile 名>`；漏传会退回默认 profile 而失败。
+
 ## Core commands
 
 | Command | Purpose |
@@ -17,6 +24,8 @@ description: 钉钉个人消息事件长连接监听、订阅与消费，输出 
 | `dws event status --event <event_key>` | 查看个人订阅、personal bus 和本地 consume |
 | `dws event stop <subscribe_id>` | 取消个人订阅并停止对应本地消费 |
 | `dws event stop --all` | 清理当前身份下本地记录的全部个人订阅 |
+
+区分两个 schema：`dws event schema <event_key>` 查事件输出字段；`dws schema "event consume"` 查 consume 命令入参（机读结构，source=cobra，含 parameters + 位置参数）。
 
 ## Event catalog
 
@@ -37,25 +46,30 @@ description: 钉钉个人消息事件长连接监听、订阅与消费，输出 
 - 用户只给单聊对端人名时，先运行 `dws aisearch person --keyword "<name>" --dimension name --format json` 解析 userId；多候选必须让用户确认。
 - 用户只给群名时，先运行 `dws chat search --query "<group>" --format json` 解析 openConversationId；多候选必须让用户确认。
 - 正常 Agent 消费使用 `-f ndjson`。抓一条样本可用 `--max-events 1 -f json`。
+- 监听非默认组织时带 `--profile <corpId 或 profile 名>`；漏传会退回默认 profile 而失败。
+- 自己发的消息不作为事件回来（`isSelfLoop` 过滤）：边监听边 `dws chat message send` 回复不成环；测试投递用别人 / 机器人发（自发会看到 0 事件）。
 - `--debug-raw-events` 只用于联调确认服务端推送是否到达本地连接；正常任务不要使用。
+- 排查：consume 报 bus 启动失败 → 报错已带真实原因，先查 `dws --profile <x> auth status`（非默认组织带对 `--profile`）；本地日志见 `~/.dws/events/<edition>/personal_stream/<hash>/bus.log`（`hash` 见 `dws event status` 的 Workdir）；有残留用 `dws event stop --all` 清理。看着"挂住"无输出多是误加了 `--foreground`（那是跑 bus、不打印事件），去掉即可。
 
 ## Call flow
 
 1. 从用户意图选择事件码；人名或群名先解析成必填 ID。
 2. 需要了解字段时运行 `dws event schema <event_key>`，读取 `jq_root_path` 和 `schema.properties`。
-3. 启动 `dws event consume <event_key> ... -f ndjson`，等待 stderr 出现 `connected bus pid=...` 后开始读 stdout。
+3. 启动 `dws event consume <event_key> ... -f ndjson`，阻塞等 stderr 出现固定就绪行 `[event] ready event_key=<key> ...` 后再开始读 stdout（不要用 sleep 猜）。
 4. stdout 每行是一个事件 JSON；业务字段在 `data` JSON 字符串内，按 `jq_root_path` 解析。
 5. 需要确认监听状态时运行 `dws event status --event <event_key>`，查看 `Subscriptions` 和 `Consumers`。
 6. 任务完成后用 `dws event stop <subscribe_id>` 取消订阅；如果是临时测试，可以在 consume 上加 `--max-events` 或 `--duration` 自动退出。
 
 ## Subprocess contract
 
-- `event consume` 是阻塞式长连接命令。stdout 只处理事件；stderr 只处理状态、debug 和错误。
-- 不要使用 `--quiet`，否则 Agent 会看不到建联状态和排障信息。
-- 无界监听需要外部进程管理；有界自测优先用 `--max-events N` 或 `--duration 10m`。
-- 不要 `kill -9` 消费进程。Ctrl+C、duration、max-events 只结束本地前台进程；取消订阅必须使用 `dws event stop <subscribe_id>`。
-- 不要运行裸 `dws event stop`；批量清理必须显式使用 `dws event stop --all`。
-- 一个 consume 对应一个事件订阅。监听多个对象时启动多个 consume；底层本机连接可以复用，但输出按 `subscribe_id` 隔离。
+- `event consume` 阻塞式长连接。stdout 只出事件；stderr 只出状态 / debug / 错误。
+- 就绪：连上后 stderr 打 `[event] ready event_key=<key> bus_pid=<pid>`，父进程等这行再读 stdout。不要 `--quiet`（会抑制它）。
+- 退出：末行 `[event] exited — received N event(s) in Xs (reason: limit|timeout|signal|bus_shutdown)`；受控退出码 0，失败非 0 无 exited 行。
+- stdin 关闭 = 停机：仅当 stdin 是管道且未设 `--max-events/--duration` 时生效；交互终端和 `< /dev/null` 不触发。用管道 stdin 又要常驻就喂 `< <(tail -f /dev/null)`。
+- 无界监听需外部进程管理；有界自测用 `--max-events N` 或 `--duration 10m`。
+- 订阅清理：本次新建的订阅任意干净退出即自动退订；`--subscribe-id` 复用的保留，`--ephemeral` 强制退订。优雅停用 SIGTERM、关 stdin，或外部 `dws event stop <subscribe_id>`。不要 `kill -9`（跳过退订、泄漏服务端订阅）。
+- 批量清理用 `dws event stop --all`。
+- 一 consume 一事件订阅；监听多个对象起多个 consume，本机连接可复用，输出按 `subscribe_id` 隔离。
 
 ## Examples
 

--- a/skills/multi/dingtalk-event/references/event-im.md
+++ b/skills/multi/dingtalk-event/references/event-im.md
@@ -64,7 +64,7 @@ dws event consume user_im_message_receive_group \
 | `user_im_message_receive_o2o` | `--user <userId> --duration 10m -f ndjson` | 让对端用户给当前登录用户发送单聊消息 |
 | `user_im_message_receive_group` | `--group <openConversationId> --duration 10m -f ndjson` | 让任意用户在该群发送消息 |
 
-stderr 出现 `connected bus pid=...` 表示本地 consume 已连接到事件 bus。stdout 每行是一个事件 JSON。
+stderr 出现固定就绪行 `[event] ready event_key=<key> bus_pid=<pid>` 表示本地 consume 已连接到事件 bus；父进程等这行再读 stdout。stdout 每行是一个事件 JSON。
 
 ## Runtime flags
 
@@ -154,7 +154,7 @@ dws event stop --all
 
 ## Troubleshooting
 
-- 没有输出：先确认 stderr 已出现 `connected bus pid=...`。
+- 没有输出：先确认 stderr 已出现 `[event] ready event_key=...`。
 - 参数缺失：单聊必须有对端 ID，群消息必须有 openConversationId。
 - 收到非预期消息：检查 stdout 的 `subscribe_id` 是否等于当前命令创建/复用的订阅 ID。
 - 需要判断服务端是否推到当前连接：临时加 `--debug --debug-raw-events`，排查后去掉。


### PR DESCRIPTION
## What

Two related additions to the personal event stack.

### 1. AI-subprocess contract for `dws event consume`

Makes event streaming drivable by an orchestrator without guessing:

- Fixed stderr ready line `[event] ready event_key=<key> bus_pid=<pid>` — block on it, don't `sleep`.
- Final `[event] exited — received N event(s) in Xs (reason: limit|timeout|signal|bus_shutdown)` line; exit code 0 on controlled exit, non-zero (and no `exited` line) on failure.
- stdin-EOF as a graceful shutdown signal, armed only for a parent-controlled pipe stdin on an unbounded run — an interactive TTY and `< /dev/null` never trigger it.
- Ownership-based subscription cleanup: a subscription this run created is unsubscribed on any clean exit; a `--subscribe-id`-reused one is left intact (`--ephemeral` still forces cleanup), so `kill -9` is the only way to leak a server-side subscription.
- Forward `--profile` to the detached bus child so non-default orgs resolve the right credentials, and surface the child's real startup error over the ready pipe instead of an opaque message.

### 2. `dws schema` for event commands

`dws schema "event consume"` (or `event.consume`) returns a machine-readable input schema synthesized from the command's cobra flags, in the same flat shape helper subtrees emit:

```
{ "description", "path", "source": "cobra",
  "parameters": { "<flag>": { "type", "required", "description", "default?" } },
  "arguments": [ { "name", "required", "variadic?" } ] }
```

- Intermediate nodes (`dws schema event`) list their subcommands.
- `source: "cobra"` distinguishes flag-synthesized schema from MCP-fetched (`mcp:<server>`).
- Inherited global flags and hidden internal flags are excluded so the schema describes just that command; visible flags match `--help` exactly.
- Built as a reusable registry (`cobraSchemaRoots`); `event` is the first consumer and more command trees can opt in without further wiring.

## Testing

- `go build`, `go vet`, lint: clean.
- Policy: `check-command-surface --strict`, `check-generated-drift`, `check-open-source-assets`: all ok.
- Unit tests: new `cobra_schema` suite (leaf shape / positional args / dot+space path equivalence / group browse / unknown subcommand / non-registered decline) plus the event contract tests (ready marker, exit reason, stdin-EOF, spawn error surfacing, profile forwarding) pass; `cli` / `contract` / `integration/extensions` suites green.
- The `test/scripts` goreleaser packaging tests fail locally due to a missing real goreleaser dist (macOS ad-hoc signing on fixture tarballs) — unrelated to this change and reproduced identically on a clean tree; they run against real artifacts in CI.

## Docs

- mono + `dingtalk-event` skills document the subprocess contract and clarify the two schema surfaces (`event schema <event_key>` for event output fields vs `dws schema "event consume"` for command input).
- Design notes in `docs/event-subprocess-contract.md`.