### PR TITLE
fix: make Gitee release sync resilient

### DIFF
--- a/.github/workflows/mirror-to-gitee.yml
+++ b/.github/workflows/mirror-to-gitee.yml
@@ -42,8 +42,7 @@ jobs:
           REMOTE="https://${GITEE_USER}:${GITEE_TOKEN}@gitee.com/${GITEE_REPO}.git"
 
           if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
-            git fetch --force --tags origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
-            git push --force "$REMOTE" "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
+            VERSION="$GITHUB_REF_NAME" ./scripts/release/sync-gitee-tag.sh
             echo "✅ 已镜像 tag ${GITHUB_REF_NAME} 到 Gitee ${GITEE_REPO}"
             exit 0
           fi
@@ -83,5 +82,7 @@ jobs:
 
           # 镜像对齐（force：Gitee 始终跟随 GitHub + Gitee 专属 README 本地化）
           git push --force "$REMOTE" 'gitee-main:refs/heads/main'
-          git push --force --tags "$REMOTE"
+          # Release tags are immutable. Push only missing tags and fail closed
+          # on a conflicting existing ref instead of trying to move it.
+          timeout --signal=TERM 180s git push --tags "$REMOTE"
           echo "✅ 已镜像 main(+Gitee README 本地化) + tags 到 Gitee ${GITEE_REPO}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,13 +252,29 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  mirror-gitee-release:
+    # Keep the optional cross-border fallback out of publish-release so all
+    # pre-sync work has an independently provable budget.
+    if: ${{ vars.ENABLE_GITEE_UPLOAD_FALLBACK == 'true' }}
+    needs:
+      - release
+      - publish-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        timeout-minutes: 5
+
+      - name: Restore finalized distribution files
+        uses: actions/download-artifact@v4
+        timeout-minutes: 10
+        with:
+          name: finalized-release-dist
+          path: dist
+
       - name: Mirror release to Gitee (China)
-        # 把 release 附件（二进制/校验和/skills 包）镜像到 Gitee release，供 install.sh
-        # 的 DWS_GITEE_REPO 开关消费（仓库代码由 Gitee 仓库镜像功能自动同步，附件不在其内）。
-        # 默认关闭：国内 release 应由 Gitee 侧本地构建发布，避免 GitHub -> Gitee 跨境传大包卡住。
-        # 仅在需要临时补救时设置 repo variable ENABLE_GITEE_UPLOAD_FALLBACK=true。
-        if: ${{ vars.ENABLE_GITEE_UPLOAD_FALLBACK == 'true' }}
-        timeout-minutes: 90
+        timeout-minutes: 100
         run: ./scripts/release/sync-to-gitee.sh
         env:
           VERSION: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,9 +170,9 @@ jobs:
       - release
       - verify-darwin-signatures
     runs-on: ubuntu-latest
-    # Mirroring every release asset to Gitee can be slow; 30 minutes previously
-    # cut the fallback upload off mid-run.
-    timeout-minutes: 60
+    # The optional Gitee fallback has its own bounded retry budget and may be
+    # enabled during a cross-border incident. Normal releases skip that step.
+    timeout-minutes: 120
 
     steps:
       - name: Check out repository
@@ -258,7 +258,7 @@ jobs:
         # 默认关闭：国内 release 应由 Gitee 侧本地构建发布，避免 GitHub -> Gitee 跨境传大包卡住。
         # 仅在需要临时补救时设置 repo variable ENABLE_GITEE_UPLOAD_FALLBACK=true。
         if: ${{ vars.ENABLE_GITEE_UPLOAD_FALLBACK == 'true' }}
-        timeout-minutes: 20
+        timeout-minutes: 90
         run: ./scripts/release/sync-to-gitee.sh
         env:
           VERSION: ${{ github.ref_name }}

--- a/.github/workflows/sync-release-to-gitee.yml
+++ b/.github/workflows/sync-release-to-gitee.yml
@@ -21,14 +21,16 @@ permissions:
 jobs:
   sync-gitee:
     runs-on: ubuntu-latest
-    # Gitee's attachment API can take several minutes per large archive. The
-    # script has bounded per-file retries; keep the job budget above that bound.
-    timeout-minutes: 90
+    # Each step has its own ceiling. Their 115-minute sum leaves five minutes
+    # for runner scheduling/teardown inside this 120-minute job deadline.
+    timeout-minutes: 120
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        timeout-minutes: 5
 
       - name: Download GitHub release assets
+        timeout-minutes: 10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -44,6 +46,7 @@ jobs:
 
       - name: Mirror release to Gitee (China)
         # Idempotent: uploads only assets not already present on the Gitee release.
+        timeout-minutes: 100
         run: ./scripts/release/sync-to-gitee.sh
         env:
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/sync-release-to-gitee.yml
+++ b/.github/workflows/sync-release-to-gitee.yml
@@ -21,7 +21,9 @@ permissions:
 jobs:
   sync-gitee:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Gitee's attachment API can take several minutes per large archive. The
+    # script has bounded per-file retries; keep the job budget above that bound.
+    timeout-minutes: 90
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/scripts/release/build-and-publish-gitee.sh
+++ b/scripts/release/build-and-publish-gitee.sh
@@ -38,8 +38,10 @@ if [ "$current_commit" != "$target_commit" ]; then
   rm -rf "$WORKDIR"
   git worktree add --detach "$WORKDIR" "$TAG"
   mkdir -p "$WORKDIR/scripts/release"
-  cp "$SCRIPT_ROOT/scripts/release/publish-gitee-local.sh" "$WORKDIR/scripts/release/publish-gitee-local.sh"
-  chmod +x "$WORKDIR/scripts/release/publish-gitee-local.sh"
+  for release_script in publish-gitee-local.sh reconcile-gitee-assets.sh; do
+    cp "$SCRIPT_ROOT/scripts/release/$release_script" "$WORKDIR/scripts/release/$release_script"
+    chmod +x "$WORKDIR/scripts/release/$release_script"
+  done
 fi
 
 cd "$WORKDIR"

--- a/scripts/release/publish-gitee-local.sh
+++ b/scripts/release/publish-gitee-local.sh
@@ -6,15 +6,13 @@
 
 set -eu
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 DIST_DIR="${DIST_DIR:-dist}"
 GITEE_API="${GITEE_API:-https://gitee.com/api/v5}"
 GITEE_REPO="${GITEE_REPO:-DingTalk-Real-AI/dingtalk-workspace-cli}"
 GITEE_TOKEN="${GITEE_TOKEN:-${GITEE_ACCESS_TOKEN:-}}"
 GITEE_CURL_CONNECT_TIMEOUT="${GITEE_CURL_CONNECT_TIMEOUT:-15}"
 GITEE_CURL_MAX_TIME="${GITEE_CURL_MAX_TIME:-120}"
