### PR TITLE
feat(im): sync Wukong read-result semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ### Changed
 
+- **Wukong IM read-result parity** — `chat message list` now documents and regression-tests quoted-message context for merged forwards and images; message-search entitlement errors preserve the server-provided friendly hint and action URL; and `ding message list` exposes each DING's content alongside its ID and status.
 - **`event consume` AI-subprocess contract** — aligns personal event streaming with the contract an orchestrator can drive without guessing: a fixed stderr ready line `[event] ready event_key=<key> bus_pid=<pid>` (block on it, don't `sleep`); a final `[event] exited — received N event(s) in Xs (reason: limit|timeout|signal|bus_shutdown)` line with exit code 0 on controlled exit and non-zero (no `exited` line) on failure; stdin-EOF as a graceful shutdown signal, armed only for a parent-controlled pipe stdin on an unbounded run (an interactive TTY and `< /dev/null` never trigger it), with a self-explaining diagnostic when it fires; and ownership-based subscription cleanup — a subscription this run created is unsubscribed on any clean exit while a `--subscribe-id`-reused one is left intact (`--ephemeral` still forces cleanup), so `kill -9` is the only way to leak a server-side subscription. Skill docs (mono + `dingtalk-event`) document the contract; design notes in `docs/event-subprocess-contract.md`.
 
 ### Added

--- a/docs/command-index.md
+++ b/docs/command-index.md
@@ -147,8 +147,8 @@ _Group chats, conversations, messages, and robot/webhook integrations._
 | `dws chat group members remove` | Remove one or more members from a group chat. | When the agent kicks users who should no longer have access to the group. |
 | `dws chat group rename` | Update the display name of a group chat. | When the agent is rebranding or clarifying the purpose of an existing group. |
 | `dws chat list-top-conversations` | Fetch the list of conversations the current user has pinned to the top of their chat list. | When the agent needs to prioritize the user's most important conversations in a summary or dashboard. |
-| `dws chat message list` | Pull the recent message history of a specific conversation (v2), paginated. | When the agent needs to read what has recently been said in a conversation to summarize or reason about it. |
-| `dws chat message list-all` | Search all messages across the current user's conversations within a time range. | When the agent needs to audit or summarize everything the user saw across chats in a window. |
+| `dws chat message list` | Pull the recent message history of a specific conversation, including quoted-message context for merged forwards and images. | When the agent needs to read what has recently been said in a conversation and retain the context of replies. |
+| `dws chat message list-all` | Search all messages across the current user's conversations within a time range, surfacing any search-entitlement guidance. | When the agent needs to audit or summarize everything the user saw across chats in a window. |
 | `dws chat message list-by-sender` | Fetch messages authored by a specific sender across both single and group chats. | When the agent needs to pull everything a particular colleague said recently. |
 | `dws chat message list-focused` | Fetch messages from users the current user has marked as "special focus" (starred contacts). | When the agent builds a priority-inbox view highlighting messages from important people. |
 | `dws chat message list-mentions` | Fetch messages where the current user was @-mentioned. | When the agent wants to surface items that explicitly require the user's attention. |

--- a/internal/cli/schema_agent_metadata/chat.json
+++ b/internal/cli/schema_agent_metadata/chat.json
@@ -10553,7 +10553,7 @@
       ]
     },
     "chat message list": {
-      "agent_summary": "分页读取指定群聊或单聊的消息",
+      "agent_summary": "分页读取指定会话消息及其引用上下文",
       "agent_summary_source": "dws-agent-selection/chat",
       "availability": "available",
       "avoid_when": [
@@ -10567,18 +10567,18 @@
       ],
       "field_provenance": {
         "agent_summary": {
-          "value": "分页读取指定群聊或单聊的消息",
+          "value": "分页读取指定会话消息及其引用上下文",
           "source": "internal/cli/schema_hints/selection/chat.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+          "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。",
           "candidates": [
             {
-              "value": "分页读取指定群聊或单聊的消息",
+              "value": "分页读取指定会话消息及其引用上下文",
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。"
             }
           ]
         },
@@ -10611,7 +10611,7 @@
           "source": "internal/cli/schema_hints/selection/chat.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+          "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。",
           "candidates": [
             {
               "value": [
@@ -10620,7 +10620,7 @@
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。"
             }
           ]
         },
@@ -10659,7 +10659,7 @@
           "source": "internal/cli/schema_hints/selection/chat.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+          "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。",
           "candidates": [
             {
               "value": [
@@ -10668,7 +10668,7 @@
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。"
             }
           ]
         },
@@ -10741,7 +10741,7 @@
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": false,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。"
             }
           ]
         },
@@ -10761,21 +10761,21 @@
         },
         "use_when": {
           "value": [
-            "用户明确指定某个会话并要查看其消息记录时"
+            "用户明确指定某个会话，并要读取消息或追溯引用回复中的原消息上下文时"
           ],
           "source": "internal/cli/schema_hints/selection/chat.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+          "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。",
           "candidates": [
             {
               "value": [
-                "用户明确指定某个会话并要查看其消息记录时"
+                "用户明确指定某个会话，并要读取消息或追溯引用回复中的原消息上下文时"
               ],
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。"
             }
           ]
         }
@@ -10799,11 +10799,11 @@
         "skills/mono/references/products/chat.md"
       ],
       "use_when": [
-        "用户明确指定某个会话并要查看其消息记录时"
+        "用户明确指定某个会话，并要读取消息或追溯引用回复中的原消息上下文时"
       ]
     },
     "chat message list-all": {
-      "agent_summary": "按时间范围查询当前用户的跨会话消息",
+      "agent_summary": "按时间范围搜索跨会话消息并保留权益指引",
       "agent_summary_source": "dws-agent-selection/chat",
       "availability": "available",
       "avoid_when": [
@@ -10817,18 +10817,18 @@
       ],
       "field_provenance": {
         "agent_summary": {
-          "value": "按时间范围查询当前用户的跨会话消息",
+          "value": "按时间范围搜索跨会话消息并保留权益指引",
           "source": "internal/cli/schema_hints/selection/chat.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+          "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。",
           "candidates": [
             {
-              "value": "按时间范围查询当前用户的跨会话消息",
+              "value": "按时间范围搜索跨会话消息并保留权益指引",
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。"
             }
           ]
         },
@@ -10861,7 +10861,7 @@
           "source": "internal/cli/schema_hints/selection/chat.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+          "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。",
           "candidates": [
             {
               "value": [
@@ -10870,7 +10870,7 @@
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。"
             }
           ]
         },
@@ -10909,7 +10909,7 @@
           "source": "internal/cli/schema_hints/selection/chat.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+          "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。",
           "candidates": [
             {
               "value": [
@@ -10918,7 +10918,7 @@
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。"
             }
           ]
         },
@@ -10997,7 +10997,7 @@
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": false,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。"
             }
           ]
         },
@@ -11022,7 +11022,7 @@
           "source": "internal/cli/schema_hints/selection/chat.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+          "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。",
           "candidates": [
             {
               "value": [
@@ -11031,7 +11031,7 @@
               "source": "internal/cli/schema_hints/selection/chat.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。"
+              "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。"
             }
           ]
         }

