### PR TITLE
feat(auth): add isolated auth instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ Until an isolated instance is explicitly created, DWS performs no registry write
 
 After explicit opt-in, `auth reset` is scoped to the current instance—including `default`—so it never removes another instance's login state or shared application configuration.
 
+Auth-state changes are protected by operating-system file locks. Operations on the same Auth Instance are serialized across DWS processes, while different instances use different lock files and can proceed in parallel. Registry updates use a separate short-lived lock; OAuth authorization and instance token/profile I/O never run under the global Registry lock.
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ env -u DWS_DISABLE_KEYCHAIN dws auth migrate-keychain --to file-dek --yes --form
 DWS_DISABLE_KEYCHAIN=1 dws auth status --format json
 ```
 
-The migration validates every selected auth ciphertext before writing, ignores unrelated application secrets, and can be rerun after an interrupted commit. If validation identifies genuinely damaged ciphertext, remove only the affected profile with `dws auth logout --profile <name|corpId>`, then log in again. Use `dws auth reset` only when you intend to discard every local profile.
+The migration validates every selected auth ciphertext before writing, ignores unrelated application secrets, and can be rerun after an interrupted commit. If validation identifies genuinely damaged ciphertext, remove only the affected profile with `dws auth logout --profile <name|corpId>`, then log in again. Use `dws auth reset` only when you intend to discard every local profile in the current auth instance (or every local profile before Auth Instance opt-in).
 
 </details>
 
@@ -286,6 +286,8 @@ dws auth logout --user-id <userId>          # log out one organization in the cu
 An auth instance is only an isolated login-state storage location, not an account or permanent person identity. The same instance may be re-logged as the same or a different user and may contain several organization profiles. Use `dws auth use` to switch instances; use `dws profile switch` to switch organizations inside the current instance. The optional alias is a display selector; persisted credentials are isolated by a generated instance ID.
 
 Until an isolated instance is explicitly created, DWS performs no registry write or migration: the config directory, Keychain service, login behavior, and reset behavior remain unchanged. Portable `auth export`, `auth import`, and `auth migrate-keychain` currently require switching back to the `default` compatibility instance.
+
+After explicit opt-in, `auth reset` is scoped to the current instance—including `default`—so it never removes another instance's login state or shared application configuration.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@
 curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh
 ```
 
+The command above keeps installing the latest release. To install a specific release instead (the leading `v` is optional):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh -s -- --version v1.0.51
+```
+
+The existing environment-variable form remains supported:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | DWS_VERSION=v1.0.51 sh
+```
+
 **Windows (PowerShell):**
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -271,6 +271,25 @@ The migration validates every selected auth ciphertext before writing, ignores u
 </details>
 
 <details>
+<summary><strong>Multiple isolated auth instances</strong></summary>
+
+Existing installations keep using the original login state without migration. Isolation is enabled only when you explicitly create an auth instance:
+
+```bash
+dws auth login --new-instance personal      # create an isolated auth instance and log in there
+dws auth list                               # list auth instances
+dws auth use personal                       # persistently switch the current auth instance
+dws auth use -                              # toggle back to the previous auth instance
+dws auth logout --user-id <userId>          # log out one organization in the current instance
+```
+
+An auth instance is only an isolated login-state storage location, not an account or permanent person identity. The same instance may be re-logged as the same or a different user and may contain several organization profiles. Use `dws auth use` to switch instances; use `dws profile switch` to switch organizations inside the current instance. The optional alias is a display selector; persisted credentials are isolated by a generated instance ID.
+
+Until an isolated instance is explicitly created, DWS performs no registry write or migration: the config directory, Keychain service, login behavior, and reset behavior remain unchanged. Portable `auth export`, `auth import`, and `auth migrate-keychain` currently require switching back to the `default` compatibility instance.
+
+</details>
+
+<details>
 <summary><strong>Migrate auth between Linux sandboxes</strong></summary>
 
 Copying only `~/.dws/app.json` does not carry the refresh token; access tokens expire after ~2 hours. Use the official export/import flow:

--- a/README_zh.md
+++ b/README_zh.md
@@ -57,6 +57,18 @@
 curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh
 ```
 
+上面的命令仍然安装最新版本。要安装指定版本（版本号开头的 `v` 可省略）：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh -s -- --version v1.0.51
+```
+
+原有的环境变量方式继续支持：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | DWS_VERSION=v1.0.51 sh
+```
+
 **Windows（PowerShell）：**
 
 ```powershell