-GITEE_UPLOAD_MAX_TIME="${GITEE_UPLOAD_MAX_TIME:-300}"
-GITEE_UPLOAD_RETRIES="${GITEE_UPLOAD_RETRIES:-3}"
-GITEE_UPLOAD_RETRY_DELAY="${GITEE_UPLOAD_RETRY_DELAY:-10}"
 
 err() {
   printf 'error: %s\n' "$*" >&2
@@ -34,12 +32,6 @@ esac
 OWNER="${GITEE_REPO%%/*}"
 NAME="${GITEE_REPO##*/}"
 base="${GITEE_API}/repos/${OWNER}/${NAME}"
-
-sha256_of() {
-  if command -v sha256sum >/dev/null 2>&1; then sha256sum ${1:+"$1"} | awk '{print $1}'
-  else shasum -a 256 ${1:+"$1"} | awk '{print $1}'
-  fi
-}
 
 api_get() {
   curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" --max-time "$GITEE_CURL_MAX_TIME" "$@"
@@ -66,79 +58,11 @@ fi
 [ -n "$release_id" ] || err "could not get/create Gitee release for ${VERSION}. Response: ${rel_json}"
 echo "   Gitee release id = ${release_id}"
 
-assets_map="$(api_get "${base}/releases/${release_id}/attach_files?access_token=${GITEE_TOKEN}" 2>/dev/null \
-  | python3 -c 'import json,sys
-try:
-    data=json.load(sys.stdin)
-    rows=data if isinstance(data,list) else data.get("attach_files",[])
-    for a in rows:
-        n=a.get("name",""); i=a.get("id",""); u=a.get("browser_download_url","")
-        if n and i!="":
-            print("%s\t%s\t%s" % (n, i, u))
-except Exception:
-    pass' 2>/dev/null || true)"
-
-gitee_attach() {
-  file="$1"
-  fn="$(basename "$file")"
-  attempt=1
-  while [ "$attempt" -le "$GITEE_UPLOAD_RETRIES" ]; do
-    response="$(curl -fsS --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" --max-time "$GITEE_UPLOAD_MAX_TIME" \
-      --retry 2 --retry-delay 5 --retry-all-errors \
-      -X POST "${base}/releases/${release_id}/attach_files" \
-      -F "access_token=${GITEE_TOKEN}" -F "file=@${file}" 2>&1 || true)"
-    if printf '%s' "$response" | grep -q '"browser_download_url"'; then
-      return 0
-    fi
-    echo "   ⚠ upload attempt ${attempt}/${GITEE_UPLOAD_RETRIES} failed for ${fn}: $(printf '%s' "$response" | head -c 240)" >&2
-    attempt=$((attempt + 1))
-    [ "$attempt" -le "$GITEE_UPLOAD_RETRIES" ] && sleep "$GITEE_UPLOAD_RETRY_DELAY"
-  done
-  return 1
-}
-
-gitee_delete() {
-  curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" --max-time "$GITEE_CURL_MAX_TIME" \
-    -X DELETE "${base}/releases/${release_id}/attach_files/${1}?access_token=${GITEE_TOKEN}" \
-    >/dev/null 2>&1 || true
-}
-
-uploaded=0
-replaced=0
-skipped=0
-failed=0
-for f in "$DIST_DIR"/dws-*.tar.gz "$DIST_DIR"/dws-*.zip "$DIST_DIR"/checksums.txt "$DIST_DIR"/dws-skills.zip; do
-  [ -f "$f" ] || continue
-  fn="$(basename "$f")"
-  local_sha="$(sha256_of "$f")"
-  ids="$(printf '%s\n' "$assets_map" | awk -F'\t' -v n="$fn" '$1==n {print $2}')"
-  aurl="$(printf '%s\n' "$assets_map" | awk -F'\t' -v n="$fn" '$1==n {print $3; exit}')"
-  count="$(printf '%s' "$ids" | grep -c . || true)"
-
-  if [ "$count" -eq 1 ]; then
-    gitee_sha="$(api_get "$aurl" 2>/dev/null | sha256_of || true)"
-    if [ "$gitee_sha" = "$local_sha" ]; then
-      echo "   ✓ ${fn} already correct on Gitee — skip"
-      skipped=$((skipped + 1))
-      continue
-    fi
-    echo "   ↻ ${fn} differs on Gitee — replacing"
-  elif [ "$count" -gt 1 ]; then
-    echo "   ↻ ${fn} has ${count} copies on Gitee — replacing"
-  else
-    echo "   ⬆ ${fn} (new)"
-  fi
-
-  printf '%s\n' "$ids" | while read -r aid; do
-    [ -n "$aid" ] && gitee_delete "$aid"
-  done
-  if gitee_attach "$f"; then
-    if [ "$count" -eq 0 ]; then uploaded=$((uploaded + 1)); else replaced=$((replaced + 1)); fi
-  else
-    echo "   ❌ upload failed for ${fn}" >&2
-    failed=$((failed + 1))
-  fi
-done
-
-[ "$failed" -eq 0 ] || err "Gitee publish finished with ${failed} failed upload(s)"
-echo "✅ Gitee release ${VERSION}: uploaded ${uploaded}, replaced ${replaced}, skipped ${skipped}"
+DIST_DIR="$DIST_DIR" \
+GITEE_API="$GITEE_API" \
+GITEE_TOKEN="$GITEE_TOKEN" \
+GITEE_REPO="$GITEE_REPO" \
+GITEE_CURL_CONNECT_TIMEOUT="$GITEE_CURL_CONNECT_TIMEOUT" \
+GITEE_CURL_MAX_TIME="$GITEE_CURL_MAX_TIME" \
+GITEE_RELEASE_ID="$release_id" \
+  "$SCRIPT_DIR/reconcile-gitee-assets.sh"

--- a/scripts/release/reconcile-gitee-assets.sh
+++ b/scripts/release/reconcile-gitee-assets.sh
@@ -7,17 +7,57 @@ DIST_DIR="${DIST_DIR:-dist}"
 GITEE_API="${GITEE_API:-https://gitee.com/api/v5}"
 GITEE_CURL_CONNECT_TIMEOUT="${GITEE_CURL_CONNECT_TIMEOUT:-15}"
 GITEE_CURL_MAX_TIME="${GITEE_CURL_MAX_TIME:-120}"
-GITEE_UPLOAD_MAX_TIME="${GITEE_UPLOAD_MAX_TIME:-180}"
+GITEE_LIST_MAX_TIME="${GITEE_LIST_MAX_TIME:-20}"
+GITEE_VERIFY_MAX_TIME="${GITEE_VERIFY_MAX_TIME:-60}"
+GITEE_MUTATION_MAX_TIME="${GITEE_MUTATION_MAX_TIME:-20}"
+GITEE_UPLOAD_MAX_TIME="${GITEE_UPLOAD_MAX_TIME:-120}"
 GITEE_UPLOAD_RETRIES="${GITEE_UPLOAD_RETRIES:-2}"
 GITEE_UPLOAD_RETRY_DELAY="${GITEE_UPLOAD_RETRY_DELAY:-5}"
-GITEE_EXISTING_VERIFY_ATTEMPTS="${GITEE_EXISTING_VERIFY_ATTEMPTS:-2}"
-GITEE_POST_UPLOAD_VERIFY_ATTEMPTS="${GITEE_POST_UPLOAD_VERIFY_ATTEMPTS:-6}"
+GITEE_EXISTING_VERIFY_ATTEMPTS="${GITEE_EXISTING_VERIFY_ATTEMPTS:-1}"
+GITEE_POST_UPLOAD_VERIFY_ATTEMPTS="${GITEE_POST_UPLOAD_VERIFY_ATTEMPTS:-2}"
 GITEE_VERIFY_RETRY_DELAY="${GITEE_VERIFY_RETRY_DELAY:-5}"
+GITEE_ASSET_TIMEOUT_SECONDS="${GITEE_ASSET_TIMEOUT_SECONDS:-600}"
+GITEE_OVERALL_TIMEOUT_SECONDS="${GITEE_OVERALL_TIMEOUT_SECONDS:-4920}"
 
 err() {
   printf 'error: %s\n' "$*" >&2
   exit 1
 }
+
+require_positive_integer() {
+  local name="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*) err "${name} must be a positive integer: ${value}" ;;
+  esac
+  [ "$value" -gt 0 ] || err "${name} must be greater than zero"
+}
+
+require_nonnegative_integer() {
+  local name="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*) err "${name} must be a non-negative integer: ${value}" ;;
+  esac
+}
+
+for setting in \
+  GITEE_CURL_CONNECT_TIMEOUT \
+  GITEE_CURL_MAX_TIME \
+  GITEE_LIST_MAX_TIME \
+  GITEE_VERIFY_MAX_TIME \
+  GITEE_MUTATION_MAX_TIME \
+  GITEE_UPLOAD_MAX_TIME \
+  GITEE_UPLOAD_RETRIES \
+  GITEE_EXISTING_VERIFY_ATTEMPTS \
+  GITEE_POST_UPLOAD_VERIFY_ATTEMPTS \
+  GITEE_ASSET_TIMEOUT_SECONDS \
+  GITEE_OVERALL_TIMEOUT_SECONDS; do
+  require_positive_integer "$setting" "${!setting}"
+done
+for setting in \
+  GITEE_UPLOAD_RETRY_DELAY \
+  GITEE_VERIFY_RETRY_DELAY; do
+  require_nonnegative_integer "$setting" "${!setting}"
+done
 
 [ -n "${GITEE_TOKEN:-}" ] || err "GITEE_TOKEN is required"
 [ -n "${GITEE_REPO:-}" ] || err "GITEE_REPO is required"
@@ -28,6 +68,49 @@ OWNER="${GITEE_REPO%%/*}"
 NAME="${GITEE_REPO##*/}"
 base="${GITEE_API}/repos/${OWNER}/${NAME}"
 release_id="$GITEE_RELEASE_ID"
+
+now_seconds() {
+  date +%s
+}
+
+overall_deadline=$(( $(now_seconds) + GITEE_OVERALL_TIMEOUT_SECONDS ))
+active_deadline="$overall_deadline"
+
+deadline_remaining() {
+  local remaining=$(( active_deadline - $(now_seconds) ))
+  [ "$remaining" -gt 0 ] || return 1
+  printf '%s\n' "$remaining"
+}
+
+bounded_max_time() {
+  local configured="$1" remaining
+  remaining="$(deadline_remaining)" || return 1
+  if [ "$configured" -lt "$remaining" ]; then
+    printf '%s\n' "$configured"
+  else
+    printf '%s\n' "$remaining"
+  fi
+}
+
+start_asset_deadline() {
+  local now candidate
+  now="$(now_seconds)"
+  [ "$now" -lt "$overall_deadline" ] || return 1
+  candidate=$(( now + GITEE_ASSET_TIMEOUT_SECONDS ))
+  if [ "$candidate" -lt "$overall_deadline" ]; then
+    active_deadline="$candidate"
+  else
+    active_deadline="$overall_deadline"
+  fi
+}
+
+sleep_within_deadline() {
+  local seconds="$1" remaining
+  [ "$seconds" -gt 0 ] || return 0
+  remaining="$(deadline_remaining)" || return 1
+  [ "$seconds" -lt "$remaining" ] || return 1
+  sleep "$seconds"
+}
 
 required_assets=(
   dws-darwin-amd64.tar.gz
@@ -49,12 +132,16 @@ if [ "${#missing_assets[@]}" -gt 0 ]; then
 fi
 
 api_get() {
+  local configured_max_time="$1" max_time
+  shift
+  max_time="$(bounded_max_time "$configured_max_time")" || return 1
   curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
-    --max-time "$GITEE_CURL_MAX_TIME" "$@"
+    --max-time "$max_time" "$@"
 }
 
 list_assets() {
-  api_get "${base}/releases/${release_id}/attach_files?access_token=${GITEE_TOKEN}" \
+  api_get "$GITEE_LIST_MAX_TIME" \
+    "${base}/releases/${release_id}/attach_files?access_token=${GITEE_TOKEN}" \
     | python3 -c 'import json,sys
 data=json.load(sys.stdin)
 rows=data if isinstance(data,list) else data.get("attach_files",[])
@@ -102,7 +189,7 @@ verify_asset_once() {
   [ "$count" -eq 1 ] || return 1
   url="$(asset_url "$assets_map" "$name")"
   [ -n "$url" ] || return 1
-  if ! remote_sha="$(api_get "$url" | sha256_of)"; then
+  if ! remote_sha="$(api_get "$GITEE_VERIFY_MAX_TIME" "$url" | sha256_of)"; then
     return 1
   fi
   [ "$remote_sha" = "$local_sha" ]
@@ -115,15 +202,18 @@ verify_asset_with_retries() {
       return 0
     fi
     attempt=$((attempt + 1))
-    [ "$attempt" -le "$attempts" ] && sleep "$GITEE_VERIFY_RETRY_DELAY"
+    if [ "$attempt" -le "$attempts" ]; then
+      sleep_within_deadline "$GITEE_VERIFY_RETRY_DELAY" || return 1
+    fi
   done
   return 1
 }
 
 delete_asset() {
-  local asset_id="$1"
+  local asset_id="$1" max_time
+  max_time="$(bounded_max_time "$GITEE_MUTATION_MAX_TIME")" || return 1
   curl -fsS --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
-    --max-time "$GITEE_CURL_MAX_TIME" \
+    --max-time "$max_time" \
     -X DELETE "${base}/releases/${release_id}/attach_files/${asset_id}?access_token=${GITEE_TOKEN}" \
     >/dev/null
 }
@@ -142,13 +232,14 @@ delete_named_assets() {
 }
 
 gitee_attach() {
-  local file="$1" name attempt response status
+  local file="$1" name attempt response status max_time
   name="$(basename "$file")"
   attempt=1
   while [ "$attempt" -le "$GITEE_UPLOAD_RETRIES" ]; do
     status=0
+    max_time="$(bounded_max_time "$GITEE_UPLOAD_MAX_TIME")" || return 1
     if response="$(curl -fsS --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
-      --max-time "$GITEE_UPLOAD_MAX_TIME" \
+      --max-time "$max_time" \
       -X POST "${base}/releases/${release_id}/attach_files" \
       -F "access_token=${GITEE_TOKEN}" -F "file=@${file}" 2>&1)"; then
       status=0
@@ -171,7 +262,7 @@ gitee_attach() {
       # Remove any partial, stale, or duplicate attachment before the one
       # explicit retry. There is deliberately no nested curl retry layer.
       delete_named_assets "$name" || return 1
-      sleep "$GITEE_UPLOAD_RETRY_DELAY"
+      sleep_within_deadline "$GITEE_UPLOAD_RETRY_DELAY" || return 1
     fi
   done
   return 1
@@ -187,8 +278,15 @@ total="${#required_assets[@]}"
 for name in "${required_assets[@]}"; do
   index=$((index + 1))
   file="${DIST_DIR}/${name}"
+  if ! start_asset_deadline; then
+    err "overall Gitee reconciliation deadline exhausted before ${name}"
+  fi
   if ! assets_map="$(list_assets)"; then
-    echo "   ❌ could not list Gitee assets before reconciling ${name}" >&2
+    if deadline_remaining >/dev/null; then
+      echo "   ❌ could not list Gitee assets before reconciling ${name}" >&2
+    else
+      echo "   ❌ ${name} exceeded its Gitee reconciliation deadline" >&2
+    fi
     failed=$((failed + 1))
     continue
   fi
@@ -219,11 +317,17 @@ for name in "${required_assets[@]}"; do
       replaced=$((replaced + 1))
     fi
   else
-    echo "   ❌ upload failed for ${name}" >&2
+    if deadline_remaining >/dev/null; then
+      echo "   ❌ upload failed for ${name}" >&2
+    else
+      echo "   ❌ upload failed for ${name}: per-asset or overall deadline exhausted" >&2
+    fi
     failed=$((failed + 1))
   fi
 done
 
+active_deadline="$overall_deadline"
+deadline_remaining >/dev/null || err "overall Gitee reconciliation deadline exhausted before final verification"
 if ! final_assets_map="$(list_assets)"; then
   err "could not list Gitee assets for final verification"
 fi

--- a/scripts/release/reconcile-gitee-assets.sh
+++ b/scripts/release/reconcile-gitee-assets.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Reconcile the complete DWS release asset set with one Gitee release.
+
+set -euo pipefail
+
+DIST_DIR="${DIST_DIR:-dist}"
+GITEE_API="${GITEE_API:-https://gitee.com/api/v5}"
+GITEE_CURL_CONNECT_TIMEOUT="${GITEE_CURL_CONNECT_TIMEOUT:-15}"
+GITEE_CURL_MAX_TIME="${GITEE_CURL_MAX_TIME:-120}"
+GITEE_UPLOAD_MAX_TIME="${GITEE_UPLOAD_MAX_TIME:-180}"
+GITEE_UPLOAD_RETRIES="${GITEE_UPLOAD_RETRIES:-2}"
+GITEE_UPLOAD_RETRY_DELAY="${GITEE_UPLOAD_RETRY_DELAY:-5}"
+GITEE_EXISTING_VERIFY_ATTEMPTS="${GITEE_EXISTING_VERIFY_ATTEMPTS:-2}"
+GITEE_POST_UPLOAD_VERIFY_ATTEMPTS="${GITEE_POST_UPLOAD_VERIFY_ATTEMPTS:-6}"
+GITEE_VERIFY_RETRY_DELAY="${GITEE_VERIFY_RETRY_DELAY:-5}"
+
+err() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+[ -n "${GITEE_TOKEN:-}" ] || err "GITEE_TOKEN is required"
+[ -n "${GITEE_REPO:-}" ] || err "GITEE_REPO is required"
+[ -n "${GITEE_RELEASE_ID:-}" ] || err "GITEE_RELEASE_ID is required"
+[ -d "$DIST_DIR" ] || err "dist dir not found: ${DIST_DIR}"
+
+OWNER="${GITEE_REPO%%/*}"
+NAME="${GITEE_REPO##*/}"
+base="${GITEE_API}/repos/${OWNER}/${NAME}"
+release_id="$GITEE_RELEASE_ID"
+
+required_assets=(
+  dws-darwin-amd64.tar.gz
+  dws-darwin-arm64.tar.gz
+  dws-linux-amd64.tar.gz
+  dws-linux-arm64.tar.gz
+  dws-windows-amd64.zip
+  dws-windows-arm64.zip
+  dws-skills.zip
+  checksums.txt
+)
+
+missing_assets=()
+for name in "${required_assets[@]}"; do
+  [ -f "${DIST_DIR}/${name}" ] || missing_assets+=("$name")
+done
+if [ "${#missing_assets[@]}" -gt 0 ]; then
+  err "required release assets are missing from ${DIST_DIR}: ${missing_assets[*]}"
+fi
+
+api_get() {
+  curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
+    --max-time "$GITEE_CURL_MAX_TIME" "$@"
+}
+
+list_assets() {
+  api_get "${base}/releases/${release_id}/attach_files?access_token=${GITEE_TOKEN}" \
+    | python3 -c 'import json,sys
+data=json.load(sys.stdin)
+rows=data if isinstance(data,list) else data.get("attach_files",[])
+if not isinstance(rows,list):
+    raise ValueError("attach_files must be a list")
+for asset in rows:
+    name=asset.get("name","")
+    asset_id=asset.get("id","")
+    url=asset.get("browser_download_url","")
+    if name and asset_id != "":
+        print("%s\t%s\t%s" % (name, asset_id, url))'
+}
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum ${1:+"$1"} | awk '{print $1}'
+  else
+    shasum -a 256 ${1:+"$1"} | awk '{print $1}'
+  fi
+}
+
+asset_ids() {
+  local assets_map="$1" name="$2"
+  printf '%s\n' "$assets_map" | awk -F'\t' -v n="$name" '$1 == n {print $2}'
+}
+
+asset_url() {
+  local assets_map="$1" name="$2"
+  printf '%s\n' "$assets_map" | awk -F'\t' -v n="$name" '$1 == n {print $3; exit}'
+}
+
+asset_count() {
+  local assets_map="$1" name="$2"
+  printf '%s\n' "$assets_map" | awk -F'\t' -v n="$name" '$1 == n {count++} END {print count + 0}'
+}
+
+verify_asset_once() {
+  local file="$1" name local_sha assets_map count url remote_sha
+  name="$(basename "$file")"
+  local_sha="$(sha256_of "$file")"
+  if ! assets_map="$(list_assets)"; then
+    return 1
+  fi
+  count="$(asset_count "$assets_map" "$name")"
+  [ "$count" -eq 1 ] || return 1
+  url="$(asset_url "$assets_map" "$name")"
+  [ -n "$url" ] || return 1
+  if ! remote_sha="$(api_get "$url" | sha256_of)"; then
+    return 1
+  fi
+  [ "$remote_sha" = "$local_sha" ]
+}
+
+verify_asset_with_retries() {
+  local file="$1" attempts="$2" attempt=1
+  while [ "$attempt" -le "$attempts" ]; do
+    if verify_asset_once "$file"; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    [ "$attempt" -le "$attempts" ] && sleep "$GITEE_VERIFY_RETRY_DELAY"
+  done
+  return 1
+}
+
+delete_asset() {
+  local asset_id="$1"
+  curl -fsS --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
+    --max-time "$GITEE_CURL_MAX_TIME" \
+    -X DELETE "${base}/releases/${release_id}/attach_files/${asset_id}?access_token=${GITEE_TOKEN}" \
+    >/dev/null
+}
+
+delete_named_assets() {
+  local name="$1" assets_map ids asset_id
+  if ! assets_map="$(list_assets)"; then
+    return 1
+  fi
+  ids="$(asset_ids "$assets_map" "$name")"
+  while IFS= read -r asset_id; do
+    [ -n "$asset_id" ] || continue
+    delete_asset "$asset_id" || return 1
+  done <<<"$ids"
+  return 0
+}
+
+gitee_attach() {
+  local file="$1" name attempt response status
+  name="$(basename "$file")"
+  attempt=1
+  while [ "$attempt" -le "$GITEE_UPLOAD_RETRIES" ]; do
+    status=0
+    if response="$(curl -fsS --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
+      --max-time "$GITEE_UPLOAD_MAX_TIME" \
+      -X POST "${base}/releases/${release_id}/attach_files" \
+      -F "access_token=${GITEE_TOKEN}" -F "file=@${file}" 2>&1)"; then
+      status=0
+    else
+      status=$?
+    fi
+
+    # Gitee can commit an upload but let the HTTP response time out. Probe the
+    # release before retrying so a lost response does not create duplicates.
+    if verify_asset_with_retries "$file" "$GITEE_POST_UPLOAD_VERIFY_ATTEMPTS"; then
+      if [ "$status" -ne 0 ]; then
+        echo "   ✓ ${name} appeared with the expected SHA after a lost upload response"
+      fi
+      return 0
+    fi
+
+    echo "   ⚠ upload attempt ${attempt}/${GITEE_UPLOAD_RETRIES} failed for ${name}: $(printf '%s' "$response" | head -c 240)" >&2
+    attempt=$((attempt + 1))
+    if [ "$attempt" -le "$GITEE_UPLOAD_RETRIES" ]; then
+      # Remove any partial, stale, or duplicate attachment before the one
+      # explicit retry. There is deliberately no nested curl retry layer.
+      delete_named_assets "$name" || return 1
+      sleep "$GITEE_UPLOAD_RETRY_DELAY"
+    fi
+  done
+  return 1
+}
+
+uploaded=0
+replaced=0
+skipped=0
+failed=0
+index=0
+total="${#required_assets[@]}"
+
+for name in "${required_assets[@]}"; do
+  index=$((index + 1))
+  file="${DIST_DIR}/${name}"
+  if ! assets_map="$(list_assets)"; then
+    echo "   ❌ could not list Gitee assets before reconciling ${name}" >&2
+    failed=$((failed + 1))
+    continue
+  fi
+  count="$(asset_count "$assets_map" "$name")"
+  existed="$count"
+
+  if [ "$count" -eq 1 ] && verify_asset_with_retries "$file" "$GITEE_EXISTING_VERIFY_ATTEMPTS"; then
+    echo "   ✓ [${index}/${total}] ${name} already correct on Gitee — skip"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if [ "$count" -gt 0 ]; then
+    echo "   ↻ [${index}/${total}] ${name} is stale or duplicated (${count} copies) — replacing"
+    if ! delete_named_assets "$name"; then
+      echo "   ❌ failed to delete stale Gitee attachment(s) for ${name}" >&2
+      failed=$((failed + 1))
+      continue
+    fi
+  else
+    echo "   ⬆ [${index}/${total}] ${name} (new)"
+  fi
+
+  if gitee_attach "$file"; then
+    if [ "$existed" -eq 0 ]; then
+      uploaded=$((uploaded + 1))
+    else
+      replaced=$((replaced + 1))
+    fi
+  else
+    echo "   ❌ upload failed for ${name}" >&2
+    failed=$((failed + 1))
+  fi
+done
+
+if ! final_assets_map="$(list_assets)"; then
+  err "could not list Gitee assets for final verification"
+fi
+for name in "${required_assets[@]}"; do
+  count="$(asset_count "$final_assets_map" "$name")"
+  if [ "$count" -ne 1 ]; then
+    echo "   ❌ final verification expected exactly one ${name}, found ${count}" >&2
+    failed=$((failed + 1))
+  fi
+done
+
+[ "$failed" -eq 0 ] || err "Gitee release reconciliation finished with ${failed} failure(s)"
+echo "✅ Gitee release assets: uploaded ${uploaded}, replaced ${replaced}, skipped ${skipped} (all ${total} verified)."

--- a/scripts/release/sync-gitee-tag.sh
+++ b/scripts/release/sync-gitee-tag.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Synchronize one immutable release tag to Gitee without moving an existing tag.
+
+set -euo pipefail
+
+VERSION="${VERSION:-}"
+GITEE_REPO="${GITEE_REPO:-}"
+GITEE_GIT_TIMEOUT_SECONDS="${GITEE_GIT_TIMEOUT_SECONDS:-180}"
+GITEE_TAG_VERIFY_ATTEMPTS="${GITEE_TAG_VERIFY_ATTEMPTS:-12}"
+GITEE_TAG_VERIFY_DELAY="${GITEE_TAG_VERIFY_DELAY:-5}"
+GITEE_SOURCE_REMOTE="${GITEE_SOURCE_REMOTE-origin}"
+
+err() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+[ -n "$VERSION" ] || err "VERSION is required"
+case "$VERSION" in
+  v*) ;;
+  *) err "VERSION must be a v-prefixed release tag: ${VERSION}" ;;
+esac
+
+if [ -z "${GITEE_GIT_REMOTE:-}" ]; then
+  [ -n "${GITEE_USER:-}" ] || err "GITEE_USER is required"
+  [ -n "${GITEE_TOKEN:-}" ] || err "GITEE_TOKEN is required"
+  [ -n "$GITEE_REPO" ] || err "GITEE_REPO is required"
+  GITEE_GIT_REMOTE="https://${GITEE_USER}:${GITEE_TOKEN}@gitee.com/${GITEE_REPO}.git"
+fi
+if [ -z "${GITEE_PUBLIC_GIT_REMOTE:-}" ]; then
+  [ -n "$GITEE_REPO" ] || err "GITEE_REPO is required"
+  GITEE_PUBLIC_GIT_REMOTE="https://gitee.com/${GITEE_REPO}.git"
+fi
+
+run_bounded() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --signal=TERM "${GITEE_GIT_TIMEOUT_SECONDS}s" "$@"
+  else
+    "$@"
+  fi
+}
+
+# A tag checkout already has the local ref. The fetch repairs shallow/manual
+# checkouts, while the rev-parse below remains the authoritative requirement.
+if [ -n "$GITEE_SOURCE_REMOTE" ]; then
+  git fetch --force --tags "$GITEE_SOURCE_REMOTE" \
+    "refs/tags/${VERSION}:refs/tags/${VERSION}" >/dev/null 2>&1 || true
+fi
+target_commit="$(git rev-parse "${VERSION}^{commit}" 2>/dev/null || true)"
+[ -n "$target_commit" ] || err "could not resolve local release tag ${VERSION}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+remote_tag_commit() {
+  local refs_file="${tmp_dir}/remote-refs"
+  if ! run_bounded git ls-remote "$GITEE_PUBLIC_GIT_REMOTE" \
+    "refs/tags/${VERSION}" "refs/tags/${VERSION}^{}" >"$refs_file"; then
+    printf 'error: could not query Gitee tag %s\n' "$VERSION" >&2
+    return 1
+  fi
+  awk -v tag="refs/tags/${VERSION}" '
+    $2 == tag "^{}" { peeled=$1 }
+    $2 == tag { direct=$1 }
+    END {
+      if (peeled != "") print peeled
+      else if (direct != "") print direct
+    }
+  ' "$refs_file"
+}
+
+if ! remote_commit="$(remote_tag_commit)"; then
+  exit 1
+fi
+if [ "$remote_commit" = "$target_commit" ]; then
+  echo "   Gitee tag ${VERSION} already aligned at ${target_commit} — skip push."
+  exit 0
+fi
+if [ -n "$remote_commit" ]; then
+  err "Gitee tag ${VERSION} already points to ${remote_commit}; refusing to move it to ${target_commit}"
+fi
+
+echo "   Pushing missing Gitee tag ${VERSION} -> ${target_commit}"
+if ! run_bounded git push "$GITEE_GIT_REMOTE" \
+  "refs/tags/${VERSION}:refs/tags/${VERSION}" >/dev/null; then
+  # A concurrent mirror may have created the same immutable tag while the push
+  # was in flight. Accept only the exact expected commit.
+  if remote_commit="$(remote_tag_commit 2>/dev/null)" && [ "$remote_commit" = "$target_commit" ]; then
+    echo "   Gitee tag ${VERSION} became aligned concurrently — continue."
+    exit 0
+  fi
+  err "failed to push missing Gitee tag ${VERSION}"
+fi
+
+attempt=1
+remote_commit=""
+while [ "$attempt" -le "$GITEE_TAG_VERIFY_ATTEMPTS" ]; do
+  if remote_commit="$(remote_tag_commit 2>/dev/null)" && [ "$remote_commit" = "$target_commit" ]; then
+    echo "   Gitee tag ${VERSION} is aligned."
+    exit 0
+  fi
+  attempt=$((attempt + 1))
+  [ "$attempt" -le "$GITEE_TAG_VERIFY_ATTEMPTS" ] && sleep "$GITEE_TAG_VERIFY_DELAY"
+done
+
+err "Gitee tag ${VERSION} is not aligned after push: got ${remote_commit:-<missing>}, want ${target_commit}"