--- a/internal/cli/schema_agent_metadata/index.json
+++ b/internal/cli/schema_agent_metadata/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "source_hash": "sha256:01044ad3498433e4e27b26f5cfc38759a9504bc4c663ef15c491e33ec4053c72",
+  "source_hash": "sha256:b42825642a99ec968d421660de7bab9de4b756d81906f1df2e1301865760a24f",
   "surface_hash": "sha256:e858be68701d256818eccd085a6f7f97655835b9c7cbbce6275ed930c2436dc3",
   "coverage": {
     "surface_products": 22,

--- a/internal/cli/schema_agent_metadata_audit.json
+++ b/internal/cli/schema_agent_metadata_audit.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "source_hash": "sha256:01044ad3498433e4e27b26f5cfc38759a9504bc4c663ef15c491e33ec4053c72",
+  "source_hash": "sha256:b42825642a99ec968d421660de7bab9de4b756d81906f1df2e1301865760a24f",
   "surface_hash": "sha256:e858be68701d256818eccd085a6f7f97655835b9c7cbbce6275ed930c2436dc3",
   "source_files": 149,
   "hint_files": 46,
@@ -1507,7 +1507,7 @@
     {
       "tool_path": "chat media upload",
       "source": "skills/mono/references/products/chat.md",
-      "line": 609,
+      "line": 610,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1521,7 +1521,7 @@
     {
       "tool_path": "chat media upload",
       "source": "skills/mono/references/products/chat.md",
-      "line": 610,
+      "line": 611,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1535,7 +1535,7 @@
     {
       "tool_path": "chat message list-emotion-replies",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1084,
+      "line": 1086,
       "candidates": [
         "chat message add-emoji",
         "chat message add-favorite",
@@ -1549,7 +1549,7 @@
     {
       "tool_path": "chat category create",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1439,
+      "line": 1441,
       "candidates": [
         "chat group create",
         "chat category create-smart",
@@ -1563,7 +1563,7 @@
     {
       "tool_path": "chat category delete",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1464,
+      "line": 1466,
       "candidates": [
         "chat category create-smart",
         "chat category list",
@@ -1577,7 +1577,7 @@
     {
       "tool_path": "chat category rename",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1475,
+      "line": 1477,
       "candidates": [
         "chat group rename",
         "chat category create-smart",
@@ -1591,7 +1591,7 @@
     {
       "tool_path": "chat category add-conv",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1487,
+      "line": 1489,
       "candidates": [
         "chat category create-smart",
         "chat category list",
@@ -1605,39 +1605,11 @@
     {
       "tool_path": "chat category remove-conv",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1500,
+      "line": 1502,
       "candidates": [
         "chat category create-smart",
         "chat category list",
         "chat category list-conversations"
-      ],
-      "review": {
-        "status": "stale",
-        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
-      }
-    },
-    {
-      "tool_path": "chat text translate",
-      "source": "skills/mono/references/products/chat.md",
-      "line": 1515,
-      "candidates": [
-        "chat bot find",
-        "chat bot search",
-        "chat category create-smart"
-      ],
-      "review": {
-        "status": "stale",
-        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
-      }
-    },
-    {
-      "tool_path": "chat text translate",
-      "source": "skills/mono/references/products/chat.md",
-      "line": 1516,
-      "candidates": [
-        "chat bot find",
-        "chat bot search",
-        "chat category create-smart"
       ],
       "review": {
         "status": "stale",
@@ -1659,9 +1631,23 @@
       }
     },
     {
-      "tool_path": "chat hide",
+      "tool_path": "chat text translate",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1554,
+      "line": 1518,
+      "candidates": [
+        "chat bot find",
+        "chat bot search",
+        "chat category create-smart"
+      ],
+      "review": {
+        "status": "stale",
+        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
+      }
+    },
+    {
+      "tool_path": "chat text translate",
+      "source": "skills/mono/references/products/chat.md",
+      "line": 1519,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1675,7 +1661,21 @@
     {
       "tool_path": "chat hide",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1555,
+      "line": 1556,
+      "candidates": [
+        "chat bot find",
+        "chat bot search",
+        "chat category create-smart"
+      ],
+      "review": {
+        "status": "stale",
+        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
+      }
+    },
+    {
+      "tool_path": "chat hide",
+      "source": "skills/mono/references/products/chat.md",
+      "line": 1557,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1689,7 +1689,7 @@
     {
       "tool_path": "chat mute-at-all",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1577,
+      "line": 1579,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1703,7 +1703,7 @@
     {
       "tool_path": "chat mute-at-all",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1578,
+      "line": 1580,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1717,7 +1717,7 @@
     {
       "tool_path": "chat mute-red-envelope",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1600,
+      "line": 1602,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1731,7 +1731,7 @@
     {
       "tool_path": "chat mute-red-envelope",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1601,
+      "line": 1603,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1745,7 +1745,7 @@
     {
       "tool_path": "chat mark-unread",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1621,
+      "line": 1623,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1759,7 +1759,7 @@
     {
       "tool_path": "chat mark-unread",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1622,
+      "line": 1624,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1773,7 +1773,7 @@
     {
       "tool_path": "chat clear-red-point",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1640,
+      "line": 1642,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1787,21 +1787,7 @@
     {
       "tool_path": "chat clear-red-point",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1641,
-      "candidates": [
-        "chat bot find",
-        "chat bot search",
-        "chat category create-smart"
-      ],
-      "review": {
-        "status": "stale",
-        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
-      }
-    },
-    {
-      "tool_path": "chat clear-all-red-point",
-      "source": "skills/mono/references/products/chat.md",
-      "line": 1657,
+      "line": 1643,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1827,23 +1813,9 @@
       }
     },
     {
-      "tool_path": "chat list-all-conversations",
+      "tool_path": "chat clear-all-red-point",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1673,
-      "candidates": [
-        "chat bot find",
-        "chat bot search",
-        "chat category create-smart"
-      ],
-      "review": {
-        "status": "stale",
-        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
-      }
-    },
-    {
-      "tool_path": "chat list-all-conversations",
-      "source": "skills/mono/references/products/chat.md",
-      "line": 1674,
+      "line": 1661,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1883,9 +1855,23 @@
       }
     },
     {
-      "tool_path": "chat clear-messages",
+      "tool_path": "chat list-all-conversations",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1696,
+      "line": 1677,
+      "candidates": [
+        "chat bot find",
+        "chat bot search",
+        "chat category create-smart"
+      ],
+      "review": {
+        "status": "stale",
+        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
+      }
+    },
+    {
+      "tool_path": "chat list-all-conversations",
+      "source": "skills/mono/references/products/chat.md",
+      "line": 1678,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1899,7 +1885,21 @@
     {
       "tool_path": "chat clear-messages",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1697,
+      "line": 1698,
+      "candidates": [
+        "chat bot find",
+        "chat bot search",
+        "chat category create-smart"
+      ],
+      "review": {
+        "status": "stale",
+        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
+      }
+    },
+    {
+      "tool_path": "chat clear-messages",
+      "source": "skills/mono/references/products/chat.md",
+      "line": 1699,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1913,7 +1913,7 @@
     {
       "tool_path": "chat mark-read",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1715,
+      "line": 1717,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -1927,39 +1927,11 @@
     {
       "tool_path": "chat mark-read",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1716,
+      "line": 1718,
       "candidates": [
         "chat bot find",
         "chat bot search",
         "chat category create-smart"
-      ],
-      "review": {
-        "status": "stale",
-        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
-      }
-    },
-    {
-      "tool_path": "chat group list-join-validations",
-      "source": "skills/mono/references/products/chat.md",
-      "line": 1759,
-      "candidates": [
-        "chat group bots",
-        "chat group create",
-        "chat group dismiss"
-      ],
-      "review": {
-        "status": "stale",
-        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
-      }
-    },
-    {
-      "tool_path": "chat group list-join-validations",
-      "source": "skills/mono/references/products/chat.md",
-      "line": 1760,
-      "candidates": [
-        "chat group bots",
-        "chat group create",
-        "chat group dismiss"
       ],
       "review": {
         "status": "stale",
@@ -1981,9 +1953,23 @@
       }
     },
     {
-      "tool_path": "chat group audit-join-validation",
+      "tool_path": "chat group list-join-validations",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1781,
+      "line": 1762,
+      "candidates": [
+        "chat group bots",
+        "chat group create",
+        "chat group dismiss"
+      ],
+      "review": {
+        "status": "stale",
+        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
+      }
+    },
+    {
+      "tool_path": "chat group list-join-validations",
+      "source": "skills/mono/references/products/chat.md",
+      "line": 1763,
       "candidates": [
         "chat group bots",
         "chat group create",
@@ -1997,7 +1983,21 @@
     {
       "tool_path": "chat group audit-join-validation",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1782,
+      "line": 1783,
+      "candidates": [
+        "chat group bots",
+        "chat group create",
+        "chat group dismiss"
+      ],
+      "review": {
+        "status": "stale",
+        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
+      }
+    },
+    {
+      "tool_path": "chat group audit-join-validation",
+      "source": "skills/mono/references/products/chat.md",
+      "line": 1784,
       "candidates": [
         "chat group bots",
         "chat group create",
@@ -2011,7 +2011,7 @@
     {
       "tool_path": "chat group members",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1814,
+      "line": 1816,
       "candidates": [
         "chat group members add",
         "chat group members add-bot",
@@ -2025,7 +2025,7 @@
     {
       "tool_path": "chat group update-alias",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1819,
+      "line": 1821,
       "candidates": [
         "chat group bots",
         "chat group create",
@@ -2039,7 +2039,7 @@
     {
       "tool_path": "chat group update-nick",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1820,
+      "line": 1822,
       "candidates": [
         "chat group bots",
         "chat group create",
@@ -2053,7 +2053,7 @@
     {
       "tool_path": "chat group members list-by-ids",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1821,
+      "line": 1823,
       "candidates": [
         "chat message list-by-ids",
         "chat group members add",
@@ -2067,7 +2067,7 @@
     {
       "tool_path": "chat category create",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1845,
+      "line": 1847,
       "candidates": [
         "chat group create",
         "chat category create-smart",
@@ -2081,7 +2081,7 @@
     {
       "tool_path": "chat category delete",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1847,
+      "line": 1849,
       "candidates": [
         "chat category create-smart",
         "chat category list",
@@ -2095,7 +2095,7 @@
     {
       "tool_path": "chat category rename",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1848,
+      "line": 1850,
       "candidates": [
         "chat group rename",
         "chat category create-smart",
@@ -2109,7 +2109,7 @@
     {
       "tool_path": "chat category add-conv",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1849,
+      "line": 1851,
       "candidates": [
         "chat category create-smart",
         "chat category list",
@@ -2123,7 +2123,7 @@
     {
       "tool_path": "chat category remove-conv",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1850,
+      "line": 1852,
       "candidates": [
         "chat category create-smart",
         "chat category list",
@@ -2137,7 +2137,7 @@
     {
       "tool_path": "chat group share-invite",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1861,
+      "line": 1863,
       "candidates": [
         "chat group bots",
         "chat group create",
@@ -2151,7 +2151,7 @@
     {
       "tool_path": "chat group notice create/edit/get/list",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1862,
+      "line": 1864,
       "candidates": [
         "chat group bots",
         "chat group create",
@@ -2165,7 +2165,7 @@
     {
       "tool_path": "chat message list-emotion-replies",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1864,
+      "line": 1866,
       "candidates": [
         "chat message add-emoji",
         "chat message add-favorite",
@@ -2179,34 +2179,6 @@
     {
       "tool_path": "chat hide",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1871,
-      "candidates": [
-        "chat bot find",
-        "chat bot search",
-        "chat category create-smart"
-      ],
-      "review": {
-        "status": "stale",
-        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
-      }
-    },
-    {
-      "tool_path": "chat mute-at-all",
-      "source": "skills/mono/references/products/chat.md",
-      "line": 1872,
-      "candidates": [
-        "chat bot find",
-        "chat bot search",
-        "chat category create-smart"
-      ],
-      "review": {
-        "status": "stale",
-        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
-      }
-    },
-    {
-      "tool_path": "chat mute-at-all",
-      "source": "skills/mono/references/products/chat.md",
       "line": 1873,
       "candidates": [
         "chat bot find",
@@ -2219,7 +2191,7 @@
       }
     },
     {
-      "tool_path": "chat mute-red-envelope",
+      "tool_path": "chat mute-at-all",
       "source": "skills/mono/references/products/chat.md",
       "line": 1874,
       "candidates": [
@@ -2233,7 +2205,7 @@
       }
     },
     {
-      "tool_path": "chat mute-red-envelope",
+      "tool_path": "chat mute-at-all",
       "source": "skills/mono/references/products/chat.md",
       "line": 1875,
       "candidates": [
@@ -2247,7 +2219,7 @@
       }
     },
     {
-      "tool_path": "chat mark-unread",
+      "tool_path": "chat mute-red-envelope",
       "source": "skills/mono/references/products/chat.md",
       "line": 1876,
       "candidates": [
@@ -2261,7 +2233,7 @@
       }
     },
     {
-      "tool_path": "chat mark-read",
+      "tool_path": "chat mute-red-envelope",
       "source": "skills/mono/references/products/chat.md",
       "line": 1877,
       "candidates": [
@@ -2275,7 +2247,7 @@
       }
     },
     {
-      "tool_path": "chat clear-red-point",
+      "tool_path": "chat mark-unread",
       "source": "skills/mono/references/products/chat.md",
       "line": 1878,
       "candidates": [
@@ -2289,7 +2261,7 @@
       }
     },
     {
-      "tool_path": "chat clear-all-red-point",
+      "tool_path": "chat mark-read",
       "source": "skills/mono/references/products/chat.md",
       "line": 1879,
       "candidates": [
@@ -2303,7 +2275,7 @@
       }
     },
     {
-      "tool_path": "chat list-all-conversations",
+      "tool_path": "chat clear-red-point",
       "source": "skills/mono/references/products/chat.md",
       "line": 1880,
       "candidates": [
@@ -2317,7 +2289,7 @@
       }
     },
     {
-      "tool_path": "chat clear-messages",
+      "tool_path": "chat clear-all-red-point",
       "source": "skills/mono/references/products/chat.md",
       "line": 1881,
       "candidates": [
@@ -2331,9 +2303,37 @@
       }
     },
     {
-      "tool_path": "chat group list-join-validations",
+      "tool_path": "chat list-all-conversations",
+      "source": "skills/mono/references/products/chat.md",
+      "line": 1882,
+      "candidates": [
+        "chat bot find",
+        "chat bot search",
+        "chat category create-smart"
+      ],
+      "review": {
+        "status": "stale",
+        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
+      }
+    },
+    {
+      "tool_path": "chat clear-messages",
       "source": "skills/mono/references/products/chat.md",
       "line": 1883,
+      "candidates": [
+        "chat bot find",
+        "chat bot search",
+        "chat category create-smart"
+      ],
+      "review": {
+        "status": "stale",
+        "reason": "旧版 Skill 或说明性引用，当前公开命令面无等价 leaf，禁止词法模糊映射"
+      }
+    },
+    {
+      "tool_path": "chat group list-join-validations",
+      "source": "skills/mono/references/products/chat.md",
+      "line": 1885,
       "candidates": [
         "chat group bots",
         "chat group create",
@@ -2347,7 +2347,7 @@
     {
       "tool_path": "chat group audit-join-validation",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1884,
+      "line": 1886,
       "candidates": [
         "chat group bots",
         "chat group create",
@@ -2361,7 +2361,7 @@
     {
       "tool_path": "chat media upload",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1891,
+      "line": 1893,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -2375,7 +2375,7 @@
     {
       "tool_path": "chat text translate",
       "source": "skills/mono/references/products/chat.md",
-      "line": 1903,
+      "line": 1905,
       "candidates": [
         "chat bot find",
         "chat bot search",
@@ -2605,7 +2605,7 @@
     {
       "tool_path": "ding message list",
       "source": "skills/mono/references/products/ding.md",
-      "line": 34,
+      "line": 37,
       "candidates": [
         "chat message list",
         "mail message list",
@@ -2619,7 +2619,7 @@
     {
       "tool_path": "ding message list",
       "source": "skills/mono/references/products/ding.md",
-      "line": 35,
+      "line": 38,
       "candidates": [
         "chat message list",
         "mail message list",
@@ -2633,7 +2633,7 @@
     {
       "tool_path": "ding message list",
       "source": "skills/mono/references/products/ding.md",
-      "line": 36,
+      "line": 39,
       "candidates": [
         "chat message list",
         "mail message list",
@@ -2647,7 +2647,7 @@
     {
       "tool_path": "ding message receiver-status",
       "source": "skills/mono/references/products/ding.md",
-      "line": 47,
+      "line": 50,
       "candidates": [
         "ding message recall",
         "ding message send"
@@ -2660,7 +2660,7 @@
     {
       "tool_path": "ding message list",
       "source": "skills/mono/references/products/ding.md",
-      "line": 117,
+      "line": 120,
       "candidates": [
         "chat message list",
         "mail message list",
@@ -2674,7 +2674,7 @@
     {
       "tool_path": "ding message receiver-status",
       "source": "skills/mono/references/products/ding.md",
-      "line": 118,
+      "line": 121,
       "candidates": [
         "ding message recall",
         "ding message send"

--- a/internal/cli/schema_hints/selection/chat.json
+++ b/internal/cli/schema_hints/selection/chat.json
@@ -378,9 +378,9 @@
       ]
     },
     "chat.list_conversation_message_v2": {
-      "agent_summary": "分页读取指定群聊或单聊的消息",
+      "agent_summary": "分页读取指定会话消息及其引用上下文",
       "use_when": [
-        "用户明确指定某个会话并要查看其消息记录时"
+        "用户明确指定某个会话，并要读取消息或追溯引用回复中的原消息上下文时"
       ],
       "avoid_when": [
         "跨全部会话按时间查询时使用 chat message list-all"
@@ -389,7 +389,7 @@
         "dws chat message list --group <openConversationId> --time \"2026-07-01 00:00:00\" --limit 50"
       ],
       "reviewed": true,
-      "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+      "review_reason": "复核 dws-wukong 2026-07-14 读取能力同步：指定会话查询应保留 quotedMessage，并覆盖被引用的合并转发与图片内容；不改写执行、安全或接口事实。",
       "source_refs": [
         "internal/cli/schema_command_registry.json#chat.list_conversation_message_v2",
         "cobra-help:dws chat message list",
@@ -1073,7 +1073,7 @@
       ]
     },
     "chat.search_messages_by_time_range": {
-      "agent_summary": "按时间范围查询当前用户的跨会话消息",
+      "agent_summary": "按时间范围搜索跨会话消息并保留权益指引",
       "use_when": [
         "需要汇总一段时间内所有可见会话消息时"
       ],
@@ -1084,7 +1084,7 @@
         "dws chat message list-all --start \"2026-07-01 00:00:00\" --end \"2026-07-02 00:00:00\" --limit 50"
       ],
       "reviewed": true,
-      "review_reason": "AI 生成并复核的 Agent 选择语义，依据精确 CommandRegistry identity、真实 Cobra help 与产品参考，不改写执行、安全或接口事实。",
+      "review_reason": "复核 dws-wukong 2026-07-14 搜索能力同步：跨会话消息搜索遇到权益限制时应向用户展示服务端指引，而不是解释为空结果；不改写执行、安全或接口事实。",
       "source_refs": [
         "internal/cli/schema_command_registry.json#chat.search_messages_by_time_range",
         "cobra-help:dws chat message list-all",

--- a/internal/errors/diagnostics.go
+++ b/internal/errors/diagnostics.go
@@ -22,13 +22,16 @@ type ServerDiagnostics struct {
 	TraceID         string `json:"trace_id,omitempty"`
 	ServerErrorCode string `json:"server_error_code,omitempty"`
 	TechnicalDetail string `json:"technical_detail,omitempty"`
+	FriendlyHint    string `json:"friendly_hint,omitempty"`
+	ActionURL       string `json:"action_url,omitempty"`
 	ServerRetryable *bool  `json:"server_retryable,omitempty"`
 }
 
 // IsEmpty returns true when no diagnostic field has been populated.
 func (d ServerDiagnostics) IsEmpty() bool {
 	return d.TraceID == "" && d.ServerErrorCode == "" &&
-		d.TechnicalDetail == "" && d.ServerRetryable == nil
+		d.TechnicalDetail == "" && d.FriendlyHint == "" &&
+		d.ActionURL == "" && d.ServerRetryable == nil
 }
 
 // WithServerDiag attaches server diagnostics to the error.

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -294,15 +294,16 @@ func PrintJSON(w io.Writer, err error) error {
 			}
 			if typed.ServerDiag.ServerErrorCode != "" {
 				errorPayload["server_error_code"] = typed.ServerDiag.ServerErrorCode
-				// Add user-friendly hint for specific server error codes
-				switch typed.ServerDiag.ServerErrorCode {
-				case "TOKEN_VERIFIED_FAILED", "CLI_ORG_NOT_AUTHORIZED":
-					errorPayload["friendly_hint"] = "该组织尚未开启 CLI 数据访问权限，请联系组织主管理员开启。"
-					errorPayload["action_url"] = config.GetDeveloperSettingsURL()
-				}
 			}
 			if typed.ServerDiag.TechnicalDetail != "" {
 				errorPayload["technical_detail"] = typed.ServerDiag.TechnicalDetail
+			}
+			friendlyHint, actionURL := serverGuidance(typed.ServerDiag)
+			if friendlyHint != "" {
+				errorPayload["friendly_hint"] = friendlyHint
+			}
+			if actionURL != "" {
+				errorPayload["action_url"] = actionURL
 			}
 		}
 		if typed.Cause != nil {
@@ -360,11 +361,13 @@ func PrintHumanAt(w io.Writer, err error, v Verbosity) error {
 		lines = append(lines, tui.Cyan(fmt.Sprintf("Hint: %s", typed.Hint)))
 	}
 
-	// Add user-friendly hint for specific server error codes
-	switch typed.ServerDiag.ServerErrorCode {
-	case "TOKEN_VERIFIED_FAILED", "CLI_ORG_NOT_AUTHORIZED":
-		lines = append(lines, tui.Cyan("Hint: 该组织尚未开启 CLI 数据访问权限，请联系组织主管理员开启。"))
-		lines = append(lines, tui.White("Action: 开启地址: "+config.GetDeveloperSettingsURL()))
+	if friendlyHint, actionURL := serverGuidance(typed.ServerDiag); friendlyHint != "" || actionURL != "" {
+		if friendlyHint != "" {
+			lines = append(lines, tui.Cyan("Hint: "+friendlyHint))
+		}
+		if actionURL != "" {
+			lines = append(lines, tui.White("Action: 开启地址: "+actionURL))
+		}
 	}
 
 	if len(typed.Actions) > 0 {
@@ -424,6 +427,23 @@ func PrintHumanAt(w io.Writer, err error, v Verbosity) error {
 
 	_, writeErr := fmt.Fprintln(w, strings.Join(lines, "\n"))
 	return writeErr
+}
+
+func serverGuidance(diag ServerDiagnostics) (string, string) {
+	friendlyHint := strings.TrimSpace(diag.FriendlyHint)
+	actionURL := strings.TrimSpace(diag.ActionURL)
+	if friendlyHint == "" || actionURL == "" {
+		switch diag.ServerErrorCode {
+		case "TOKEN_VERIFIED_FAILED", "CLI_ORG_NOT_AUTHORIZED":
+			if friendlyHint == "" {
+				friendlyHint = "该组织尚未开启 CLI 数据访问权限，请联系组织主管理员开启。"
+			}
+			if actionURL == "" {
+				actionURL = config.GetDeveloperSettingsURL()
+			}
+		}
+	}
+	return friendlyHint, actionURL
 }
 
 func category(err error) string {

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -170,6 +170,8 @@ func TestPrintJSONIncludesServerDiag(t *testing.T) {
 			TraceID:         "trace-xyz",
 			ServerErrorCode: "TIMEOUT_ERROR",
 			TechnicalDetail: "deadline exceeded",
+			FriendlyHint:    "请开通消息搜索权益",
+			ActionURL:       "https://example.test/enable-search",
 		}),
 	)); err != nil {
 		t.Fatalf("PrintJSON() error = %v", err)
@@ -184,6 +186,36 @@ func TestPrintJSONIncludesServerDiag(t *testing.T) {
 	}
 	if !strings.Contains(got, `"technical_detail": "deadline exceeded"`) {
 		t.Fatalf("expected technical_detail in output, got %q", got)
+	}
+	if !strings.Contains(got, `"friendly_hint": "请开通消息搜索权益"`) {
+		t.Fatalf("expected server friendly_hint in output, got %q", got)
+	}
+	if !strings.Contains(got, `"action_url": "https://example.test/enable-search"`) {
+		t.Fatalf("expected server action_url in output, got %q", got)
+	}
+}
+
+func TestPrintHumanIncludesServerGuidance(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	if err := PrintHuman(&b, NewAPI(
+		"search entitlement required",
+		WithServerDiag(ServerDiagnostics{
+			ServerErrorCode: "SEARCH_ENTITLEMENT_REQUIRED",
+			FriendlyHint:    "请联系管理员开通消息搜索权益",
+			ActionURL:       "https://example.test/enable-search",
+		}),
+	)); err != nil {
+		t.Fatalf("PrintHuman() error = %v", err)
+	}
+
+	got := b.String()
+	if !strings.Contains(got, "Hint: 请联系管理员开通消息搜索权益") {
+		t.Fatalf("expected server guidance in output, got %q", got)
+	}
+	if !strings.Contains(got, "Action: 开启地址: https://example.test/enable-search") {
+		t.Fatalf("expected server action URL in output, got %q", got)
 	}
 }
 

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -1326,7 +1326,7 @@ func newChatCommand() *cobra.Command {
 	chatMessageListCmd := &cobra.Command{
 		Use:   "list",
 		Short: "拉取会话消息内容",
-		Long:  `拉取指定群聊或单聊的会话消息内容。--group 指定群聊，--user 指定单聊用户（userId），--open-dingtalk-id 指定单聊用户（openDingTalkId），三者互斥。推荐使用 --direction newer/older 控制时间方向：newer 表示从给定时间往现在拉，older 表示从给定时间往以前拉。hasMore=true 时用结果中的边界 createTime 作为下次 --time 翻页。如果返回的会话消息中包含 openConvThreadId 字段，说明是话题消息，可以调用 dws chat message list-topic-replies 拉取话题回复消息列表，openConvThreadId 作为 topic-id 参数。`,
+		Long:  `拉取指定群聊或单聊的会话消息内容。--group 指定群聊，--user 指定单聊用户（userId），--open-dingtalk-id 指定单聊用户（openDingTalkId），三者互斥。推荐使用 --direction newer/older 控制时间方向：newer 表示从给定时间往现在拉，older 表示从给定时间往以前拉。hasMore=true 时用结果中的边界 createTime 作为下次 --time 翻页。引用回复消息会返回 quotedMessage 引用上下文；被引用的原消息是合并转发或图片时，对应的类型与内容也会随引用上下文返回。如果返回的会话消息中包含 openConvThreadId 字段，说明是话题消息，可以调用 dws chat message list-topic-replies 拉取话题回复消息列表，openConvThreadId 作为 topic-id 参数。`,
 		Example: `  dws chat message list --group <openconversation_id> --time "2025-03-01 00:00:00"
   dws chat message list --user <userId> --time "2025-03-01 00:00:00" --limit 50
   dws chat message list --open-dingtalk-id <openDingTalkId> --time "2025-03-01 00:00:00" --limit 50
@@ -1922,7 +1922,7 @@ func newChatCommand() *cobra.Command {
 	chatMessageListAllCmd := &cobra.Command{
 		Use:   "list-all",
 		Short: "拉取指定时间范围内当前用户的所有会话消息",
-		Long:  `分页拉取当前登录用户在指定时间范围内的所有会话消息。--start 和 --end 限定时间范围，--limit 指定每页数量，--cursor 传分页游标（首页传 0）。服务端按 cursor 分页返回，hasMore=true 时用返回的 nextCursor 值继续翻页。`,
+		Long:  `分页拉取当前登录用户在指定时间范围内的所有会话消息。--start 和 --end 限定时间范围，--limit 指定每页数量，--cursor 传分页游标（首页传 0）。服务端按 cursor 分页返回，hasMore=true 时用返回的 nextCursor 值继续翻页。如果当前账号没有消息搜索权益，CLI 会保留服务端返回的友好提示与开通入口；不要把权限错误解释为时间范围内没有消息。`,
 		Example: `  dws chat message list-all --start "2025-03-01 00:00:00" --end "2025-03-31 23:59:59" --limit 50
   dws chat message list-all --start "2025-03-01 00:00:00" --end "2025-03-31 23:59:59" --limit 50 --cursor "abc123token"`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/helpers/ding.go
+++ b/internal/helpers/ding.go
@@ -94,7 +94,8 @@ func newDingCommand() *cobra.Command {
 		Short: "查询 DING 消息历史",
 		Long: `查询当前用户的 DING 消息列表，支持按类型过滤。
 --type 支持: ALL(全部)、UNREAD(未读)、SEND(已发)、NEW_COMMENT(新评论)、DELETED(已删除)。
---type 为服务端必填字段，空值会报「type不能为空」；不传时 CLI 默认按 ALL 查询。`,
+--type 为服务端必填字段，空值会报「type不能为空」；不传时 CLI 默认按 ALL 查询。
+列表项会返回 DING 内容，调用方可在同一结果中读取 openDingId、状态与 content，无需再发起详情查询。`,
 		Example: `  dws ding message list                 # 默认 --type ALL
   dws ding message list --type UNREAD
   dws ding message list --type SEND --cursor 10`,

--- a/internal/helpers/im_read_result_contract_test.go
+++ b/internal/helpers/im_read_result_contract_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
+)
+
+type imReadResultCall struct {
+	productID string
+	toolName  string
+}
+
+type imReadResultCaller struct {
+	responses map[string]string
+	calls     []imReadResultCall
+}
+
+func (c *imReadResultCaller) CallTool(_ context.Context, productID, toolName string, _ map[string]any) (*edition.ToolResult, error) {
+	c.calls = append(c.calls, imReadResultCall{productID: productID, toolName: toolName})
+	return &edition.ToolResult{Content: []edition.ContentBlock{{Type: "text", Text: c.responses[toolName]}}}, nil
+}
+
+func (*imReadResultCaller) Format() string { return "json" }
+func (*imReadResultCaller) DryRun() bool   { return false }
+func (*imReadResultCaller) Fields() string { return "" }
+func (*imReadResultCaller) JQ() string     { return "" }
+
+func executeIMReadCommand(t *testing.T, caller *imReadResultCaller, processArgs []string, build func() *cobra.Command, args ...string) (string, error) {
+	t.Helper()
+	previousDeps := deps
+	previousArgs := os.Args
+	t.Cleanup(func() {
+		deps = previousDeps
+		os.Args = previousArgs
+	})
+
+	InitDeps(caller)
+	var stdout bytes.Buffer
+	deps.Out.w = &stdout
+	deps.Out.errW = io.Discard
+	os.Args = processArgs
+
+	root := build()
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	root.SetArgs(args)
+	err := root.Execute()
+	return stdout.String(), err
+}
+
+func requireSameJSON(t *testing.T, got, want string) {
+	t.Helper()
+	var gotValue any
+	if err := json.Unmarshal([]byte(got), &gotValue); err != nil {
+		t.Fatalf("decode command output: %v\noutput: %s", err, got)
+	}
+	var wantValue any
+	if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+		t.Fatalf("decode fixture: %v", err)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("command output = %#v, want %#v", gotValue, wantValue)
+	}
+}
+
+func TestChatMessageListPreservesQuotedRichMessageContext(t *testing.T) {
+	payload := `{
+		"result": {
+			"messages": [
+				{"msgType":"reply","quotedMessage":{"msgType":"merged_forward","content":{"items":[{"text":"原消息"}]}}},
+				{"msgType":"reply","quotedMessage":{"msgType":"image","content":{"mediaId":"media-1"}}}
+			]
+		}
+	}`
+	caller := &imReadResultCaller{responses: map[string]string{"list_conversation_message_v2": payload}}
+
+	got, err := executeIMReadCommand(t, caller, []string{"dws", "chat"}, newChatCommand,
+		"message", "list", "--group", "cid-1", "--time", "2026-07-14 00:00:00", "--limit", "50")
+	if err != nil {
+		t.Fatalf("chat message list returned error: %v", err)
+	}
+	if len(caller.calls) != 1 || caller.calls[0] != (imReadResultCall{productID: "chat", toolName: "list_conversation_message_v2"}) {
+		t.Fatalf("calls = %#v, want chat/list_conversation_message_v2", caller.calls)
+	}
+	requireSameJSON(t, got, payload)
+}
+
+func TestDingMessageListPreservesContent(t *testing.T) {
+	payload := `{"result":{"dingMessages":[{"openDingId":"ding-1","status":"READ","content":"升级提醒"}]}}`
+	caller := &imReadResultCaller{responses: map[string]string{"list_ding_messages": payload}}
+
+	got, err := executeIMReadCommand(t, caller, []string{"dws", "ding"}, newDingCommand,
+		"message", "list", "--type", "ALL")
+	if err != nil {
+		t.Fatalf("ding message list returned error: %v", err)
+	}
+	if len(caller.calls) != 1 || caller.calls[0] != (imReadResultCall{productID: "im", toolName: "list_ding_messages"}) {
+		t.Fatalf("calls = %#v, want im/list_ding_messages", caller.calls)
+	}
+	requireSameJSON(t, got, payload)
+}

--- a/internal/transport/diagnostics.go
+++ b/internal/transport/diagnostics.go
@@ -45,11 +45,41 @@ func ExtractServerDiagnosticsFromMap(content map[string]any) apperrors.ServerDia
 		TraceID:         stringFromMap(content, "trace_id", "traceId"),
 		ServerErrorCode: serverErrorCodeFromMap(content, 0),
 		TechnicalDetail: stringFromMap(content, "technical_detail"),
+		FriendlyHint:    stringFromMapRecursive(content, 0, "friendly_hint", "friendlyHint"),
+		ActionURL:       stringFromMapRecursive(content, 0, "action_url", "actionUrl"),
 	}
 	if v, ok := content["retryable"].(bool); ok {
 		diag.ServerRetryable = &v
 	}
 	return diag
+}
+
+func stringFromMapRecursive(content map[string]any, depth int, keys ...string) string {
+	if content == nil || depth > 8 {
+		return ""
+	}
+	if value := stringFromMap(content, keys...); value != "" {
+		return value
+	}
+	for _, key := range []string{"content", "result", "data"} {
+		switch child := content[key].(type) {
+		case map[string]any:
+			if value := stringFromMapRecursive(child, depth+1, keys...); value != "" {
+				return value
+			}
+		case []any:
+			for _, item := range child {
+				childMap, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				if value := stringFromMapRecursive(childMap, depth+1, keys...); value != "" {
+					return value
+				}
+			}
+		}
+	}
+	return ""
 }
 
 // ExtractTraceIDFromHeaders reads a trace ID from standard HTTP response

--- a/internal/transport/diagnostics_test.go
+++ b/internal/transport/diagnostics_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestExtractServerDiagnostics_SnakeCase(t *testing.T) {
 	t.Parallel()
-	data := json.RawMessage(`{"trace_id":"abc123","code":"PARAM_ERROR","technical_detail":"field required","retryable":false}`)
+	data := json.RawMessage(`{"trace_id":"abc123","code":"PARAM_ERROR","technical_detail":"field required","friendly_hint":"请开通消息搜索权益","action_url":"https://example.test/enable-search","retryable":false}`)
 	diag := ExtractServerDiagnostics(data)
 	if diag.TraceID != "abc123" {
 		t.Fatalf("TraceID = %q, want abc123", diag.TraceID)
@@ -19,6 +19,12 @@ func TestExtractServerDiagnostics_SnakeCase(t *testing.T) {
 	if diag.TechnicalDetail != "field required" {
 		t.Fatalf("TechnicalDetail = %q, want 'field required'", diag.TechnicalDetail)
 	}
+	if diag.FriendlyHint != "请开通消息搜索权益" {
+		t.Fatalf("FriendlyHint = %q, want search entitlement guidance", diag.FriendlyHint)
+	}
+	if diag.ActionURL != "https://example.test/enable-search" {
+		t.Fatalf("ActionURL = %q, want entitlement URL", diag.ActionURL)
+	}
 	if diag.ServerRetryable == nil || *diag.ServerRetryable != false {
 		t.Fatalf("ServerRetryable = %v, want false", diag.ServerRetryable)
 	}
@@ -26,13 +32,16 @@ func TestExtractServerDiagnostics_SnakeCase(t *testing.T) {
 
 func TestExtractServerDiagnostics_CamelCase(t *testing.T) {
 	t.Parallel()
-	data := json.RawMessage(`{"traceId":"xyz789","errorCode":"AUTH_ERROR"}`)
+	data := json.RawMessage(`{"traceId":"xyz789","errorCode":"AUTH_ERROR","friendlyHint":"request access","actionUrl":"https://example.test/request"}`)
 	diag := ExtractServerDiagnostics(data)
 	if diag.TraceID != "xyz789" {
 		t.Fatalf("TraceID = %q, want xyz789", diag.TraceID)
 	}
 	if diag.ServerErrorCode != "AUTH_ERROR" {
 		t.Fatalf("ServerErrorCode = %q, want AUTH_ERROR", diag.ServerErrorCode)
+	}
+	if diag.FriendlyHint != "request access" || diag.ActionURL != "https://example.test/request" {
+		t.Fatalf("guidance = (%q, %q), want camelCase values", diag.FriendlyHint, diag.ActionURL)
 	}
 }
 
@@ -82,9 +91,11 @@ func TestExtractServerDiagnosticsFromMapNestedBusinessCode(t *testing.T) {
 		"trace_id": "trace-002",
 		"code":     "BUSINESS_ERROR",
 		"result": map[string]any{
-			"success":   false,
-			"errorCode": "ROBOT_NOT_FOUND",
-			"errorMsg":  "robot info is not exist",
+			"success":       false,
+			"errorCode":     "ROBOT_NOT_FOUND",
+			"errorMsg":      "robot info is not exist",
+			"friendly_hint": "请检查机器人是否仍在群内",
+			"action_url":    "https://example.test/robots",
 		},
 	}
 	diag := ExtractServerDiagnosticsFromMap(content)
@@ -93,6 +104,9 @@ func TestExtractServerDiagnosticsFromMapNestedBusinessCode(t *testing.T) {
 	}
 	if diag.ServerErrorCode != "ROBOT_NOT_FOUND" {
 		t.Fatalf("ServerErrorCode = %q, want ROBOT_NOT_FOUND", diag.ServerErrorCode)
+	}
+	if diag.FriendlyHint != "请检查机器人是否仍在群内" || diag.ActionURL != "https://example.test/robots" {
+		t.Fatalf("nested guidance = (%q, %q), want nested values", diag.FriendlyHint, diag.ActionURL)
 	}
 }
 

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -492,7 +492,7 @@ Flags:
 
 #### 拉取会话消息内容 — 拉取指定群聊或单聊的会话消息内容
 
---group 指定群聊，--user 指定单聊用户（通过 userId），--open-dingtalk-id 指定单聊用户（通过 openDingTalkId），三者互斥。用 --direction 控制时间方向：newer=从给定时间往现在拉，older=从给定时间往以前拉。hasMore=true 时用结果中的边界 createTime 作为下次 --time 翻页。
+--group 指定群聊，--user 指定单聊用户（通过 userId），--open-dingtalk-id 指定单聊用户（通过 openDingTalkId），三者互斥。用 --direction 控制时间方向：newer=从给定时间往现在拉，older=从给定时间往以前拉。hasMore=true 时用结果中的边界 createTime 作为下次 --time 翻页。引用回复消息会带 `quotedMessage`；被引用的原消息是合并转发或图片时，其类型与内容也会保留在引用上下文中。
 ```
 Usage:
   dws chat message list [flags]
@@ -516,6 +516,7 @@ Flags:
     - --open-dingtalk-id 传 openDingTalkId（三方应用或跨组织场景常用，无法获取 userId 时使用）
   - --group 的别名: --id, --chat, --conversation-id (均可替代 --group)
   - 翻页：hasMore=true 时，用结果中的边界 createTime 作为下次 --time
+  - 处理引用回复时读取 quotedMessage，不要只看回复正文；合并转发与图片引用的原消息内容也在该上下文中
   - 话题圈消息拉取流程：如果返回的会话消息中包含 openConvThreadId 字段，说明是话题类消息。要获取完整的话题内容，需要两步操作：(1) 先通过 dws chat message list 拉取话题主消息（即话题帖子本身）；(2) 再调用 dws chat message list-topic-replies --group <openConversationId> --topic-id <openConvThreadId> 分页拉取该话题下的所有回复消息。只有话题主消息 + 回复列表合在一起，才是一条话题的完整内容。
 ```
 
@@ -773,7 +774,7 @@ Flags:
 
 #### 拉取指定时间范围内当前用户的所有会话消息 — 分页拉取当前登录用户在指定时间范围内的所有会话消息
 
---start 和 --end 限定时间范围，--limit 指定每页数量，--cursor 传分页游标（首页传 "0"，后续从响应中的 nextCursor 获取）。服务端按 cursor 分页返回，hasMore=true 时用返回的 nextCursor 值作为下次 --cursor 继续翻页。
+--start 和 --end 限定时间范围，--limit 指定每页数量，--cursor 传分页游标（首页传 "0"，后续从响应中的 nextCursor 获取）。服务端按 cursor 分页返回，hasMore=true 时用返回的 nextCursor 值作为下次 --cursor 继续翻页。若当前账号没有消息搜索权益，CLI 会透传服务端的友好提示与开通入口。
 ```
 Usage:
   dws chat message list-all [flags]
@@ -791,6 +792,7 @@ Flags:
   - 与 chat message list 的区别：list 拉取指定单个会话（群聊或单聊）的消息，list-all 拉取当前用户所有会话的消息
   - 翻页：hasMore=true 时，用响应中的 nextCursor 值作为下次 --cursor 参数继续翻页
   - 时间格式统一为 yyyy-MM-dd HH:mm:ss
+  - 权限/权益错误不是空结果；应把返回的 friendly_hint 与 action_url 展示给用户，不要继续盲目翻页
 ```
 
 #### 拉取指定发送者的消息 — 搜索特定人发送给我的消息（包含单聊和群聊）

--- a/skills/mono/references/products/ding.md
+++ b/skills/mono/references/products/ding.md
@@ -27,6 +27,9 @@ Flags:
 ```
 
 ### 查询 DING 消息历史
+
+列表项会同时返回 DING 的 `content`、`openDingId` 与状态，可直接读取钉内容，无需再调用详情接口。
+
 ```
 Usage:
   dws ding message list [flags]

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -494,7 +494,7 @@ Flags:
 
 #### 拉取会话消息内容 — 拉取指定群聊或单聊的会话消息内容
 
---group 指定群聊，--user 指定单聊用户（通过 userId），--open-dingtalk-id 指定单聊用户（通过 openDingTalkId），三者互斥。用 --direction 控制时间方向：newer=从给定时间往现在拉，older=从给定时间往以前拉。hasMore=true 时用结果中的边界 createTime 作为下次 --time 翻页。
+--group 指定群聊，--user 指定单聊用户（通过 userId），--open-dingtalk-id 指定单聊用户（通过 openDingTalkId），三者互斥。用 --direction 控制时间方向：newer=从给定时间往现在拉，older=从给定时间往以前拉。hasMore=true 时用结果中的边界 createTime 作为下次 --time 翻页。引用回复消息会带 `quotedMessage`；被引用的原消息是合并转发或图片时，其类型与内容也会保留在引用上下文中。
 ```
 Usage:
   dws chat message list [flags]
@@ -518,6 +518,7 @@ Flags:
     - --open-dingtalk-id 传 openDingTalkId（三方应用或跨组织场景常用，无法获取 userId 时使用）
   - --group 的别名: --id, --chat, --conversation-id (均可替代 --group)
   - 翻页：hasMore=true 时，用结果中的边界 createTime 作为下次 --time
+  - 处理引用回复时读取 quotedMessage，不要只看回复正文；合并转发与图片引用的原消息内容也在该上下文中
   - 话题圈消息拉取流程：如果返回的会话消息中包含 openConvThreadId 字段，说明是话题类消息。要获取完整的话题内容，需要两步操作：(1) 先通过 dws chat message list 拉取话题主消息（即话题帖子本身）；(2) 再调用 dws chat message list-topic-replies --group <openConversationId> --topic-id <openConvThreadId> 分页拉取该话题下的所有回复消息。只有话题主消息 + 回复列表合在一起，才是一条话题的完整内容。
 ```
 
@@ -738,7 +739,7 @@ Flags:
 
 #### 拉取指定时间范围内当前用户的所有会话消息 — 分页拉取当前登录用户在指定时间范围内的所有会话消息
 
---start 和 --end 限定时间范围，--limit 指定每页数量，--cursor 传分页游标（首页传 "0"，后续从响应中的 nextCursor 获取）。服务端按 cursor 分页返回，hasMore=true 时用返回的 nextCursor 值作为下次 --cursor 继续翻页。
+--start 和 --end 限定时间范围，--limit 指定每页数量，--cursor 传分页游标（首页传 "0"，后续从响应中的 nextCursor 获取）。服务端按 cursor 分页返回，hasMore=true 时用返回的 nextCursor 值作为下次 --cursor 继续翻页。若当前账号没有消息搜索权益，CLI 会透传服务端的友好提示与开通入口。
 ```
 Usage:
   dws chat message list-all [flags]
@@ -756,6 +757,7 @@ Flags:
   - 与 chat message list 的区别：list 拉取指定单个会话（群聊或单聊）的消息，list-all 拉取当前用户所有会话的消息
   - 翻页：hasMore=true 时，用响应中的 nextCursor 值作为下次 --cursor 参数继续翻页
   - 时间格式统一为 yyyy-MM-dd HH:mm:ss
+  - 权限/权益错误不是空结果；应把返回的 friendly_hint 与 action_url 展示给用户，不要继续盲目翻页
 ```
 
 #### 拉取指定发送者的消息 — 搜索特定人发送给我的消息（包含单聊和群聊）

--- a/skills/multi/dingtalk-ding/references/ding.md
+++ b/skills/multi/dingtalk-ding/references/ding.md
@@ -27,6 +27,9 @@ Flags:
 ```
 
 ### 查询 DING 消息历史
+
+列表项会同时返回 DING 的 `content`、`openDingId` 与状态，可直接读取钉内容，无需再调用详情接口。
+
 ```
 Usage:
   dws ding message list [flags]


### PR DESCRIPTION
## Commands and capabilities

1. `dws chat message list` — preserve `quotedMessage` for reply messages, including the referenced merged-forward or image type and content.
2. `dws chat message list-all` — surface server-provided `friendly_hint` and `action_url` fields (including nested business errors) when message-search entitlement is unavailable, instead of presenting the failure like an empty result.
3. `dws ding message list` — preserve each DING item's `content` together with its `openDingId` and status.

The change also regenerates the reviewed Chat selection metadata/Catalog and updates the open-source mono/multi Skill references for these behaviors.

## Why

Wukong's read APIs now return richer IM context and actionable search-entitlement guidance. The open-source CLI already forwards successful JSON payloads, but its structured error path dropped the server guidance fields. This change locks the successful payloads as opaque contracts and carries the missing diagnostics through both human and JSON error rendering.

## Verification

- [x] `make build`
- [ ] `make lint` — blocked by an existing `origin/main` staticcheck finding at `internal/generator/agentmetadata/metadata.go:372` (`ST1005`); the changed packages pass staticcheck.
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./...`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test ./scripts/dev/coverage.sh /tmp/dws-wukong-im-read-results.coverage` (51.4%)
- [x] `make policy`
- [x] `./scripts/policy/check-generated-drift.sh`
- [x] `./scripts/policy/check-command-surface.sh --strict`
- [x] `./scripts/policy/check-runtime-confirmation-truth.sh`
- [x] `go test ./internal/app -run '^TestSheetFinalSchemaConfirmationMatchesRuntimeGuards$' -count=1`

## Notes

- No command identity, flag, RPC mapping, safety gate, or compatibility wire format changed.
- Live wukong01 E2E was not run: the isolated `dws-wukong` binary is not logged in, and the active open-source `dws` session is not the dedicated wukong01 test account. No credentials were borrowed or switched.