--- a/internal/app/access_token_resolve.go
+++ b/internal/app/access_token_resolve.go
@@ -40,6 +40,15 @@ func resolveAccessTokenFromDir(ctx context.Context, configDir string) (string, e
 	if tokenErr != nil && errors.Is(tokenErr, authpkg.ErrTokenDecryption) {
 		return "", tokenErr
 	}
+	// An explicitly isolated auth instance must never fall back to the historical
+	// base-home token. Missing or invalid instance credentials fail closed so a
+	// command cannot silently run as the legacy user.
+	if authpkg.ResolveAuthStore(configDir).Isolated() {
+		if tokenErr != nil {
+			return "", tokenErr
+		}
+		return "", nil
+	}
 	manager := authpkg.NewManager(configDir, nil)
 	configureLegacyAuthManagerCompatibility(manager)
 	if leg, _, err := manager.GetToken(); err == nil && strings.TrimSpace(leg) != "" {

--- a/internal/app/audit_runtime.go
+++ b/internal/app/audit_runtime.go
@@ -24,7 +24,7 @@ var (
 	auditIDMu      sync.Mutex
 	cachedActor    audit.Actor
 	cachedAgentID  string
-	cachedProfile  string
+	cachedAuthKey  string
 	identityLoaded bool
 
 	// loadTokenForProfile is the profile-scoped token loader. It is a package
@@ -76,19 +76,20 @@ func auditReport(format string, args ...any) {
 	}
 }
 
-// auditIdentity resolves the Actor for the active runtime profile. The result
-// is cached per-profile so a profile switch within a long-running process (e.g.
-// serve mode) re-resolves rather than reusing a stale identity.
+// auditIdentity resolves the Actor for the active auth instance and runtime
+// profile. Both are part of the cache key so a long-running process never
+// attributes an event to a stale identity after either selection changes.
 func auditIdentity() (audit.Actor, string) {
 	profile := auth.RuntimeProfile()
+	configDir := defaultConfigDir()
+	authKey := auth.ResolveAuthStore(configDir).KeychainService + "\x00" + profile
 
 	auditIDMu.Lock()
 	defer auditIDMu.Unlock()
-	if identityLoaded && profile == cachedProfile {
+	if identityLoaded && authKey == cachedAuthKey {
 		return cachedActor, cachedAgentID
 	}
 
-	configDir := defaultConfigDir()
 	var actor audit.Actor
 	if td, err := loadTokenForProfile(configDir, profile); err == nil && td != nil {
 		actor = audit.Actor{
@@ -106,7 +107,7 @@ func auditIdentity() (audit.Actor, string) {
 		agentID = id.AgentID
 	}
 
-	cachedActor, cachedAgentID, cachedProfile, identityLoaded = actor, agentID, profile, true
+	cachedActor, cachedAgentID, cachedAuthKey, identityLoaded = actor, agentID, authKey, true
 	return actor, agentID
 }
 

--- a/internal/app/audit_runtime_test.go
+++ b/internal/app/audit_runtime_test.go
@@ -71,8 +71,60 @@ func resetAuditIdentityCache() {
 	defer auditIDMu.Unlock()
 	cachedActor = audit.Actor{}
 	cachedAgentID = ""
-	cachedProfile = ""
+	cachedAuthKey = ""
 	identityLoaded = false
+}
+
+// TestAuditIdentityReresolvesOnAuthInstanceSwitch prevents two instances with
+// the same runtime profile (commonly empty) from sharing audit Actor metadata.
+func TestAuditIdentityReresolvesOnAuthInstanceSwitch(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", configDir)
+	auth.DeactivateAuthStore(configDir)
+	prevLoader := loadTokenForProfile
+	prevProfile := auth.RuntimeProfile()
+	t.Cleanup(func() {
+		loadTokenForProfile = prevLoader
+		auth.SetRuntimeProfile(prevProfile)
+		auth.DeactivateAuthStore(configDir)
+		resetAuditIdentityCache()
+	})
+	resetAuditIdentityCache()
+	auth.SetRuntimeProfile("")
+	legacyService := auth.ResolveAuthStore(configDir).KeychainService
+
+	var mu sync.Mutex
+	calls := map[string]int{}
+	loadTokenForProfile = func(configDir, _ string) (*auth.TokenData, error) {
+		service := auth.ResolveAuthStore(configDir).KeychainService
+		mu.Lock()
+		calls[service]++
+		mu.Unlock()
+		if service == legacyService {
+			return &auth.TokenData{UserID: "legacy-user", CorpID: "legacy-corp"}, nil
+		}
+		return &auth.TokenData{UserID: "isolated-user", CorpID: "isolated-corp"}, nil
+	}
+
+	if actor, _ := auditIdentity(); actor.UserID != "legacy-user" {
+		t.Fatalf("legacy actor = %+v", actor)
+	}
+	tx, err := auth.BeginNewInstance(configDir, "personal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if actor, _ := auditIdentity(); actor.UserID != "isolated-user" || actor.CorpID != "isolated-corp" {
+		t.Fatalf("isolated actor = %+v, want isolated identity", actor)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls[legacyService] != 1 || calls[tx.Store().KeychainService] != 1 {
+		t.Fatalf("actor loads by service = %#v, want one per auth instance", calls)
+	}
 }
 
 // TestCloseAuditSinkDrainsOnErrorPath guards the reviewer's V5 finding: when a

--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -45,6 +45,7 @@ type authLoginConfig struct {
 	Recommend    bool
 	Yes          bool
 	TargetCorpID string
+	NewInstance  string
 }
 
 type authLoginGuideAction string
@@ -80,6 +81,8 @@ func buildAuthCommand(patCaller edition.ToolCaller) *cobra.Command {
 		cmd.AddCommand(newAuthLoginCommand(patCaller))
 	}
 	cmd.AddCommand(
+		newAuthListCommand(),
+		newAuthUseCommand(),
 		newAuthLogoutCommand(),
 		newAuthStatusCommand(),
 		newAuthMigrateKeychainCommand(),
@@ -89,6 +92,90 @@ func buildAuthCommand(patCaller edition.ToolCaller) *cobra.Command {
 		newAuthResetCommand(),
 	)
 	return cmd
+}
+
+type authInstanceListItem struct {
+	ID      string                   `json:"id,omitempty"`
+	Alias   string                   `json:"alias"`
+	Kind    authpkg.AuthInstanceKind `json:"kind"`
+	Current bool                     `json:"current"`
+}
+
+func newAuthListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "list",
+		Aliases:           []string{"ls"},
+		Short:             "列出登录态实例",
+		Args:              cobra.NoArgs,
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			instances, currentID, err := authpkg.ListAuthInstances(defaultConfigDir())
+			if err != nil {
+				return apperrors.NewInternal(fmt.Sprintf("failed to list auth instances: %v", err))
+			}
+			items := make([]authInstanceListItem, 0, len(instances))
+			for _, instance := range instances {
+				current := instance.ID != "" && instance.ID == currentID
+				if currentID == "" && instance.Kind == authpkg.AuthInstanceKindLegacy {
+					current = true
+				}
+				items = append(items, authInstanceListItem{
+					ID: instance.ID, Alias: instance.Alias, Kind: instance.Kind, Current: current,
+				})
+			}
+
+			format, _ := cmd.Root().PersistentFlags().GetString("format")
+			if strings.EqualFold(strings.TrimSpace(format), "json") {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(struct {
+					CurrentInstanceID string                 `json:"currentInstanceId,omitempty"`
+					Instances         []authInstanceListItem `json:"instances"`
+				}{CurrentInstanceID: currentID, Instances: items})
+			}
+
+			w := cmd.OutOrStdout()
+			fmt.Fprintln(w, "当前\t登录态实例\t类型\t实例 ID")
+			for _, item := range items {
+				marker := ""
+				if item.Current {
+					marker = "*"
+				}
+				id := item.ID
+				if id == "" {
+					id = "-"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", marker, item.Alias, item.Kind, id)
+			}
+			return nil
+		},
+	}
+}
+
+func newAuthUseCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:               "use <alias|instanceId|->",
+		Short:             "切换当前登录态实例（使用 - 切回上一个实例）",
+		Example:           "  dws auth use personal\n  dws auth use -",
+		Args:              cobra.ExactArgs(1),
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			instance, err := authpkg.UseAuthInstance(defaultConfigDir(), args[0])
+			if err != nil {
+				return apperrors.NewValidation(err.Error())
+			}
+			ResetRuntimeTokenCache()
+			clearCompatCache()
+
+			format, _ := cmd.Root().PersistentFlags().GetString("format")
+			if strings.EqualFold(strings.TrimSpace(format), "json") {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(struct {
+					OK       bool                 `json:"ok"`
+					Instance authInstanceListItem `json:"instance"`
+				}{OK: true, Instance: authInstanceListItem{ID: instance.ID, Alias: instance.Alias, Kind: instance.Kind, Current: true}})
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "[OK] 已切换到登录态实例 %s\n", instance.Alias)
+			return nil
+		},
+	}
 }
 
 func newAuthLoginCommand(patCaller edition.ToolCaller) *cobra.Command {
@@ -112,6 +199,7 @@ func newAuthLoginCommand(patCaller edition.ToolCaller) *cobra.Command {
 
 示例:
   dws auth login              # 本机登录并新增/刷新一个组织 profile
+  dws auth login --new-instance personal # 显式创建一个独立登录态实例并在其中登录
   dws auth login --profile <corpId>  # 指定本次授权目标组织，不持久切换当前组织
   dws auth login --recommend  # 无交互批量授权服务端推荐权限
   dws auth login --device     # SSH 远程 / 无头环境登录 (设备流)
@@ -124,6 +212,20 @@ func newAuthLoginCommand(patCaller edition.ToolCaller) *cobra.Command {
 				return err
 			}
 			configDir := defaultConfigDir()
+			var newInstanceTx *authpkg.NewInstanceTransaction
+			if cfg.NewInstance != "" {
+				newInstanceTx, err = authpkg.BeginNewInstance(configDir, cfg.NewInstance)
+				if err != nil {
+					return apperrors.NewValidation(fmt.Sprintf("failed to create auth instance: %v", err))
+				}
+				// A failed login must not register a half-created instance. Rollback is
+				// a no-op after Commit succeeds.
+				defer func() {
+					if rollbackErr := newInstanceTx.Rollback(); rollbackErr != nil {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Warning: failed to clean unpublished auth instance: %v\n", rollbackErr)
+					}
+				}()
+			}
 			var tokenData *authpkg.TokenData
 			format, _ := cmd.Root().PersistentFlags().GetString("format")
 			postLoginTUIMode := !cfg.Yes && authLoginShouldUsePostLoginTUIMode(cmd, format, cfg.Recommend)
@@ -171,6 +273,11 @@ func newAuthLoginCommand(patCaller edition.ToolCaller) *cobra.Command {
 				_ = enrichAuthLoginProfileFromContact(cmd.Context(), configDir, patCaller, tokenData)
 				ResetRuntimeTokenCache()
 				clearCompatCache()
+			}
+			if newInstanceTx != nil {
+				if err := newInstanceTx.Commit(); err != nil {
+					return apperrors.NewInternal(fmt.Sprintf("failed to activate new auth instance: %v", err))
+				}
 			}
 
 			w := cmd.OutOrStdout()
@@ -261,6 +368,7 @@ func newAuthLoginCommand(patCaller edition.ToolCaller) *cobra.Command {
 	cmd.Flags().Bool("device", false, "Use device authorization flow")
 	cmd.Flags().Bool("force", false, "兼容保留；login 默认已忽略缓存并进入授权流程")
 	cmd.Flags().Bool("recommend", false, "登录成功后无交互批量授权服务端推荐权限")
+	cmd.Flags().String("new-instance", "", "显式创建独立登录态实例并登录（例如 personal）")
 	// Hidden compatibility flags
 	cmd.Flags().String("redirect-url", "", "Loopback redirect URL")
 	cmd.Flags().String("scopes", "", "Space-separated DingTalk OAuth scopes")
@@ -385,12 +493,14 @@ func selectLoginRecommendScopeMode() (pat.LoginRecommendScopeMode, error) {
 func newAuthLogoutCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "logout",
-		Short: "清除认证信息（默认退出所有组织）",
+		Short: "清除当前登录态实例的认证信息（默认退出全部组织）",
 		Long: `清除本机钉钉登录态。
 
-默认退出所有已登录组织 profile；指定 --profile 时只退出该组织，不影响其他组织。`,
+默认退出当前登录态实例内所有已登录组织；指定 --profile 时只退出该组织，
+指定 --user-id 时按当前实例内的 userId 精确退出对应组织，不影响其他登录态实例。`,
 		Example: `  dws auth logout
   dws auth logout --profile <corpId>
+  dws auth logout --user-id <userId>
   dws auth logout --profile "钉钉"`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -399,9 +509,26 @@ func newAuthLogoutCommand() *cobra.Command {
 			if err != nil {
 				return apperrors.NewInternal("failed to read --profile")
 			}
+			userID, err := cmd.Flags().GetString("user-id")
+			if err != nil {
+				return apperrors.NewInternal("failed to read --user-id")
+			}
+			profileSelector = strings.TrimSpace(profileSelector)
+			userID = strings.TrimSpace(userID)
+			if profileSelector != "" && userID != "" {
+				return apperrors.NewValidation("--profile 与 --user-id 只能指定一个")
+			}
 			revokeCtx, cancel := context.WithTimeout(cmd.Context(), 15*time.Second)
 			defer cancel()
-			if strings.TrimSpace(profileSelector) != "" {
+			if userID != "" {
+				profile, err := authpkg.ResolveProfileByUserID(configDir, userID)
+				if err != nil {
+					return apperrors.NewValidation(err.Error())
+				}
+				if err := logoutOneProfile(cmd, revokeCtx, configDir, profile.CorpID); err != nil {
+					return err
+				}
+			} else if profileSelector != "" {
 				if err := logoutOneProfile(cmd, revokeCtx, configDir, profileSelector); err != nil {
 					return err
 				}
@@ -421,6 +548,7 @@ func newAuthLogoutCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().String("profile", "", "指定要退出的 profile 名或 corpId")
+	cmd.Flags().String("user-id", "", "按当前登录态实例内的 userId 退出对应组织")
 	return cmd
 }
 
@@ -536,6 +664,10 @@ func newAuthMigrateKeychainCommand() *cobra.Command {
 		Args:              cobra.NoArgs,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			configDir := defaultConfigDir()
+			if err := rejectIsolatedAuthOperation(configDir, "migrate-keychain"); err != nil {
+				return err
+			}
 			target, err := cmd.Flags().GetString("to")
 			if err != nil {
 				return apperrors.NewInternal("failed to read --to")
@@ -555,7 +687,7 @@ func newAuthMigrateKeychainCommand() *cobra.Command {
 			if !dryRun && !yes {
 				return apperrors.NewValidation("迁移会重加密全部本地登录 token；请先使用 --dry-run 预检，确认后加 --yes 执行")
 			}
-			count, err := migrateKeychainToFileDEK(defaultConfigDir(), dryRun)
+			count, err := migrateKeychainToFileDEK(configDir, dryRun)
 			if err != nil {
 				return apperrors.NewInternal(fmt.Sprintf("keychain migration failed: %v", err))
 			}
@@ -588,7 +720,7 @@ func logoutOneProfile(_ *cobra.Command, ctx context.Context, configDir, selector
 	}
 	restoreProfile := pushRuntimeProfile(selector)
 	defer restoreProfile()
-	_ = authpkg.RevokeTokenRemote(ctx)
+	_ = authpkg.RevokeTokenRemoteAt(ctx, configDir)
 	if err := authpkg.DeleteTokenDataForProfile(configDir, selector); err != nil {
 		return apperrors.NewInternal(fmt.Sprintf("failed to clear token data: %v", err))
 	}
@@ -604,11 +736,11 @@ func logoutAllProfiles(_ *cobra.Command, ctx context.Context, configDir string) 
 		return apperrors.NewInternal(fmt.Sprintf("failed to load profiles: %v", err))
 	}
 	if cfg == nil || len(cfg.Profiles) == 0 {
-		_ = authpkg.RevokeTokenRemote(ctx)
+		_ = authpkg.RevokeTokenRemoteAt(ctx, configDir)
 	} else {
 		for _, profile := range cfg.Profiles {
 			restoreProfile := pushRuntimeProfile(profile.CorpID)
-			_ = authpkg.RevokeTokenRemote(ctx)
+			_ = authpkg.RevokeTokenRemoteAt(ctx, configDir)
 			restoreProfile()
 		}
 	}
@@ -643,6 +775,10 @@ func newAuthExportCommand() *cobra.Command {
   dws auth export --base64 > dws-auth.b64`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			configDir := defaultConfigDir()
+			if err := rejectIsolatedAuthOperation(configDir, "export"); err != nil {
+				return err
+			}
 			output, err := cmd.Flags().GetString("output")
 			if err != nil {
 				return apperrors.NewInternal("failed to read --output")
@@ -666,7 +802,7 @@ func newAuthExportCommand() *cobra.Command {
 			}
 
 			var bundle bytes.Buffer
-			if err := authpkg.ExportPortableAuthBundle(defaultConfigDir(), &bundle); err != nil {
+			if err := authpkg.ExportPortableAuthBundle(configDir, &bundle); err != nil {
 				return apperrors.NewInternal(fmt.Sprintf("failed to export auth bundle: %v", err))
 			}
 
@@ -728,6 +864,9 @@ func newAuthImportCommand() *cobra.Command {
 			}
 
 			configDir := defaultConfigDir()
+			if err := rejectIsolatedAuthOperation(configDir, "import"); err != nil {
+				return err
+			}
 			if !force && authpkg.PortableAuthTargetPopulated(configDir) {
 				return apperrors.NewValidation("检测到已有登录态，请使用 --force 确认覆盖")
 			}
@@ -826,12 +965,17 @@ func newAuthResetCommand() *cobra.Command {
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configDir := defaultConfigDir()
+			isolated := authpkg.ResolveAuthStore(configDir).Isolated()
 			if err := authpkg.DeleteAllTokenData(configDir); err != nil {
 				return apperrors.NewInternal(fmt.Sprintf("failed to reset token data: %v", err))
 			}
-			_ = os.Remove(filepath.Join(configDir, "mcp_url"))
-			_ = os.Remove(filepath.Join(configDir, "token"))
-			_ = authpkg.DeleteAppConfig(configDir)
+			// The legacy-backed default keeps the online reset contract. Isolated
+			// instances clear only their own auth data and preserve shared app config.
+			if !isolated {
+				_ = os.Remove(filepath.Join(configDir, "mcp_url"))
+				_ = os.Remove(filepath.Join(configDir, "token"))
+				_ = authpkg.DeleteAppConfig(configDir)
+			}
 			ResetRuntimeTokenCache()
 			clearCompatCache()
 			w := cmd.OutOrStdout()
@@ -842,6 +986,16 @@ func newAuthResetCommand() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func rejectIsolatedAuthOperation(configDir, operation string) error {
+	if !authpkg.ResolveAuthStore(configDir).Isolated() {
+		return nil
+	}
+	return apperrors.NewValidation(fmt.Sprintf(
+		"auth %s 暂不支持隔离登录态；请先运行 `dws auth use default` 切回兼容登录态",
+		operation,
+	))
 }
 
 func timeOrEmpty(t time.Time) string {
@@ -1094,6 +1248,14 @@ func resolveAuthLoginConfig(cmd *cobra.Command) (authLoginConfig, error) {
 	if err != nil {
 		return authLoginConfig{}, apperrors.NewInternal("failed to read --recommend")
 	}
+	newInstance, err := cmd.Flags().GetString("new-instance")
+	if err != nil {
+		return authLoginConfig{}, apperrors.NewInternal("failed to read --new-instance")
+	}
+	newInstance = strings.TrimSpace(newInstance)
+	if cmd.Flags().Changed("new-instance") && newInstance == "" {
+		return authLoginConfig{}, apperrors.NewValidation("--new-instance 不能为空")
+	}
 	yes := false
 	profileSelector := ""
 	if cmd.Root() != nil {
@@ -1111,6 +1273,7 @@ func resolveAuthLoginConfig(cmd *cobra.Command) (authLoginConfig, error) {
 		Recommend:    recommend,
 		Yes:          yes,
 		TargetCorpID: targetCorpID,
+		NewInstance:  newInstance,
 	}, nil
 }
 

--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -965,19 +964,8 @@ func newAuthResetCommand() *cobra.Command {
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configDir := defaultConfigDir()
-			// A generated ID exists only after explicit Auth Instance opt-in,
-			// including when the legacy-backed default is currently selected.
-			instanceScoped := authpkg.ResolveAuthStore(configDir).InstanceID != ""
-			if err := authpkg.DeleteAllTokenData(configDir); err != nil {
+			if err := authpkg.ResetCurrentAuthData(configDir); err != nil {
 				return apperrors.NewInternal(fmt.Sprintf("failed to reset token data: %v", err))
-			}
-			// Before opt-in, preserve the online full-reset contract exactly. After
-			// opt-in, every instance (including default) resets only its own auth
-			// state so one instance cannot remove configuration used by another.
-			if !instanceScoped {
-				_ = os.Remove(filepath.Join(configDir, "mcp_url"))
-				_ = os.Remove(filepath.Join(configDir, "token"))
-				_ = authpkg.DeleteAppConfig(configDir)
 			}
 			ResetRuntimeTokenCache()
 			clearCompatCache()

--- a/internal/app/auth_command.go
+++ b/internal/app/auth_command.go
@@ -965,13 +965,16 @@ func newAuthResetCommand() *cobra.Command {
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			configDir := defaultConfigDir()
-			isolated := authpkg.ResolveAuthStore(configDir).Isolated()
+			// A generated ID exists only after explicit Auth Instance opt-in,
+			// including when the legacy-backed default is currently selected.
+			instanceScoped := authpkg.ResolveAuthStore(configDir).InstanceID != ""
 			if err := authpkg.DeleteAllTokenData(configDir); err != nil {
 				return apperrors.NewInternal(fmt.Sprintf("failed to reset token data: %v", err))
 			}
-			// The legacy-backed default keeps the online reset contract. Isolated
-			// instances clear only their own auth data and preserve shared app config.
-			if !isolated {
+			// Before opt-in, preserve the online full-reset contract exactly. After
+			// opt-in, every instance (including default) resets only its own auth
+			// state so one instance cannot remove configuration used by another.
+			if !instanceScoped {
 				_ = os.Remove(filepath.Join(configDir, "mcp_url"))
 				_ = os.Remove(filepath.Join(configDir, "token"))
 				_ = authpkg.DeleteAppConfig(configDir)

--- a/internal/app/auth_command_test.go
+++ b/internal/app/auth_command_test.go
@@ -635,6 +635,7 @@ func TestResolveAuthLoginConfigReadsInheritedYes(t *testing.T) {
 	login.Flags().Bool("device", false, "")
 	login.Flags().Bool("force", false, "")
 	login.Flags().Bool("recommend", false, "")
+	login.Flags().String("new-instance", "", "")
 	root.AddCommand(login)
 
 	if err := root.PersistentFlags().Set("yes", "true"); err != nil {

--- a/internal/app/auth_instance_command_test.go
+++ b/internal/app/auth_instance_command_test.go
@@ -183,6 +183,50 @@ func TestAuthInstanceCLIUseAndPreviousClearRuntimeTokenCache(t *testing.T) {
 	}
 }
 
+func TestRootFailsClosedWhenAuthInstanceChangesAfterPluginConstruction(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+	createAuthInstanceFixture(t, configDir, "personal",
+		[]*authpkg.TokenData{authAccountTestToken("corp-default", "user-default", "token-default")},
+		[]*authpkg.TokenData{authAccountTestToken("corp-personal", "user-personal", "token-personal")},
+	)
+
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		wantError bool
+	}{
+		{name: "token-reading-command", args: []string{"auth", "status"}, wantError: true},
+		{name: "token-free-auth-list", args: []string{"auth", "list"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := authpkg.UseAuthInstance(configDir, "default"); err != nil {
+				t.Fatal(err)
+			}
+			authpkg.DeactivateAuthStore(configDir)
+			cmd := NewRootCommand()
+			// Simulate another process changing registry.json after plugin
+			// construction but before Cobra PersistentPreRunE.
+			if _, err := authpkg.UseAuthInstance(configDir, "personal"); err != nil {
+				t.Fatal(err)
+			}
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if tc.wantError {
+				if err == nil || !strings.Contains(err.Error(), "登录态实例在命令初始化期间发生变化") {
+					t.Fatalf("Execute() error = %v, output=%q; want fail-closed instance-change error", err, output.String())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("token-free recovery command error = %v, output=%q", err, output.String())
+			}
+		})
+	}
+}
+
 func TestAuthInstanceLogoutByUserIDOnlyTouchesCurrentInstance(t *testing.T) {
 	configDir := setupAuthInstanceCommandTest(t)
 	createAuthInstanceFixture(t, configDir, "personal",

--- a/internal/app/auth_instance_command_test.go
+++ b/internal/app/auth_instance_command_test.go
@@ -1,0 +1,514 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
+	"github.com/spf13/cobra"
+)
+
+func TestAuthInstanceHelpContracts(t *testing.T) {
+	setupAuthInstanceCommandTest(t)
+
+	loginHelp, err := executeAuthInstanceCommand(t, "auth", "login", "--help")
+	if err != nil {
+		t.Fatalf("auth login --help error = %v\noutput:\n%s", err, loginHelp)
+	}
+	if !strings.Contains(loginHelp, "--new-instance") {
+		t.Fatalf("auth login --help missing --new-instance:\n%s", loginHelp)
+	}
+
+	authHelp, err := executeAuthInstanceCommand(t, "auth", "--help")
+	if err != nil {
+		t.Fatalf("auth --help error = %v\noutput:\n%s", err, authHelp)
+	}
+	for _, command := range []string{"list", "use"} {
+		if !strings.Contains(authHelp, "\n  "+command) {
+			t.Fatalf("auth --help missing %q subcommand:\n%s", command, authHelp)
+		}
+	}
+}
+
+func TestAuthInstanceListLegacyIsReadOnly(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+
+	out, err := executeAuthInstanceCommand(t, "--format", "json", "auth", "list")
+	if err != nil {
+		t.Fatalf("auth list error = %v\noutput:\n%s", err, out)
+	}
+	var response struct {
+		CurrentInstanceID string `json:"currentInstanceId"`
+		Instances         []struct {
+			ID      string                   `json:"id"`
+			Alias   string                   `json:"alias"`
+			Kind    authpkg.AuthInstanceKind `json:"kind"`
+			Current bool                     `json:"current"`
+		} `json:"instances"`
+	}
+	if err := json.Unmarshal([]byte(out), &response); err != nil {
+		t.Fatalf("unmarshal auth list output: %v\noutput:\n%s", err, out)
+	}
+	if response.CurrentInstanceID != "" {
+		t.Fatalf("legacy list unexpectedly enabled registry: %#v", response)
+	}
+	if len(response.Instances) != 1 || response.Instances[0].Alias != authpkg.DefaultAuthInstanceAlias ||
+		response.Instances[0].Kind != authpkg.AuthInstanceKindLegacy || !response.Instances[0].Current {
+		t.Fatalf("legacy auth list = %#v, want one current default instance", response.Instances)
+	}
+	if _, err := os.Stat(filepath.Join(configDir, "auth")); !os.IsNotExist(err) {
+		t.Fatalf("read-only auth list created auth directory, stat error = %v", err)
+	}
+}
+
+func TestAuthLoginNewInstanceCommitsAfterTokenPersistence(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+
+	out, err := executeAuthInstanceCommand(t,
+		"--format", "json", "auth", "login",
+		"--token", "isolated-login-token", "--new-instance", "personal", "--yes",
+	)
+	if err != nil {
+		t.Fatalf("auth login --new-instance error = %v\noutput:\n%s", err, out)
+	}
+	instances, currentID, err := authpkg.ListAuthInstances(configDir)
+	if err != nil {
+		t.Fatalf("ListAuthInstances() error = %v", err)
+	}
+	if currentID == "" || len(instances) != 2 {
+		t.Fatalf("instances = %#v, currentID = %q; want committed two-instance registry", instances, currentID)
+	}
+	current := authInstanceByID(instances, currentID)
+	if current == nil || current.Alias != "personal" || current.Kind != authpkg.AuthInstanceKindIsolated {
+		t.Fatalf("current instance = %#v, want isolated personal", current)
+	}
+	store := authpkg.ResolveAuthStore(configDir)
+	if !store.Isolated() || store.InstanceID != currentID {
+		t.Fatalf("active store = %#v, want committed personal store", store)
+	}
+	data, err := authpkg.LoadTokenData(configDir)
+	if err != nil {
+		t.Fatalf("LoadTokenData() error = %v", err)
+	}
+	if data.AccessToken != "isolated-login-token" {
+		t.Fatalf("isolated access token = %q, want isolated-login-token", data.AccessToken)
+	}
+}
+
+func TestAuthLoginNewInstanceCanTargetExistingProfile(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+	if err := authpkg.SaveTokenData(configDir, authAccountTestToken("corp-target", "user-target", "legacy-token")); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeAuthInstanceCommand(t,
+		"--profile", "corp-target", "--format", "json", "auth", "login",
+		"--token", "isolated-token", "--new-instance", "targeted", "--yes",
+	)
+	if err != nil {
+		t.Fatalf("auth login --new-instance with --profile error = %v\noutput:\n%s", err, out)
+	}
+	instances, currentID, err := authpkg.ListAuthInstances(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current := authInstanceByID(instances, currentID)
+	if current == nil || current.Alias != "targeted" || current.Kind != authpkg.AuthInstanceKindIsolated {
+		t.Fatalf("current instance = %#v, want targeted isolated instance", current)
+	}
+}
+
+func TestAuthInstanceCLIUseAndPreviousClearRuntimeTokenCache(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+	createAuthInstanceFixture(t, configDir, "personal",
+		[]*authpkg.TokenData{authAccountTestToken("corp-default", "user-default", "token-default")},
+		[]*authpkg.TokenData{authAccountTestToken("corp-personal", "user-personal", "token-personal")},
+	)
+
+	// Simulate a fresh process: no runtime selection exists before root command
+	// construction. NewRootCommand must activate the persisted main account
+	// before plugin construction performs any token read.
+	authpkg.DeactivateAuthStore(configDir)
+	cmd := NewRootCommand()
+	if got := authpkg.ResolveAuthStore(configDir); got.InstanceAlias != "personal" || !got.Isolated() {
+		t.Fatalf("root construction did not pre-activate persisted main account: %#v", got)
+	}
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"auth", "use", "default"})
+	setAuthInstanceRuntimeTokenCache("stale-personal")
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth use default error = %v\noutput:\n%s", err, output.String())
+	}
+	assertAuthInstanceRuntimeTokenCacheEmpty(t)
+	if got := authpkg.ResolveAuthStore(configDir); got.InstanceAlias != "default" || got.Isolated() {
+		t.Fatalf("active store after auth use default = %#v", got)
+	}
+
+	output.Reset()
+	cmd = NewRootCommand()
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"auth", "use", "-"})
+	setAuthInstanceRuntimeTokenCache("stale-default")
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("auth use - error = %v\noutput:\n%s", err, output.String())
+	}
+	assertAuthInstanceRuntimeTokenCacheEmpty(t)
+	if got := authpkg.ResolveAuthStore(configDir); got.InstanceAlias != "personal" || !got.Isolated() {
+		t.Fatalf("active store after auth use - = %#v", got)
+	}
+}
+
+func TestAuthInstanceLogoutByUserIDOnlyTouchesCurrentInstance(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+	createAuthInstanceFixture(t, configDir, "personal",
+		[]*authpkg.TokenData{authAccountTestToken("corp-default", "shared-user", "token-default")},
+		[]*authpkg.TokenData{
+			authAccountTestToken("corp-target", "shared-user", "token-target"),
+			authAccountTestToken("corp-keep", "other-user", "token-keep"),
+		},
+	)
+
+	originalTransport := http.DefaultTransport
+	http.DefaultTransport = authAccountRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("remote revoke disabled in auth account test")
+	})
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	out, err := executeAuthInstanceCommand(t, "auth", "logout", "--user-id", "shared-user")
+	if err != nil {
+		t.Fatalf("auth logout --user-id error = %v\noutput:\n%s", err, out)
+	}
+	if got := authpkg.ResolveAuthStore(configDir); got.InstanceAlias != "personal" || !got.Isolated() {
+		t.Fatalf("logout changed active account: %#v", got)
+	}
+	profiles, err := authpkg.LoadProfiles(configDir)
+	if err != nil {
+		t.Fatalf("LoadProfiles(personal) error = %v", err)
+	}
+	if len(profiles.Profiles) != 1 || profiles.Profiles[0].CorpID != "corp-keep" {
+		t.Fatalf("personal profiles after logout = %#v, want only corp-keep", profiles.Profiles)
+	}
+	if authpkg.TokenDataExistsKeychainForCorpIDAt(configDir, "corp-target") {
+		t.Fatal("target token still exists in current account")
+	}
+	if !authpkg.TokenDataExistsKeychainForCorpIDAt(configDir, "corp-keep") {
+		t.Fatal("unmatched token was deleted from current account")
+	}
+
+	if _, err := authpkg.UseAuthInstance(configDir, "default"); err != nil {
+		t.Fatalf("UseAuthInstance(default) error = %v", err)
+	}
+	legacy, err := authpkg.LoadTokenDataForProfile(configDir, "corp-default")
+	if err != nil {
+		t.Fatalf("legacy account token was removed: %v", err)
+	}
+	if legacy.AccessToken != "token-default" || legacy.UserID != "shared-user" {
+		t.Fatalf("legacy account token = %#v, want untouched shared-user token", legacy)
+	}
+}
+
+func TestAuthInstanceIsolatedPortableGuardsAndResetPreservesSharedAppConfig(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+	if err := authpkg.SaveAppConfig(configDir, &authpkg.AppConfig{ClientID: "shared-client"}); err != nil {
+		t.Fatalf("SaveAppConfig() error = %v", err)
+	}
+	for _, name := range []string{"mcp_url", "token"} {
+		if err := os.WriteFile(filepath.Join(configDir, name), []byte("shared-"+name), 0o600); err != nil {
+			t.Fatalf("write shared %s: %v", name, err)
+		}
+	}
+	createAuthInstanceFixture(t, configDir, "personal",
+		[]*authpkg.TokenData{authAccountTestToken("corp-default", "user-default", "token-default")},
+		[]*authpkg.TokenData{authAccountTestToken("corp-personal", "user-personal", "token-personal")},
+	)
+	inputPath := filepath.Join(t.TempDir(), "auth-bundle")
+	if err := os.WriteFile(inputPath, []byte("not-used"), 0o600); err != nil {
+		t.Fatalf("write import stub: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "export", args: []string{"auth", "export", "--base64"}},
+		{name: "import", args: []string{"auth", "import", "--input", inputPath}},
+		{name: "migrate", args: []string{"auth", "migrate-keychain", "--dry-run"}},
+	} {
+		out, err := executeAuthInstanceCommand(t, tc.args...)
+		if err == nil {
+			t.Fatalf("isolated auth %s unexpectedly succeeded\noutput:\n%s", tc.name, out)
+		}
+		if !strings.Contains(err.Error(), "auth use default") {
+			t.Fatalf("isolated auth %s error = %v, want default-account hint", tc.name, err)
+		}
+	}
+
+	out, err := executeAuthInstanceCommand(t, "auth", "reset")
+	if err != nil {
+		t.Fatalf("isolated auth reset error = %v\noutput:\n%s", err, out)
+	}
+	shared, err := authpkg.LoadAppConfig(configDir)
+	if err != nil {
+		t.Fatalf("LoadAppConfig() after isolated reset error = %v", err)
+	}
+	if shared == nil || shared.ClientID != "shared-client" {
+		t.Fatalf("shared app config after isolated reset = %#v", shared)
+	}
+	if authpkg.TokenDataExistsKeychainForCorpIDAt(configDir, "corp-personal") {
+		t.Fatal("isolated reset retained personal token")
+	}
+
+	out, err = executeAuthInstanceCommand(t, "auth", "use", "default")
+	if err != nil {
+		t.Fatalf("auth use default error = %v\noutput:\n%s", err, out)
+	}
+	if err := rejectIsolatedAuthOperation(configDir, "export"); err != nil {
+		t.Fatalf("portable guard rejected legacy-backed account after auth use default: %v", err)
+	}
+	legacy, err := authpkg.LoadTokenDataForProfile(configDir, "corp-default")
+	if err != nil || legacy.AccessToken != "token-default" {
+		t.Fatalf("isolated reset changed legacy token: token=%#v err=%v", legacy, err)
+	}
+
+}
+
+func TestAuthInstanceLegacyResetKeepsHistoricalFullResetBeforeOptIn(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+	if err := authpkg.SaveAppConfig(configDir, &authpkg.AppConfig{ClientID: "legacy-client"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"mcp_url", "token"} {
+		if err := os.WriteFile(filepath.Join(configDir, name), []byte("legacy-"+name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := authpkg.SaveTokenData(configDir, authAccountTestToken("legacy-corp", "legacy-user", "legacy-access")); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeAuthInstanceCommand(t, "auth", "reset")
+	if err != nil {
+		t.Fatalf("legacy auth reset error = %v\noutput:\n%s", err, out)
+	}
+	if authpkg.HasAppConfig(configDir) {
+		t.Fatal("zero-registry reset retained historical app config")
+	}
+	for _, name := range []string{"mcp_url", "token"} {
+		if _, err := os.Stat(filepath.Join(configDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("zero-registry reset retained %s: %v", name, err)
+		}
+	}
+}
+
+func TestAuthInstanceHookEditionCanListAndRecoverToDefault(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+	createAuthInstanceFixture(t, configDir, "personal", nil,
+		[]*authpkg.TokenData{authAccountTestToken("corp-personal", "user-personal", "token-personal")},
+	)
+
+	previous := edition.Get()
+	preRunCalls := 0
+	edition.Override(&edition.Hooks{
+		Name: "hooked",
+		LoadToken: func(string) ([]byte, error) {
+			return nil, authpkg.ErrTokenDataNotFound
+		},
+		AfterPersistentPreRun: func(*cobra.Command, []string) error {
+			preRunCalls++
+			return nil
+		},
+	})
+	t.Cleanup(func() { edition.Override(previous) })
+
+	out, err := executeAuthInstanceCommand(t, "--format", "json", "auth", "list")
+	if err != nil || !strings.Contains(out, `"alias":"personal"`) {
+		t.Fatalf("hook edition auth list = %q, %v", out, err)
+	}
+	if preRunCalls != 1 {
+		t.Fatalf("hook edition pre-run calls after list = %d, want 1", preRunCalls)
+	}
+	out, err = executeAuthInstanceCommand(t, "auth", "status")
+	if err == nil || !strings.Contains(err.Error(), "failed to activate login state") {
+		t.Fatalf("hook edition token command = %q, %v; want fail-closed", out, err)
+	}
+	if preRunCalls != 1 {
+		t.Fatalf("failed-closed status unexpectedly ran edition pre-run: %d", preRunCalls)
+	}
+	out, err = executeAuthInstanceCommand(t, "auth", "use", "default")
+	if err != nil {
+		t.Fatalf("hook edition auth use default = %q, %v", out, err)
+	}
+	if preRunCalls != 2 {
+		t.Fatalf("hook edition pre-run calls after use = %d, want 2", preRunCalls)
+	}
+	store, err := authpkg.ActivateCurrentInstance(configDir)
+	if err != nil || store.Isolated() || store.ConfigDir != configDir {
+		t.Fatalf("hook edition recovered store = %#v, %v", store, err)
+	}
+}
+
+func TestAuthInstanceCorruptRegistryRootPreRunFailsClosed(t *testing.T) {
+	configDir := setupAuthInstanceCommandTest(t)
+	if err := authpkg.SaveTokenData(configDir, authAccountTestToken("corp-default", "user-default", "legacy-secret")); err != nil {
+		t.Fatalf("SaveTokenData() error = %v", err)
+	}
+	registryPath := authpkg.AuthRegistryPath(configDir)
+	if err := os.MkdirAll(filepath.Dir(registryPath), 0o700); err != nil {
+		t.Fatalf("create registry dir: %v", err)
+	}
+	corrupt := []byte(`{"version":1,"revision":1,"instance":`)
+	if err := os.WriteFile(registryPath, corrupt, 0o600); err != nil {
+		t.Fatalf("write corrupt registry: %v", err)
+	}
+
+	out, err := executeAuthInstanceCommand(t, "--format", "json", "auth", "list")
+	if err == nil {
+		t.Fatalf("auth list accepted corrupt registry\noutput:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "failed to activate login state") ||
+		!strings.Contains(err.Error(), "parse auth registry") {
+		t.Fatalf("corrupt registry error = %v, want fail-closed activation error", err)
+	}
+	if strings.Contains(out, `"instances"`) {
+		t.Fatalf("auth list body ran despite corrupt registry:\n%s", out)
+	}
+	if got := authpkg.ResolveAuthStore(configDir); got.InstanceID != "" {
+		t.Fatalf("corrupt registry left an account activated: %#v", got)
+	}
+	data, readErr := os.ReadFile(registryPath)
+	if readErr != nil || !bytes.Equal(data, corrupt) {
+		t.Fatalf("corrupt registry was modified: data=%q err=%v", data, readErr)
+	}
+}
+
+func setupAuthInstanceCommandTest(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	configDir := filepath.Join(root, "config")
+	t.Setenv("DWS_CONFIG_DIR", configDir)
+	t.Setenv("DWS_CLIENT_ID", "")
+	t.Setenv(keychain.DisableKeychainEnv, "1")
+	t.Setenv(keychain.StorageDirEnv, filepath.Join(root, "keychain"))
+	authpkg.DeactivateAuthStore(configDir)
+	authpkg.SetRuntimeProfile("")
+	ResetRuntimeTokenCache()
+	clearCompatCache()
+	t.Cleanup(func() {
+		authpkg.DeactivateAuthStore(configDir)
+		authpkg.SetRuntimeProfile("")
+		ResetRuntimeTokenCache()
+		clearCompatCache()
+		CloseFileLogger()
+	})
+	return configDir
+}
+
+func executeAuthInstanceCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := NewRootCommand()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	CloseFileLogger()
+	return output.String(), err
+}
+
+func createAuthInstanceFixture(t *testing.T, configDir, alias string, legacy, isolated []*authpkg.TokenData) {
+	t.Helper()
+	for _, token := range legacy {
+		if err := authpkg.SaveTokenData(configDir, token); err != nil {
+			t.Fatalf("SaveTokenData(legacy %s) error = %v", token.CorpID, err)
+		}
+	}
+	tx, err := authpkg.BeginNewInstance(configDir, alias)
+	if err != nil {
+		t.Fatalf("BeginNewInstance(%s) error = %v", alias, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	for _, token := range isolated {
+		if err := authpkg.SaveTokenData(configDir, token); err != nil {
+			t.Fatalf("SaveTokenData(isolated %s) error = %v", token.CorpID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit(%s) error = %v", alias, err)
+	}
+	committed = true
+	ResetRuntimeTokenCache()
+}
+
+func authAccountTestToken(corpID, userID, accessToken string) *authpkg.TokenData {
+	return &authpkg.TokenData{
+		AccessToken:  accessToken,
+		RefreshToken: "refresh-" + corpID,
+		ExpiresAt:    time.Now().Add(time.Hour),
+		RefreshExpAt: time.Now().Add(24 * time.Hour),
+		CorpID:       corpID,
+		CorpName:     corpID + " org",
+		UserID:       userID,
+		UserName:     userID + " name",
+		ClientID:     "client-" + corpID,
+	}
+}
+
+func authInstanceByID(instances []authpkg.AuthInstance, id string) *authpkg.AuthInstance {
+	for i := range instances {
+		if instances[i].ID == id {
+			return &instances[i]
+		}
+	}
+	return nil
+}
+
+func setAuthInstanceRuntimeTokenCache(token string) {
+	cachedRuntimeTokenMu.Lock()
+	defer cachedRuntimeTokenMu.Unlock()
+	cachedRuntimeTokens = map[string]string{"sentinel": token}
+}
+
+func assertAuthInstanceRuntimeTokenCacheEmpty(t *testing.T) {
+	t.Helper()
+	cachedRuntimeTokenMu.Lock()
+	defer cachedRuntimeTokenMu.Unlock()
+	if len(cachedRuntimeTokens) != 0 {
+		t.Fatalf("runtime token cache was not cleared: %#v", cachedRuntimeTokens)
+	}
+}
+
+type authAccountRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f authAccountRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/app/auth_instance_command_test.go
+++ b/internal/app/auth_instance_command_test.go
@@ -232,7 +232,7 @@ func TestAuthInstanceLogoutByUserIDOnlyTouchesCurrentInstance(t *testing.T) {
 	}
 }
 
-func TestAuthInstanceIsolatedPortableGuardsAndResetPreservesSharedAppConfig(t *testing.T) {
+func TestAuthInstanceScopedResetPreservesOtherInstancesAndSharedAppConfig(t *testing.T) {
 	configDir := setupAuthInstanceCommandTest(t)
 	if err := authpkg.SaveAppConfig(configDir, &authpkg.AppConfig{ClientID: "shared-client"}); err != nil {
 		t.Fatalf("SaveAppConfig() error = %v", err)
@@ -294,7 +294,40 @@ func TestAuthInstanceIsolatedPortableGuardsAndResetPreservesSharedAppConfig(t *t
 	if err != nil || legacy.AccessToken != "token-default" {
 		t.Fatalf("isolated reset changed legacy token: token=%#v err=%v", legacy, err)
 	}
+	if _, err := authpkg.UseAuthInstance(configDir, "personal"); err != nil {
+		t.Fatal(err)
+	}
+	if err := authpkg.SaveTokenData(configDir, authAccountTestToken("corp-personal", "user-personal", "token-personal-restored")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := authpkg.UseAuthInstance(configDir, "default"); err != nil {
+		t.Fatal(err)
+	}
 
+	out, err = executeAuthInstanceCommand(t, "auth", "reset")
+	if err != nil {
+		t.Fatalf("default instance reset error = %v\noutput:\n%s", err, out)
+	}
+	shared, err = authpkg.LoadAppConfig(configDir)
+	if err != nil || shared == nil || shared.ClientID != "shared-client" {
+		t.Fatalf("shared app config after default instance reset = %#v, %v", shared, err)
+	}
+	for _, name := range []string{"mcp_url", "token"} {
+		if _, err := os.Stat(filepath.Join(configDir, name)); err != nil {
+			t.Fatalf("default instance reset removed shared %s: %v", name, err)
+		}
+	}
+	if authpkg.TokenDataExistsKeychainForCorpIDAt(configDir, "corp-default") {
+		t.Fatal("default instance reset retained its own user token")
+	}
+	out, err = executeAuthInstanceCommand(t, "auth", "use", "personal")
+	if err != nil {
+		t.Fatalf("auth use personal after default reset error = %v\noutput:\n%s", err, out)
+	}
+	personal, err := authpkg.LoadTokenDataForProfile(configDir, "corp-personal")
+	if err != nil || personal.AccessToken != "token-personal-restored" {
+		t.Fatalf("default reset changed personal instance: token=%#v err=%v", personal, err)
+	}
 }
 
 func TestAuthInstanceLegacyResetKeepsHistoricalFullResetBeforeOptIn(t *testing.T) {

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -295,6 +295,11 @@ func NewRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine) 
 	}
 	flags := &GlobalFlags{}
 	authpkg.SetRuntimeProfile(preparseProfileFlag(os.Args[1:]))
+	// Plugin construction reads the current user token to populate stdio
+	// context, so auth instance activation must happen before loadPlugins—not only in
+	// PersistentPreRunE. Keep the error for pre-run while suppressing every
+	// construction-time token read on a corrupt/unsupported registry.
+	_, initialAuthActivationErr := authpkg.ActivateCurrentInstance(defaultConfigDir())
 	loader := cli.EnvironmentLoader{
 		LookupEnv: os.LookupEnv,
 	}
@@ -313,6 +318,18 @@ func NewRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine) 
 			return cmd.Help()
 		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Auth instance selection is an auth-only routing decision. Keep the global
+			// DWS config directory unchanged so logs, skills, recovery data and
+			// application credentials retain their historical locations.
+			recoveryCommand := authInstanceHookRecoveryCommand(cmd, initialAuthActivationErr)
+			if initialAuthActivationErr != nil && !recoveryCommand {
+				return apperrors.NewInternal(fmt.Sprintf("failed to activate login state: %v", initialAuthActivationErr))
+			}
+			if !recoveryCommand {
+				if _, err := authpkg.ActivateCurrentInstance(defaultConfigDir()); err != nil {
+					return apperrors.NewInternal(fmt.Sprintf("failed to activate login state: %v", err))
+				}
+			}
 			authpkg.SetRuntimeProfile(flags.Profile)
 			// Apply OAuth credential overrides from CLI flags (highest priority).
 			if flags.ClientID != "" {
@@ -372,7 +389,7 @@ func NewRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine) 
 
 	// --- Plugin loading: runs AFTER legacy commands so plugin endpoints can
 	// be appended on top of the static endpoint registry.
-	pluginCmds := loadPlugins(engine, runner)
+	pluginCmds := loadPlugins(engine, runner, initialAuthActivationErr == nil)
 	if len(pluginCmds) > 0 {
 		addPluginCommandsSafe(root, pluginCmds)
 	}
@@ -393,6 +410,21 @@ func NewRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine) 
 	root.SetContext(rootCtx)
 
 	return root
+}
+
+// A hook-backed edition cannot activate an isolated standard DWS store. Keep a
+// narrow recovery path for registry inspection and switching to default. The
+// edition's normal AfterPersistentPreRun contract still runs for both commands;
+// every token-reading command remains fail-closed.
+func authInstanceHookRecoveryCommand(cmd *cobra.Command, activationErr error) bool {
+	if cmd == nil || !stderrors.Is(activationErr, authpkg.ErrAuthInstanceIsolationUnsupported) {
+		return false
+	}
+	parent := cmd.Parent()
+	if parent == nil || parent.Name() != "auth" {
+		return false
+	}
+	return cmd.Name() == "list" || cmd.Name() == "use"
 }
 
 func preparseProfileFlag(args []string) string {
@@ -803,7 +835,7 @@ func CloseFileLogger() {
 // the dynamic server registry, and registers their pipeline hooks.
 // This runs before legacy command construction so that plugin servers
 // are available for EnvironmentLoader.Load().
-func loadPlugins(engine *pipeline.Engine, runner executor.Runner) []*cobra.Command {
+func loadPlugins(engine *pipeline.Engine, runner executor.Runner, authAvailable bool) []*cobra.Command {
 	pluginLoader := plugin.NewLoader(RawVersion())
 
 	// 0a. Inject plugin config values from settings.json as environment
@@ -812,8 +844,12 @@ func loadPlugins(engine *pipeline.Engine, runner executor.Runner) []*cobra.Comma
 	// precedence (InjectPluginConfigEnv skips already-set keys).
 	pluginLoader.InjectPluginConfigEnv()
 
-	// Load TokenData once; reused for stdio injection below.
-	tokenData, _ := authpkg.LoadTokenData(defaultConfigDir())
+	// Load TokenData once; reused for stdio injection below. A malformed auth
+	// registry must fail closed instead of injecting the legacy user's identity.
+	var tokenData *authpkg.TokenData
+	if authAvailable {
+		tokenData, _ = authpkg.LoadTokenData(defaultConfigDir())
+	}
 	var userCtx *plugin.UserContext
 	if tokenData != nil {
 		// Inject user context if either UserID or CorpID is present.

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -301,7 +301,7 @@ func NewRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine) 
 	// context, so auth instance activation must happen before loadPlugins—not only in
 	// PersistentPreRunE. Keep the error for pre-run while suppressing every
 	// construction-time token read on a corrupt/unsupported registry.
-	_, initialAuthActivationErr := authpkg.ActivateCurrentInstance(defaultConfigDir())
+	initialAuthStore, initialAuthActivationErr := authpkg.ActivateCurrentInstance(defaultConfigDir())
 	loader := cli.EnvironmentLoader{
 		LookupEnv: os.LookupEnv,
 	}
@@ -324,12 +324,23 @@ func NewRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine) 
 			// DWS config directory unchanged so logs, skills, recovery data and
 			// application credentials retain their historical locations.
 			recoveryCommand := authInstanceHookRecoveryCommand(cmd, initialAuthActivationErr)
+			selectionCommand := authInstanceSelectionCommand(cmd)
 			if initialAuthActivationErr != nil && !recoveryCommand {
 				return apperrors.NewInternal(fmt.Sprintf("failed to activate login state: %v", initialAuthActivationErr))
 			}
 			if !recoveryCommand {
-				if _, err := authpkg.ActivateCurrentInstance(defaultConfigDir()); err != nil {
+				preRunStore, err := authpkg.ActivateCurrentInstance(defaultConfigDir())
+				if err != nil {
 					return apperrors.NewInternal(fmt.Sprintf("failed to activate login state: %v", err))
+				}
+				// Plugin construction may already have read token/user context from
+				// initialAuthStore. If another process changes the persisted current
+				// instance before execution, fail closed instead of combining plugin
+				// context from A with command credentials from B. Registry inspection
+				// and selection commands are token-free recovery operations.
+				if initialAuthActivationErr == nil && !selectionCommand &&
+					!sameAuthStoreCoordinate(initialAuthStore, preRunStore) {
+					return apperrors.NewValidation("登录态实例在命令初始化期间发生变化，请重试当前命令")
 				}
 			}
 			authpkg.SetRuntimeProfile(flags.Profile)
@@ -424,11 +435,21 @@ func authInstanceHookRecoveryCommand(cmd *cobra.Command, activationErr error) bo
 	if cmd == nil || !stderrors.Is(activationErr, authpkg.ErrAuthInstanceIsolationUnsupported) {
 		return false
 	}
-	parent := cmd.Parent()
-	if parent == nil || parent.Name() != "auth" {
+	return authInstanceSelectionCommand(cmd)
+}
+
+func authInstanceSelectionCommand(cmd *cobra.Command) bool {
+	if cmd == nil {
 		return false
 	}
-	return cmd.Name() == "list" || cmd.Name() == "use"
+	parent := cmd.Parent()
+	return parent != nil && parent.Name() == "auth" && (cmd.Name() == "list" || cmd.Name() == "use")
+}
+
+func sameAuthStoreCoordinate(a, b authpkg.AuthStore) bool {
+	return filepath.Clean(a.ConfigDir) == filepath.Clean(b.ConfigDir) &&
+		a.KeychainService == b.KeychainService &&
+		a.InstanceID == b.InstanceID
 }
 
 func preparseProfileFlag(args []string) string {

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -767,10 +767,14 @@ var (
 // getCachedRuntimeToken returns a cached access token, loading it only once per process.
 // This avoids repeated Keychain access which takes ~70ms each time.
 func getCachedRuntimeToken(ctx context.Context) string {
-	cacheKey := strings.TrimSpace(authpkg.RuntimeProfile())
-	if cacheKey == "" {
-		cacheKey = "__default__"
+	profileKey := strings.TrimSpace(authpkg.RuntimeProfile())
+	if profileKey == "" {
+		profileKey = "__default__"
 	}
+	// Auth instance and organization are independent selection axes. Include the
+	// auth-store namespace so equal corp/profile names in two instances can
+	// never share a process-cached token.
+	cacheKey := authpkg.ResolveAuthStore(defaultConfigDir()).KeychainService + "\x00" + profileKey
 	cachedRuntimeTokenMu.Lock()
 	if token := cachedRuntimeTokens[cacheKey]; token != "" {
 		cachedRuntimeTokenMu.Unlock()

--- a/internal/app/testmain_test.go
+++ b/internal/app/testmain_test.go
@@ -15,6 +15,7 @@ package app
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
@@ -48,6 +49,27 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv(keychain.StorageDirEnv, tmpDir); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		panic("set " + keychain.StorageDirEnv + ": " + err.Error())
+	}
+	if err := os.Setenv(keychain.DisableKeychainEnv, "1"); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		panic("set " + keychain.DisableKeychainEnv + ": " + err.Error())
+	}
+	testHome := filepath.Join(tmpDir, "home")
+	if err := os.MkdirAll(testHome, 0o700); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		panic("create test home: " + err.Error())
+	}
+	if err := os.Setenv("HOME", testHome); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		panic("set HOME: " + err.Error())
+	}
+	if err := os.Setenv("USERPROFILE", testHome); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		panic("set USERPROFILE: " + err.Error())
+	}
+	if err := os.Setenv("DWS_CONFIG_DIR", filepath.Join(tmpDir, "config")); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		panic("set DWS_CONFIG_DIR: " + err.Error())
 	}
 	openBrowserFunc = func(string) error { return nil }
 	code := m.Run()

--- a/internal/auth/auth_store.go
+++ b/internal/auth/auth_store.go
@@ -1,0 +1,709 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
+)
+
+const (
+	authRegistryVersion       = 1
+	authRegistryDirName       = "auth"
+	authRegistryFileName      = "registry.json"
+	authRegistryLockFileName  = ".registry.lock"
+	authInstancesDirName      = "instances"
+	authInstanceServicePrefix = keychain.Service + "-instance-"
+	DefaultAuthInstanceAlias  = "default"
+	maxAuthInstanceAliasRunes = 64
+	maxAuthRegistryFileBytes  = 1 << 20
+)
+
+// AuthInstanceKind identifies whether an instance reuses the historical
+// online store or owns an explicitly-created isolated store.
+type AuthInstanceKind string
+
+const (
+	AuthInstanceKindLegacy   AuthInstanceKind = "legacy"
+	AuthInstanceKindIsolated AuthInstanceKind = "isolated"
+)
+
+var (
+	// ErrAuthInstanceIsolationUnsupported is returned before an isolated state
+	// is created when an edition owns token persistence through hooks. Splitting
+	// only part of a hook-owned backend would make instance selection ambiguous.
+	ErrAuthInstanceIsolationUnsupported = errors.New("isolated auth instances are not supported by the current edition token hooks")
+	ErrAuthRegistryConflict             = errors.New("auth instance registry changed; retry the operation")
+)
+
+// AuthInstance is non-sensitive metadata for one login-state storage
+// location. It does not bind a natural person or organization. Identities
+// remain in the instance-local profiles.json.
+type AuthInstance struct {
+	ID    string           `json:"id"`
+	Alias string           `json:"alias"`
+	Kind  AuthInstanceKind `json:"kind"`
+}
+
+// AuthStore is the effective user-auth storage coordinate for one process.
+// BaseConfigDir continues to own shared application configuration. ConfigDir
+// and KeychainService contain only the selected login state.
+type AuthStore struct {
+	BaseConfigDir   string
+	ConfigDir       string
+	KeychainService string
+	InstanceID      string
+	InstanceAlias   string
+	InstanceKind    AuthInstanceKind
+}
+
+// Isolated reports whether this store belongs to an explicitly-created auth
+// instance. The legacy-backed default returns false.
+func (s AuthStore) Isolated() bool {
+	return s.InstanceKind == AuthInstanceKindIsolated
+}
+
+type authRegistry struct {
+	Version            int            `json:"version"`
+	Revision           int64          `json:"revision"`
+	CurrentInstanceID  string         `json:"currentInstanceId"`
+	PreviousInstanceID string         `json:"previousInstanceId,omitempty"`
+	Instances          []AuthInstance `json:"instances"`
+}
+
+var (
+	runtimeAuthStores sync.Map // normalized base config dir -> AuthStore
+	registryLocks     sync.Map // normalized base config dir -> *sync.Mutex
+	pendingAuthTxs    sync.Map // isolated keychain service -> *NewInstanceTransaction
+)
+
+// ResolveAuthStore is deliberately side-effect free. Unless an instance was
+// explicitly activated in this process, it returns the exact historical
+// configDir + dws-cli coordinate, including custom DWS_CONFIG_DIR values.
+func ResolveAuthStore(baseConfigDir string) AuthStore {
+	if value, ok := runtimeAuthStores.Load(authStoreRuntimeKey(baseConfigDir)); ok {
+		if store, valid := value.(AuthStore); valid {
+			return store
+		}
+	}
+	return legacyAuthStore(baseConfigDir, AuthInstance{})
+}
+
+// DeactivateAuthStore clears only the process-local selection. It never
+// changes registry.json or deletes credentials.
+func DeactivateAuthStore(baseConfigDir string) {
+	runtimeAuthStores.Delete(authStoreRuntimeKey(baseConfigDir))
+}
+
+// AuthRegistryPath returns the fixed registry location for one DWS config
+// home. Merely resolving this path does not create it.
+func AuthRegistryPath(baseConfigDir string) string {
+	return filepath.Join(baseConfigDir, authRegistryDirName, authRegistryFileName)
+}
+
+// ActivateCurrentInstance activates the persisted current auth instance. A
+// missing registry is the online-compatible state: it performs no write and
+// keeps the historical configDir + dws-cli coordinate. A malformed registry
+// fails closed instead of falling back to unrelated legacy credentials.
+func ActivateCurrentInstance(baseConfigDir string) (AuthStore, error) {
+	registry, exists, err := readAuthRegistry(baseConfigDir)
+	if err != nil {
+		DeactivateAuthStore(baseConfigDir)
+		return AuthStore{}, err
+	}
+	if !exists {
+		DeactivateAuthStore(baseConfigDir)
+		return ResolveAuthStore(baseConfigDir), nil
+	}
+	instance := findAuthInstanceByID(&registry, registry.CurrentInstanceID)
+	if instance == nil {
+		DeactivateAuthStore(baseConfigDir)
+		return AuthStore{}, fmt.Errorf("invalid auth registry: current instance %q not found", registry.CurrentInstanceID)
+	}
+	if authHooksOwnTokenStorage() && instance.Kind == AuthInstanceKindIsolated {
+		DeactivateAuthStore(baseConfigDir)
+		return AuthStore{}, fmt.Errorf(
+			"%w: selected instance %q is isolated; switch it with an edition that uses the standard DWS auth store, or use a separate DWS_CONFIG_DIR",
+			ErrAuthInstanceIsolationUnsupported, instance.Alias,
+		)
+	}
+	store := authStoreForInstance(baseConfigDir, *instance)
+	setRuntimeAuthStore(baseConfigDir, store)
+	return store, nil
+}
+
+// ListAuthInstances returns registry order and the current ID. Before explicit
+// opt-in it reports one synthetic legacy instance without creating a file.
+func ListAuthInstances(baseConfigDir string) (instances []AuthInstance, currentID string, err error) {
+	registry, exists, err := readAuthRegistry(baseConfigDir)
+	if err != nil {
+		return nil, "", err
+	}
+	if !exists {
+		return []AuthInstance{{Alias: DefaultAuthInstanceAlias, Kind: AuthInstanceKindLegacy}}, "", nil
+	}
+	return append([]AuthInstance(nil), registry.Instances...), registry.CurrentInstanceID, nil
+}
+
+// UseAuthInstance makes one login-state storage location current. Selector
+// accepts its alias, generated ID, or "-" for the previous instance.
+func UseAuthInstance(baseConfigDir, selector string) (AuthInstance, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return AuthInstance{}, fmt.Errorf("auth instance selector is required")
+	}
+
+	var selected AuthInstance
+	var selectedStore AuthStore
+	err := withAuthRegistryLock(baseConfigDir, func() error {
+		registry, exists, err := readAuthRegistry(baseConfigDir)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("isolated auth instances are not enabled; use auth login --new-instance <alias>")
+		}
+		lookup := selector
+		if selector == "-" {
+			lookup = registry.PreviousInstanceID
+			if lookup == "" {
+				return fmt.Errorf("previous auth instance is empty")
+			}
+		}
+		instance := findAuthInstance(&registry, lookup)
+		if instance == nil {
+			return fmt.Errorf("auth instance %q not found", selector)
+		}
+		if authHooksOwnTokenStorage() && instance.Kind == AuthInstanceKindIsolated {
+			return fmt.Errorf("%w: instance %q is isolated", ErrAuthInstanceIsolationUnsupported, instance.Alias)
+		}
+		selected = *instance
+		selectedStore = authStoreForInstance(baseConfigDir, selected)
+		if selected.ID == registry.CurrentInstanceID {
+			setRuntimeAuthStore(baseConfigDir, selectedStore)
+			return nil
+		}
+		registry.PreviousInstanceID = registry.CurrentInstanceID
+		registry.CurrentInstanceID = selected.ID
+		registry.Revision++
+		if err := writeAuthRegistry(baseConfigDir, registry); err != nil {
+			return err
+		}
+		setRuntimeAuthStore(baseConfigDir, selectedStore)
+		return nil
+	})
+	if err != nil {
+		return AuthInstance{}, err
+	}
+	return selected, nil
+}
+
+// NewInstanceTransaction keeps a new instance invisible to other processes
+// until the existing login flow succeeds and Commit atomically publishes it.
+type NewInstanceTransaction struct {
+	mu                      sync.Mutex
+	baseConfigDir           string
+	expectedRegistryExists  bool
+	expectedRevision        int64
+	pending                 authRegistry
+	instance                AuthInstance
+	store                   AuthStore
+	previousStore           AuthStore
+	previousWasExplicit     bool
+	writtenKeychainAccounts map[string]struct{}
+	done                    bool
+}
+
+// BeginNewInstance process-activates a fresh isolated store without copying
+// any legacy token, profile, marker, secret, or application config. Commit must
+// be called only after login succeeds; otherwise call Rollback.
+func BeginNewInstance(baseConfigDir, alias string) (*NewInstanceTransaction, error) {
+	if strings.TrimSpace(baseConfigDir) == "" {
+		return nil, fmt.Errorf("base config directory is required")
+	}
+	if authHooksOwnTokenStorage() {
+		return nil, ErrAuthInstanceIsolationUnsupported
+	}
+	alias, err := validateAuthInstanceAlias(alias)
+	if err != nil {
+		return nil, err
+	}
+
+	registry, exists, err := readAuthRegistry(baseConfigDir)
+	if err != nil {
+		return nil, err
+	}
+	previousStore := ResolveAuthStore(baseConfigDir)
+	previousWasExplicit := previousStore.InstanceID != ""
+	if exists {
+		if findAuthInstance(&registry, alias) != nil {
+			return nil, fmt.Errorf("auth instance alias %q already exists", alias)
+		}
+		if previousStore.InstanceID == "" {
+			current := findAuthInstanceByID(&registry, registry.CurrentInstanceID)
+			if current == nil {
+				return nil, fmt.Errorf("invalid auth registry: current instance %q not found", registry.CurrentInstanceID)
+			}
+			previousStore = authStoreForInstance(baseConfigDir, *current)
+			previousWasExplicit = true
+		}
+	} else {
+		if strings.EqualFold(alias, DefaultAuthInstanceAlias) {
+			return nil, fmt.Errorf("auth instance alias %q is reserved for the existing login", alias)
+		}
+		legacyInstance := AuthInstance{
+			ID:    uuid.NewString(),
+			Alias: DefaultAuthInstanceAlias,
+			Kind:  AuthInstanceKindLegacy,
+		}
+		registry = authRegistry{
+			Version:           authRegistryVersion,
+			CurrentInstanceID: legacyInstance.ID,
+			Instances:         []AuthInstance{legacyInstance},
+		}
+	}
+
+	instance := AuthInstance{ID: uuid.NewString(), Alias: alias, Kind: AuthInstanceKindIsolated}
+	registry.PreviousInstanceID = registry.CurrentInstanceID
+	registry.CurrentInstanceID = instance.ID
+	registry.Instances = append(registry.Instances, instance)
+	registry.Revision++
+	if err := validateAuthRegistry(&registry); err != nil {
+		return nil, err
+	}
+	store := authStoreForInstance(baseConfigDir, instance)
+	tx := &NewInstanceTransaction{
+		baseConfigDir:           baseConfigDir,
+		expectedRegistryExists:  exists,
+		expectedRevision:        registry.Revision - 1,
+		pending:                 registry,
+		instance:                instance,
+		store:                   store,
+		previousStore:           previousStore,
+		previousWasExplicit:     previousWasExplicit,
+		writtenKeychainAccounts: make(map[string]struct{}),
+	}
+	pendingAuthTxs.Store(store.KeychainService, tx)
+	setRuntimeAuthStore(baseConfigDir, store)
+	return tx, nil
+}
+
+// Store returns the pending isolated storage coordinate used by login.
+func (tx *NewInstanceTransaction) Store() AuthStore {
+	if tx == nil {
+		return AuthStore{}
+	}
+	return tx.store
+}
+
+// Instance returns the pending instance metadata.
+func (tx *NewInstanceTransaction) Instance() AuthInstance {
+	if tx == nil {
+		return AuthInstance{}
+	}
+	return tx.instance
+}
+
+// Commit atomically publishes the pending instance after verifying that no
+// other process changed the registry during interactive login.
+func (tx *NewInstanceTransaction) Commit() error {
+	if tx == nil {
+		return fmt.Errorf("nil auth instance transaction")
+	}
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+	if tx.done {
+		return fmt.Errorf("auth instance transaction is already closed")
+	}
+
+	err := withAuthRegistryLock(tx.baseConfigDir, func() error {
+		current, exists, err := readAuthRegistry(tx.baseConfigDir)
+		if err != nil {
+			return err
+		}
+		if exists != tx.expectedRegistryExists {
+			return ErrAuthRegistryConflict
+		}
+		if exists && current.Revision != tx.expectedRevision {
+			return ErrAuthRegistryConflict
+		}
+		if err := ensurePrivateAuthStoreDirs(tx.store); err != nil {
+			return err
+		}
+		return writeAuthRegistry(tx.baseConfigDir, tx.pending)
+	})
+	if err != nil {
+		return err
+	}
+	tx.done = true
+	pendingAuthTxs.Delete(tx.store.KeychainService)
+	setRuntimeAuthStore(tx.baseConfigDir, tx.store)
+	return nil
+}
+
+// Rollback restores the previous process selection and best-effort removes the
+// unpublished instance's unique files and token slots. It never writes the
+// registry.
+func (tx *NewInstanceTransaction) Rollback() error {
+	if tx == nil {
+		return nil
+	}
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+	if tx.done {
+		return nil
+	}
+	tx.done = true
+	pendingAuthTxs.Delete(tx.store.KeychainService)
+	cleanupErr := cleanupUncommittedAuthStore(tx.store, tx.writtenKeychainAccounts)
+	if tx.previousWasExplicit {
+		setRuntimeAuthStore(tx.baseConfigDir, tx.previousStore)
+	} else {
+		DeactivateAuthStore(tx.baseConfigDir)
+	}
+	return cleanupErr
+}
+
+func legacyAuthStore(baseConfigDir string, instance AuthInstance) AuthStore {
+	return AuthStore{
+		BaseConfigDir:   baseConfigDir,
+		ConfigDir:       baseConfigDir,
+		KeychainService: keychain.Service,
+		InstanceID:      instance.ID,
+		InstanceAlias:   instance.Alias,
+		InstanceKind:    instance.Kind,
+	}
+}
+
+func authStoreForInstance(baseConfigDir string, instance AuthInstance) AuthStore {
+	if instance.Kind == AuthInstanceKindLegacy {
+		return legacyAuthStore(baseConfigDir, instance)
+	}
+	return AuthStore{
+		BaseConfigDir:   baseConfigDir,
+		ConfigDir:       filepath.Join(baseConfigDir, authRegistryDirName, authInstancesDirName, instance.ID),
+		KeychainService: authInstanceServicePrefix + instance.ID,
+		InstanceID:      instance.ID,
+		InstanceAlias:   instance.Alias,
+		InstanceKind:    instance.Kind,
+	}
+}
+
+func setRuntimeAuthStore(baseConfigDir string, store AuthStore) {
+	runtimeAuthStores.Store(authStoreRuntimeKey(baseConfigDir), store)
+}
+
+func authStoreRuntimeKey(baseConfigDir string) string {
+	clean := filepath.Clean(baseConfigDir)
+	if absolute, err := filepath.Abs(clean); err == nil {
+		clean = absolute
+	}
+	return clean
+}
+
+func authRegistryRoot(baseConfigDir string) string {
+	return filepath.Join(baseConfigDir, authRegistryDirName)
+}
+
+func readAuthRegistry(baseConfigDir string) (authRegistry, bool, error) {
+	path := AuthRegistryPath(baseConfigDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return authRegistry{}, false, nil
+		}
+		return authRegistry{}, false, fmt.Errorf("read auth registry: %w", err)
+	}
+	if len(data) > maxAuthRegistryFileBytes {
+		return authRegistry{}, true, fmt.Errorf("auth registry exceeds %d bytes", maxAuthRegistryFileBytes)
+	}
+	var registry authRegistry
+	if err := json.Unmarshal(data, &registry); err != nil {
+		return authRegistry{}, true, fmt.Errorf("parse auth registry: %w", err)
+	}
+	if err := validateAuthRegistry(&registry); err != nil {
+		return authRegistry{}, true, err
+	}
+	return registry, true, nil
+}
+
+func writeAuthRegistry(baseConfigDir string, registry authRegistry) error {
+	if err := validateAuthRegistry(&registry); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(&registry, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal auth registry: %w", err)
+	}
+	if err := ensurePrivateDir(authRegistryRoot(baseConfigDir)); err != nil {
+		return err
+	}
+	if err := helpers.AtomicWrite(AuthRegistryPath(baseConfigDir), append(data, '\n'), config.FilePerm); err != nil {
+		return fmt.Errorf("write auth registry: %w", err)
+	}
+	return nil
+}
+
+func validateAuthRegistry(registry *authRegistry) error {
+	if registry == nil {
+		return fmt.Errorf("invalid auth registry: empty")
+	}
+	if registry.Version != authRegistryVersion {
+		return fmt.Errorf("unsupported auth registry version %d", registry.Version)
+	}
+	if registry.Revision < 1 {
+		return fmt.Errorf("invalid auth registry revision %d", registry.Revision)
+	}
+	if len(registry.Instances) == 0 {
+		return fmt.Errorf("invalid auth registry: instances are empty")
+	}
+	ids := make(map[string]struct{}, len(registry.Instances))
+	aliases := make([]string, 0, len(registry.Instances))
+	legacyCount := 0
+	for i := range registry.Instances {
+		instance := &registry.Instances[i]
+		if err := validateCanonicalUUID("instance", instance.ID); err != nil {
+			return err
+		}
+		if _, duplicate := ids[instance.ID]; duplicate {
+			return fmt.Errorf("invalid auth registry: duplicate instance id %q", instance.ID)
+		}
+		ids[instance.ID] = struct{}{}
+		alias, err := validateAuthInstanceAlias(instance.Alias)
+		if err != nil {
+			return fmt.Errorf("invalid auth registry instance %q: %w", instance.ID, err)
+		}
+		if alias != instance.Alias {
+			return fmt.Errorf("invalid auth registry instance %q: alias is not normalized", instance.ID)
+		}
+		for _, existing := range aliases {
+			if strings.EqualFold(existing, alias) {
+				return fmt.Errorf("invalid auth registry: duplicate instance alias %q", alias)
+			}
+		}
+		aliases = append(aliases, alias)
+		switch instance.Kind {
+		case AuthInstanceKindLegacy:
+			legacyCount++
+		case AuthInstanceKindIsolated:
+		default:
+			return fmt.Errorf("invalid auth registry instance %q: unsupported kind %q", instance.ID, instance.Kind)
+		}
+	}
+	if legacyCount != 1 {
+		return fmt.Errorf("invalid auth registry: expected one legacy instance, got %d", legacyCount)
+	}
+	if _, ok := ids[registry.CurrentInstanceID]; !ok {
+		return fmt.Errorf("invalid auth registry: current instance %q not found", registry.CurrentInstanceID)
+	}
+	if previous := registry.PreviousInstanceID; previous != "" {
+		if _, ok := ids[previous]; !ok {
+			return fmt.Errorf("invalid auth registry: previous instance %q not found", previous)
+		}
+		if previous == registry.CurrentInstanceID {
+			return fmt.Errorf("invalid auth registry: previous and current instances are identical")
+		}
+	}
+	return nil
+}
+
+func validateCanonicalUUID(kind, value string) error {
+	parsed, err := uuid.Parse(value)
+	if err != nil || parsed.String() != value {
+		return fmt.Errorf("invalid auth registry %s id %q", kind, value)
+	}
+	return nil
+}
+
+func validateAuthInstanceAlias(alias string) (string, error) {
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return "", fmt.Errorf("auth instance alias is required")
+	}
+	if !utf8.ValidString(alias) {
+		return "", fmt.Errorf("auth instance alias must be valid UTF-8")
+	}
+	if utf8.RuneCountInString(alias) > maxAuthInstanceAliasRunes {
+		return "", fmt.Errorf("auth instance alias exceeds %d characters", maxAuthInstanceAliasRunes)
+	}
+	for _, r := range alias {
+		if unicode.IsControl(r) {
+			return "", fmt.Errorf("auth instance alias contains control characters")
+		}
+	}
+	if alias == "-" {
+		return "", fmt.Errorf("auth instance alias %q is reserved", alias)
+	}
+	return alias, nil
+}
+
+func findAuthInstance(registry *authRegistry, selector string) *AuthInstance {
+	if registry == nil {
+		return nil
+	}
+	selector = strings.TrimSpace(selector)
+	for i := range registry.Instances {
+		instance := &registry.Instances[i]
+		if instance.ID == selector || strings.EqualFold(instance.Alias, selector) {
+			return instance
+		}
+	}
+	return nil
+}
+
+func findAuthInstanceByID(registry *authRegistry, id string) *AuthInstance {
+	if registry == nil {
+		return nil
+	}
+	for i := range registry.Instances {
+		if registry.Instances[i].ID == id {
+			return &registry.Instances[i]
+		}
+	}
+	return nil
+}
+
+func authHooksOwnTokenStorage() bool {
+	hooks := edition.Get()
+	return hooks != nil && (hooks.SaveToken != nil || hooks.LoadToken != nil || hooks.DeleteToken != nil)
+}
+
+func withAuthRegistryLock(baseConfigDir string, fn func() error) error {
+	key := authStoreRuntimeKey(baseConfigDir)
+	value, _ := registryLocks.LoadOrStore(key, &sync.Mutex{})
+	mu := value.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+
+	root := authRegistryRoot(baseConfigDir)
+	if err := ensurePrivateDir(root); err != nil {
+		return err
+	}
+	path := filepath.Join(root, authRegistryLockFileName)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, config.FilePerm)
+	if err != nil {
+		return fmt.Errorf("open auth registry lock: %w", err)
+	}
+	defer file.Close()
+	if err := file.Chmod(config.FilePerm); err != nil {
+		return fmt.Errorf("set auth registry lock permissions: %w", err)
+	}
+	deadline := time.Now().Add(config.LockTimeout)
+	for {
+		if err := lockFile(file); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout acquiring auth registry lock after %v", config.LockTimeout)
+		}
+		time.Sleep(lockRetryDelay)
+	}
+	defer unlockFile(file)
+	return fn()
+}
+
+func ensurePrivateAuthStoreDirs(store AuthStore) error {
+	if !store.Isolated() {
+		return nil
+	}
+	return ensurePrivateDir(store.ConfigDir)
+}
+
+func ensurePrivateDir(path string) error {
+	if err := os.MkdirAll(path, config.DirPerm); err != nil {
+		return fmt.Errorf("create private auth directory: %w", err)
+	}
+	if err := os.Chmod(path, config.DirPerm); err != nil {
+		return fmt.Errorf("set private auth directory permissions: %w", err)
+	}
+	return nil
+}
+
+func recordPendingAuthKeychainWrite(service, account string) {
+	value, ok := pendingAuthTxs.Load(service)
+	if !ok {
+		return
+	}
+	tx, ok := value.(*NewInstanceTransaction)
+	if !ok || tx == nil {
+		return
+	}
+	tx.mu.Lock()
+	defer tx.mu.Unlock()
+	if tx.done {
+		return
+	}
+	tx.writtenKeychainAccounts[account] = struct{}{}
+}
+
+func cleanupUncommittedAuthStore(store AuthStore, writtenAccounts map[string]struct{}) error {
+	if !store.Isolated() {
+		return nil
+	}
+	var firstErr error
+	accounts := make(map[string]struct{}, len(writtenAccounts)+1)
+	for account := range writtenAccounts {
+		accounts[account] = struct{}{}
+	}
+	accounts[keychain.AccountToken] = struct{}{}
+	profilesPath := filepath.Join(store.ConfigDir, profilesJSONFile)
+	if data, err := os.ReadFile(profilesPath); err == nil {
+		var profiles ProfilesConfig
+		if json.Unmarshal(data, &profiles) == nil {
+			for _, profile := range profiles.Profiles {
+				if profile.CorpID != "" {
+					accounts[TokenAccountForCorpID(profile.CorpID)] = struct{}{}
+				}
+			}
+		}
+	}
+	for account := range accounts {
+		if err := keychain.Remove(store.KeychainService, account); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if err := os.RemoveAll(keychain.StorageDir(store.KeychainService)); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	if err := os.RemoveAll(store.ConfigDir); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	pruneEmptyAuthParents(store)
+	return firstErr
+}
+
+func pruneEmptyAuthParents(store AuthStore) {
+	stop := authRegistryRoot(store.BaseConfigDir)
+	for dir := filepath.Dir(store.ConfigDir); dir != stop && dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
+		if err := os.Remove(dir); err != nil {
+			return
+		}
+	}
+	_ = os.Remove(stop)
+}

--- a/internal/auth/auth_store.go
+++ b/internal/auth/auth_store.go
@@ -14,11 +14,13 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -98,9 +100,10 @@ type authRegistry struct {
 }
 
 var (
-	runtimeAuthStores sync.Map // normalized base config dir -> AuthStore
-	registryLocks     sync.Map // normalized base config dir -> *sync.Mutex
-	pendingAuthTxs    sync.Map // isolated keychain service -> *NewInstanceTransaction
+	runtimeAuthStores     sync.Map // normalized base config dir -> AuthStore
+	runtimeAuthStoreLocks sync.Map // normalized base config dir -> *sync.RWMutex
+	registryLocks         sync.Map // normalized base config dir -> *sync.Mutex
+	pendingAuthTxs        sync.Map // isolated keychain service -> *NewInstanceTransaction
 )
 
 // ResolveAuthStore is deliberately side-effect free. Unless an instance was
@@ -118,7 +121,10 @@ func ResolveAuthStore(baseConfigDir string) AuthStore {
 // DeactivateAuthStore clears only the process-local selection. It never
 // changes registry.json or deletes credentials.
 func DeactivateAuthStore(baseConfigDir string) {
-	runtimeAuthStores.Delete(authStoreRuntimeKey(baseConfigDir))
+	mu := authStoreSelectionMutex(baseConfigDir)
+	mu.Lock()
+	deactivateAuthStoreLocked(baseConfigDir)
+	mu.Unlock()
 }
 
 // AuthRegistryPath returns the fixed registry location for one DWS config
@@ -132,29 +138,33 @@ func AuthRegistryPath(baseConfigDir string) string {
 // keeps the historical configDir + dws-cli coordinate. A malformed registry
 // fails closed instead of falling back to unrelated legacy credentials.
 func ActivateCurrentInstance(baseConfigDir string) (AuthStore, error) {
+	mu := authStoreSelectionMutex(baseConfigDir)
+	mu.Lock()
+	defer mu.Unlock()
+
 	registry, exists, err := readAuthRegistry(baseConfigDir)
 	if err != nil {
-		DeactivateAuthStore(baseConfigDir)
+		deactivateAuthStoreLocked(baseConfigDir)
 		return AuthStore{}, err
 	}
 	if !exists {
-		DeactivateAuthStore(baseConfigDir)
+		deactivateAuthStoreLocked(baseConfigDir)
 		return ResolveAuthStore(baseConfigDir), nil
 	}
 	instance := findAuthInstanceByID(&registry, registry.CurrentInstanceID)
 	if instance == nil {
-		DeactivateAuthStore(baseConfigDir)
+		deactivateAuthStoreLocked(baseConfigDir)
 		return AuthStore{}, fmt.Errorf("invalid auth registry: current instance %q not found", registry.CurrentInstanceID)
 	}
 	if authHooksOwnTokenStorage() && instance.Kind == AuthInstanceKindIsolated {
-		DeactivateAuthStore(baseConfigDir)
+		deactivateAuthStoreLocked(baseConfigDir)
 		return AuthStore{}, fmt.Errorf(
 			"%w: selected instance %q is isolated; switch it with an edition that uses the standard DWS auth store, or use a separate DWS_CONFIG_DIR",
 			ErrAuthInstanceIsolationUnsupported, instance.Alias,
 		)
 	}
 	store := authStoreForInstance(baseConfigDir, *instance)
-	setRuntimeAuthStore(baseConfigDir, store)
+	setRuntimeAuthStoreLocked(baseConfigDir, store)
 	return store, nil
 }
 
@@ -181,6 +191,9 @@ func UseAuthInstance(baseConfigDir, selector string) (AuthInstance, error) {
 
 	var selected AuthInstance
 	var selectedStore AuthStore
+	selectionMu := authStoreSelectionMutex(baseConfigDir)
+	selectionMu.Lock()
+	defer selectionMu.Unlock()
 	err := withAuthRegistryLock(baseConfigDir, func() error {
 		registry, exists, err := readAuthRegistry(baseConfigDir)
 		if err != nil {
@@ -206,7 +219,6 @@ func UseAuthInstance(baseConfigDir, selector string) (AuthInstance, error) {
 		selected = *instance
 		selectedStore = authStoreForInstance(baseConfigDir, selected)
 		if selected.ID == registry.CurrentInstanceID {
-			setRuntimeAuthStore(baseConfigDir, selectedStore)
 			return nil
 		}
 		registry.PreviousInstanceID = registry.CurrentInstanceID
@@ -215,12 +227,12 @@ func UseAuthInstance(baseConfigDir, selector string) (AuthInstance, error) {
 		if err := writeAuthRegistry(baseConfigDir, registry); err != nil {
 			return err
 		}
-		setRuntimeAuthStore(baseConfigDir, selectedStore)
 		return nil
 	})
 	if err != nil {
 		return AuthInstance{}, err
 	}
+	setRuntimeAuthStoreLocked(baseConfigDir, selectedStore)
 	return selected, nil
 }
 
@@ -238,6 +250,7 @@ type NewInstanceTransaction struct {
 	previousWasExplicit     bool
 	writtenKeychainAccounts map[string]struct{}
 	done                    bool
+	closing                 bool
 }
 
 // BeginNewInstance process-activates a fresh isolated store without copying
@@ -254,6 +267,9 @@ func BeginNewInstance(baseConfigDir, alias string) (*NewInstanceTransaction, err
 	if err != nil {
 		return nil, err
 	}
+	selectionMu := authStoreSelectionMutex(baseConfigDir)
+	selectionMu.Lock()
+	defer selectionMu.Unlock()
 
 	registry, exists, err := readAuthRegistry(baseConfigDir)
 	if err != nil {
@@ -310,7 +326,7 @@ func BeginNewInstance(baseConfigDir, alias string) (*NewInstanceTransaction, err
 		writtenKeychainAccounts: make(map[string]struct{}),
 	}
 	pendingAuthTxs.Store(store.KeychainService, tx)
-	setRuntimeAuthStore(baseConfigDir, store)
+	setRuntimeAuthStoreLocked(baseConfigDir, store)
 	return tx, nil
 }
 
@@ -337,12 +353,52 @@ func (tx *NewInstanceTransaction) Commit() error {
 		return fmt.Errorf("nil auth instance transaction")
 	}
 	tx.mu.Lock()
-	defer tx.mu.Unlock()
 	if tx.done {
+		tx.mu.Unlock()
 		return fmt.Errorf("auth instance transaction is already closed")
 	}
+	if tx.closing {
+		tx.mu.Unlock()
+		return fmt.Errorf("auth instance transaction is already being closed")
+	}
+	tx.closing = true
+	tx.mu.Unlock()
+	completed := false
+	defer func() {
+		if completed {
+			return
+		}
+		tx.mu.Lock()
+		tx.closing = false
+		tx.mu.Unlock()
+	}()
 
-	err := withAuthRegistryLock(tx.baseConfigDir, func() error {
+	// Lock order is selection -> instance store(s) -> Registry. OAuth/network
+	// work has already completed before Commit, so these locks cover only the
+	// local publication boundary. Sorting instance paths prevents two first-time
+	// commits from acquiring the legacy and pending stores in opposite orders.
+	selectionMu := authStoreSelectionMutex(tx.baseConfigDir)
+	selectionMu.Lock()
+	defer selectionMu.Unlock()
+	stores := []AuthStore{tx.store}
+	if !tx.expectedRegistryExists {
+		// The first opt-in is also the boundary where legacy full-reset semantics
+		// stop applying. Share the stable default-instance lock so Registry cannot
+		// appear midway through a legacy reset's shared-config cleanup.
+		stores = append(stores, legacyAuthStore(tx.baseConfigDir, AuthInstance{}))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), config.LockTimeout)
+	defer cancel()
+	locks, err := acquireAuthStoreLocks(ctx, stores...)
+	if err != nil {
+		return err
+	}
+	defer releaseAuthStoreLocks(locks)
+	if err := ensurePrivateAuthStoreDirs(tx.store); err != nil {
+		return err
+	}
+
+	err = withAuthRegistryLock(tx.baseConfigDir, func() error {
 		current, exists, err := readAuthRegistry(tx.baseConfigDir)
 		if err != nil {
 			return err
@@ -353,17 +409,18 @@ func (tx *NewInstanceTransaction) Commit() error {
 		if exists && current.Revision != tx.expectedRevision {
 			return ErrAuthRegistryConflict
 		}
-		if err := ensurePrivateAuthStoreDirs(tx.store); err != nil {
-			return err
-		}
 		return writeAuthRegistry(tx.baseConfigDir, tx.pending)
 	})
 	if err != nil {
 		return err
 	}
+	tx.mu.Lock()
 	tx.done = true
+	tx.closing = false
+	tx.mu.Unlock()
 	pendingAuthTxs.Delete(tx.store.KeychainService)
-	setRuntimeAuthStore(tx.baseConfigDir, tx.store)
+	setRuntimeAuthStoreLocked(tx.baseConfigDir, tx.store)
+	completed = true
 	return nil
 }
 
@@ -375,18 +432,63 @@ func (tx *NewInstanceTransaction) Rollback() error {
 		return nil
 	}
 	tx.mu.Lock()
-	defer tx.mu.Unlock()
 	if tx.done {
+		tx.mu.Unlock()
 		return nil
 	}
-	tx.done = true
-	pendingAuthTxs.Delete(tx.store.KeychainService)
-	cleanupErr := cleanupUncommittedAuthStore(tx.store, tx.writtenKeychainAccounts)
-	if tx.previousWasExplicit {
-		setRuntimeAuthStore(tx.baseConfigDir, tx.previousStore)
-	} else {
-		DeactivateAuthStore(tx.baseConfigDir)
+	if tx.closing {
+		tx.mu.Unlock()
+		return fmt.Errorf("auth instance transaction is already being closed")
 	}
+	tx.closing = true
+	tx.mu.Unlock()
+	completed := false
+	defer func() {
+		if completed {
+			return
+		}
+		tx.mu.Lock()
+		tx.closing = false
+		tx.mu.Unlock()
+	}()
+
+	selectionMu := authStoreSelectionMutex(tx.baseConfigDir)
+	selectionMu.Lock()
+	defer selectionMu.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), config.LockTimeout)
+	defer cancel()
+	locks, err := acquireAuthStoreLocks(ctx, tx.store)
+	if err != nil {
+		return err
+	}
+
+	// No current-store writer can begin while the selection write lock is held,
+	// and acquiring the pending store lock waits for any writer already in flight.
+	tx.mu.Lock()
+	writtenAccounts := make(map[string]struct{}, len(tx.writtenKeychainAccounts))
+	for account := range tx.writtenKeychainAccounts {
+		writtenAccounts[account] = struct{}{}
+	}
+	tx.mu.Unlock()
+	cleanupErr := cleanupUncommittedAuthStoreData(tx.store, writtenAccounts)
+	releaseAuthStoreLocks(locks)
+	// Windows cannot remove a directory containing an open LockFileEx handle;
+	// remove the now-unpublished directory only after releasing its data lock.
+	if err := removeUncommittedAuthStoreDir(tx.store); cleanupErr == nil {
+		cleanupErr = err
+	}
+
+	tx.mu.Lock()
+	tx.done = true
+	tx.closing = false
+	tx.mu.Unlock()
+	pendingAuthTxs.Delete(tx.store.KeychainService)
+	if tx.previousWasExplicit {
+		setRuntimeAuthStoreLocked(tx.baseConfigDir, tx.previousStore)
+	} else {
+		deactivateAuthStoreLocked(tx.baseConfigDir)
+	}
+	completed = true
 	return cleanupErr
 }
 
@@ -416,7 +518,24 @@ func authStoreForInstance(baseConfigDir string, instance AuthInstance) AuthStore
 }
 
 func setRuntimeAuthStore(baseConfigDir string, store AuthStore) {
+	mu := authStoreSelectionMutex(baseConfigDir)
+	mu.Lock()
+	setRuntimeAuthStoreLocked(baseConfigDir, store)
+	mu.Unlock()
+}
+
+func setRuntimeAuthStoreLocked(baseConfigDir string, store AuthStore) {
 	runtimeAuthStores.Store(authStoreRuntimeKey(baseConfigDir), store)
+}
+
+func deactivateAuthStoreLocked(baseConfigDir string) {
+	runtimeAuthStores.Delete(authStoreRuntimeKey(baseConfigDir))
+}
+
+func authStoreSelectionMutex(baseConfigDir string) *sync.RWMutex {
+	key := authStoreRuntimeKey(baseConfigDir)
+	value, _ := runtimeAuthStoreLocks.LoadOrStore(key, &sync.RWMutex{})
+	return value.(*sync.RWMutex)
 }
 
 func authStoreRuntimeKey(baseConfigDir string) string {
@@ -425,6 +544,39 @@ func authStoreRuntimeKey(baseConfigDir string) string {
 		clean = absolute
 	}
 	return clean
+}
+
+func acquireAuthStoreLocks(ctx context.Context, stores ...AuthStore) ([]*DualLock, error) {
+	dirsByKey := make(map[string]string, len(stores))
+	keys := make([]string, 0, len(stores))
+	for _, store := range stores {
+		if strings.TrimSpace(store.ConfigDir) == "" {
+			continue
+		}
+		key := authStoreRuntimeKey(store.ConfigDir)
+		if _, exists := dirsByKey[key]; exists {
+			continue
+		}
+		dirsByKey[key] = store.ConfigDir
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	locks := make([]*DualLock, 0, len(keys))
+	for _, key := range keys {
+		lock, err := acquireDualLockAt(ctx, dirsByKey[key])
+		if err != nil {
+			releaseAuthStoreLocks(locks)
+			return nil, err
+		}
+		locks = append(locks, lock)
+	}
+	return locks, nil
+}
+
+func releaseAuthStoreLocks(locks []*DualLock) {
+	for i := len(locks) - 1; i >= 0; i-- {
+		locks[i].Release()
+	}
 }
 
 func authRegistryRoot(baseConfigDir string) string {
@@ -451,6 +603,84 @@ func readAuthRegistry(baseConfigDir string) (authRegistry, bool, error) {
 		return authRegistry{}, true, err
 	}
 	return registry, true, nil
+}
+
+type currentAuthStoreSnapshot struct {
+	store          AuthStore
+	registryExists bool
+	revision       int64
+	currentID      string
+}
+
+func readCurrentAuthStoreSnapshot(baseConfigDir string) (currentAuthStoreSnapshot, error) {
+	registry, exists, err := readAuthRegistry(baseConfigDir)
+	if err != nil {
+		return currentAuthStoreSnapshot{}, err
+	}
+	if !exists {
+		return currentAuthStoreSnapshot{store: legacyAuthStore(baseConfigDir, AuthInstance{})}, nil
+	}
+	instance := findAuthInstanceByID(&registry, registry.CurrentInstanceID)
+	if instance == nil {
+		return currentAuthStoreSnapshot{}, fmt.Errorf("invalid auth registry: current instance %q not found", registry.CurrentInstanceID)
+	}
+	return currentAuthStoreSnapshot{
+		store:          authStoreForInstance(baseConfigDir, *instance),
+		registryExists: true,
+		revision:       registry.Revision,
+		currentID:      registry.CurrentInstanceID,
+	}, nil
+}
+
+func (s currentAuthStoreSnapshot) sameSelection(other currentAuthStoreSnapshot) bool {
+	return s.registryExists == other.registryExists &&
+		s.revision == other.revision &&
+		s.currentID == other.currentID &&
+		authStoreRuntimeKey(s.store.ConfigDir) == authStoreRuntimeKey(other.store.ConfigDir) &&
+		s.store.KeychainService == other.store.KeychainService
+}
+
+// withLockedCurrentAuthStore linearizes a current-instance mutation without
+// holding the global Registry lock across instance data I/O:
+//
+//  1. snapshot the Registry using its atomic file contract;
+//  2. acquire only that instance's process + operating-system file lock;
+//  3. re-read and validate revision/current ID while the instance lock is held;
+//  4. retry if auth use/new-instance won the race, otherwise mutate the fixed
+//     ConfigDir + KeychainService passed to fn.
+//
+// A Registry change after step 3 is ordered after this mutation. It may change
+// which instance is current, but it cannot redirect fn to another store.
+func withLockedCurrentAuthStore(
+	ctx context.Context,
+	baseConfigDir string,
+	fn func(store AuthStore, registryExists bool) error,
+) (bool, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		before, err := readCurrentAuthStoreSnapshot(baseConfigDir)
+		if err != nil {
+			return false, err
+		}
+		lock, err := acquireDualLockAt(ctx, before.store.ConfigDir)
+		if err != nil {
+			return false, err
+		}
+		after, err := readCurrentAuthStoreSnapshot(baseConfigDir)
+		if err != nil {
+			lock.Release()
+			return false, err
+		}
+		if !before.sameSelection(after) {
+			lock.Release()
+			continue
+		}
+		err = fn(before.store, before.registryExists)
+		lock.Release()
+		return before.registryExists, err
+	}
 }
 
 func writeAuthRegistry(baseConfigDir string, registry authRegistry) error {
@@ -662,7 +892,7 @@ func recordPendingAuthKeychainWrite(service, account string) {
 	tx.writtenKeychainAccounts[account] = struct{}{}
 }
 
-func cleanupUncommittedAuthStore(store AuthStore, writtenAccounts map[string]struct{}) error {
+func cleanupUncommittedAuthStoreData(store AuthStore, writtenAccounts map[string]struct{}) error {
 	if !store.Isolated() {
 		return nil
 	}
@@ -691,11 +921,18 @@ func cleanupUncommittedAuthStore(store AuthStore, writtenAccounts map[string]str
 	if err := os.RemoveAll(keychain.StorageDir(store.KeychainService)); err != nil && firstErr == nil {
 		firstErr = err
 	}
-	if err := os.RemoveAll(store.ConfigDir); err != nil && firstErr == nil {
-		firstErr = err
+	return firstErr
+}
+
+func removeUncommittedAuthStoreDir(store AuthStore) error {
+	if !store.Isolated() {
+		return nil
+	}
+	if err := os.RemoveAll(store.ConfigDir); err != nil {
+		return err
 	}
 	pruneEmptyAuthParents(store)
-	return firstErr
+	return nil
 }
 
 func pruneEmptyAuthParents(store AuthStore) {

--- a/internal/auth/auth_store_test.go
+++ b/internal/auth/auth_store_test.go
@@ -228,6 +228,54 @@ func TestAuthInstanceIsLoginSlotAndAllowsReplacingIdentity(t *testing.T) {
 	}
 }
 
+func TestDeleteAllTokenDataOnlyClearsActiveInstance(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+
+	txA, err := BeginNewInstance(base, "instance-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupAuthServiceForTest(t, txA.Store().KeychainService)
+	if err := SaveTokenData(base, testAccountToken("same-corp", "user-a", "access-a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := txA.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	txB, err := BeginNewInstance(base, "instance-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupAuthServiceForTest(t, txB.Store().KeychainService)
+	if err := SaveTokenData(base, testAccountToken("same-corp", "user-b", "access-b")); err != nil {
+		t.Fatal(err)
+	}
+	if err := txB.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := UseAuthInstance(base, txA.Instance().ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := DeleteAllTokenData(base); err != nil {
+		t.Fatal(err)
+	}
+	if TokenDataExistsKeychainForCorpIDAt(base, "same-corp") {
+		t.Fatal("reset retained the active instance token")
+	}
+
+	if _, err := UseAuthInstance(base, txB.Instance().ID); err != nil {
+		t.Fatal(err)
+	}
+	data, err := LoadTokenDataForProfile(base, "same-corp")
+	if err != nil || data.UserID != "user-b" || data.AccessToken != "access-b" {
+		t.Fatalf("reset of instance-a changed instance-b: token=%#v err=%v", data, err)
+	}
+}
+
 func TestRollbackDoesNotPublishFailedLogin(t *testing.T) {
 	base := t.TempDir()
 	DeactivateAuthStore(base)

--- a/internal/auth/auth_store_test.go
+++ b/internal/auth/auth_store_test.go
@@ -14,12 +14,17 @@
 package auth
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"errors"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -276,6 +281,232 @@ func TestDeleteAllTokenDataOnlyClearsActiveInstance(t *testing.T) {
 	}
 }
 
+func TestAuthInstanceSystemLocksSerializeSameStoreAndParallelizeDifferentStores(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+
+	txA, err := BeginNewInstance(base, "lock-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := txA.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	txB, err := BeginNewInstance(base, "lock-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := txB.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	held := startCrossProcessAuthStoreLock(t, txA.Store().ConfigDir)
+
+	// B owns a different lock file and must remain available while another
+	// process holds A.
+	bResult := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		lock, err := acquireDualLockAt(ctx, txB.Store().ConfigDir)
+		if err == nil {
+			lock.Release()
+		}
+		bResult <- err
+	}()
+	select {
+	case err := <-bResult:
+		if err != nil {
+			t.Fatalf("instance B lock was blocked by instance A: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("instance B lock was blocked by instance A")
+	}
+
+	// A is protected by the same cross-process operating-system lock and must
+	// not be acquired before the helper releases it.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	_, err = acquireDualLockAt(ctx, txA.Store().ConfigDir)
+	cancel()
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("same-instance lock error = %v, want context deadline", err)
+	}
+	held.Release()
+	lock, err := acquireDualLockAt(context.Background(), txA.Store().ConfigDir)
+	if err != nil {
+		t.Fatalf("reacquire instance A after process release: %v", err)
+	}
+	lock.Release()
+}
+
+func TestResetRetriesFixedStoreWhenConcurrentUseWins(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+
+	txA, err := BeginNewInstance(base, "reset-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupAuthServiceForTest(t, txA.Store().KeychainService)
+	if err := SaveTokenData(base, testAccountToken("corp-a", "user-a", "access-a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := txA.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	txB, err := BeginNewInstance(base, "reset-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupAuthServiceForTest(t, txB.Store().KeychainService)
+	if err := SaveTokenData(base, testAccountToken("corp-b", "user-b", "access-b")); err != nil {
+		t.Fatal(err)
+	}
+	if err := txB.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UseAuthInstance(base, txA.Instance().ID); err != nil {
+		t.Fatal(err)
+	}
+
+	held := startCrossProcessAuthStoreLock(t, txA.Store().ConfigDir)
+	resetDone := make(chan error, 1)
+	go func() { resetDone <- ResetCurrentAuthData(base) }()
+	waitForProcessAuthStoreLock(t, txA.Store().ConfigDir)
+	if _, err := UseAuthInstance(base, txB.Instance().ID); err != nil {
+		t.Fatalf("concurrent UseAuthInstance(B): %v", err)
+	}
+	held.Release()
+	select {
+	case err := <-resetDone:
+		if err != nil {
+			t.Fatalf("ResetCurrentAuthData() error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("reset did not finish after instance A lock release")
+	}
+
+	if !keychain.Exists(txA.Store().KeychainService, TokenAccountForCorpID("corp-a")) {
+		t.Fatal("reset/use race deleted the previously selected instance A")
+	}
+	if keychain.Exists(txB.Store().KeychainService, TokenAccountForCorpID("corp-b")) {
+		t.Fatal("reset/use race retained instance B after B won current selection")
+	}
+}
+
+func TestLegacyResetAndFirstCommitShareBoundaryLock(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+	cleanupAuthServiceForTest(t, keychain.Service)
+
+	if err := SaveTokenData(base, testAccountToken("legacy-corp", "legacy-user", "legacy-access")); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveAppConfig(base, &AppConfig{ClientID: "legacy-client"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"mcp_url", "token"} {
+		if err := os.WriteFile(filepath.Join(base, name), []byte("legacy"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tx, err := BeginNewInstance(base, "first-isolated")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupAuthServiceForTest(t, tx.Store().KeychainService)
+	if err := SaveTokenData(base, testAccountToken("isolated-corp", "isolated-user", "isolated-access")); err != nil {
+		t.Fatal(err)
+	}
+
+	held := startCrossProcessAuthStoreLock(t, base)
+	resetDone := make(chan error, 1)
+	go func() { resetDone <- ResetCurrentAuthData(base) }()
+	waitForProcessAuthStoreLock(t, base)
+	commitDone := make(chan error, 1)
+	go func() { commitDone <- tx.Commit() }()
+	held.Release()
+
+	select {
+	case err := <-resetDone:
+		if err != nil {
+			t.Fatalf("legacy reset error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("legacy reset did not complete")
+	}
+	select {
+	case err := <-commitDone:
+		if err != nil {
+			t.Fatalf("first Commit() error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("first Commit() did not complete after legacy reset")
+	}
+
+	if _, err := os.Stat(AuthRegistryPath(base)); err != nil {
+		t.Fatalf("first commit did not publish Registry: %v", err)
+	}
+	if !keychain.Exists(tx.Store().KeychainService, TokenAccountForCorpID("isolated-corp")) {
+		t.Fatal("legacy reset changed the pending isolated instance")
+	}
+	if cfg, err := LoadAppConfig(base); err != nil || cfg != nil {
+		t.Fatalf("legacy reset did not preserve historical app-config cleanup: cfg=%#v err=%v", cfg, err)
+	}
+	for _, name := range []string{"mcp_url", "token"} {
+		if _, err := os.Stat(filepath.Join(base, name)); !os.IsNotExist(err) {
+			t.Fatalf("legacy reset retained %s: %v", name, err)
+		}
+	}
+}
+
+func TestCommitAndRollbackWaitForPendingInstanceWriter(t *testing.T) {
+	for _, operation := range []string{"commit", "rollback"} {
+		t.Run(operation, func(t *testing.T) {
+			base := t.TempDir()
+			DeactivateAuthStore(base)
+			t.Cleanup(func() { DeactivateAuthStore(base) })
+			tx, err := BeginNewInstance(base, operation+"-pending")
+			if err != nil {
+				t.Fatal(err)
+			}
+			cleanupAuthServiceForTest(t, tx.Store().KeychainService)
+
+			writerLock, err := AcquireDualLock(context.Background(), base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan error, 1)
+			go func() {
+				if operation == "commit" {
+					done <- tx.Commit()
+				} else {
+					done <- tx.Rollback()
+				}
+			}()
+			select {
+			case err := <-done:
+				writerLock.Release()
+				t.Fatalf("%s completed before pending writer released: %v", operation, err)
+			case <-time.After(100 * time.Millisecond):
+			}
+			writerLock.Release()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("%s after writer release: %v", operation, err)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatalf("%s did not finish after pending writer released", operation)
+			}
+		})
+	}
+}
+
 func TestRollbackDoesNotPublishFailedLogin(t *testing.T) {
 	base := t.TempDir()
 	DeactivateAuthStore(base)
@@ -514,6 +745,113 @@ func permissionOf(info os.FileInfo) os.FileMode {
 		return 0
 	}
 	return info.Mode().Perm()
+}
+
+const (
+	authStoreLockHelperEnv = "DWS_AUTH_STORE_LOCK_HELPER"
+	authStoreLockDirEnv    = "DWS_AUTH_STORE_LOCK_DIR"
+)
+
+// TestAuthStoreCrossProcessLockHelper is re-executed in a separate test
+// process. A stdout handshake proves that the OS lock is held; closing stdin
+// releases it without timing-based sleeps.
+func TestAuthStoreCrossProcessLockHelper(t *testing.T) {
+	if os.Getenv(authStoreLockHelperEnv) != "1" {
+		return
+	}
+	dir := os.Getenv(authStoreLockDirEnv)
+	if dir == "" {
+		t.Fatal("missing auth store lock directory")
+	}
+	lock, err := acquireDualLockAt(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Release()
+	if _, err := os.Stdout.WriteString("locked\n"); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, os.Stdin)
+}
+
+type crossProcessAuthStoreLock struct {
+	t      *testing.T
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stderr bytes.Buffer
+	once   sync.Once
+}
+
+func startCrossProcessAuthStoreLock(t *testing.T, authDir string) *crossProcessAuthStoreLock {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAuthStoreCrossProcessLockHelper$")
+	cmd.Env = append(os.Environ(), authStoreLockHelperEnv+"=1", authStoreLockDirEnv+"="+authDir)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	held := &crossProcessAuthStoreLock{t: t, cmd: cmd, stdin: stdin}
+	cmd.Stderr = &held.stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	ready := make(chan error, 1)
+	go func() {
+		line, err := bufio.NewReader(stdout).ReadString('\n')
+		if err == nil && strings.TrimSpace(line) != "locked" {
+			err = errors.New("unexpected auth lock helper handshake: " + strings.TrimSpace(line))
+		}
+		ready <- err
+	}()
+	select {
+	case err := <-ready:
+		if err != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			t.Fatalf("start auth lock helper: %v; stderr=%s", err, held.stderr.String())
+		}
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatalf("auth lock helper handshake timed out; stderr=%s", held.stderr.String())
+	}
+	t.Cleanup(held.Release)
+	return held
+}
+
+func (h *crossProcessAuthStoreLock) Release() {
+	if h == nil {
+		return
+	}
+	h.once.Do(func() {
+		_ = h.stdin.Close()
+		if err := h.cmd.Wait(); err != nil {
+			h.t.Errorf("auth lock helper exit: %v; stderr=%s", err, h.stderr.String())
+		}
+	})
+}
+
+func waitForProcessAuthStoreLock(t *testing.T, authDir string) {
+	t.Helper()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.NewTimer(2 * time.Second)
+	defer timeout.Stop()
+	key := processLockKey(authDir)
+	for {
+		if _, ok := processLocks.Load(key); ok {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-timeout.C:
+			t.Fatalf("process auth store lock %q was not acquired", key)
+		}
+	}
 }
 
 func cleanupAuthServiceForTest(t *testing.T, service string) {

--- a/internal/auth/auth_store_test.go
+++ b/internal/auth/auth_store_test.go
@@ -1,0 +1,498 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
+)
+
+func withAuthStoreEdition(t *testing.T, hooks *edition.Hooks) {
+	t.Helper()
+	previous := edition.Get()
+	edition.Override(hooks)
+	t.Cleanup(func() { edition.Override(previous) })
+}
+
+func TestLegacyAndCustomConfigDirRemainZeroWriteUntilExplicitOptIn(t *testing.T) {
+	for _, name := range []string{"default-like", "custom-dws-config-dir"} {
+		t.Run(name, func(t *testing.T) {
+			base := filepath.Join(t.TempDir(), "not-created", name)
+			DeactivateAuthStore(base)
+			t.Cleanup(func() { DeactivateAuthStore(base) })
+
+			store := ResolveAuthStore(base)
+			if store.ConfigDir != base || store.KeychainService != keychain.Service || store.InstanceID != "" {
+				t.Fatalf("ResolveAuthStore() = %#v, want exact legacy coordinate", store)
+			}
+			activated, err := ActivateCurrentInstance(base)
+			if err != nil {
+				t.Fatalf("ActivateCurrentInstance() error = %v", err)
+			}
+			if activated != store {
+				t.Fatalf("ActivateCurrentInstance() = %#v, want %#v", activated, store)
+			}
+			instances, currentID, err := ListAuthInstances(base)
+			if err != nil {
+				t.Fatalf("ListAuthInstances() error = %v", err)
+			}
+			if len(instances) != 1 || instances[0].Kind != AuthInstanceKindLegacy || currentID != "" {
+				t.Fatalf("ListAuthInstances() = %#v, %q", instances, currentID)
+			}
+			if _, err := os.Stat(base); !os.IsNotExist(err) {
+				t.Fatalf("ordinary auth lookup wrote config home: stat error = %v", err)
+			}
+		})
+	}
+}
+
+func TestBeginNewInstanceRegistersLegacyInPlaceWithoutCopy(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+	cleanupAuthServiceForTest(t, keychain.Service)
+
+	legacyProfiles := []byte(`{"version":1,"currentProfile":"legacy-corp","profiles":[{"name":"legacy","corpId":"legacy-corp","userId":"legacy-user"}]}`)
+	if err := os.WriteFile(filepath.Join(base, profilesJSONFile), legacyProfiles, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, tokenJSONFile), []byte(`{"updated_at":"legacy"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	legacyToken := testAccountToken("legacy-corp", "legacy-user", "legacy-access")
+	if err := SaveTokenDataKeychainAt(base, legacyToken); err != nil {
+		t.Fatalf("save legacy keychain token: %v", err)
+	}
+	t.Cleanup(func() { _ = keychain.Remove(keychain.Service, keychain.AccountToken) })
+
+	tx, err := BeginNewInstance(base, "personal")
+	if err != nil {
+		t.Fatalf("BeginNewInstance() error = %v", err)
+	}
+	store := tx.Store()
+	cleanupAuthServiceForTest(t, store.KeychainService)
+	if !store.Isolated() || store.ConfigDir == base || store.KeychainService == keychain.Service {
+		t.Fatalf("pending Store() = %#v, want isolated coordinate", store)
+	}
+	if store.InstanceID != tx.Instance().ID ||
+		store.ConfigDir != filepath.Join(base, authRegistryDirName, authInstancesDirName, tx.Instance().ID) ||
+		store.KeychainService != authInstanceServicePrefix+tx.Instance().ID {
+		t.Fatalf("pending Store() = %#v, want one direct coordinate for instance %q", store, tx.Instance().ID)
+	}
+	for _, name := range []string{profilesJSONFile, tokenJSONFile, secureDataFile} {
+		if _, err := os.Stat(filepath.Join(store.ConfigDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("legacy file %s was copied before commit: %v", name, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	for _, name := range []string{profilesJSONFile, tokenJSONFile, secureDataFile} {
+		if _, err := os.Stat(filepath.Join(store.ConfigDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("legacy file %s was copied at commit: %v", name, err)
+		}
+	}
+	if got, err := LoadTokenDataKeychainAt(base); !errors.Is(err, ErrTokenDataNotFound) || got != nil {
+		t.Fatalf("isolated account unexpectedly copied legacy token: %#v, %v", got, err)
+	}
+	if got, err := keychain.Get(keychain.Service, keychain.AccountToken); err != nil || got == "" {
+		t.Fatalf("legacy keychain token changed: value=%q err=%v", got, err)
+	}
+	instances, currentID, err := ListAuthInstances(base)
+	if err != nil || len(instances) != 2 || currentID != tx.Instance().ID {
+		t.Fatalf("registry = %#v, current=%q, err=%v", instances, currentID, err)
+	}
+	if instances[0].Kind != AuthInstanceKindLegacy || instances[0].Alias != DefaultAuthInstanceAlias {
+		t.Fatalf("first instance = %#v, want legacy-backed default", instances[0])
+	}
+}
+
+func TestIsolatedInstancesKeepProfilesAndTokensSeparateAndUsePrevious(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+	cleanupAuthServiceForTest(t, keychain.Service)
+
+	if err := SaveTokenData(base, testAccountToken("shared-corp", "legacy-user", "legacy-access")); err != nil {
+		t.Fatalf("SaveTokenData(legacy) error = %v", err)
+	}
+	txA, err := BeginNewInstance(base, "work")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveTokenData(base, testAccountToken("shared-corp", "user-a", "access-a")); err != nil {
+		t.Fatalf("SaveTokenData(account A) error = %v", err)
+	}
+	if err := txA.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	cleanupAuthServiceForTest(t, txA.Store().KeychainService)
+
+	txB, err := BeginNewInstance(base, "personal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveTokenData(base, testAccountToken("shared-corp", "user-b", "access-b")); err != nil {
+		t.Fatalf("SaveTokenData(account B) error = %v", err)
+	}
+	if err := txB.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	cleanupAuthServiceForTest(t, txB.Store().KeychainService)
+
+	if txA.Store().InstanceID == txB.Store().InstanceID {
+		t.Fatalf("auth instances share generated ID %q", txA.Store().InstanceID)
+	}
+	if txA.Store().KeychainService == txB.Store().KeychainService {
+		t.Fatalf("accounts share keychain service %q", txA.Store().KeychainService)
+	}
+	assertActiveToken(t, base, "access-b", "shared-corp")
+	selected, err := UseAuthInstance(base, "-")
+	if err != nil || selected.ID != txA.Instance().ID {
+		t.Fatalf("UseAuthInstance(-) = %#v, %v; want account A", selected, err)
+	}
+	assertActiveToken(t, base, "access-a", "shared-corp")
+	if profile, err := ResolveProfileByUserID(base, "user-a"); err != nil || profile.CorpID != "shared-corp" {
+		t.Fatalf("ResolveProfileByUserID(user-a) = %#v, %v", profile, err)
+	}
+
+	selected, err = UseAuthInstance(base, "-")
+	if err != nil || selected.ID != txB.Instance().ID {
+		t.Fatalf("second UseAuthInstance(-) = %#v, %v; want account B", selected, err)
+	}
+	assertActiveToken(t, base, "access-b", "shared-corp")
+	if _, err := ResolveProfileByUserID(base, "user-a"); err == nil {
+		t.Fatal("account B resolved account A's userId")
+	}
+
+	selected, err = UseAuthInstance(base, DefaultAuthInstanceAlias)
+	if err != nil || selected.Kind != AuthInstanceKindLegacy {
+		t.Fatalf("UseAuthInstance(default) = %#v, %v", selected, err)
+	}
+	assertActiveToken(t, base, "legacy-access", "shared-corp")
+
+	instances, _, err := ListAuthInstances(base)
+	if err != nil || len(instances) != 3 {
+		t.Fatalf("ListAuthInstances() = %#v, %v; want 3 instances", instances, err)
+	}
+}
+
+func TestAuthInstanceIsLoginSlotAndAllowsReplacingIdentity(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+
+	tx, err := BeginNewInstance(base, "reusable-slot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupAuthServiceForTest(t, tx.Store().KeychainService)
+	if err := SaveTokenData(base, testAccountToken("same-corp", "user-a", "access-a")); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// An auth instance is an isolated login-state location, not a permanent
+	// person identity. Re-login there keeps the online overwrite semantics.
+	if err := SaveTokenData(base, testAccountToken("same-corp", "user-b", "access-b")); err != nil {
+		t.Fatalf("SaveTokenData(replacement identity) error = %v", err)
+	}
+	loaded, err := LoadTokenDataForProfile(base, "same-corp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.UserID != "user-b" || loaded.AccessToken != "access-b" {
+		t.Fatalf("login slot did not adopt replacement identity: %#v", loaded)
+	}
+}
+
+func TestRollbackDoesNotPublishFailedLogin(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+	cleanupAuthServiceForTest(t, keychain.Service)
+
+	legacy := testAccountToken("legacy-corp", "legacy-user", "legacy-access")
+	if err := SaveTokenData(base, legacy); err != nil {
+		t.Fatalf("save legacy token: %v", err)
+	}
+	legacyProfiles, err := os.ReadFile(ProfilesPath(base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyKeychain, err := keychain.Get(keychain.Service, keychain.AccountToken)
+	if err != nil || legacyKeychain == "" {
+		t.Fatalf("read legacy keychain: value=%q err=%v", legacyKeychain, err)
+	}
+
+	tx, err := BeginNewInstance(base, "failed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := tx.Store()
+	if err := SaveTokenData(base, testAccountToken("corp-failed", "user-failed", "access-failed")); err != nil {
+		t.Fatal(err)
+	}
+	// Model a partial failure after a corp-scoped Keychain write but before
+	// profiles.json records that corp. Rollback must still remove this slot,
+	// including on the Windows registry backend where removing files is not
+	// sufficient.
+	orphanCorpID := "corp-unindexed"
+	if err := SaveTokenDataKeychainForCorpIDAt(base, orphanCorpID, testAccountToken(orphanCorpID, "user-unindexed", "access-unindexed")); err != nil {
+		t.Fatal(err)
+	}
+	if !keychain.Exists(store.KeychainService, TokenAccountForCorpID(orphanCorpID)) {
+		t.Fatal("unindexed pending token was not written")
+	}
+	if _, err := os.Stat(AuthRegistryPath(base)); !os.IsNotExist(err) {
+		t.Fatalf("pending login published registry: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	if _, err := os.Stat(AuthRegistryPath(base)); !os.IsNotExist(err) {
+		t.Fatalf("rollback published registry: %v", err)
+	}
+	if keychain.Exists(store.KeychainService, TokenAccountForCorpID(orphanCorpID)) {
+		t.Fatal("rollback left an unindexed pending token behind")
+	}
+	if _, err := os.Stat(store.ConfigDir); !os.IsNotExist(err) {
+		t.Fatalf("rollback left account data dir: %v", err)
+	}
+	resolved := ResolveAuthStore(base)
+	if resolved.ConfigDir != base || resolved.KeychainService != keychain.Service || resolved.InstanceID != "" {
+		t.Fatalf("store after rollback = %#v, want legacy", resolved)
+	}
+	if got, _ := keychain.Get(store.KeychainService, keychain.AccountToken); got != "" {
+		t.Fatalf("rollback left isolated keychain token: %q", got)
+	}
+	if got, err := os.ReadFile(ProfilesPath(base)); err != nil || string(got) != string(legacyProfiles) {
+		t.Fatalf("rollback changed legacy profiles: err=%v\ngot=%q\nwant=%q", err, got, legacyProfiles)
+	}
+	if got, err := keychain.Get(keychain.Service, keychain.AccountToken); err != nil || got != legacyKeychain {
+		t.Fatalf("rollback changed legacy keychain: value=%q err=%v", got, err)
+	}
+}
+
+func TestConcurrentNewInstanceCommitDetectsRegistryConflict(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+
+	txA, err := BeginNewInstance(base, "account-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	txB, err := BeginNewInstance(base, "account-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := txA.Commit(); err != nil {
+		t.Fatalf("first Commit() error = %v", err)
+	}
+	if err := txB.Commit(); !errors.Is(err, ErrAuthRegistryConflict) {
+		t.Fatalf("second Commit() error = %v, want ErrAuthRegistryConflict", err)
+	}
+	if err := txB.Rollback(); err != nil {
+		t.Fatalf("second Rollback() error = %v", err)
+	}
+
+	instances, currentID, err := ListAuthInstances(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := authRegistry{Instances: instances}
+	if len(instances) != 2 || currentID != txA.Instance().ID || findAuthInstanceByID(&registry, txB.Instance().ID) != nil {
+		t.Fatalf("registry after conflict = %#v current=%q, want only default + instance-a", instances, currentID)
+	}
+}
+
+func TestRegistryCorruptionFailsClosedAndHooksRejectOptIn(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+	if err := os.MkdirAll(filepath.Dir(AuthRegistryPath(base)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(AuthRegistryPath(base), []byte(`{"version":1,"broken":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ActivateCurrentInstance(base); err == nil {
+		t.Fatal("ActivateCurrentInstance() accepted corrupt registry")
+	}
+	if got := ResolveAuthStore(base); got.ConfigDir != base || got.KeychainService != keychain.Service {
+		t.Fatalf("corrupt registry activated a credential store: %#v", got)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		hooks *edition.Hooks
+	}{
+		{name: "save", hooks: &edition.Hooks{Name: "hooked-save", SaveToken: func(string, []byte) error { return nil }}},
+		{name: "load", hooks: &edition.Hooks{Name: "hooked-load", LoadToken: func(string) ([]byte, error) { return nil, nil }}},
+		{name: "delete", hooks: &edition.Hooks{Name: "hooked-delete", DeleteToken: func(string) error { return nil }}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			withAuthStoreEdition(t, tc.hooks)
+			hookBase := filepath.Join(t.TempDir(), "not-created")
+			if _, err := BeginNewInstance(hookBase, "blocked"); !errors.Is(err, ErrAuthInstanceIsolationUnsupported) {
+				t.Fatalf("BeginNewInstance() error = %v, want unsupported", err)
+			}
+			if _, err := os.Stat(hookBase); !os.IsNotExist(err) {
+				t.Fatalf("unsupported BeginNewInstance wrote base: %v", err)
+			}
+		})
+	}
+}
+
+func TestRegistryAndAccountDirectoriesUsePrivatePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not authoritative on Windows")
+	}
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+	tx, err := BeginNewInstance(base, "private")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(AuthRegistryPath(base)); err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("registry permission = %v, err=%v; want 0600", permissionOf(info), err)
+	}
+	for path := tx.Store().ConfigDir; strings.HasPrefix(path, filepath.Join(base, authRegistryDirName)); path = filepath.Dir(path) {
+		info, err := os.Stat(path)
+		if err != nil || info.Mode().Perm() != 0o700 {
+			t.Fatalf("directory %s permission = %v, err=%v; want 0700", path, permissionOf(info), err)
+		}
+		if path == filepath.Join(base, authRegistryDirName) {
+			break
+		}
+	}
+}
+
+func TestExplicitInstanceSurvivesConfigDirMove(t *testing.T) {
+	root := t.TempDir()
+	baseA := filepath.Join(root, "config-a")
+	baseB := filepath.Join(root, "config-b")
+	if err := os.MkdirAll(baseA, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	DeactivateAuthStore(baseA)
+	DeactivateAuthStore(baseB)
+	t.Cleanup(func() {
+		DeactivateAuthStore(baseA)
+		DeactivateAuthStore(baseB)
+	})
+
+	tx, err := BeginNewInstance(baseA, "portable-path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveTokenData(baseA, testAccountToken("corp-move", "user-move", "access-move")); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	service := tx.Store().KeychainService
+	cleanupAuthServiceForTest(t, service)
+	DeactivateAuthStore(baseA)
+
+	if err := os.Rename(baseA, baseB); err != nil {
+		t.Fatalf("move config directory: %v", err)
+	}
+	store, err := ActivateCurrentInstance(baseB)
+	if err != nil {
+		t.Fatalf("ActivateCurrentInstance(moved) error = %v", err)
+	}
+	if store.KeychainService != service || !strings.HasPrefix(store.ConfigDir, baseB+string(filepath.Separator)) {
+		t.Fatalf("moved store = %#v, want service %q under %q", store, service, baseB)
+	}
+	registryData, err := os.ReadFile(AuthRegistryPath(baseB))
+	if err != nil {
+		t.Fatalf("read moved registry: %v", err)
+	}
+	for _, secret := range []string{"access-move", "refresh-access-move", "corp-move", "user-move"} {
+		if bytes.Contains(registryData, []byte(secret)) {
+			t.Fatalf("registry leaked login identity or token %q: %s", secret, registryData)
+		}
+	}
+	assertActiveToken(t, baseB, "access-move", "corp-move")
+}
+
+func TestResolveProfileByUserIDRejectsAmbiguousOrganization(t *testing.T) {
+	base := t.TempDir()
+	DeactivateAuthStore(base)
+	t.Cleanup(func() { DeactivateAuthStore(base) })
+	cleanupAuthServiceForTest(t, keychain.Service)
+	if err := SaveTokenData(base, testAccountToken("corp-one", "same-user", "access-one")); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveTokenData(base, testAccountToken("corp-two", "same-user", "access-two")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolveProfileByUserID(base, "same-user"); err == nil || !strings.Contains(err.Error(), "multiple organizations") {
+		t.Fatalf("ResolveProfileByUserID() error = %v, want ambiguity", err)
+	}
+}
+
+func permissionOf(info os.FileInfo) os.FileMode {
+	if info == nil {
+		return 0
+	}
+	return info.Mode().Perm()
+}
+
+func cleanupAuthServiceForTest(t *testing.T, service string) {
+	t.Helper()
+	t.Cleanup(func() { _ = os.RemoveAll(keychain.StorageDir(service)) })
+}
+
+func testAccountToken(corpID, userID, accessToken string) *TokenData {
+	return &TokenData{
+		AccessToken:  accessToken,
+		RefreshToken: "refresh-" + accessToken,
+		ExpiresAt:    time.Now().Add(time.Hour),
+		RefreshExpAt: time.Now().Add(24 * time.Hour),
+		CorpID:       corpID,
+		CorpName:     corpID + "-name",
+		UserID:       userID,
+		UserName:     userID + "-name",
+	}
+}
+
+func assertActiveToken(t *testing.T, base, wantAccess, wantCorp string) {
+	t.Helper()
+	token, err := LoadTokenData(base)
+	if err != nil {
+		t.Fatalf("LoadTokenData() error = %v", err)
+	}
+	if token.AccessToken != wantAccess || token.CorpID != wantCorp {
+		t.Fatalf("LoadTokenData() = %#v, want access=%q corp=%q", token, wantAccess, wantCorp)
+	}
+}

--- a/internal/auth/filelock.go
+++ b/internal/auth/filelock.go
@@ -37,7 +37,7 @@ var processLocks sync.Map // map[string]chan struct{}
 
 // processLockKey generates a unique key for process-level locking.
 func processLockKey(configDir string) string {
-	return "refresh:" + configDir
+	return "refresh:" + authStoreRuntimeKey(configDir)
 }
 
 // acquireProcessLock attempts to acquire the process-level lock.
@@ -93,6 +93,17 @@ type tokenFileLock struct {
 // It blocks (with timeout) if another process holds the lock.
 // The caller MUST call release() when done.
 func acquireTokenLock(configDir string) (*tokenFileLock, error) {
+	return acquireTokenLockContext(context.Background(), configDir)
+}
+
+// acquireTokenLockContext is the context-aware form used by higher-level auth
+// instance operations. The operating-system lock is always attempted in
+// non-blocking mode so cancellation and the DWS lock timeout remain effective
+// on every supported platform.
+func acquireTokenLockContext(ctx context.Context, configDir string) (*tokenFileLock, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if err := os.MkdirAll(configDir, config.DirPerm); err != nil {
 		return nil, fmt.Errorf("creating config dir for lock: %w", err)
 	}
@@ -105,16 +116,35 @@ func acquireTokenLock(configDir string) (*tokenFileLock, error) {
 
 	deadline := time.Now().Add(config.LockTimeout)
 	for {
+		select {
+		case <-ctx.Done():
+			_ = f.Close()
+			return nil, ctx.Err()
+		default:
+		}
 		if err := lockFile(f); err == nil {
 			return &tokenFileLock{path: lockPath, file: f}, nil
 		}
 
-		if time.Now().After(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
 			_ = f.Close()
 			return nil, fmt.Errorf("timeout acquiring token lock after %v (another dws process may be running)", config.LockTimeout)
 		}
-
-		time.Sleep(lockRetryDelay)
+		wait := lockRetryDelay
+		if remaining < wait {
+			wait = remaining
+		}
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			_ = f.Close()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
 	}
 }
 
@@ -134,6 +164,7 @@ func (l *tokenFileLock) release() {
 type DualLock struct {
 	processRelease func()
 	fileLock       *tokenFileLock
+	selectionMu    *sync.RWMutex
 	Waited         bool // true if we waited for another goroutine/process
 }
 
@@ -144,9 +175,26 @@ type DualLock struct {
 //
 // The caller MUST call Release() when done.
 func AcquireDualLock(ctx context.Context, configDir string) (*DualLock, error) {
-	// Only user login state is auth-instance-scoped. Callers continue passing the
-	// stable base config directory; the runtime selection chooses its lock root.
-	authDir := ResolveAuthStore(configDir).ConfigDir
+	// Pin the process-local selection for the complete critical section. Helpers
+	// called after this function returns may resolve the store again; the read
+	// lock guarantees they keep seeing the same ConfigDir and Keychain service.
+	selectionMu := authStoreSelectionMutex(configDir)
+	selectionMu.RLock()
+	store := ResolveAuthStore(configDir)
+	lock, err := acquireDualLockAt(ctx, store.ConfigDir)
+	if err != nil {
+		selectionMu.RUnlock()
+		return nil, err
+	}
+	lock.selectionMu = selectionMu
+	return lock, nil
+}
+
+// acquireDualLockAt locks one already-resolved auth store directory. It does
+// not consult or pin the global current-instance pointer, which lets callers
+// safely operate on an explicit instance while another instance proceeds in
+// parallel.
+func acquireDualLockAt(ctx context.Context, authDir string) (*DualLock, error) {
 	// 1. Acquire process-level lock first (fast, in-memory)
 	processRelease, waited, err := acquireProcessLock(ctx, authDir)
 	if err != nil {
@@ -154,7 +202,7 @@ func AcquireDualLock(ctx context.Context, configDir string) (*DualLock, error) {
 	}
 
 	// 2. Acquire file-level lock (cross-process)
-	fileLock, err := acquireTokenLock(authDir)
+	fileLock, err := acquireTokenLockContext(ctx, authDir)
 	if err != nil {
 		processRelease() // Release process lock on failure
 		return nil, fmt.Errorf("acquiring file lock: %w", err)
@@ -176,5 +224,9 @@ func (d *DualLock) Release() {
 	if d.processRelease != nil {
 		d.processRelease()
 		d.processRelease = nil
+	}
+	if d.selectionMu != nil {
+		d.selectionMu.RUnlock()
+		d.selectionMu = nil
 	}
 }

--- a/internal/auth/filelock.go
+++ b/internal/auth/filelock.go
@@ -144,14 +144,17 @@ type DualLock struct {
 //
 // The caller MUST call Release() when done.
 func AcquireDualLock(ctx context.Context, configDir string) (*DualLock, error) {
+	// Only user login state is auth-instance-scoped. Callers continue passing the
+	// stable base config directory; the runtime selection chooses its lock root.
+	authDir := ResolveAuthStore(configDir).ConfigDir
 	// 1. Acquire process-level lock first (fast, in-memory)
-	processRelease, waited, err := acquireProcessLock(ctx, configDir)
+	processRelease, waited, err := acquireProcessLock(ctx, authDir)
 	if err != nil {
 		return nil, fmt.Errorf("acquiring process lock: %w", err)
 	}
 
 	// 2. Acquire file-level lock (cross-process)
-	fileLock, err := acquireTokenLock(configDir)
+	fileLock, err := acquireTokenLock(authDir)
 	if err != nil {
 		processRelease() // Release process lock on failure
 		return nil, fmt.Errorf("acquiring file lock: %w", err)

--- a/internal/auth/filelock_windows.go
+++ b/internal/auth/filelock_windows.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	lockfileExclusiveLock = 0x00000002
+	lockfileExclusiveLock   = 0x00000002
+	lockfileFailImmediately = 0x00000001
 )
 
 func lockFile(f *os.File) error {
@@ -31,7 +32,7 @@ func lockFile(f *os.File) error {
 	ol := new(windows.Overlapped)
 	return windows.LockFileEx(
 		handle,
-		lockfileExclusiveLock,
+		lockfileExclusiveLock|lockfileFailImmediately,
 		0,
 		1,
 		0,

--- a/internal/auth/keychain_store.go
+++ b/internal/auth/keychain_store.go
@@ -36,7 +36,13 @@ var ErrTokenDataNotFound = errors.New("token data not found")
 // SaveTokenDataKeychain saves TokenData to the platform keychain.
 // This is the new secure storage method using random master key.
 func SaveTokenDataKeychain(data *TokenData) error {
-	return saveTokenDataKeychainAccount(keychain.AccountToken, data)
+	return SaveTokenDataKeychainAt(getDefaultConfigDir(), data)
+}
+
+// SaveTokenDataKeychainAt saves TokenData in the auth store selected for
+// configDir.
+func SaveTokenDataKeychainAt(configDir string, data *TokenData) error {
+	return saveTokenDataKeychainAccountAt(configDir, keychain.AccountToken, data)
 }
 
 // TokenAccountForCorpID returns the keychain account used for a corp-bound token.
@@ -46,14 +52,20 @@ func TokenAccountForCorpID(corpID string) string {
 
 // SaveTokenDataKeychainForCorpID saves TokenData to a corp-scoped keychain slot.
 func SaveTokenDataKeychainForCorpID(corpID string, data *TokenData) error {
+	return SaveTokenDataKeychainForCorpIDAt(getDefaultConfigDir(), corpID, data)
+}
+
+// SaveTokenDataKeychainForCorpIDAt saves corp-scoped TokenData in the auth
+// store selected for configDir.
+func SaveTokenDataKeychainForCorpIDAt(configDir, corpID string, data *TokenData) error {
 	corpID = strings.TrimSpace(corpID)
 	if corpID == "" {
 		return fmt.Errorf("corpId is required for profile token storage")
 	}
-	return saveTokenDataKeychainAccount(TokenAccountForCorpID(corpID), data)
+	return saveTokenDataKeychainAccountAt(configDir, TokenAccountForCorpID(corpID), data)
 }
 
-func saveTokenDataKeychainAccount(account string, data *TokenData) error {
+func saveTokenDataKeychainAccountAt(configDir, account string, data *TokenData) error {
 	jsonData, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal token data: %w", err)
@@ -65,28 +77,42 @@ func saveTokenDataKeychainAccount(account string, data *TokenData) error {
 		}
 	}()
 
-	if err := keychain.Set(keychain.Service, account, string(jsonData)); err != nil {
+	service := ResolveAuthStore(configDir).KeychainService
+	if err := keychain.Set(service, account, string(jsonData)); err != nil {
 		return fmt.Errorf("save to keychain: %w", err)
 	}
+	recordPendingAuthKeychainWrite(service, account)
 	return nil
 }
 
 // LoadTokenDataKeychain loads TokenData from the platform keychain.
 func LoadTokenDataKeychain() (*TokenData, error) {
-	return loadTokenDataKeychainAccount(keychain.AccountToken)
+	return LoadTokenDataKeychainAt(getDefaultConfigDir())
+}
+
+// LoadTokenDataKeychainAt loads TokenData from the auth store selected for
+// configDir.
+func LoadTokenDataKeychainAt(configDir string) (*TokenData, error) {
+	return loadTokenDataKeychainAccountAt(configDir, keychain.AccountToken)
 }
 
 // LoadTokenDataKeychainForCorpID loads TokenData from a corp-scoped keychain slot.
 func LoadTokenDataKeychainForCorpID(corpID string) (*TokenData, error) {
+	return LoadTokenDataKeychainForCorpIDAt(getDefaultConfigDir(), corpID)
+}
+
+// LoadTokenDataKeychainForCorpIDAt loads corp-scoped TokenData from the auth
+// store selected for configDir.
+func LoadTokenDataKeychainForCorpIDAt(configDir, corpID string) (*TokenData, error) {
 	corpID = strings.TrimSpace(corpID)
 	if corpID == "" {
 		return nil, fmt.Errorf("corpId is required for profile token storage")
 	}
-	return loadTokenDataKeychainAccount(TokenAccountForCorpID(corpID))
+	return loadTokenDataKeychainAccountAt(configDir, TokenAccountForCorpID(corpID))
 }
 
-func loadTokenDataKeychainAccount(account string) (*TokenData, error) {
-	jsonStr, err := keychain.Get(keychain.Service, account)
+func loadTokenDataKeychainAccountAt(configDir, account string) (*TokenData, error) {
+	jsonStr, err := keychain.Get(ResolveAuthStore(configDir).KeychainService, account)
 	if err != nil {
 		return nil, fmt.Errorf("load from keychain: %w", err)
 	}
@@ -111,7 +137,7 @@ func preflightTokenPersistence(configDir string) error {
 		return nil
 	}
 
-	if _, err := LoadTokenDataKeychain(); err != nil && !errors.Is(err, ErrTokenDataNotFound) {
+	if _, err := LoadTokenDataKeychainAt(configDir); err != nil && !errors.Is(err, ErrTokenDataNotFound) {
 		return fmt.Errorf("legacy token slot %q is unreadable: %w", keychain.AccountToken, err)
 	}
 
@@ -130,14 +156,14 @@ func preflightTokenPersistence(configDir string) error {
 		}
 		seen[corpID] = struct{}{}
 
-		if _, err := LoadTokenDataKeychainForCorpID(corpID); err != nil && !errors.Is(err, ErrTokenDataNotFound) {
+		if _, err := LoadTokenDataKeychainForCorpIDAt(configDir, corpID); err != nil && !errors.Is(err, ErrTokenDataNotFound) {
 			return fmt.Errorf(
 				"profile token slot %q is unreadable; on macOS first try `env -u DWS_DISABLE_KEYCHAIN dws auth migrate-keychain --to file-dek --dry-run`; if the ciphertext is damaged, remove only this profile with `dws auth logout --profile %q`, or use `dws auth reset` only when discarding all local profiles: %w",
 				TokenAccountForCorpID(corpID), corpID, err,
 			)
 		}
 	}
-	if err := keychain.ValidateAuthTokenEntries(keychain.Service); err != nil {
+	if err := keychain.ValidateAuthTokenEntries(ResolveAuthStore(configDir).KeychainService); err != nil {
 		return fmt.Errorf(
 			"auth token ciphertext inventory is unreadable; on macOS first try `env -u DWS_DISABLE_KEYCHAIN dws auth migrate-keychain --to file-dek --dry-run`; if the ciphertext is damaged, use `dws auth reset` only when discarding all local profiles: %w",
 			err,
@@ -150,18 +176,22 @@ func preflightTokenPersistence(configDir string) error {
 // An unrelated broken profile must not prevent the current profile from using
 // its still-valid credentials.
 func preflightTokenRefreshPersistence(data *TokenData) error {
+	return preflightTokenRefreshPersistenceAt(getDefaultConfigDir(), data)
+}
+
+func preflightTokenRefreshPersistenceAt(configDir string, data *TokenData) error {
 	if h := edition.Get(); h.SaveToken != nil {
 		return nil
 	}
 
-	if _, err := LoadTokenDataKeychain(); err != nil && !errors.Is(err, ErrTokenDataNotFound) {
+	if _, err := LoadTokenDataKeychainAt(configDir); err != nil && !errors.Is(err, ErrTokenDataNotFound) {
 		return fmt.Errorf("legacy token slot %q is unreadable: %w", keychain.AccountToken, err)
 	}
 	if data == nil || strings.TrimSpace(data.CorpID) == "" {
 		return nil
 	}
 	corpID := strings.TrimSpace(data.CorpID)
-	if _, err := LoadTokenDataKeychainForCorpID(corpID); err != nil && !errors.Is(err, ErrTokenDataNotFound) {
+	if _, err := LoadTokenDataKeychainForCorpIDAt(configDir, corpID); err != nil && !errors.Is(err, ErrTokenDataNotFound) {
 		return fmt.Errorf("profile token slot %q is unreadable: %w", TokenAccountForCorpID(corpID), err)
 	}
 	return nil
@@ -169,30 +199,54 @@ func preflightTokenRefreshPersistence(data *TokenData) error {
 
 // DeleteTokenDataKeychain removes TokenData from the platform keychain.
 func DeleteTokenDataKeychain() error {
-	return keychain.Remove(keychain.Service, keychain.AccountToken)
+	return DeleteTokenDataKeychainAt(getDefaultConfigDir())
+}
+
+// DeleteTokenDataKeychainAt removes TokenData from the auth store selected for
+// configDir.
+func DeleteTokenDataKeychainAt(configDir string) error {
+	return keychain.Remove(ResolveAuthStore(configDir).KeychainService, keychain.AccountToken)
 }
 
 // DeleteTokenDataKeychainForCorpID removes TokenData from a corp-scoped keychain slot.
 func DeleteTokenDataKeychainForCorpID(corpID string) error {
+	return DeleteTokenDataKeychainForCorpIDAt(getDefaultConfigDir(), corpID)
+}
+
+// DeleteTokenDataKeychainForCorpIDAt removes corp-scoped TokenData from the
+// auth store selected for configDir.
+func DeleteTokenDataKeychainForCorpIDAt(configDir, corpID string) error {
 	corpID = strings.TrimSpace(corpID)
 	if corpID == "" {
 		return fmt.Errorf("corpId is required for profile token storage")
 	}
-	return keychain.Remove(keychain.Service, TokenAccountForCorpID(corpID))
+	return keychain.Remove(ResolveAuthStore(configDir).KeychainService, TokenAccountForCorpID(corpID))
 }
 
 // TokenDataExistsKeychain checks if token data exists in keychain.
 func TokenDataExistsKeychain() bool {
-	return keychain.Exists(keychain.Service, keychain.AccountToken)
+	return TokenDataExistsKeychainAt(getDefaultConfigDir())
+}
+
+// TokenDataExistsKeychainAt reports whether TokenData exists in the auth store
+// selected for configDir.
+func TokenDataExistsKeychainAt(configDir string) bool {
+	return keychain.Exists(ResolveAuthStore(configDir).KeychainService, keychain.AccountToken)
 }
 
 // TokenDataExistsKeychainForCorpID checks if a corp-scoped token exists.
 func TokenDataExistsKeychainForCorpID(corpID string) bool {
+	return TokenDataExistsKeychainForCorpIDAt(getDefaultConfigDir(), corpID)
+}
+
+// TokenDataExistsKeychainForCorpIDAt reports whether corp-scoped TokenData
+// exists in the auth store selected for configDir.
+func TokenDataExistsKeychainForCorpIDAt(configDir, corpID string) bool {
 	corpID = strings.TrimSpace(corpID)
 	if corpID == "" {
 		return false
 	}
-	return keychain.Exists(keychain.Service, TokenAccountForCorpID(corpID))
+	return keychain.Exists(ResolveAuthStore(configDir).KeychainService, TokenAccountForCorpID(corpID))
 }
 
 // EnsureMigration performs one-time migration from legacy .data to keychain.
@@ -200,7 +254,7 @@ func TokenDataExistsKeychainForCorpID(corpID string) bool {
 // The migration is idempotent and thread-safe.
 func EnsureMigration(configDir string, logger *slog.Logger) {
 	migrationOnce.Do(func() {
-		result := keychain.MigrateFromLegacy(configDir)
+		result := keychain.MigrateFromLegacy(ResolveAuthStore(configDir).ConfigDir)
 		migrationDone = true
 
 		if result.Migrated {

--- a/internal/auth/oauth_provider.go
+++ b/internal/auth/oauth_provider.go
@@ -626,7 +626,7 @@ func (p *OAuthProvider) lockedRefresh(ctx context.Context) (*TokenData, error) {
 	if !data.IsRefreshTokenValid() {
 		return nil, fmt.Errorf("refresh_token 已过期")
 	}
-	if err := preflightTokenRefreshPersistence(data); err != nil {
+	if err := preflightTokenRefreshPersistenceAt(p.configDir, data); err != nil {
 		return nil, fmt.Errorf("%s: %w", i18n.T("本地登录态无法安全更新"), err)
 	}
 

--- a/internal/auth/profiles.go
+++ b/internal/auth/profiles.go
@@ -100,7 +100,7 @@ func RuntimeProfile() string {
 
 // ProfilesPath returns the profile metadata path for a config dir.
 func ProfilesPath(configDir string) string {
-	return filepath.Join(configDir, profilesJSONFile)
+	return filepath.Join(ResolveAuthStore(configDir).ConfigDir, profilesJSONFile)
 }
 
 // LoadProfiles reads profiles.json. A missing file returns an empty config.
@@ -132,7 +132,8 @@ func SaveProfiles(configDir string, cfg *ProfilesConfig) error {
 		cfg = &ProfilesConfig{}
 	}
 	normalizeProfilesConfig(cfg)
-	if err := os.MkdirAll(configDir, config.DirPerm); err != nil {
+	authDir := ResolveAuthStore(configDir).ConfigDir
+	if err := os.MkdirAll(authDir, config.DirPerm); err != nil {
 		return fmt.Errorf("create config dir: %w", err)
 	}
 	data, err := json.MarshalIndent(cfg, "", "  ")
@@ -173,14 +174,14 @@ func ensureProfilesMigrationLocked(configDir string) error {
 	if len(cfg.Profiles) > 0 {
 		return nil
 	}
-	if !TokenDataExistsKeychain() {
+	if !TokenDataExistsKeychainAt(configDir) {
 		return nil
 	}
-	data, err := LoadTokenDataKeychain()
+	data, err := LoadTokenDataKeychainAt(configDir)
 	if err != nil || data == nil || strings.TrimSpace(data.CorpID) == "" {
 		return nil
 	}
-	if err := SaveTokenDataKeychainForCorpID(data.CorpID, data); err != nil {
+	if err := SaveTokenDataKeychainForCorpIDAt(configDir, data.CorpID, data); err != nil {
 		return err
 	}
 	return upsertProfileFromToken(configDir, cfg, data, false)
@@ -299,6 +300,38 @@ func ResolveProfile(configDir, selector string) (*Profile, error) {
 	return nil, nil
 }
 
+// ResolveProfileByUserID resolves one organization identity inside the active
+// auth instance. userId is not global across organizations, so zero and multiple
+// matches both fail instead of silently selecting a corporation.
+func ResolveProfileByUserID(configDir, userID string) (*Profile, error) {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return nil, fmt.Errorf("userId is required")
+	}
+	if err := EnsureProfilesMigration(configDir); err != nil {
+		return nil, err
+	}
+	cfg, err := LoadProfiles(configDir)
+	if err != nil {
+		return nil, err
+	}
+	var match *Profile
+	for i := range cfg.Profiles {
+		if strings.TrimSpace(cfg.Profiles[i].UserID) != userID {
+			continue
+		}
+		if match != nil {
+			return nil, fmt.Errorf("userId %q matches multiple organizations in the current auth instance; use --profile <corpId> to select one", userID)
+		}
+		copy := cfg.Profiles[i]
+		match = &copy
+	}
+	if match == nil {
+		return nil, fmt.Errorf("userId %q not found in the current auth instance", userID)
+	}
+	return match, nil
+}
+
 func resolveProfileForLoad(configDir, selector string) (*Profile, error) {
 	if err := ensureProfilesMigrationLocked(configDir); err != nil {
 		return nil, err
@@ -316,7 +349,7 @@ func resolveProfileForLoad(configDir, selector string) (*Profile, error) {
 		return p, nil
 	}
 	for _, candidate := range []string{cfg.CurrentProfile, cfg.PrimaryProfile} {
-		if p := findProfile(cfg, candidate); p != nil && TokenDataExistsKeychainForCorpID(p.CorpID) {
+		if p := findProfile(cfg, candidate); p != nil && TokenDataExistsKeychainForCorpIDAt(configDir, p.CorpID) {
 			return p, nil
 		}
 	}
@@ -499,14 +532,14 @@ func syncLegacyTokenMirrorLocked(configDir string) error {
 		if p == nil {
 			continue
 		}
-		data, loadErr := LoadTokenDataKeychainForCorpID(p.CorpID)
+		data, loadErr := LoadTokenDataKeychainForCorpIDAt(configDir, p.CorpID)
 		if loadErr != nil {
 			// Transient keychain read failure: do NOT touch the existing mirror.
 			hadReadError = true
 			continue
 		}
 		if data != nil {
-			if err := SaveTokenDataKeychain(data); err != nil {
+			if err := SaveTokenDataKeychainAt(configDir, data); err != nil {
 				return err
 			}
 			return WriteTokenMarker(configDir)
@@ -518,7 +551,7 @@ func syncLegacyTokenMirrorLocked(configDir string) error {
 		return nil
 	}
 	// All candidate profiles confirmed absent (no token): clear the mirror.
-	_ = DeleteTokenDataKeychain()
+	_ = DeleteTokenDataKeychainAt(configDir)
 	_ = DeleteTokenMarker(configDir)
 	return nil
 }

--- a/internal/auth/secure_store.go
+++ b/internal/auth/secure_store.go
@@ -66,19 +66,20 @@ func resolvePassword() ([]byte, error) {
 // file lock (via acquireTokenLock) to prevent two processes from refreshing
 // simultaneously. See OAuthProvider.lockedRefresh().
 func SaveSecureTokenData(configDir string, data *TokenData) error {
+	authDir := ResolveAuthStore(configDir).ConfigDir
 	password, err := resolvePassword()
 	if err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(configDir, config.DirPerm); err != nil {
-		return fmt.Errorf("creating config dir %s: %w", configDir, err)
+	if err := os.MkdirAll(authDir, config.DirPerm); err != nil {
+		return fmt.Errorf("creating config dir %s: %w", authDir, err)
 	}
 	// Verify the directory permissions are strict even if it already existed.
-	if info, statErr := os.Stat(configDir); statErr == nil {
+	if info, statErr := os.Stat(authDir); statErr == nil {
 		if perm := info.Mode().Perm(); perm&0o077 != 0 {
-			if chErr := os.Chmod(configDir, config.DirPerm); chErr != nil {
-				return fmt.Errorf("config dir %s has unsafe permissions %o and chmod failed: %w", configDir, perm, chErr)
+			if chErr := os.Chmod(authDir, config.DirPerm); chErr != nil {
+				return fmt.Errorf("config dir %s has unsafe permissions %o and chmod failed: %w", authDir, perm, chErr)
 			}
 		}
 	}
@@ -98,7 +99,7 @@ func SaveSecureTokenData(configDir string, data *TokenData) error {
 		return fmt.Errorf("encrypting token data: %w", err)
 	}
 
-	finalPath := filepath.Join(configDir, secureDataFile)
+	finalPath := filepath.Join(authDir, secureDataFile)
 	tmpPath := finalPath + ".tmp"
 
 	// Atomic write with fsync to ensure data durability
@@ -141,7 +142,7 @@ func LoadSecureTokenData(configDir string) (*TokenData, error) {
 		return nil, err
 	}
 
-	path := filepath.Join(configDir, secureDataFile)
+	path := filepath.Join(ResolveAuthStore(configDir).ConfigDir, secureDataFile)
 	ciphertext, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading secure data file: %w", err)
@@ -168,7 +169,7 @@ func LoadSecureTokenData(configDir string) (*TokenData, error) {
 
 // DeleteSecureData removes .data file from configDir.
 func DeleteSecureData(configDir string) error {
-	path := filepath.Join(configDir, secureDataFile)
+	path := filepath.Join(ResolveAuthStore(configDir).ConfigDir, secureDataFile)
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("deleting secure data file: %w", err)
 	}
@@ -178,7 +179,7 @@ func DeleteSecureData(configDir string) error {
 
 // SecureDataExists checks if the secure .data file exists in the given directory.
 func SecureDataExists(configDir string) bool {
-	path := filepath.Join(configDir, secureDataFile)
+	path := filepath.Join(ResolveAuthStore(configDir).ConfigDir, secureDataFile)
 	_, err := os.Stat(path)
 	return err == nil
 }

--- a/internal/auth/testmain_test.go
+++ b/internal/auth/testmain_test.go
@@ -15,6 +15,7 @@ package auth
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
@@ -33,6 +34,23 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv(keychain.StorageDirEnv, tmpDir); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		panic("set " + keychain.StorageDirEnv + ": " + err.Error())
+	}
+	if err := os.Setenv(keychain.DisableKeychainEnv, "1"); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		panic("set " + keychain.DisableKeychainEnv + ": " + err.Error())
+	}
+	testHome := filepath.Join(tmpDir, "home")
+	if err := os.MkdirAll(testHome, 0o700); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		panic("create test home: " + err.Error())
+	}
+	if err := os.Setenv("HOME", testHome); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		panic("set HOME: " + err.Error())
+	}
+	if err := os.Setenv("USERPROFILE", testHome); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		panic("set USERPROFILE: " + err.Error())
 	}
 	code := m.Run()
 	_ = os.RemoveAll(tmpDir)

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -81,21 +81,22 @@ type TokenMarker struct {
 // timestamp. The host application uses this file's presence and mtime to
 // decide whether it needs to trigger a new auth exchange.
 func WriteTokenMarker(configDir string) error {
+	authDir := ResolveAuthStore(configDir).ConfigDir
 	marker := TokenMarker{UpdatedAt: time.Now().Format(time.RFC3339)}
 	data, _ := json.MarshalIndent(marker, "", "  ")
-	if err := os.MkdirAll(configDir, 0o700); err != nil {
+	if err := os.MkdirAll(authDir, 0o700); err != nil {
 		return err
 	}
-	tmp := filepath.Join(configDir, tokenJSONFile+"."+uuid.New().String()+".tmp")
+	tmp := filepath.Join(authDir, tokenJSONFile+"."+uuid.New().String()+".tmp")
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return err
 	}
-	return os.Rename(tmp, filepath.Join(configDir, tokenJSONFile))
+	return os.Rename(tmp, filepath.Join(authDir, tokenJSONFile))
 }
 
 // DeleteTokenMarker removes the token.json marker file.
 func DeleteTokenMarker(configDir string) error {
-	if err := os.Remove(filepath.Join(configDir, tokenJSONFile)); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(filepath.Join(ResolveAuthStore(configDir).ConfigDir, tokenJSONFile)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil
@@ -123,7 +124,7 @@ func saveTokenDataLocked(configDir string, data *TokenData) error {
 		return saveTokenViaHook(h, configDir, data)
 	}
 	if data != nil && strings.TrimSpace(data.CorpID) != "" {
-		if err := SaveTokenDataKeychainForCorpID(data.CorpID, data); err != nil {
+		if err := SaveTokenDataKeychainForCorpIDAt(configDir, data.CorpID, data); err != nil {
 			return err
 		}
 		makeCurrent := strings.TrimSpace(RuntimeProfile()) == ""
@@ -131,7 +132,7 @@ func saveTokenDataLocked(configDir string, data *TokenData) error {
 			return err
 		}
 		if makeCurrent {
-			if err := SaveTokenDataKeychain(data); err != nil {
+			if err := SaveTokenDataKeychainAt(configDir, data); err != nil {
 				return err
 			}
 		} else if err := syncLegacyTokenMirrorLocked(configDir); err != nil {
@@ -139,7 +140,7 @@ func saveTokenDataLocked(configDir string, data *TokenData) error {
 		}
 		return WriteTokenMarker(configDir)
 	}
-	if err := SaveTokenDataKeychain(data); err != nil {
+	if err := SaveTokenDataKeychainAt(configDir, data); err != nil {
 		return err
 	}
 	return WriteTokenMarker(configDir)
@@ -184,7 +185,7 @@ func LoadTokenDataForProfile(configDir, profile string) (*TokenData, error) {
 		return nil, err
 	}
 	if selected != nil {
-		data, err := LoadTokenDataKeychainForCorpID(selected.CorpID)
+		data, err := LoadTokenDataKeychainForCorpIDAt(configDir, selected.CorpID)
 		if err == nil {
 			return data, nil
 		}
@@ -195,7 +196,7 @@ func LoadTokenDataForProfile(configDir, profile string) (*TokenData, error) {
 		// profile. Only fall back to the legacy single slot when it belongs to
 		// the SAME org; otherwise surface the error instead of silently acting
 		// as a different organization (the legacy mirror may have drifted).
-		if legacy, lerr := LoadTokenDataKeychain(); lerr == nil && legacy != nil &&
+		if legacy, lerr := LoadTokenDataKeychainAt(configDir); lerr == nil && legacy != nil &&
 			strings.TrimSpace(legacy.CorpID) == strings.TrimSpace(selected.CorpID) {
 			return legacy, nil
 		} else if lerr != nil && !errors.Is(lerr, ErrTokenDataNotFound) {
@@ -203,8 +204,8 @@ func LoadTokenDataForProfile(configDir, profile string) (*TokenData, error) {
 		}
 		return nil, err
 	}
-	if TokenDataExistsKeychain() {
-		return LoadTokenDataKeychain()
+	if TokenDataExistsKeychainAt(configDir) {
+		return LoadTokenDataKeychainAt(configDir)
 	}
 	data, err := LoadSecureTokenData(configDir)
 	if err != nil {
@@ -245,7 +246,7 @@ func deleteTokenDataForProfileLocked(configDir, profile string) error {
 		return err
 	}
 	if selected != nil {
-		keychainErr := DeleteTokenDataKeychainForCorpID(selected.CorpID)
+		keychainErr := DeleteTokenDataKeychainForCorpIDAt(configDir, selected.CorpID)
 		_, removeErr := removeProfileLocked(configDir, selected.CorpID)
 		legacyErr := syncLegacyTokenMirrorLocked(configDir)
 		secureErr := DeleteSecureData(configDir)
@@ -261,7 +262,7 @@ func deleteTokenDataForProfileLocked(configDir, profile string) error {
 		return secureErr
 	}
 
-	keychainErr := DeleteTokenDataKeychain()
+	keychainErr := DeleteTokenDataKeychainAt(configDir)
 	legacyErr := DeleteSecureData(configDir)
 	markerErr := DeleteTokenMarker(configDir)
 	if keychainErr != nil {
@@ -284,7 +285,7 @@ func DeleteAllTokenData(configDir string) error {
 		// other slot so the user can always self-heal via auth reset / logout.
 		if cfg, err := LoadProfiles(configDir); err == nil {
 			for _, profile := range cfg.Profiles {
-				if e := DeleteTokenDataKeychainForCorpID(profile.CorpID); e != nil && firstErr == nil {
+				if e := DeleteTokenDataKeychainForCorpIDAt(configDir, profile.CorpID); e != nil && firstErr == nil {
 					firstErr = e
 				}
 			}
@@ -300,7 +301,7 @@ func DeleteAllTokenData(configDir string) error {
 				}
 			}
 		}
-		if e := DeleteTokenDataKeychain(); e != nil && firstErr == nil {
+		if e := DeleteTokenDataKeychainAt(configDir); e != nil && firstErr == nil {
 			firstErr = e
 		}
 		if e := DeleteSecureData(configDir); e != nil && firstErr == nil {
@@ -318,9 +319,16 @@ func DeleteAllTokenData(configDir string) error {
 // This should be called before deleting local token data.
 // The function is best-effort: errors are returned but callers may choose to ignore them.
 func RevokeTokenRemote(ctx context.Context) error {
+	return RevokeTokenRemoteAt(ctx, getDefaultConfigDir())
+}
+
+// RevokeTokenRemoteAt revokes the token selected for configDir. The explicit
+// form prevents custom DWS homes and isolated auth instances from accidentally
+// loading the process-default login state during logout.
+func RevokeTokenRemoteAt(ctx context.Context, configDir string) error {
 	// Use MCP revoke endpoint when clientID is from MCP
 	if IsClientIDFromMCP() {
-		return revokeTokenViaMCP(ctx)
+		return revokeTokenViaMCPAt(ctx, configDir)
 	}
 	// Direct mode: use DingTalk logout endpoint
 	logoutURL, err := url.Parse(LogoutURL)
@@ -362,13 +370,17 @@ func RevokeTokenRemote(ctx context.Context) error {
 
 // revokeTokenViaMCP revokes token via MCP endpoint.
 func revokeTokenViaMCP(ctx context.Context) error {
+	return revokeTokenViaMCPAt(ctx, getDefaultConfigDir())
+}
+
+func revokeTokenViaMCPAt(ctx context.Context, configDir string) error {
 	revokeURL := GetRevokeTokenURL()
 	if revokeURL == "" {
 		return nil // No revoke endpoint available
 	}
 
 	// Load current token to get accessToken
-	tokenData, err := LoadTokenData(getDefaultConfigDir())
+	tokenData, err := LoadTokenData(configDir)
 	if err != nil || tokenData == nil {
 		return nil // No token to revoke
 	}

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
 
@@ -312,6 +314,85 @@ func DeleteAllTokenData(configDir string) error {
 		}
 		return firstErr
 	})
+}
+
+// ResetCurrentAuthData resets exactly one linearized current Auth Instance.
+// Registry selection is snapshotted, its per-instance operating-system lock is
+// acquired, then the Registry revision/current pointer is revalidated before
+// any fixed ConfigDir or KeychainService is changed. A concurrent auth use or
+// new-instance commit therefore either happens before this reset (and its new
+// current instance is reset) or after it (and the previously current instance
+// is reset); the operation can never lock one instance and delete another.
+//
+// Before Auth Instance opt-in, the callback also preserves the historical
+// online reset contract by removing shared auth application configuration.
+// The first Registry Commit shares the legacy instance lock, so it cannot make
+// opt-in visible halfway through that cleanup.
+func ResetCurrentAuthData(configDir string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), config.LockTimeout)
+	defer cancel()
+	_, err := withLockedCurrentAuthStore(ctx, configDir, func(store AuthStore, registryExists bool) error {
+		if h := edition.Get(); h.DeleteToken != nil {
+			if err := h.DeleteToken(configDir); err != nil {
+				return err
+			}
+		} else if err := deleteAllTokenDataFromStoreLocked(store); err != nil {
+			return err
+		}
+		if !registryExists {
+			// Preserve the pre-opt-in reset behavior exactly. These removals were
+			// historically best-effort and remain so.
+			_ = os.Remove(filepath.Join(configDir, "mcp_url"))
+			_ = os.Remove(filepath.Join(configDir, "token"))
+			_ = DeleteAppConfig(configDir)
+		}
+		return nil
+	})
+	return err
+}
+
+// deleteAllTokenDataFromStoreLocked uses only the already-resolved storage
+// coordinate. The caller must hold that store's data lock.
+func deleteAllTokenDataFromStoreLocked(store AuthStore) error {
+	var firstErr error
+	profilesPath := filepath.Join(store.ConfigDir, profilesJSONFile)
+	if data, err := os.ReadFile(profilesPath); err == nil {
+		var profiles ProfilesConfig
+		if json.Unmarshal(data, &profiles) == nil {
+			for _, profile := range profiles.Profiles {
+				corpID := strings.TrimSpace(profile.CorpID)
+				if corpID == "" {
+					continue
+				}
+				if err := keychain.Remove(store.KeychainService, TokenAccountForCorpID(corpID)); err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+	}
+	if err := os.Remove(profilesPath); err != nil && !os.IsNotExist(err) && firstErr == nil {
+		firstErr = err
+	}
+	if matches, _ := filepath.Glob(profilesPath + ".corrupt-*"); len(matches) > 0 {
+		for _, match := range matches {
+			if err := os.Remove(match); err != nil && !os.IsNotExist(err) && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	if err := keychain.Remove(store.KeychainService, keychain.AccountToken); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	for _, path := range []string{
+		filepath.Join(store.ConfigDir, secureDataFile),
+		filepath.Join(store.ConfigDir, secureDataFile+".tmp"),
+		filepath.Join(store.ConfigDir, tokenJSONFile),
+	} {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // RevokeTokenRemote calls the appropriate logout/revoke endpoint to invalidate the access token.

--- a/internal/auth/token_preflight_test.go
+++ b/internal/auth/token_preflight_test.go
@@ -343,6 +343,48 @@ func TestLockedRefreshPreflightsLegacyMirrorBeforeHTTP(t *testing.T) {
 	}
 }
 
+func TestLockedRefreshPreflightsSelectedIsolatedInstance(t *testing.T) {
+	cleanupKeychain(t)
+	t.Setenv(keychain.DisableKeychainEnv, "1")
+	setPreflightTestCredentials(t)
+	configDir := t.TempDir()
+	DeactivateAuthStore(configDir)
+	t.Cleanup(func() { DeactivateAuthStore(configDir) })
+
+	tx, err := BeginNewInstance(configDir, "personal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := tx.Store()
+	t.Cleanup(func() { _ = os.RemoveAll(keychain.StorageDir(store.KeychainService)) })
+	data := testToken("at_isolated_refresh", "corp_isolated_refresh", "Isolated Refresh Org")
+	data.ExpiresAt = time.Now().Add(-time.Hour)
+	if err := SaveTokenData(configDir, data); err != nil {
+		t.Fatalf("SaveTokenData() error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	legacyPath := filepath.Join(keychain.StorageDir(store.KeychainService), keychain.AccountToken+".enc")
+	if err := os.WriteFile(legacyPath, []byte("corrupt isolated legacy ciphertext"), 0o600); err != nil {
+		t.Fatalf("WriteFile(isolated legacy ciphertext) error = %v", err)
+	}
+
+	var calls atomic.Int32
+	provider := NewOAuthProvider(configDir, nil)
+	provider.httpClient = &http.Client{Transport: preflightRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls.Add(1)
+		return nil, errors.New("unexpected refresh request")
+	})}
+	_, err = provider.lockedRefresh(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "legacy token slot") {
+		t.Fatalf("lockedRefresh() error = %v, want isolated token persistence preflight error", err)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("refresh HTTP calls = %d, want 0", got)
+	}
+}
+
 func TestExchangeAuthCodeAllowsFirstLogin(t *testing.T) {
 	cleanupKeychain(t)
 	t.Setenv(keychain.DisableKeychainEnv, "1")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,7 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh -s -- --version v1.0.51
 #
 # Environment variables (all optional):
 #   DWS_INSTALL_DIR   — where to put the binary       (default: ~/.local/bin)
@@ -36,6 +37,7 @@ GITEE_FALLBACK_REPO="${DWS_GITEE_FALLBACK_REPO:-DingTalk-Real-AI/dingtalk-worksp
 INSTALL_DIR="${DWS_INSTALL_DIR:-$HOME/.local/bin}"
 INSTALL_NAME="${DWS_INSTALL_NAME:-$BIN_NAME}"
 VERSION="${DWS_VERSION:-latest}"
+VERSION_FROM_CLI=0
 NO_SKILLS="${DWS_NO_SKILLS:-0}"
 SKILLS_ONLY="${DWS_SKILLS_ONLY:-0}"
 SKILL_NAME="dws"
@@ -50,6 +52,73 @@ say() {
 err() {
   printf '  ❌ %s\n' "$@" >&2
   exit 1
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh
+  curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | sh -s -- --version <version>
+  curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install.sh | DWS_VERSION=<version> sh
+  ./scripts/install.sh [--version <version>]
+
+Options:
+  --version <version>  Install a release tag such as v1.0.51 (the leading v is optional).
+  -h, --help           Show this help message.
+
+Without --version or DWS_VERSION, the installer keeps the existing behavior and installs latest.
+EOF
+}
+
+normalize_version() {
+  [ "$VERSION" = "latest" ] && return 0
+
+  # Preserve the existing DWS_VERSION contract and future release tag formats:
+  # safe tag names pass through unchanged. Only the CLI convenience form
+  # X.Y.Z with an optional safe suffix gains a leading v.
+  case "$VERSION" in
+    [0-9A-Za-z]*)
+      case "$VERSION" in
+        *[!0-9A-Za-z._+-]*) err "Invalid version '${VERSION}'. Use a release tag such as v1.0.51." ;;
+      esac
+      ;;
+    *) err "Invalid version '${VERSION}'. Use a release tag such as v1.0.51." ;;
+  esac
+
+  if [ "$VERSION_FROM_CLI" = "1" ] && printf '%s\n' "$VERSION" \
+    | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([._+-][0-9A-Za-z][0-9A-Za-z._+-]*)?$'; then
+    VERSION="v${VERSION}"
+  fi
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --version)
+        if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+          err "--version requires a release tag, for example: --version v1.0.51"
+        fi
+        VERSION="$2"
+        VERSION_FROM_CLI=1
+        shift 2
+        ;;
+      --version=*)
+        VERSION="${1#--version=}"
+        [ -n "$VERSION" ] || err "--version requires a release tag, for example: --version v1.0.51"
+        VERSION_FROM_CLI=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        err "Unknown argument '$1'. Run with --help for usage."
+        ;;
+    esac
+  done
+
+  normalize_version
 }
 
 need_cmd() {
@@ -687,4 +756,5 @@ main() {
   printf '\n'
 }
 
+parse_args "$@"
 main

--- a/test/scripts/install_script_test.go
+++ b/test/scripts/install_script_test.go
@@ -3,6 +3,7 @@ package scripts_test
 import (
 	"archive/tar"
 	"archive/zip"
+	"bytes"
 	"compress/gzip"
 	"os"
 	"os/exec"
@@ -137,6 +138,73 @@ done
 		if _, err := os.Stat(skillPath); err != nil {
 			t.Fatalf("Stat(%s) error = %v\noutput:\n%s", skillPath, err, string(output))
 		}
+	}
+}
+
+func TestInstallScriptStreamSelectsRequestedRelease(t *testing.T) {
+	t.Parallel()
+	requireInstallScriptPlatform(t)
+
+	tests := []struct {
+		name          string
+		args          []string
+		envVersion    string
+		latestVersion string
+		wantVersion   string
+	}{
+		{"space form overrides env and adds v", []string{"--version", "1.0.51"}, "v1.0.50", "", "v1.0.51"},
+		{"equals form accepts suffix", []string{"--version=v1.0.52-beta.4"}, "", "", "v1.0.52-beta.4"},
+		{"future release prefix passes through", []string{"--version", "release-2026.07"}, "", "", "release-2026.07"},
+		{"two-part v tag passes through", []string{"--version", "v2026.07"}, "", "", "v2026.07"},
+		{"underscore suffix passes through", []string{"--version", "v1.0.51_hotfix1"}, "", "", "v1.0.51_hotfix1"},
+		{"DWS_VERSION numeric tag remains exact", nil, "1.0.51", "", "1.0.51"},
+		{"DWS_VERSION future tag remains exact", nil, "release-2026.07", "", "release-2026.07"},
+		{"no version still resolves latest", nil, "", "v1.0.51", "v1.0.51"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			curlLog := runStreamedInstall(t, tc.args, tc.envVersion, tc.latestVersion)
+			asset := "dws-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz"
+			want := "/releases/download/" + tc.wantVersion + "/" + asset
+			if !strings.Contains(curlLog, want) {
+				t.Fatalf("curl log missing requested release path %q:\n%s", want, curlLog)
+			}
+		})
+	}
+}
+
+func TestInstallScriptVersionInputHandling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		args       []string
+		envVersion string
+		wantError  string
+	}{
+		{"help", []string{"--help"}, "", ""},
+		{"reject path input", []string{"--version", "../v1.0.51"}, "", "Invalid version"},
+		{"validate DWS_VERSION", nil, "v1.0.51?bad", "Invalid version"},
+		{"reject control input", []string{"--version", "v1.0.51\nnext"}, "", "Invalid version"},
+		{"reject unknown option", []string{"--channel", "beta"}, "", "Unknown argument '--channel'"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			output, err := runStreamedInput(t, tc.args, tc.envVersion)
+			if tc.wantError == "" {
+				if err != nil || !strings.Contains(output, "sh -s -- --version <version>") {
+					t.Fatalf("--help failed: %v\n%s", err, output)
+				}
+			} else if err == nil || !strings.Contains(output, tc.wantError) {
+				t.Fatalf("want error %q, got %v:\n%s", tc.wantError, err, output)
+			}
+		})
 	}
 }
 
@@ -731,6 +799,111 @@ done
 	}
 }
 
+func requireInstallScriptPlatform(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" || (runtime.GOOS != "darwin" && runtime.GOOS != "linux") {
+		t.Skipf("POSIX installer test is unsupported on %s", runtime.GOOS)
+	}
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+		t.Skipf("POSIX installer test is unsupported on %s", runtime.GOARCH)
+	}
+}
+
+func readInstallScript(t *testing.T) []byte {
+	t.Helper()
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "install.sh"))
+	if err != nil {
+		t.Fatalf("Abs(install.sh) error = %v", err)
+	}
+	script, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", scriptPath, err)
+	}
+	return script
+}
+
+func runStreamedInstall(t *testing.T, args []string, envVersion, latestVersion string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	releaseDir := filepath.Join(root, "release")
+	stubRoot := filepath.Join(root, "stubs")
+	curlLogPath := filepath.Join(root, "curl.log")
+	assetName := "dws-" + runtime.GOOS + "-" + runtime.GOARCH + ".tar.gz"
+
+	writeTarGz(t, filepath.Join(releaseDir, assetName), map[string]string{
+		"dws": "versioned-install-binary\n",
+	})
+	writeFakeCurl(t, filepath.Join(stubRoot, "curl"))
+
+	shellArgs := append([]string{"-s", "--"}, args...)
+	cmd := exec.Command("sh", shellArgs...)
+	cmd.Stdin = bytes.NewReader(readInstallScript(t))
+	cmd.Env = []string{
+		"HOME=" + filepath.Join(root, "home"),
+		"PATH=" + stubRoot + ":" + os.Getenv("PATH"),
+		"DWS_INSTALL_DIR=" + filepath.Join(root, "bin"),
+		"DWS_NO_SKILLS=1",
+		"DWS_NO_FALLBACK=1",
+		"FAKE_RELEASE_DIR=" + releaseDir,
+		"FAKE_ASSET_NAME=" + assetName,
+		"FAKE_CURL_LOG=" + curlLogPath,
+		"FAKE_LATEST_VERSION=" + latestVersion,
+	}
+	if envVersion != "" {
+		cmd.Env = append(cmd.Env, "DWS_VERSION="+envVersion)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("streamed install.sh error = %v\noutput:\n%s", err, string(output))
+	}
+	curlLog, err := os.ReadFile(curlLogPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", curlLogPath, err)
+	}
+
+	return string(curlLog)
+}
+
+func runStreamedInput(t *testing.T, args []string, envVersion string) (string, error) {
+	t.Helper()
+	root := t.TempDir()
+	stubRoot := filepath.Join(root, "stubs")
+	marker := filepath.Join(root, "curl-called")
+	installDir := filepath.Join(root, "bin")
+	writeNetworkMarkerCurl(t, filepath.Join(stubRoot, "curl"))
+
+	cmd := exec.Command("sh", append([]string{"-s", "--"}, args...)...)
+	cmd.Stdin = bytes.NewReader(readInstallScript(t))
+	cmd.Env = []string{
+		"HOME=" + filepath.Join(root, "home"),
+		"PATH=" + stubRoot + ":" + os.Getenv("PATH"),
+		"DWS_INSTALL_DIR=" + installDir,
+		"DWS_VERSION=" + envVersion,
+		"FAKE_CURL_MARKER=" + marker,
+	}
+	output, runErr := cmd.CombinedOutput()
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("input handling accessed the network, marker stat error = %v", err)
+	}
+	if _, err := os.Stat(installDir); !os.IsNotExist(err) {
+		t.Fatalf("input handling mutated install dir, stat error = %v", err)
+	}
+	return string(output), runErr
+}
+
+func writeNetworkMarkerCurl(t *testing.T, path string) {
+	t.Helper()
+	const script = `#!/bin/sh
+set -eu
+: > "$FAKE_CURL_MARKER"
+echo "network should not be called" >&2
+exit 99
+`
+	mustWriteFile(t, path, []byte(script), 0o755)
+}
+
 func writeTarGz(t *testing.T, path string, files map[string]string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -806,7 +979,17 @@ while [ "$#" -gt 0 ]; do
     *) url="$1"; shift ;;
   esac
 done
-[ -n "$out" ] || { echo "fake curl: missing -o" >&2; exit 1; }
+[ -z "${FAKE_CURL_LOG:-}" ] || printf '%s\n' "$url" >> "$FAKE_CURL_LOG"
+if [ -z "$out" ]; then
+  case "$url" in
+    */releases/latest)
+      printf 'HTTP/2 302\r\nlocation: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/tag/%s\r\n\r\n' "${FAKE_LATEST_VERSION:-}"
+      exit 0
+      ;;
+  esac
+  echo "fake curl: missing -o" >&2
+  exit 1
+fi
 case "$url" in
   *"/${FAKE_ASSET_NAME}") cp "$FAKE_RELEASE_DIR/$FAKE_ASSET_NAME" "$out" ;;
   *"/dws-skills.zip") cp "$FAKE_RELEASE_DIR/dws-skills.zip" "$out" ;;


### PR DESCRIPTION
## What changed

- Add opt-in Auth Instances as isolated login-state storage locations, selected with `dws auth list` and `dws auth use`.
- Add `dws auth login --new-instance [alias]` to create a new storage location and log in without affecting another instance.
- Keep organization/profile switching separate from Auth Instance switching; an instance may contain any user and multiple organizations.
- Scope `auth reset`, runtime token lookup, profile state, and audit actor cache to the selected instance.
- Serialize mutations to the same instance with process and operating-system file locks, while allowing different instances to proceed in parallel.
- Keep Registry updates under a separate short-lived lock and fail closed if the selected store changes during command initialization.

## Compatibility

- The feature is strictly opt-in. Before the first explicit new instance, DWS does not create a Registry, migrate credentials, change the Keychain service, or alter existing login/reset behavior.
- The existing login state becomes the `default` compatibility instance only when isolation is explicitly enabled.
- After opt-in, reset affects only the current instance, including `default`, and never clears another instance or shared app configuration.

## Why

Multiple DWS processes need independently selectable login-state locations without redefining identity around account or organization. The implementation therefore isolates the storage coordinate itself and uses generated instance IDs only as stable storage keys.

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/auth`
- focused app Auth Instance/reset/root-switch race tests
- cross-process lock scenarios repeated 10 times
- `go vet ./internal/auth ./internal/app ./internal/keychain`
- Linux amd64 and Windows amd64 cross-compilation
- `git diff --check` and `gofmt` verification

No P0/P1/P2 blocking findings remain after the final scope and concurrency review.

## Follow-up coverage

The OS-lock holder is exercised in a real helper process. Fully end-to-end two-CLI-process `auth use` and concurrent first-Commit scenarios, plus runtime `LockFileEx` contention on a Windows runner, can be added as non-blocking coverage follow-ups.