--- a/scripts/release/sync-gitee-tag.sh
+++ b/scripts/release/sync-gitee-tag.sh
@@ -6,14 +6,42 @@ set -euo pipefail
 VERSION="${VERSION:-}"
 GITEE_REPO="${GITEE_REPO:-}"
 GITEE_GIT_TIMEOUT_SECONDS="${GITEE_GIT_TIMEOUT_SECONDS:-180}"
+GITEE_TAG_TIMEOUT_SECONDS="${GITEE_TAG_TIMEOUT_SECONDS:-300}"
 GITEE_TAG_VERIFY_ATTEMPTS="${GITEE_TAG_VERIFY_ATTEMPTS:-12}"
 GITEE_TAG_VERIFY_DELAY="${GITEE_TAG_VERIFY_DELAY:-5}"
 GITEE_SOURCE_REMOTE="${GITEE_SOURCE_REMOTE-origin}"
+GITEE_PARENT_DEADLINE_EPOCH="${GITEE_PARENT_DEADLINE_EPOCH:-}"
 
 err() {
   printf 'error: %s\n' "$*" >&2
   exit 1
 }
+
+require_positive_integer() {
+  local name="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*) err "${name} must be a positive integer: ${value}" ;;
+  esac
+  [ "$value" -gt 0 ] || err "${name} must be greater than zero"
+}
+
+require_nonnegative_integer() {
+  local name="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*) err "${name} must be a non-negative integer: ${value}" ;;
+  esac
+}
+
+for setting in \
+  GITEE_GIT_TIMEOUT_SECONDS \
+  GITEE_TAG_TIMEOUT_SECONDS \
+  GITEE_TAG_VERIFY_ATTEMPTS; do
+  require_positive_integer "$setting" "${!setting}"
+done
+require_nonnegative_integer GITEE_TAG_VERIFY_DELAY "$GITEE_TAG_VERIFY_DELAY"
+if [ -n "$GITEE_PARENT_DEADLINE_EPOCH" ]; then
+  require_positive_integer GITEE_PARENT_DEADLINE_EPOCH "$GITEE_PARENT_DEADLINE_EPOCH"
+fi
 
 [ -n "$VERSION" ] || err "VERSION is required"
 case "$VERSION" in
@@ -32,19 +60,87 @@ if [ -z "${GITEE_PUBLIC_GIT_REMOTE:-}" ]; then
   GITEE_PUBLIC_GIT_REMOTE="https://gitee.com/${GITEE_REPO}.git"
 fi
 
-run_bounded() {
-  if command -v timeout >/dev/null 2>&1; then
-    timeout --signal=TERM "${GITEE_GIT_TIMEOUT_SECONDS}s" "$@"
+now_seconds() {
+  date +%s
+}
+
+tag_deadline=$(( $(now_seconds) + GITEE_TAG_TIMEOUT_SECONDS ))
+if [ -n "$GITEE_PARENT_DEADLINE_EPOCH" ] && [ "$GITEE_PARENT_DEADLINE_EPOCH" -lt "$tag_deadline" ]; then
+  tag_deadline="$GITEE_PARENT_DEADLINE_EPOCH"
+fi
+
+deadline_remaining() {
+  local remaining=$(( tag_deadline - $(now_seconds) ))
+  [ "$remaining" -gt 0 ] || return 1
+  printf '%s\n' "$remaining"
+}
+
+bounded_git_timeout() {
+  local remaining
+  remaining="$(deadline_remaining)" || return 1
+  if [ "$GITEE_GIT_TIMEOUT_SECONDS" -lt "$remaining" ]; then
+    printf '%s\n' "$GITEE_GIT_TIMEOUT_SECONDS"
   else
-    "$@"
+    printf '%s\n' "$remaining"
   fi
+}
+
+run_python_bounded() {
+  local seconds="$1"
+  shift
+  python3 - "$seconds" "$@" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+timeout = int(sys.argv[1])
+process = subprocess.Popen(sys.argv[2:], start_new_session=True)
+try:
+    returncode = process.wait(timeout=timeout)
+except subprocess.TimeoutExpired:
+    os.killpg(process.pid, signal.SIGTERM)
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        process.wait()
+    sys.exit(124)
+sys.exit(returncode)
+PY
+}
+
+run_bounded() {
+  local seconds
+  seconds="$(bounded_git_timeout)" || {
+    printf 'error: Gitee tag synchronization deadline exhausted\n' >&2
+    return 124
+  }
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --signal=TERM "${seconds}s" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout --signal=TERM "${seconds}s" "$@"
+  elif command -v python3 >/dev/null 2>&1; then
+    run_python_bounded "$seconds" "$@"
+  else
+    printf 'error: timeout, gtimeout, or python3 is required for bounded git operations\n' >&2
+    return 127
+  fi
+}
+
+sleep_within_deadline() {
+  local seconds="$1" remaining
+  [ "$seconds" -gt 0 ] || return 0
+  remaining="$(deadline_remaining)" || return 1
+  [ "$seconds" -lt "$remaining" ] || return 1
+  sleep "$seconds"
 }
 
 # A tag checkout already has the local ref. The fetch repairs shallow/manual
 # checkouts, while the rev-parse below remains the authoritative requirement.
 fetch_failed=0
 if [ -n "$GITEE_SOURCE_REMOTE" ]; then
-  git fetch --force --tags "$GITEE_SOURCE_REMOTE" \
+  run_bounded git fetch --force --tags "$GITEE_SOURCE_REMOTE" \
     "refs/tags/${VERSION}:refs/tags/${VERSION}" >/dev/null 2>&1 || fetch_failed=1
 fi
 target_commit="$(git rev-parse --verify "${VERSION}^{commit}" 2>/dev/null || true)"
@@ -106,7 +202,9 @@ while [ "$attempt" -le "$GITEE_TAG_VERIFY_ATTEMPTS" ]; do
     exit 0
   fi
   attempt=$((attempt + 1))
-  [ "$attempt" -le "$GITEE_TAG_VERIFY_ATTEMPTS" ] && sleep "$GITEE_TAG_VERIFY_DELAY"
+  if [ "$attempt" -le "$GITEE_TAG_VERIFY_ATTEMPTS" ]; then
+    sleep_within_deadline "$GITEE_TAG_VERIFY_DELAY" || break
+  fi
 done
 
 err "Gitee tag ${VERSION} is not aligned after push: got ${remote_commit:-<missing>}, want ${target_commit}"

--- a/scripts/release/sync-gitee-tag.sh
+++ b/scripts/release/sync-gitee-tag.sh
@@ -42,12 +42,18 @@ run_bounded() {
 
 # A tag checkout already has the local ref. The fetch repairs shallow/manual
 # checkouts, while the rev-parse below remains the authoritative requirement.
+fetch_failed=0
 if [ -n "$GITEE_SOURCE_REMOTE" ]; then
   git fetch --force --tags "$GITEE_SOURCE_REMOTE" \
-    "refs/tags/${VERSION}:refs/tags/${VERSION}" >/dev/null 2>&1 || true
+    "refs/tags/${VERSION}:refs/tags/${VERSION}" >/dev/null 2>&1 || fetch_failed=1
 fi
-target_commit="$(git rev-parse "${VERSION}^{commit}" 2>/dev/null || true)"
-[ -n "$target_commit" ] || err "could not resolve local release tag ${VERSION}"
+target_commit="$(git rev-parse --verify "${VERSION}^{commit}" 2>/dev/null || true)"
+if [ -z "$target_commit" ]; then
+  if [ "$fetch_failed" -eq 1 ]; then
+    err "source tag fetch failed and local release tag ${VERSION} could not be resolved"
+  fi
+  err "could not resolve local release tag ${VERSION}"
+fi
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT

--- a/scripts/release/sync-to-gitee.sh
+++ b/scripts/release/sync-to-gitee.sh
@@ -31,6 +31,37 @@ DIST_DIR="${DIST_DIR:-dist}"
 GITEE_API="${GITEE_API:-https://gitee.com/api/v5}"
 GITEE_CURL_CONNECT_TIMEOUT="${GITEE_CURL_CONNECT_TIMEOUT:-15}"
 GITEE_CURL_MAX_TIME="${GITEE_CURL_MAX_TIME:-120}"
+GITEE_SYNC_TIMEOUT_SECONDS="${GITEE_SYNC_TIMEOUT_SECONDS:-5700}"
+GITEE_TAG_TIMEOUT_SECONDS="${GITEE_TAG_TIMEOUT_SECONDS:-300}"
+GITEE_RELEASE_LOOKUP_MAX_TIME="${GITEE_RELEASE_LOOKUP_MAX_TIME:-60}"
+GITEE_RELEASE_CREATE_MAX_TIME="${GITEE_RELEASE_CREATE_MAX_TIME:-60}"
+GITEE_RECONCILE_TIMEOUT_SECONDS="${GITEE_RECONCILE_TIMEOUT_SECONDS:-4920}"
+GITEE_CHILD_DEADLINE_RESERVE_SECONDS="${GITEE_CHILD_DEADLINE_RESERVE_SECONDS:-5}"
+
+err() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_positive_integer() {
+  local name="$1" value="$2"
+  case "$value" in
+    ''|*[!0-9]*) err "${name} must be a positive integer: ${value}" ;;
+  esac
+  [ "$value" -gt 0 ] || err "${name} must be greater than zero"
+}
+
+for setting in \
+  GITEE_CURL_CONNECT_TIMEOUT \
+  GITEE_CURL_MAX_TIME \
+  GITEE_SYNC_TIMEOUT_SECONDS \
+  GITEE_TAG_TIMEOUT_SECONDS \
+  GITEE_RELEASE_LOOKUP_MAX_TIME \
+  GITEE_RELEASE_CREATE_MAX_TIME \
+  GITEE_RECONCILE_TIMEOUT_SECONDS \
+  GITEE_CHILD_DEADLINE_RESERVE_SECONDS; do
+  require_positive_integer "$setting" "${!setting}"
+done
 
 missing=""
 [ -z "${GITEE_TOKEN:-}" ] && missing="$missing GITEE_TOKEN"
@@ -41,6 +72,28 @@ if [ -n "$missing" ]; then
   echo "   Set these as repo secrets to auto-mirror releases to Gitee for China users."
   exit 0
 fi
+
+now_seconds() {
+  date +%s
+}
+
+sync_deadline=$(( $(now_seconds) + GITEE_SYNC_TIMEOUT_SECONDS ))
+
+deadline_remaining() {
+  local remaining=$(( sync_deadline - $(now_seconds) ))
+  [ "$remaining" -gt 0 ] || return 1
+  printf '%s\n' "$remaining"
+}
+
+bounded_max_time() {
+  local configured="$1" remaining
+  remaining="$(deadline_remaining)" || return 1
+  if [ "$configured" -lt "$remaining" ]; then
+    printf '%s\n' "$configured"
+  else
+    printf '%s\n' "$remaining"
+  fi
+}
 
 VERSION="${VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)}"
 OWNER="${GITEE_REPO%%/*}"
@@ -53,22 +106,33 @@ echo "📦 Mirroring release ${VERSION} → Gitee ${GITEE_REPO}"
 # Creating a Gitee release with target_commitish=main can silently create a tag
 # at the Gitee-localized main commit. The helper skips an already-aligned tag,
 # pushes only a missing tag, and refuses to move a published tag.
-VERSION="$VERSION" "$SCRIPT_DIR/sync-gitee-tag.sh"
-target_commit="$(git rev-parse "${VERSION}^{commit}")"
+VERSION="$VERSION" \
+GITEE_PARENT_DEADLINE_EPOCH="$sync_deadline" \
+GITEE_TAG_TIMEOUT_SECONDS="$GITEE_TAG_TIMEOUT_SECONDS" \
+  "$SCRIPT_DIR/sync-gitee-tag.sh"
+deadline_remaining >/dev/null || err "overall Gitee sync deadline exhausted during tag synchronization"
+target_commit="$(git rev-parse --verify "${VERSION}^{commit}")"
 
 api_get() {
+  local configured_max_time="$1" max_time
+  shift
+  max_time="$(bounded_max_time "$configured_max_time")" || return 1
   curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
-    --max-time "$GITEE_CURL_MAX_TIME" "$@"
+    --max-time "$max_time" "$@"
 }
 
 # ── Resolve or create the Gitee release for this tag ──────────────────────────
-rel_json="$(api_get "${base}/releases/tags/${VERSION}?access_token=${GITEE_TOKEN}" 2>/dev/null || true)"
+rel_json="$(api_get "$GITEE_RELEASE_LOOKUP_MAX_TIME" \
+  "${base}/releases/tags/${VERSION}?access_token=${GITEE_TOKEN}" 2>/dev/null || true)"
 release_id="$(printf '%s' "$rel_json" | grep -o '"id":[ ]*[0-9]*' | head -1 | grep -o '[0-9]*' || true)"
 
 if [ -z "$release_id" ]; then
+  deadline_remaining >/dev/null || err "overall Gitee sync deadline exhausted during release lookup"
   echo "   No Gitee release for ${VERSION} yet — creating it."
+  create_max_time="$(bounded_max_time "$GITEE_RELEASE_CREATE_MAX_TIME")" \
+    || err "overall Gitee sync deadline exhausted before release creation"
   rel_json="$(curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
-    --max-time "$GITEE_CURL_MAX_TIME" -X POST "${base}/releases" \
+    --max-time "$create_max_time" -X POST "${base}/releases" \
     -F "access_token=${GITEE_TOKEN}" \
     -F "tag_name=${VERSION}" \
     -F "name=${VERSION}" \
@@ -80,6 +144,14 @@ fi
 echo "   Gitee release id = ${release_id}"
 
 # ── Reconcile the complete, byte-verified release asset set ──────────────────
+remaining="$(deadline_remaining)" || err "overall Gitee sync deadline exhausted before asset reconciliation"
+reconcile_timeout="$GITEE_RECONCILE_TIMEOUT_SECONDS"
+max_child_timeout=$(( remaining - GITEE_CHILD_DEADLINE_RESERVE_SECONDS ))
+[ "$max_child_timeout" -gt 0 ] || err "insufficient Gitee sync budget for asset reconciliation"
+if [ "$reconcile_timeout" -gt "$max_child_timeout" ]; then
+  reconcile_timeout="$max_child_timeout"
+fi
+
 DIST_DIR="$DIST_DIR" \
 GITEE_API="$GITEE_API" \
 GITEE_TOKEN="$GITEE_TOKEN" \
@@ -87,7 +159,10 @@ GITEE_REPO="$GITEE_REPO" \
 GITEE_CURL_CONNECT_TIMEOUT="$GITEE_CURL_CONNECT_TIMEOUT" \
 GITEE_CURL_MAX_TIME="$GITEE_CURL_MAX_TIME" \
 GITEE_RELEASE_ID="$release_id" \
+GITEE_OVERALL_TIMEOUT_SECONDS="$reconcile_timeout" \
   "$SCRIPT_DIR/reconcile-gitee-assets.sh"
+
+deadline_remaining >/dev/null || err "overall Gitee sync deadline exhausted after asset reconciliation"
 
 echo "   China install:  DWS_GITEE_REPO=${GITEE_REPO} \\"
 echo "     curl -fsSL https://gitee.com/${GITEE_REPO}/raw/main/scripts/install.sh | sh"

--- a/scripts/release/sync-to-gitee.sh
+++ b/scripts/release/sync-to-gitee.sh
@@ -26,13 +26,11 @@
 
 set -eu
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 DIST_DIR="${DIST_DIR:-dist}"
 GITEE_API="${GITEE_API:-https://gitee.com/api/v5}"
 GITEE_CURL_CONNECT_TIMEOUT="${GITEE_CURL_CONNECT_TIMEOUT:-15}"
 GITEE_CURL_MAX_TIME="${GITEE_CURL_MAX_TIME:-120}"
-GITEE_UPLOAD_MAX_TIME="${GITEE_UPLOAD_MAX_TIME:-300}"
-GITEE_UPLOAD_RETRIES="${GITEE_UPLOAD_RETRIES:-3}"
-GITEE_UPLOAD_RETRY_DELAY="${GITEE_UPLOAD_RETRY_DELAY:-10}"
 
 missing=""
 [ -z "${GITEE_TOKEN:-}" ] && missing="$missing GITEE_TOKEN"
@@ -48,52 +46,29 @@ VERSION="${VERSION:-$(git describe --tags --always 2>/dev/null || echo dev)}"
 OWNER="${GITEE_REPO%%/*}"
 NAME="${GITEE_REPO##*/}"
 base="${GITEE_API}/repos/${OWNER}/${NAME}"
-git_remote="https://${GITEE_USER}:${GITEE_TOKEN}@gitee.com/${GITEE_REPO}.git"
-public_git_remote="https://gitee.com/${GITEE_REPO}.git"
 
 echo "📦 Mirroring release ${VERSION} → Gitee ${GITEE_REPO}"
 
 # ── Keep the Gitee git tag aligned with the GitHub release tag ───────────────
 # Creating a Gitee release with target_commitish=main can silently create a tag
-# at the Gitee-localized main commit. Always push the exact GitHub tag first,
-# then verify the peeled commit before touching release attachments.
-git fetch --force --tags origin "refs/tags/${VERSION}:refs/tags/${VERSION}" >/dev/null 2>&1 || true
-target_commit="$(git rev-parse "${VERSION}^{commit}" 2>/dev/null || true)"
-[ -n "$target_commit" ] || { echo "❌ Could not resolve local release tag ${VERSION}; fetch tags before syncing." >&2; exit 1; }
+# at the Gitee-localized main commit. The helper skips an already-aligned tag,
+# pushes only a missing tag, and refuses to move a published tag.
+VERSION="$VERSION" "$SCRIPT_DIR/sync-gitee-tag.sh"
+target_commit="$(git rev-parse "${VERSION}^{commit}")"
 
-gitee_tag_commit() {
-  git ls-remote "$public_git_remote" "refs/tags/${VERSION}*" 2>/dev/null \
-    | awk -v tag="refs/tags/${VERSION}" '
-        $2 == tag "^{}" { peeled=$1 }
-        $2 == tag { direct=$1 }
-        END {
-          if (peeled != "") print peeled;
-          else if (direct != "") print direct;
-        }'
+api_get() {
+  curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
+    --max-time "$GITEE_CURL_MAX_TIME" "$@"
 }
-
-echo "   Syncing Gitee tag ${VERSION} -> ${target_commit}"
-git push --force "$git_remote" "refs/tags/${VERSION}:refs/tags/${VERSION}" >/dev/null
-
-gitee_commit=""
-for _ in 1 2 3 4 5 6 7 8 9 10 11 12; do
-  gitee_commit="$(gitee_tag_commit || true)"
-  [ "$gitee_commit" = "$target_commit" ] && break
-  sleep 5
-done
-[ "$gitee_commit" = "$target_commit" ] || {
-  echo "❌ Gitee tag ${VERSION} is not aligned after push: got ${gitee_commit:-<missing>}, want ${target_commit}" >&2
-  exit 1
-}
-echo "   Gitee tag ${VERSION} is aligned."
 
 # ── Resolve or create the Gitee release for this tag ──────────────────────────
-rel_json="$(curl -fsSL "${base}/releases/tags/${VERSION}?access_token=${GITEE_TOKEN}" 2>/dev/null || true)"
+rel_json="$(api_get "${base}/releases/tags/${VERSION}?access_token=${GITEE_TOKEN}" 2>/dev/null || true)"
 release_id="$(printf '%s' "$rel_json" | grep -o '"id":[ ]*[0-9]*' | head -1 | grep -o '[0-9]*' || true)"
 
 if [ -z "$release_id" ]; then
   echo "   No Gitee release for ${VERSION} yet — creating it."
-  rel_json="$(curl -fsSL -X POST "${base}/releases" \
+  rel_json="$(curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
+    --max-time "$GITEE_CURL_MAX_TIME" -X POST "${base}/releases" \
     -F "access_token=${GITEE_TOKEN}" \
     -F "tag_name=${VERSION}" \
     -F "name=${VERSION}" \
@@ -104,109 +79,15 @@ fi
 [ -n "$release_id" ] || { echo "❌ Could not get/create Gitee release for ${VERSION}. Response: ${rel_json}" >&2; exit 1; }
 echo "   Gitee release id = ${release_id}"
 
-# ── Mirror each artifact, verifying content so re-runs self-heal ─────────────
-# Pull the current attachment list (name + attach id + download url) so we can,
-# per file:
-#   • skip it when it is already on Gitee, unique, AND byte-identical,
-#   • REPLACE it when present but stale (different bytes) — e.g. the darwin
-#     binaries are re-signed and so differ between GitHub and a prior mirror
-#     run, which breaks install.sh's checksums.txt verification on macOS,
-#   • DEDUP it when the same name has >1 attachment — a prior run that failed to
-#     delete (see below) left the old copy *and* an extra upload; Gitee then
-#     serves the OLDER one by name, so the stale binary wins. We delete every
-#     copy and upload one fresh.
-#   • upload it when missing.
-# This brings the Gitee release into byte-for-byte agreement with $DIST_DIR,
-# which the caller fills from the GitHub release whose checksums.txt is what
-# install.sh verifies against.
-#
-# We list attachments via the dedicated /attach_files endpoint, NOT the release
-# detail (/releases/{id}) endpoint: the latter's "assets" array omits the attach
-# id, so DELETE /attach_files/{id} was previously called with an empty id and
-# silently no-op'd — leaving stale + duplicate darwin binaries on Gitee.
-assets_map="$(curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" --max-time "$GITEE_CURL_MAX_TIME" "${base}/releases/${release_id}/attach_files?access_token=${GITEE_TOKEN}" 2>/dev/null \
-  | python3 -c 'import json,sys
-try:
-    data=json.load(sys.stdin)
-    rows=data if isinstance(data,list) else data.get("attach_files",[])
-    for a in rows:
-        n=a.get("name",""); i=a.get("id",""); u=a.get("browser_download_url","")
-        if n and i!="":
-            print("%s\t%s\t%s" % (n, i, u))
-except Exception:
-    pass' 2>/dev/null || true)"
+# ── Reconcile the complete, byte-verified release asset set ──────────────────
+DIST_DIR="$DIST_DIR" \
+GITEE_API="$GITEE_API" \
+GITEE_TOKEN="$GITEE_TOKEN" \
+GITEE_REPO="$GITEE_REPO" \
+GITEE_CURL_CONNECT_TIMEOUT="$GITEE_CURL_CONNECT_TIMEOUT" \
+GITEE_CURL_MAX_TIME="$GITEE_CURL_MAX_TIME" \
+GITEE_RELEASE_ID="$release_id" \
+  "$SCRIPT_DIR/reconcile-gitee-assets.sh"
 
-sha256_of() {  # sha256 of a file ($1) or, with no arg, of stdin
-  if command -v sha256sum >/dev/null 2>&1; then sha256sum ${1:+"$1"} | awk '{print $1}';
-  else shasum -a 256 ${1:+"$1"} | awk '{print $1}'; fi
-}
-
-gitee_attach() {  # upload file $1; success when the response carries a download url
-  file="$1"
-  fn="$(basename "$file")"
-  attempt=1
-  while [ "$attempt" -le "$GITEE_UPLOAD_RETRIES" ]; do
-    response="$(curl -fsS --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" --max-time "$GITEE_UPLOAD_MAX_TIME" \
-      --retry 2 --retry-delay 5 --retry-all-errors \
-      -X POST "${base}/releases/${release_id}/attach_files" \
-      -F "access_token=${GITEE_TOKEN}" -F "file=@${file}" 2>&1 || true)"
-    if printf '%s' "$response" | grep -q '"browser_download_url"'; then
-      return 0
-    fi
-    echo "   ⚠ upload attempt ${attempt}/${GITEE_UPLOAD_RETRIES} failed for ${fn}: $(printf '%s' "$response" | head -c 240)" >&2
-    attempt=$((attempt + 1))
-    [ "$attempt" -le "$GITEE_UPLOAD_RETRIES" ] && sleep "$GITEE_UPLOAD_RETRY_DELAY"
-  done
-  return 1
-}
-
-gitee_delete() {  # delete attachment by id $1
-  curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" --max-time "$GITEE_CURL_MAX_TIME" \
-    -X DELETE "${base}/releases/${release_id}/attach_files/${1}?access_token=${GITEE_TOKEN}" \
-    >/dev/null 2>&1 || true
-}
-
-uploaded=0
-replaced=0
-skipped=0
-for f in "$DIST_DIR"/dws-*.tar.gz "$DIST_DIR"/dws-*.zip "$DIST_DIR"/checksums.txt; do
-  [ -f "$f" ] || continue
-  fn="$(basename "$f")"
-  local_sha="$(sha256_of "$f")"
-  # Every attach id currently carrying this name (may be >1 from a botched run).
-  ids="$(printf '%s\n' "$assets_map" | awk -F'\t' -v n="$fn" '$1==n {print $2}')"
-  aurl="$(printf '%s\n' "$assets_map" | awk -F'\t' -v n="$fn" '$1==n {print $3; exit}')"
-  count="$(printf '%s' "$ids" | grep -c . || true)"
-
-  if [ "$count" -eq 0 ]; then
-    echo "   ⬆ ${fn} (new)"
-    if gitee_attach "$f"; then uploaded=$((uploaded + 1)); else echo "   ⚠ upload may have failed for ${fn}" >&2; fi
-    continue
-  fi
-
-  if [ "$count" -eq 1 ]; then
-    gitee_sha="$(curl -fsSL --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" --max-time "$GITEE_CURL_MAX_TIME" "$aurl" 2>/dev/null | sha256_of || true)"
-    if [ "$gitee_sha" = "$local_sha" ]; then
-      echo "   ✓ ${fn} already correct on Gitee — skip"
-      skipped=$((skipped + 1))
-      continue
-    fi
-    echo "   ↻ ${fn} differs on Gitee (stale) — deleting + re-uploading"
-  else
-    echo "   ↻ ${fn} has ${count} copies on Gitee (dup) — deleting all + re-uploading one"
-  fi
-
-  # Delete every copy, then upload exactly one fresh, correct file.
-  printf '%s\n' "$ids" | while read -r aid; do
-    [ -n "$aid" ] && gitee_delete "$aid"
-  done
-  if gitee_attach "$f"; then replaced=$((replaced + 1)); else echo "   ⚠ re-upload may have failed for ${fn}" >&2; fi
-done
-
-if [ "$uploaded" -eq 0 ] && [ "$replaced" -eq 0 ] && [ "$skipped" -eq 0 ]; then
-  echo "❌ No artifacts found to mirror. Did the build (goreleaser) run / were assets downloaded into ${DIST_DIR}?" >&2
-  exit 1
-fi
-echo "✅ Gitee release ${VERSION}: uploaded ${uploaded}, replaced ${replaced}, skipped ${skipped} (already correct)."
 echo "   China install:  DWS_GITEE_REPO=${GITEE_REPO} \\"
 echo "     curl -fsSL https://gitee.com/${GITEE_REPO}/raw/main/scripts/install.sh | sh"

--- a/test/scripts/gitee_sync_test.go
+++ b/test/scripts/gitee_sync_test.go
@@ -1,0 +1,399 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+var requiredGiteeAssets = []string{
+	"dws-darwin-amd64.tar.gz",
+	"dws-darwin-arm64.tar.gz",
+	"dws-linux-amd64.tar.gz",
+	"dws-linux-arm64.tar.gz",
+	"dws-windows-amd64.zip",
+	"dws-windows-arm64.zip",
+	"dws-skills.zip",
+	"checksums.txt",
+}
+
+func TestSyncGiteeTagSkipsAnAlreadyAlignedImmutableTag(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "sync-gitee-tag.sh"))
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	remoteDir := filepath.Join(root, "gitee.git")
+	seedTaggedRepository(t, workDir, "v1.2.3")
+	mustRun(t, root, "git", "init", "--bare", remoteDir)
+
+	firstOutput := runGiteeTagSync(t, scriptPath, workDir, remoteDir, "v1.2.3", true)
+	if !strings.Contains(firstOutput, "Gitee tag v1.2.3 is aligned") {
+		t.Fatalf("first tag sync did not report alignment:\n%s", firstOutput)
+	}
+
+	// Reject every subsequent push. A truly idempotent second run succeeds only
+	// if it observes the aligned peeled commit and skips git push entirely.
+	mustWriteFile(t, filepath.Join(remoteDir, "hooks", "pre-receive"), []byte("#!/bin/sh\nexit 1\n"), 0o755)
+	secondOutput := runGiteeTagSync(t, scriptPath, workDir, remoteDir, "v1.2.3", true)
+	if !strings.Contains(secondOutput, "already aligned") || !strings.Contains(secondOutput, "skip push") {
+		t.Fatalf("second tag sync did not take the idempotent path:\n%s", secondOutput)
+	}
+}
+
+func TestSyncGiteeTagRefusesToMoveAnExistingTag(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "sync-gitee-tag.sh"))
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	remoteDir := filepath.Join(root, "gitee.git")
+	seedTaggedRepository(t, workDir, "v1.2.3")
+	mustRun(t, root, "git", "init", "--bare", remoteDir)
+	mustRun(t, workDir, "git", "push", remoteDir, "refs/tags/v1.2.3:refs/tags/v1.2.3")
+	originalCommit := peeledRemoteTag(t, workDir, remoteDir, "v1.2.3")
+
+	mustRun(t, workDir, "git", "tag", "-d", "v1.2.3")
+	mustWriteFile(t, filepath.Join(workDir, "payload.txt"), []byte("new release bytes\n"), 0o644)
+	mustRun(t, workDir, "git", "add", "payload.txt")
+	mustRun(t, workDir, "git", "commit", "-m", "new release commit")
+	mustRun(t, workDir, "git", "tag", "-a", "v1.2.3", "-m", "v1.2.3 moved locally")
+
+	output := runGiteeTagSync(t, scriptPath, workDir, remoteDir, "v1.2.3", false)
+	if !strings.Contains(output, "refusing to move it") {
+		t.Fatalf("conflicting tag sync did not fail closed:\n%s", output)
+	}
+	if got := peeledRemoteTag(t, workDir, remoteDir, "v1.2.3"); got != originalCommit {
+		t.Fatalf("remote tag moved from %s to %s", originalCommit, got)
+	}
+}
+
+func TestReconcileGiteeAssetsRecoversACommittedUploadWithLostResponse(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "reconcile-gitee-assets.sh"))
+	distDir := seedGiteeDist(t)
+	fake := newFakeGiteeRelease(true, false)
+	server := httptest.NewServer(fake)
+	defer server.Close()
+	fake.baseURL = server.URL
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Env = giteeAssetEnv(distDir, server.URL, "2")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("reconcile-gitee-assets.sh error = %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "appeared with the expected SHA after a lost upload response") {
+		t.Fatalf("sync did not recognize the committed upload after the response was lost:\n%s", output)
+	}
+	if !strings.Contains(string(output), "all 8 verified") {
+		t.Fatalf("sync did not report complete final verification:\n%s", output)
+	}
+
+	secondCmd := exec.Command("bash", scriptPath)
+	secondCmd.Env = giteeAssetEnv(distDir, server.URL, "2")
+	secondOutput, err := secondCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("idempotent reconcile error = %v\noutput:\n%s", err, secondOutput)
+	}
+	if !strings.Contains(string(secondOutput), "uploaded 0, replaced 0, skipped 8") {
+		t.Fatalf("second reconcile did not skip all verified assets:\n%s", secondOutput)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	for _, name := range requiredGiteeAssets {
+		if got := fake.uploadCalls[name]; got != 1 {
+			t.Errorf("upload calls for %s = %d, want 1", name, got)
+		}
+	}
+}
+
+func TestReconcileGiteeAssetsFailsWhenAnyUploadIsMissing(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "reconcile-gitee-assets.sh"))
+	distDir := seedGiteeDist(t)
+	fake := newFakeGiteeRelease(false, true)
+	server := httptest.NewServer(fake)
+	defer server.Close()
+	fake.baseURL = server.URL
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Env = giteeAssetEnv(distDir, server.URL, "1")
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("reconcile-gitee-assets.sh unexpectedly succeeded with failed uploads:\n%s", output)
+	}
+	if !strings.Contains(string(output), "reconciliation finished with") {
+		t.Fatalf("failed reconciliation did not report a hard final error:\n%s", output)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	for _, name := range requiredGiteeAssets {
+		if got := fake.uploadCalls[name]; got != 1 {
+			t.Errorf("upload calls for %s = %d, want exactly the configured single attempt", name, got)
+		}
+	}
+}
+
+func TestGiteeWorkflowsUseImmutableTagsAndBoundedRetryBudget(t *testing.T) {
+	mirrorPath := mustAbs(t, filepath.Join("..", "..", ".github", "workflows", "mirror-to-gitee.yml"))
+	mirrorData, err := os.ReadFile(mirrorPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", mirrorPath, err)
+	}
+	mirror := string(mirrorData)
+	if !strings.Contains(mirror, `VERSION="$GITHUB_REF_NAME" ./scripts/release/sync-gitee-tag.sh`) {
+		t.Fatal("tag workflow must delegate immutable tag reconciliation to sync-gitee-tag.sh")
+	}
+	for _, forbidden := range []string{
+		`git push --force "$REMOTE" "refs/tags/`,
+		`git push --force --tags`,
+	} {
+		if strings.Contains(mirror, forbidden) {
+			t.Fatalf("tag workflow still contains unsafe force push %q", forbidden)
+		}
+	}
+
+	manualPath := mustAbs(t, filepath.Join("..", "..", ".github", "workflows", "sync-release-to-gitee.yml"))
+	manualData, err := os.ReadFile(manualPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", manualPath, err)
+	}
+	if !strings.Contains(string(manualData), "timeout-minutes: 90") {
+		t.Fatal("manual Gitee repair workflow must exceed the bounded per-file retry budget")
+	}
+
+	localBuildPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "build-and-publish-gitee.sh"))
+	localBuildData, err := os.ReadFile(localBuildPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", localBuildPath, err)
+	}
+	if !strings.Contains(string(localBuildData), "publish-gitee-local.sh reconcile-gitee-assets.sh") {
+		t.Fatal("detached-tag Gitee builds must copy the shared asset reconciler with the publisher")
+	}
+}
+
+func mustAbs(t *testing.T, path string) string {
+	t.Helper()
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("Abs(%s) error = %v", path, err)
+	}
+	return abs
+}
+
+func seedTaggedRepository(t *testing.T, workDir, tag string) {
+	t.Helper()
+	mustRun(t, t.TempDir(), "git", "init", workDir)
+	mustRun(t, workDir, "git", "config", "user.name", "Release Test")
+	mustRun(t, workDir, "git", "config", "user.email", "release-test@example.com")
+	mustWriteFile(t, filepath.Join(workDir, "payload.txt"), []byte("release bytes\n"), 0o644)
+	mustRun(t, workDir, "git", "add", "payload.txt")
+	mustRun(t, workDir, "git", "commit", "-m", "release commit")
+	mustRun(t, workDir, "git", "tag", "-a", tag, "-m", tag)
+}
+
+func runGiteeTagSync(t *testing.T, scriptPath, workDir, remoteDir, tag string, wantSuccess bool) string {
+	t.Helper()
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(),
+		"VERSION="+tag,
+		"GITEE_SOURCE_REMOTE=",
+		"GITEE_GIT_REMOTE="+remoteDir,
+		"GITEE_PUBLIC_GIT_REMOTE="+remoteDir,
+		"GITEE_TAG_VERIFY_ATTEMPTS=1",
+		"GITEE_TAG_VERIFY_DELAY=0",
+		"GITEE_GIT_TIMEOUT_SECONDS=10",
+	)
+	output, err := cmd.CombinedOutput()
+	if wantSuccess && err != nil {
+		t.Fatalf("sync-gitee-tag.sh error = %v\noutput:\n%s", err, output)
+	}
+	if !wantSuccess && err == nil {
+		t.Fatalf("sync-gitee-tag.sh unexpectedly succeeded:\n%s", output)
+	}
+	return string(output)
+}
+
+func peeledRemoteTag(t *testing.T, workDir, remoteDir, tag string) string {
+	t.Helper()
+	output := mustOutput(t, workDir, "git", "ls-remote", remoteDir, "refs/tags/"+tag+"^{}")
+	fields := strings.Fields(output)
+	if len(fields) != 2 {
+		t.Fatalf("unexpected ls-remote output for %s: %q", tag, output)
+	}
+	return fields[0]
+}
+
+func seedGiteeDist(t *testing.T) string {
+	t.Helper()
+	distDir := t.TempDir()
+	for _, name := range requiredGiteeAssets {
+		mustWriteFile(t, filepath.Join(distDir, name), []byte("payload for "+name+"\n"), 0o644)
+	}
+	return distDir
+}
+
+func giteeAssetEnv(distDir, apiURL, retries string) []string {
+	return append(os.Environ(),
+		"DIST_DIR="+distDir,
+		"GITEE_API="+apiURL,
+		"GITEE_TOKEN=test-token",
+		"GITEE_REPO=owner/repo",
+		"GITEE_RELEASE_ID=1",
+		"GITEE_CURL_CONNECT_TIMEOUT=2",
+		"GITEE_CURL_MAX_TIME=2",
+		"GITEE_UPLOAD_MAX_TIME=2",
+		"GITEE_UPLOAD_RETRIES="+retries,
+		"GITEE_UPLOAD_RETRY_DELAY=0",
+		"GITEE_EXISTING_VERIFY_ATTEMPTS=1",
+		"GITEE_POST_UPLOAD_VERIFY_ATTEMPTS=1",
+		"GITEE_VERIFY_RETRY_DELAY=0",
+	)
+}
+
+type fakeGiteeAsset struct {
+	id   int
+	name string
+	data []byte
+}
+
+type fakeGiteeRelease struct {
+	mu                sync.Mutex
+	baseURL           string
+	nextID            int
+	assets            map[int]fakeGiteeAsset
+	uploadCalls       map[string]int
+	dropFirstResponse bool
+	droppedResponse   bool
+	failUploads       bool
+}
+
+func newFakeGiteeRelease(dropFirstResponse, failUploads bool) *fakeGiteeRelease {
+	return &fakeGiteeRelease{
+		nextID:            1,
+		assets:            make(map[int]fakeGiteeAsset),
+		uploadCalls:       make(map[string]int),
+		dropFirstResponse: dropFirstResponse,
+		failUploads:       failUploads,
+	}
+}
+
+func (f *fakeGiteeRelease) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	const attachPath = "/repos/owner/repo/releases/1/attach_files"
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == attachPath:
+		f.list(w)
+	case r.Method == http.MethodPost && r.URL.Path == attachPath:
+		f.upload(w, r)
+	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, attachPath+"/"):
+		f.delete(w, strings.TrimPrefix(r.URL.Path, attachPath+"/"))
+	case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/download/"):
+		f.download(w, strings.TrimPrefix(r.URL.Path, "/download/"))
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (f *fakeGiteeRelease) list(w http.ResponseWriter) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	rows := make([]map[string]any, 0, len(f.assets))
+	for _, asset := range f.assets {
+		rows = append(rows, map[string]any{
+			"id":                   asset.id,
+			"name":                 asset.name,
+			"browser_download_url": fmt.Sprintf("%s/download/%d", f.baseURL, asset.id),
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(rows)
+}
+
+func (f *fakeGiteeRelease) upload(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	f.mu.Lock()
+	f.uploadCalls[header.Filename]++
+	if f.failUploads {
+		f.mu.Unlock()
+		http.Error(w, "temporary Gitee failure", http.StatusServiceUnavailable)
+		return
+	}
+	id := f.nextID
+	f.nextID++
+	f.assets[id] = fakeGiteeAsset{id: id, name: header.Filename, data: data}
+	drop := f.dropFirstResponse && !f.droppedResponse
+	if drop {
+		f.droppedResponse = true
+	}
+	f.mu.Unlock()
+
+	if drop {
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijacking unavailable", http.StatusInternalServerError)
+			return
+		}
+		conn, _, err := hijacker.Hijack()
+		if err == nil {
+			_ = conn.Close()
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id":                   id,
+		"name":                 header.Filename,
+		"browser_download_url": fmt.Sprintf("%s/download/%d", f.baseURL, id),
+	})
+}
+
+func (f *fakeGiteeRelease) delete(w http.ResponseWriter, rawID string) {
+	id, err := strconv.Atoi(rawID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	f.mu.Lock()
+	delete(f.assets, id)
+	f.mu.Unlock()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (f *fakeGiteeRelease) download(w http.ResponseWriter, rawID string) {
+	id, err := strconv.Atoi(rawID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	f.mu.Lock()
+	asset, ok := f.assets[id]
+	f.mu.Unlock()
+	if !ok {
+		http.Error(w, "asset not found", http.StatusNotFound)
+		return
+	}
+	_, _ = w.Write(asset.data)
+}

--- a/test/scripts/gitee_sync_test.go
+++ b/test/scripts/gitee_sync_test.go
@@ -111,6 +111,176 @@ func TestSyncGiteeTagReportsFetchFailureWhenItCannotRecoverAMissingTag(t *testin
 	}
 }
 
+func TestSyncGiteeTagHonorsItsDeadlineDuringFetch(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "sync-gitee-tag.sh"))
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	remoteDir := filepath.Join(root, "gitee.git")
+	seedTaggedRepository(t, workDir, "v1.2.3")
+	mustRun(t, root, "git", "init", "--bare", remoteDir)
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath(git) error = %v", err)
+	}
+	wrapperDir := t.TempDir()
+	mustWriteFile(t, filepath.Join(wrapperDir, "git"), []byte(fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "fetch" ]; then
+  sleep 5
+  exit 1
+fi
+exec %q "$@"
+`, realGit)), 0o755)
+
+	started := time.Now()
+	output := runGiteeTagSync(
+		t, scriptPath, workDir, remoteDir, "v1.2.3", false,
+		"PATH="+wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GITEE_SOURCE_REMOTE=origin",
+		"GITEE_TAG_TIMEOUT_SECONDS=1",
+		"GITEE_GIT_TIMEOUT_SECONDS=10",
+	)
+	elapsed := time.Since(started)
+	if elapsed > 6*time.Second {
+		t.Fatalf("tag deadline took %s, want no more than 6s\noutput:\n%s", elapsed, output)
+	}
+	if !strings.Contains(output, "deadline exhausted") {
+		t.Fatalf("tag deadline failure was not reported clearly:\n%s", output)
+	}
+}
+
+func TestSyncGiteeTagAndReleasePathShareOneOverallDeadline(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "sync-to-gitee.sh"))
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	remoteDir := filepath.Join(root, "gitee.git")
+	seedTaggedRepository(t, workDir, "v1.2.3")
+	mustRun(t, root, "git", "init", "--bare", remoteDir)
+	mustRun(t, workDir, "git", "push", remoteDir, "refs/tags/v1.2.3:refs/tags/v1.2.3")
+	distDir := seedGiteeDist(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(10 * time.Second)
+		http.Error(w, "slow Gitee API", http.StatusGatewayTimeout)
+	}))
+	defer server.Close()
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(),
+		"VERSION=v1.2.3",
+		"DIST_DIR="+distDir,
+		"GITEE_API="+server.URL,
+		"GITEE_TOKEN=test-token",
+		"GITEE_USER=test-user",
+		"GITEE_REPO=owner/repo",
+		"GITEE_SOURCE_REMOTE=",
+		"GITEE_GIT_REMOTE="+remoteDir,
+		"GITEE_PUBLIC_GIT_REMOTE="+remoteDir,
+		"GITEE_SYNC_TIMEOUT_SECONDS=6",
+		"GITEE_TAG_TIMEOUT_SECONDS=3",
+		"GITEE_GIT_TIMEOUT_SECONDS=3",
+		"GITEE_RELEASE_LOOKUP_MAX_TIME=10",
+		"GITEE_RELEASE_CREATE_MAX_TIME=10",
+		"GITEE_RECONCILE_TIMEOUT_SECONDS=10",
+	)
+	started := time.Now()
+	output, err := cmd.CombinedOutput()
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatalf("full Gitee sync unexpectedly succeeded after its deadline:\n%s", output)
+	}
+	if elapsed > 12*time.Second {
+		t.Fatalf("full Gitee sync deadline took %s, want no more than 12s\noutput:\n%s", elapsed, output)
+	}
+	if !strings.Contains(string(output), "overall Gitee sync deadline exhausted") {
+		t.Fatalf("full-path deadline failure was not reported clearly:\n%s", output)
+	}
+}
+
+func TestSyncToGiteeRunsTagReleaseCreationAndAssetReconciliationWithinOneBudget(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "sync-to-gitee.sh"))
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	remoteDir := filepath.Join(root, "gitee.git")
+	seedTaggedRepository(t, workDir, "v1.2.3")
+	mustRun(t, root, "git", "init", "--bare", remoteDir)
+	mustRun(t, workDir, "git", "push", remoteDir, "refs/tags/v1.2.3:refs/tags/v1.2.3")
+	distDir := seedGiteeDist(t)
+
+	fake := newFakeGiteeRelease(false, false)
+	var releaseMu sync.Mutex
+	releaseLookups := 0
+	releaseCreates := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/owner/repo/releases/tags/v1.2.3":
+			releaseMu.Lock()
+			releaseLookups++
+			releaseMu.Unlock()
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/repos/owner/repo/releases":
+			releaseMu.Lock()
+			releaseCreates++
+			releaseMu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		default:
+			fake.ServeHTTP(w, r)
+		}
+	}))
+	defer server.Close()
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(),
+		"VERSION=v1.2.3",
+		"DIST_DIR="+distDir,
+		"GITEE_API="+server.URL,
+		"GITEE_TOKEN=test-token",
+		"GITEE_USER=test-user",
+		"GITEE_REPO=owner/repo",
+		"GITEE_SOURCE_REMOTE=",
+		"GITEE_GIT_REMOTE="+remoteDir,
+		"GITEE_PUBLIC_GIT_REMOTE="+remoteDir,
+		"GITEE_SYNC_TIMEOUT_SECONDS=30",
+		"GITEE_TAG_TIMEOUT_SECONDS=5",
+		"GITEE_GIT_TIMEOUT_SECONDS=3",
+		"GITEE_RELEASE_LOOKUP_MAX_TIME=2",
+		"GITEE_RELEASE_CREATE_MAX_TIME=2",
+		"GITEE_RECONCILE_TIMEOUT_SECONDS=20",
+		"GITEE_CHILD_DEADLINE_RESERVE_SECONDS=1",
+		"GITEE_CURL_CONNECT_TIMEOUT=2",
+		"GITEE_CURL_MAX_TIME=2",
+		"GITEE_UPLOAD_MAX_TIME=2",
+		"GITEE_UPLOAD_RETRIES=1",
+		"GITEE_UPLOAD_RETRY_DELAY=0",
+		"GITEE_EXISTING_VERIFY_ATTEMPTS=1",
+		"GITEE_POST_UPLOAD_VERIFY_ATTEMPTS=1",
+		"GITEE_VERIFY_RETRY_DELAY=0",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("full Gitee sync error = %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "all 8 verified") {
+		t.Fatalf("full Gitee sync did not reconcile every release asset:\n%s", output)
+	}
+
+	releaseMu.Lock()
+	if releaseLookups != 1 || releaseCreates != 1 {
+		t.Errorf("release lookup/create calls = %d/%d, want 1/1", releaseLookups, releaseCreates)
+	}
+	releaseMu.Unlock()
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	for _, name := range requiredGiteeAssets {
+		if got := fake.uploadCalls[name]; got != 1 {
+			t.Errorf("upload calls for %s = %d, want 1", name, got)
+		}
+	}
+}
+
 func TestReconcileGiteeAssetsRecoversACommittedUploadWithLostResponse(t *testing.T) {
 	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "reconcile-gitee-assets.sh"))
 	distDir := seedGiteeDist(t)
@@ -229,6 +399,18 @@ func TestGiteeWorkflowsUseImmutableTagsAndBoundedRetryBudget(t *testing.T) {
 		t.Fatalf("ReadFile(%s) error = %v", manualPath, err)
 	}
 
+	syncPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "sync-to-gitee.sh"))
+	syncData, err := os.ReadFile(syncPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", syncPath, err)
+	}
+	syncScript := string(syncData)
+	syncSeconds := shellDefaultInt(t, syncScript, "GITEE_SYNC_TIMEOUT_SECONDS")
+	tagSeconds := shellDefaultInt(t, syncScript, "GITEE_TAG_TIMEOUT_SECONDS")
+	lookupSeconds := shellDefaultInt(t, syncScript, "GITEE_RELEASE_LOOKUP_MAX_TIME")
+	createSeconds := shellDefaultInt(t, syncScript, "GITEE_RELEASE_CREATE_MAX_TIME")
+	reconcileSeconds := shellDefaultInt(t, syncScript, "GITEE_RECONCILE_TIMEOUT_SECONDS")
+
 	reconcilerPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "reconcile-gitee-assets.sh"))
 	reconcilerData, err := os.ReadFile(reconcilerPath)
 	if err != nil {
@@ -245,13 +427,40 @@ func TestGiteeWorkflowsUseImmutableTagsAndBoundedRetryBudget(t *testing.T) {
 			completeAssetBudget, len(requiredGiteeAssets), perAssetSeconds, finalListSeconds, overallSeconds,
 		)
 	}
-
-	manualWorkflowSeconds := firstWorkflowTimeoutMinutes(t, string(manualData)) * 60
-	const workflowReserveSeconds = 5 * 60
-	if overallSeconds+workflowReserveSeconds > manualWorkflowSeconds {
+	if completeAssetBudget > reconcileSeconds || reconcileSeconds > overallSeconds {
 		t.Fatalf(
-			"overall deadline %ds plus %ds workflow reserve exceeds manual workflow budget %ds",
-			overallSeconds, workflowReserveSeconds, manualWorkflowSeconds,
+			"asset budget nesting invalid: complete=%ds configured-reconcile=%ds reconciler-overall=%ds",
+			completeAssetBudget, reconcileSeconds, overallSeconds,
+		)
+	}
+
+	completeSyncBudget := tagSeconds + lookupSeconds + createSeconds + reconcileSeconds
+	if completeSyncBudget > syncSeconds {
+		t.Fatalf(
+			"complete sync budget = %ds (tag=%d + lookup=%d + create=%d + reconcile=%d), exceeds sync deadline %ds",
+			completeSyncBudget, tagSeconds, lookupSeconds, createSeconds, reconcileSeconds, syncSeconds,
+		)
+	}
+
+	const workflowReserveMinutes = 5
+	assertWorkflowBudget(
+		t,
+		string(manualData),
+		"sync-gitee:",
+		[]string{
+			"name: Check out repository",
+			"name: Download GitHub release assets",
+			"name: Mirror release to Gitee (China)",
+		},
+		workflowReserveMinutes,
+	)
+	manualSyncStepSeconds := workflowTimeoutMinutesAfter(
+		t, string(manualData), "name: Mirror release to Gitee (China)",
+	) * 60
+	if syncSeconds+workflowReserveMinutes*60 > manualSyncStepSeconds {
+		t.Fatalf(
+			"sync deadline %ds plus reserve exceeds manual sync step %ds",
+			syncSeconds, manualSyncStepSeconds,
 		)
 	}
 
@@ -260,15 +469,24 @@ func TestGiteeWorkflowsUseImmutableTagsAndBoundedRetryBudget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(%s) error = %v", releasePath, err)
 	}
-	releaseStepMinutes := workflowTimeoutMinutesAfter(
+	assertWorkflowBudget(
 		t,
 		string(releaseData),
-		"name: Mirror release to Gitee (China)",
+		"mirror-gitee-release:",
+		[]string{
+			"name: Check out repository",
+			"name: Restore finalized distribution files",
+			"name: Mirror release to Gitee (China)",
+		},
+		workflowReserveMinutes,
 	)
-	if overallSeconds+workflowReserveSeconds > releaseStepMinutes*60 {
+	releaseSyncStepSeconds := workflowTimeoutMinutesAfter(
+		t, string(releaseData), "mirror-gitee-release:", "name: Mirror release to Gitee (China)",
+	) * 60
+	if syncSeconds+workflowReserveMinutes*60 > releaseSyncStepSeconds {
 		t.Fatalf(
-			"overall deadline %ds plus %ds workflow reserve exceeds release fallback step budget %ds",
-			overallSeconds, workflowReserveSeconds, releaseStepMinutes*60,
+			"sync deadline %ds plus reserve exceeds release fallback step %ds",
+			syncSeconds, releaseSyncStepSeconds,
 		)
 	}
 
@@ -345,14 +563,9 @@ func shellDefaultInt(t *testing.T, content, name string) int {
 	return 0
 }
 
-func firstWorkflowTimeoutMinutes(t *testing.T, content string) int {
+func workflowTimeoutMinutesAfter(t *testing.T, content string, markers ...string) int {
 	t.Helper()
-	return workflowTimeoutMinutesAfter(t, content, "")
-}
-
-func workflowTimeoutMinutesAfter(t *testing.T, content, marker string) int {
-	t.Helper()
-	if marker != "" {
+	for _, marker := range markers {
 		index := strings.Index(content, marker)
 		if index < 0 {
 			t.Fatalf("workflow marker %q not found", marker)
@@ -374,6 +587,22 @@ func workflowTimeoutMinutesAfter(t *testing.T, content, marker string) int {
 	}
 	t.Fatal("workflow timeout-minutes not found")
 	return 0
+}
+
+func assertWorkflowBudget(t *testing.T, content, jobMarker string, stepMarkers []string, reserveMinutes int) {
+	t.Helper()
+	jobMinutes := workflowTimeoutMinutesAfter(t, content, jobMarker)
+	stepMinutes := 0
+	jobContent := content[strings.Index(content, jobMarker)+len(jobMarker):]
+	for _, marker := range stepMarkers {
+		stepMinutes += workflowTimeoutMinutesAfter(t, jobContent, marker)
+	}
+	if stepMinutes+reserveMinutes > jobMinutes {
+		t.Fatalf(
+			"workflow budget for %s = %d step minutes + %d reserve, exceeds %d-minute job",
+			jobMarker, stepMinutes, reserveMinutes, jobMinutes,
+		)
+	}
 }
 
 func peeledRemoteTag(t *testing.T, workDir, remoteDir, tag string) string {

--- a/test/scripts/gitee_sync_test.go
+++ b/test/scripts/gitee_sync_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 var requiredGiteeAssets = []string{
@@ -73,13 +74,49 @@ func TestSyncGiteeTagRefusesToMoveAnExistingTag(t *testing.T) {
 	}
 }
 
+func TestSyncGiteeTagRejectsAMissingLocalTagWithoutInventingACommit(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "sync-gitee-tag.sh"))
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	remoteDir := filepath.Join(root, "gitee.git")
+	seedTaggedRepository(t, workDir, "v1.2.3")
+	mustRun(t, root, "git", "init", "--bare", remoteDir)
+
+	output := runGiteeTagSync(t, scriptPath, workDir, remoteDir, "v9.9.9", false)
+	if !strings.Contains(output, "could not resolve local release tag v9.9.9") {
+		t.Fatalf("missing tag did not report a local resolution failure:\n%s", output)
+	}
+	for _, misleading := range []string{"refusing to move it", "v9.9.9^{commit}"} {
+		if strings.Contains(output, misleading) {
+			t.Fatalf("missing tag output contains misleading commit information %q:\n%s", misleading, output)
+		}
+	}
+}
+
+func TestSyncGiteeTagReportsFetchFailureWhenItCannotRecoverAMissingTag(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "sync-gitee-tag.sh"))
+	root := t.TempDir()
+	workDir := filepath.Join(root, "work")
+	remoteDir := filepath.Join(root, "gitee.git")
+	seedTaggedRepository(t, workDir, "v1.2.3")
+	mustRun(t, root, "git", "init", "--bare", remoteDir)
+
+	output := runGiteeTagSync(
+		t, scriptPath, workDir, remoteDir, "v9.9.9", false,
+		"GITEE_SOURCE_REMOTE=missing-source-remote",
+	)
+	if !strings.Contains(output, "source tag fetch failed") ||
+		!strings.Contains(output, "local release tag v9.9.9 could not be resolved") {
+		t.Fatalf("fetch failure did not preserve the actionable cause:\n%s", output)
+	}
+}
+
 func TestReconcileGiteeAssetsRecoversACommittedUploadWithLostResponse(t *testing.T) {
 	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "reconcile-gitee-assets.sh"))
 	distDir := seedGiteeDist(t)
 	fake := newFakeGiteeRelease(true, false)
 	server := httptest.NewServer(fake)
 	defer server.Close()
-	fake.baseURL = server.URL
 
 	cmd := exec.Command("bash", scriptPath)
 	cmd.Env = giteeAssetEnv(distDir, server.URL, "2")
@@ -119,7 +156,6 @@ func TestReconcileGiteeAssetsFailsWhenAnyUploadIsMissing(t *testing.T) {
 	fake := newFakeGiteeRelease(false, true)
 	server := httptest.NewServer(fake)
 	defer server.Close()
-	fake.baseURL = server.URL
 
 	cmd := exec.Command("bash", scriptPath)
 	cmd.Env = giteeAssetEnv(distDir, server.URL, "1")
@@ -137,6 +173,34 @@ func TestReconcileGiteeAssetsFailsWhenAnyUploadIsMissing(t *testing.T) {
 		if got := fake.uploadCalls[name]; got != 1 {
 			t.Errorf("upload calls for %s = %d, want exactly the configured single attempt", name, got)
 		}
+	}
+}
+
+func TestReconcileGiteeAssetsHonorsTheOverallDeadline(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "reconcile-gitee-assets.sh"))
+	distDir := seedGiteeDist(t)
+	fake := newFakeGiteeRelease(false, false)
+	fake.uploadDelay = 5 * time.Second
+	server := httptest.NewServer(fake)
+	defer server.Close()
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Env = append(giteeAssetEnv(distDir, server.URL, "2"),
+		"GITEE_ASSET_TIMEOUT_SECONDS=1",
+		"GITEE_OVERALL_TIMEOUT_SECONDS=3",
+		"GITEE_UPLOAD_MAX_TIME=10",
+	)
+	started := time.Now()
+	output, err := cmd.CombinedOutput()
+	elapsed := time.Since(started)
+	if err == nil {
+		t.Fatalf("reconcile unexpectedly succeeded after the overall deadline:\n%s", output)
+	}
+	if elapsed > 8*time.Second {
+		t.Fatalf("overall deadline took %s, want no more than 8s\noutput:\n%s", elapsed, output)
+	}
+	if !strings.Contains(string(output), "deadline") {
+		t.Fatalf("deadline failure was not reported clearly:\n%s", output)
 	}
 }
 
@@ -164,8 +228,48 @@ func TestGiteeWorkflowsUseImmutableTagsAndBoundedRetryBudget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(%s) error = %v", manualPath, err)
 	}
-	if !strings.Contains(string(manualData), "timeout-minutes: 90") {
-		t.Fatal("manual Gitee repair workflow must exceed the bounded per-file retry budget")
+
+	reconcilerPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "reconcile-gitee-assets.sh"))
+	reconcilerData, err := os.ReadFile(reconcilerPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", reconcilerPath, err)
+	}
+	reconciler := string(reconcilerData)
+	perAssetSeconds := shellDefaultInt(t, reconciler, "GITEE_ASSET_TIMEOUT_SECONDS")
+	overallSeconds := shellDefaultInt(t, reconciler, "GITEE_OVERALL_TIMEOUT_SECONDS")
+	finalListSeconds := shellDefaultInt(t, reconciler, "GITEE_LIST_MAX_TIME")
+	completeAssetBudget := perAssetSeconds*len(requiredGiteeAssets) + finalListSeconds
+	if completeAssetBudget > overallSeconds {
+		t.Fatalf(
+			"complete asset budget = %ds (%d assets x %ds + %ds final list), exceeds overall deadline %ds",
+			completeAssetBudget, len(requiredGiteeAssets), perAssetSeconds, finalListSeconds, overallSeconds,
+		)
+	}
+
+	manualWorkflowSeconds := firstWorkflowTimeoutMinutes(t, string(manualData)) * 60
+	const workflowReserveSeconds = 5 * 60
+	if overallSeconds+workflowReserveSeconds > manualWorkflowSeconds {
+		t.Fatalf(
+			"overall deadline %ds plus %ds workflow reserve exceeds manual workflow budget %ds",
+			overallSeconds, workflowReserveSeconds, manualWorkflowSeconds,
+		)
+	}
+
+	releasePath := mustAbs(t, filepath.Join("..", "..", ".github", "workflows", "release.yml"))
+	releaseData, err := os.ReadFile(releasePath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", releasePath, err)
+	}
+	releaseStepMinutes := workflowTimeoutMinutesAfter(
+		t,
+		string(releaseData),
+		"name: Mirror release to Gitee (China)",
+	)
+	if overallSeconds+workflowReserveSeconds > releaseStepMinutes*60 {
+		t.Fatalf(
+			"overall deadline %ds plus %ds workflow reserve exceeds release fallback step budget %ds",
+			overallSeconds, workflowReserveSeconds, releaseStepMinutes*60,
+		)
 	}
 
 	localBuildPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "build-and-publish-gitee.sh"))
@@ -198,7 +302,7 @@ func seedTaggedRepository(t *testing.T, workDir, tag string) {
 	mustRun(t, workDir, "git", "tag", "-a", tag, "-m", tag)
 }
 
-func runGiteeTagSync(t *testing.T, scriptPath, workDir, remoteDir, tag string, wantSuccess bool) string {
+func runGiteeTagSync(t *testing.T, scriptPath, workDir, remoteDir, tag string, wantSuccess bool, extraEnv ...string) string {
 	t.Helper()
 	cmd := exec.Command("bash", scriptPath)
 	cmd.Dir = workDir
@@ -211,6 +315,7 @@ func runGiteeTagSync(t *testing.T, scriptPath, workDir, remoteDir, tag string, w
 		"GITEE_TAG_VERIFY_DELAY=0",
 		"GITEE_GIT_TIMEOUT_SECONDS=10",
 	)
+	cmd.Env = append(cmd.Env, extraEnv...)
 	output, err := cmd.CombinedOutput()
 	if wantSuccess && err != nil {
 		t.Fatalf("sync-gitee-tag.sh error = %v\noutput:\n%s", err, output)
@@ -219,6 +324,56 @@ func runGiteeTagSync(t *testing.T, scriptPath, workDir, remoteDir, tag string, w
 		t.Fatalf("sync-gitee-tag.sh unexpectedly succeeded:\n%s", output)
 	}
 	return string(output)
+}
+
+func shellDefaultInt(t *testing.T, content, name string) int {
+	t.Helper()
+	prefix := name + `="${` + name + `:-`
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) || !strings.HasSuffix(line, `}"`) {
+			continue
+		}
+		raw := strings.TrimSuffix(strings.TrimPrefix(line, prefix), `}"`)
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			t.Fatalf("parse %s default %q: %v", name, raw, err)
+		}
+		return value
+	}
+	t.Fatalf("shell default %s not found", name)
+	return 0
+}
+
+func firstWorkflowTimeoutMinutes(t *testing.T, content string) int {
+	t.Helper()
+	return workflowTimeoutMinutesAfter(t, content, "")
+}
+
+func workflowTimeoutMinutesAfter(t *testing.T, content, marker string) int {
+	t.Helper()
+	if marker != "" {
+		index := strings.Index(content, marker)
+		if index < 0 {
+			t.Fatalf("workflow marker %q not found", marker)
+		}
+		content = content[index+len(marker):]
+	}
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		const prefix = "timeout-minutes:"
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		raw := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+		value, err := strconv.Atoi(raw)
+		if err != nil {
+			t.Fatalf("parse workflow timeout %q: %v", raw, err)
+		}
+		return value
+	}
+	t.Fatal("workflow timeout-minutes not found")
+	return 0
 }
 
 func peeledRemoteTag(t *testing.T, workDir, remoteDir, tag string) string {
@@ -266,13 +421,13 @@ type fakeGiteeAsset struct {
 
 type fakeGiteeRelease struct {
 	mu                sync.Mutex
-	baseURL           string
 	nextID            int
 	assets            map[int]fakeGiteeAsset
 	uploadCalls       map[string]int
 	dropFirstResponse bool
 	droppedResponse   bool
 	failUploads       bool
+	uploadDelay       time.Duration
 }
 
 func newFakeGiteeRelease(dropFirstResponse, failUploads bool) *fakeGiteeRelease {
@@ -289,7 +444,7 @@ func (f *fakeGiteeRelease) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	const attachPath = "/repos/owner/repo/releases/1/attach_files"
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == attachPath:
-		f.list(w)
+		f.list(w, r)
 	case r.Method == http.MethodPost && r.URL.Path == attachPath:
 		f.upload(w, r)
 	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, attachPath+"/"):
@@ -301,15 +456,16 @@ func (f *fakeGiteeRelease) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (f *fakeGiteeRelease) list(w http.ResponseWriter) {
+func (f *fakeGiteeRelease) list(w http.ResponseWriter, r *http.Request) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	baseURL := requestBaseURL(r)
 	rows := make([]map[string]any, 0, len(f.assets))
 	for _, asset := range f.assets {
 		rows = append(rows, map[string]any{
 			"id":                   asset.id,
 			"name":                 asset.name,
-			"browser_download_url": fmt.Sprintf("%s/download/%d", f.baseURL, asset.id),
+			"browser_download_url": fmt.Sprintf("%s/download/%d", baseURL, asset.id),
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -332,6 +488,10 @@ func (f *fakeGiteeRelease) upload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if f.uploadDelay > 0 {
+		time.Sleep(f.uploadDelay)
+	}
+	baseURL := requestBaseURL(r)
 
 	f.mu.Lock()
 	f.uploadCalls[header.Filename]++
@@ -366,8 +526,16 @@ func (f *fakeGiteeRelease) upload(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"id":                   id,
 		"name":                 header.Filename,
-		"browser_download_url": fmt.Sprintf("%s/download/%d", f.baseURL, id),
+		"browser_download_url": fmt.Sprintf("%s/download/%d", baseURL, id),
 	})
+}
+
+func requestBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
 }
 
 func (f *fakeGiteeRelease) delete(w http.ResponseWriter, rawID string) {


### PR DESCRIPTION
## Summary

- make Gitee release-tag mirroring immutable and idempotent: skip an aligned tag, push only a missing tag, and fail closed on a conflicting tag
- replace nested attachment retries with one bounded retry owner and probe Gitee after a lost HTTP response before uploading again
- reconcile the complete eight-asset release set through one shared implementation used by GitHub fallback sync and Gitee-local publishing
- enforce one 5,700-second deadline across tag sync, release lookup/create, and asset reconciliation
- isolate the optional release fallback in its own 120-minute job and bound checkout, artifact download, and sync steps independently
- hard-fail on missing, duplicate, stale, failed, or deadline-exhausted assets

## Root cause

Three independent Gitee failure modes were present:

1. The code mirror always force-pushed a release tag. Gitee rejects an update when the tag ref already exists, even when Git is invoked with `--force`, so rerunning `v1.0.52-beta.5` failed with `reference already exists`.
2. Attachment upload had three outer attempts and two curl retries inside every attempt, each with a five-minute request timeout. One file could consume about 45 minutes while the repair job had a 60-minute budget. Individual upload failures were also downgraded to warnings, so a run could finish successfully with missing assets.
3. The first deadline fix covered only the reconciler. Tag fetch/push/verification, release lookup/create, checkout, and release download still shared an unproven job-level budget, so the script could not guarantee that it would exit before the workflow timeout.

Evidence:

- tag mirror failure: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/29379912687
- attachment sync timeout: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/29381405032

## Review fixes

1. **Complete retry budget:** every asset has a 600-second deadline and the reconciler has a 4,920-second overall deadline. List, download verification, delete, upload, and retry sleeps all clip themselves to the remaining deadline.
2. **Missing local tags:** `git rev-parse --verify` is required. Missing-tag and failed-fetch cases return an explicit local-resolution error instead of treating `<tag>^{commit}` as a commit.
3. **Race-free fake server:** test download URLs are derived from the incoming request host; the mutable `baseURL` field and post-start write were removed.
4. **Full-path deadline:** `sync-to-gitee.sh` owns a 5,700-second deadline. It passes an absolute parent deadline into tag synchronization, clips release API calls to remaining time, and passes the remaining reconciler budget to `reconcile-gitee-assets.sh`.
5. **Bounded tag operations on every runner:** fetch, lookup, push, and verification use the smaller of the per-command and tag deadlines. GNU `timeout`/`gtimeout` is preferred, with a Python process-group timeout fallback.
6. **Provable workflow pre-steps:** manual and release-fallback syncs run in isolated 120-minute jobs with 5-minute checkout, 10-minute artifact download, and 100-minute sync step ceilings.
7. **Executable full-path regression:** a local bare Git remote plus fake Gitee API runs the real tag -> release lookup/create -> eight-asset reconciliation path successfully; separate slow-fetch, slow-release-API, and slow-upload cases verify each enclosing deadline.
8. **Reproducibility:** environment, fixtures, credentials, acceptance mapping, expected results, observed results, and live-test boundaries are recorded below.

## Runtime budget

| Budget component | Default |
|---|---:|
| Tag synchronization | 300 seconds |
| Release lookup | 60 seconds |
| Release creation | 60 seconds |
| Asset reconciler | 4,920 seconds |
| Complete allocated script path | 5,340 seconds |
| `sync-to-gitee.sh` overall deadline | 5,700 seconds (95 minutes) |
| Workflow sync step | 6,000 seconds (100 minutes) |
| Checkout + artifact download | 15 minutes |
| Manual/fallback job | 7,200 seconds (120 minutes) |

This leaves six minutes inside the script, five minutes between the script and sync-step deadlines, and five minutes at job level after the three step ceilings. The test reads defaults from the actual scripts and workflow YAML, computes the complete tag + lookup + create + reconcile budget, verifies nested reconciler/per-asset budgets, and proves both workflow job allocations.

## Behavior after this change

- Published tags are never deleted, recreated, or moved.
- A repeated sync of an already-correct tag performs no push.
- A missing local tag cannot become a fake commit string.
- Slow tag Git operations and release API calls consume the same outer deadline as attachment reconciliation.
- A timed-out upload response is followed by a name/count/SHA probe; if Gitee committed the bytes, the sync continues without creating a duplicate.
- Every release must end with exactly one byte-verified copy of each of the six platform archives, `dws-skills.zip`, and `checksums.txt`.
- Any unresolved upload, deadline exhaustion, or final completeness mismatch returns non-zero.

## Reproduction environment

- OS/arch: macOS 15.5, Darwin 24.5.0, arm64
- Go: `go1.25.9 darwin/arm64`
- Bash: GNU bash `3.2.57(1)-release`
- Git: `2.39.5 (Apple Git-154)`
- staticcheck: `2026.1 (v0.7.0)`, resolved by `scripts/dev/lint.sh` from `$(go env GOPATH)/bin`
- GitHub CLI: `2.89.0`

Fixtures and prerequisites:

- tag tests use temporary local Git worktrees and bare repositories; no network or credentials
- attachment/full-path tests use `httptest.Server` plus a temporary `dist/` containing the exact eight required fixture filenames
- focused tests require Go, Bash, Git, curl, Python 3, and a SHA-256 utility; no Gitee token
- the read-only live tag check uses the public Gitee Git endpoint and an intentionally unusable write URL
- **no real Gitee release attachment was created, deleted, or replaced during validation**; attachment mutation is covered by the fake server only

## Acceptance criteria and verification

| Acceptance criterion | Verification | Expected | Observed |
|---|---|---|---|
| aligned immutable tag does not push | focused tag tests + read-only `v1.0.52` live check | skip push at the peeled commit | PASS; skipped at `4e59f9aa7ab057da8d5512ae9818fb66d4c6a045` |
| conflicting tag never moves | `TestSyncGiteeTagRefusesToMoveAnExistingTag` | non-zero and original remote commit retained | PASS |
| missing/fetch-failed tag is not misclassified | missing-tag and fetch-failure tests | explicit local resolution failure; no literal `^{commit}` | PASS |
| tag fetch cannot exceed its budget | `TestSyncGiteeTagHonorsItsDeadlineDuringFetch` | slow fetch is terminated with a deadline error | PASS |
| full path shares one outer deadline | `TestSyncGiteeTagAndReleasePathShareOneOverallDeadline` | tag succeeds; slow release lookup exits on the outer deadline | PASS, including `-race` |
| tag, release create, and reconcile execute together | `TestSyncToGiteeRunsTagReleaseCreationAndAssetReconciliationWithinOneBudget` | one lookup, one create, one upload for each of eight assets | PASS, including `-race` |
| lost upload response does not duplicate | fake Gitee lost-response test | one upload per asset and all eight verified | PASS |
| upload failure remains a hard failure | fake Gitee failure test | non-zero with incomplete release | PASS |
| complete script and workflow budgets fit | computed script/workflow budget test | all child budgets plus reserves fit their parent deadlines | PASS |
| repository contracts stay intact | full test and policy checks | no release-sync regression | PASS |

## Commands: expected and observed

| Command | Expected | Observed |
|---|---|---|
| `go test ./test/scripts -run 'TestSyncGiteeTag|TestSyncToGitee|TestReconcileGiteeAssets|TestGiteeWorkflows' -count=1` | all focused cases pass | PASS |
| `go test -race ./test/scripts -run 'TestSyncGiteeTag|TestSyncToGitee|TestReconcileGiteeAssets|TestGiteeWorkflows' -count=1` | focused cases pass without races | PASS |
| `go test ./test/scripts -count=1` | all release-script tests pass | PASS |
| `DWS_PACKAGE_VERSION=0.0.0-test go test ./...` | repository-prescribed full suite passes | PASS |
| `make policy` | policy, generated drift, schema contract, and example gates pass | PASS |
| `bash -n scripts/release/*.sh` | all release scripts parse | PASS |
| `rg --files .github/workflows \| xargs go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7` | every workflow is valid | PASS |
| `git diff --check` | no whitespace errors | PASS |
| `go build ./cmd` | repository guide build | FAILS before compilation because output path `cmd` is an existing directory |
| `go build -o /tmp/dws-gitee-sync-pr622-v2 ./cmd` | equivalent explicit-output build | PASS |
| `make lint` | gofmt, vet, and staticcheck | gofmt/vet pass; staticcheck stops on pre-existing unchanged `internal/generator/agentmetadata/metadata.go:372:27` ST1005 |
| `DWS_PACKAGE_VERSION=0.0.0-test go test ./... -count=1` | extra uncached diagnostic | previously timed out after 10 minutes in unchanged `TestIntegration_BusRestartConsumerReconnects`; all reported remaining packages, including `test/scripts`, passed |

The uncached consume timeout and ST1005 file are outside this PR's diff. They are retained as environment/baseline observations rather than reported as successful gates. Checks for the updated head run after push.

## Scope

This PR changes only Gitee code/release mirroring and its tests/workflow budgets. It does not change installers, package contents, release versioning, or the Gitee Go pipeline definition.

## Risk and rollback

The main behavior change is stricter, earlier failure reporting: an incomplete or over-budget Gitee release keeps CI red instead of emitting a warning. The sync remains rerunnable and self-healing. Reverting this PR restores the previous behavior; no migration or published-tag mutation is involved.
