### PR TITLE
refactor(policy): reuse built binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,9 +291,6 @@ jobs:
       - name: Policy
         run: make policy
 
-      - name: Generated Drift
-        run: ./scripts/policy/check-generated-drift.sh
-
   interface-integrity:
     name: Interface Integrity
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 GO ?= go
+DWS_POLICY_TMPDIR ?= $(CURDIR)/.worktrees/policy-tmp
+POLICY_GOTMPDIR ?= $(DWS_POLICY_TMPDIR)/go
+POLICY_ENV = DWS_POLICY_TMPDIR="$(DWS_POLICY_TMPDIR)" GOTMPDIR="$(POLICY_GOTMPDIR)"
 
 .PHONY: all help build rebuild test lint fmt policy edition-test interface-integrity authoritative-interface-integrity coverage-gate coverage-gate-platform update-interface-baseline reset-interface-baseline schema-compatibility skill-command-integrity cli-smoke mock-mcp-smoke test-schema-agent-examples generate-schema generate-schema-agent-metadata generate-schema-catalog package release publish-homebrew-formula setup-hooks
 
@@ -10,7 +13,7 @@ help:
 	@printf "  make test          - Run the Go test suite\n"
 	@printf "  make lint          - Run formatting checks and golangci-lint when available\n"
 	@printf "  make fmt           - Format Go source files\n"
-	@printf "  make policy        - Run open-source asset and Schema registry checks\n"
+	@printf "  make policy        - Check the built dws plus open-source and Schema policies\n"
 	@printf "  make interface-integrity - Check historical commands and help contracts still work\n"
 	@printf "  make authoritative-interface-integrity BASE_REF=<ref> - Check the Git-owned PR merge-base\n"
 	@printf "  make coverage-gate BASE_REF=<ref> - Enforce overall non-regression and changed-code coverage\n"
@@ -45,13 +48,14 @@ fmt:
 	@find cmd internal test scripts/policy -name '*.go' -print0 2>/dev/null | xargs -0r gofmt -w
 
 policy:
-	@./scripts/policy/check-open-source-assets.sh
-	@./scripts/policy/check-schema-command-registry.sh
-	@./scripts/policy/check-command-surface.sh --strict
-	@./scripts/policy/check-generated-drift.sh
-	@./scripts/policy/check-schema-catalog.sh
-	@./scripts/policy/check-schema-binary.sh
-	@$(MAKE) test-schema-agent-examples
+	@mkdir -p "$(POLICY_GOTMPDIR)"
+	@$(POLICY_ENV) ./scripts/policy/check-open-source-assets.sh
+	@$(POLICY_ENV) ./scripts/policy/check-schema-command-registry.sh
+	@$(POLICY_ENV) ./scripts/policy/check-command-surface.sh --strict
+	@$(POLICY_ENV) ./scripts/policy/check-generated-drift.sh
+	@$(POLICY_ENV) ./scripts/policy/check-schema-catalog.sh
+	@$(POLICY_ENV) ./scripts/policy/check-schema-binary.sh
+	@$(POLICY_ENV) $(MAKE) test-schema-agent-examples
 
 edition-test:
 	$(GO) test -v -count=1 ./pkg/editiontest/...

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,7 @@ These repo-local entrypoints are the supported shell entrypoints for building, t
 - `make test`: run `go test ./...`
 - `make lint`: run formatting checks and required `golangci-lint`
 - `make fmt`: format Go source files under `cmd/`, `internal/`, and `test/`
+- `make policy`: reuse the current `dws` binary and run the complete policy suite (`make build` first)
 - `make package`: build all release artifacts locally via `goreleaser --snapshot`
 - `make release`: build and publish a release via `goreleaser`
 
@@ -15,4 +16,5 @@ Script groups:
 - Product convenience installers: `./scripts/install-devapp.sh`, `./scripts/install-devapp.ps1`, `./scripts/install-event.sh`
 - Dev helpers: `./scripts/dev/build.sh`, `./scripts/dev/lint.sh`, `./scripts/dev/ci-local.sh`, `./scripts/dev/run-mock-e2e.sh`, `./scripts/dev/coverage.sh`
 - Policy checks: `./scripts/policy/check-schema-command-registry.sh`, `./scripts/policy/check-generated-drift.sh`, `./scripts/policy/check-command-surface.sh`, `./scripts/policy/check-schema-catalog.sh`, `./scripts/policy/check-schema-binary.sh`, `./scripts/policy/check-open-source-assets.sh`
+- Policy runtime files: set `DWS_POLICY_TMPDIR` to override the default `.worktrees/policy-tmp` workspace
 - Release helpers: `./scripts/release/post-goreleaser.sh`, `./scripts/release/verify-package-managers.sh`, `./scripts/release/publish-homebrew-formula.sh`

--- a/scripts/policy/check-authoritative-interface-baselines.sh
+++ b/scripts/policy/check-authoritative-interface-baselines.sh
@@ -34,12 +34,15 @@ done
 [ -n "$BASE_REF" ] || { usage; exit 2; }
 
 cd "$ROOT"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
+
 git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null || {
   printf 'error: interface authority is not available locally: %s\n' "$BASE_REF" >&2
   exit 2
 }
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dws-interface-authority.XXXXXX")"
+TMP_ROOT="$(policy_runtime_mktemp_dir dws-interface-authority)"
 BASE_WORKTREE="$TMP_ROOT/base-worktree"
 BASELINE="$TMP_ROOT/merge-base.txt"
 CANDIDATE_BIN="$TMP_ROOT/interface-baseline"

--- a/scripts/policy/check-authoritative-schema-compatibility.sh
+++ b/scripts/policy/check-authoritative-schema-compatibility.sh
@@ -35,6 +35,9 @@ done
 [ -n "$BASE_REF" ] || { usage; exit 2; }
 
 cd "$ROOT"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
+
 git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null || {
 	printf 'error: Schema authority is not available locally: %s\n' "$BASE_REF" >&2
 	exit 2
@@ -44,7 +47,7 @@ if [ ! -x "$BIN" ]; then
 	exit 2
 fi
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dws-schema-authority.XXXXXX")"
+TMP_ROOT="$(policy_runtime_mktemp_dir dws-schema-authority)"
 BASE_WORKTREE="$TMP_ROOT/base-worktree"
 BASE_BIN="$TMP_ROOT/base-dws"
 BASE_RAW="$TMP_ROOT/base-schema.json"

--- a/scripts/policy/check-command-surface.sh
+++ b/scripts/policy/check-command-surface.sh
@@ -5,6 +5,7 @@ set -eu
 # Stub placeholder — extend with actual surface comparison logic as needed.
 
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+BIN="${DWS_BIN:-$ROOT/dws}"
 
 STRICT=0
 if [ "${1:-}" = "--strict" ]; then
@@ -13,32 +14,27 @@ fi
 
 cd "$ROOT"
 
-# Verify that all expected top-level commands exist in the built binary
-if command -v go >/dev/null 2>&1; then
-  BIN_PATH="/tmp/dws-surface-check"
-  trap 'rm -f "$BIN_PATH"' EXIT HUP INT TERM
-  go build -ldflags="-s -w" -o "$BIN_PATH" ./cmd 2>/dev/null || { echo "build failed";  exit 1; }
+if [ ! -x "$BIN" ]; then
+  printf 'error: dws binary not found at %s (run make build first)\n' "$BIN" >&2
+  exit 2
+fi
 
-  # These utility commands are stable across the current open-source CLI shape.
-  EXPECTED_COMMANDS="auth cache completion version"
-  missing=0
-  for cmd in $EXPECTED_COMMANDS; do
-    # Use `help <command>` so hidden commands are also validated.
-    if ! "$BIN_PATH" help "$cmd" >/dev/null 2>&1; then
-      printf 'missing command: %s\n' "$cmd" >&2
-      missing=$((missing + 1))
-    fi
-  done
-
-  # Full Schema canonical/primary/alias delivery is exercised once by
-  # check-schema-binary.sh. Keep this check focused on the basic command tree.
-  rm -f "$BIN_PATH"
-  trap - EXIT HUP INT TERM
-
-  if [ "$STRICT" -eq 1 ] && [ "$missing" -gt 0 ]; then
-    printf 'command surface check: %d missing commands\n' "$missing" >&2
-    exit 1
+# These utility commands are stable across the current open-source CLI shape.
+EXPECTED_COMMANDS="auth cache completion version"
+missing=0
+for cmd in $EXPECTED_COMMANDS; do
+  # Use `help <command>` so hidden commands are also validated.
+  if ! "$BIN" help "$cmd" >/dev/null 2>&1; then
+    printf 'missing command: %s\n' "$cmd" >&2
+    missing=$((missing + 1))
   fi
+done
+
+# Full Schema canonical/primary/alias delivery is exercised once by
+# check-schema-binary.sh. Keep this check focused on the basic command tree.
+if [ "$STRICT" -eq 1 ] && [ "$missing" -gt 0 ]; then
+  printf 'command surface check: %d missing commands\n' "$missing" >&2
+  exit 1
 fi
 
 printf 'command surface check: ok\n'

--- a/scripts/policy/check-coverage-gate.sh
+++ b/scripts/policy/check-coverage-gate.sh
@@ -56,13 +56,21 @@ done
 
 [ -n "$BASE_REF" ] || { usage; exit 2; }
 cd "$ROOT"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
+
 git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null || {
   printf 'error: coverage base ref is not available locally: %s\n' "$BASE_REF" >&2
   exit 2
 }
 
+TMP_ROOT="$(policy_runtime_mktemp_dir dws-coverage-gate)"
+CHECKER="$TMP_ROOT/coverage-gate"
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+go build -o "$CHECKER" ./scripts/policy/coverage-gate
+
 module="$(go list -m -f '{{.Path}}')"
-set -- go run ./scripts/policy/coverage-gate \
+set -- "$CHECKER" \
   --diff-profile "$DIFF_PROFILE" \
   --base-ref "$BASE_REF" \
   --module "$module" \

--- a/scripts/policy/check-generated-drift.sh
+++ b/scripts/policy/check-generated-drift.sh
@@ -7,9 +7,17 @@ set -eu
 
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$ROOT"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+exec_tmp="$(policy_runtime_mktemp_dir dws-generated-drift)"
+metadata_generator="$exec_tmp/schema-agent-metadata"
+catalog_generator="$exec_tmp/schema-catalog"
+trap 'rm -rf "$tmp" "$exec_tmp"' EXIT HUP INT TERM
+
+go build -o "$metadata_generator" ./internal/generator/cmd_schema_agent_metadata
+go build -a -o "$catalog_generator" ./internal/generator/cmd_schema_catalog
 
 # CommandRegistry is a reviewed input, never a generated artifact. Keep an
 # independent byte-for-byte guard around the ordinary downstream generators.
@@ -26,7 +34,7 @@ audit_tmp="$tmp/audit.json"
 catalog_tmp="$tmp/catalog.json"
 catalog_tmp_second="$tmp/catalog-second.json"
 
-go run ./internal/generator/cmd_schema_agent_metadata \
+"$metadata_generator" \
   -root . \
   -registry internal/cli/schema_command_registry.json \
   -output-dir "$metadata_tmp" \
@@ -46,11 +54,11 @@ if ! cmp -s internal/cli/schema_agent_metadata_audit.json "$audit_tmp"; then
 	exit 1
 fi
 
-go run -a ./internal/generator/cmd_schema_catalog \
+"$catalog_generator" \
 	-root . \
 	-output "$catalog_tmp"
 
-go run -a ./internal/generator/cmd_schema_catalog \
+"$catalog_generator" \
 	-root . \
 	-output "$catalog_tmp_second"
 

--- a/scripts/policy/check-interface-baseline.sh
+++ b/scripts/policy/check-interface-baseline.sh
@@ -7,12 +7,17 @@ set -eu
 
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 BASELINE="${INTERFACE_BASELINE:-$ROOT/test/fixtures/cli-interface-baseline.txt}"
-SNAPSHOT_HOME="$(mktemp -d)"
-SNAPSHOT_BIN="$(mktemp)"
-CURRENT="$(mktemp)"
-trap 'rm -rf "$CURRENT" "$SNAPSHOT_HOME" "$SNAPSHOT_BIN"' EXIT
-
 cd "$ROOT"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
+
+TMP_ROOT="$(policy_runtime_mktemp_dir dws-interface-baseline)"
+SNAPSHOT_HOME="$TMP_ROOT/home"
+SNAPSHOT_BIN="$TMP_ROOT/interface-baseline"
+CURRENT="$TMP_ROOT/current.txt"
+mkdir -p "$SNAPSHOT_HOME"
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
 # Compile with the caller's normal Go cache, then isolate only the execution
 # HOME so user-installed DWS plugins cannot alter the public command tree.
 go build -o "$SNAPSHOT_BIN" ./scripts/policy/interface-baseline

--- a/scripts/policy/check-schema-binary.sh
+++ b/scripts/policy/check-schema-binary.sh
@@ -2,16 +2,26 @@
 set -eu
 
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+BIN="${DWS_BIN:-$ROOT/dws}"
 cd "$ROOT"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
+
+if [ ! -x "$BIN" ]; then
+	printf 'error: dws binary not found at %s (run make build first)\n' "$BIN" >&2
+	exit 2
+fi
 
 tmp="$(mktemp -d)"
-trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+exec_tmp="$(policy_runtime_mktemp_dir dws-schema-binary)"
+smoke_generator="$exec_tmp/schema-registry-smoke"
+trap 'rm -rf "$tmp" "$exec_tmp"' EXIT HUP INT TERM
 
-go build -o "$tmp/dws" ./cmd
-go run ./internal/generator/cmd_schema_registry_smoke >"$tmp/smoke-vector.json"
+go build -o "$smoke_generator" ./internal/generator/cmd_schema_registry_smoke
+"$smoke_generator" >"$tmp/smoke-vector.json"
 
-"$tmp/dws" schema list --format json >"$tmp/list.json"
-"$tmp/dws" schema --all --format json >"$tmp/all.json"
+"$BIN" schema list --format json >"$tmp/list.json"
+"$BIN" schema --all --format json >"$tmp/all.json"
 
 if ! jq -e '
   .version == 1 and
@@ -111,8 +121,8 @@ while IFS= read -r command; do
 	canonical="$(printf '%s\n' "$command" | jq -r '.canonical_path')"
 	primary="$(printf '%s\n' "$command" | jq -r '.primary_cli_path')"
 
-	"$tmp/dws" schema "$canonical" --format json >"$tmp/canonical.json"
-	"$tmp/dws" schema --cli-path "$primary" --format json >"$tmp/primary.json"
+	"$BIN" schema "$canonical" --format json >"$tmp/canonical.json"
+	"$BIN" schema --cli-path "$primary" --format json >"$tmp/primary.json"
 	jq -S --arg canonical "$canonical" '
       [.products[].tools[] | select(.canonical_path == $canonical)] |
       if length == 1 then .[0] else null end
@@ -132,8 +142,8 @@ alias_command="$(jq -c 'first(.commands[] | select((.alias_cli_paths | length) >
 if [ -n "$alias_command" ]; then
 	canonical="$(printf '%s\n' "$alias_command" | jq -r '.canonical_path')"
 	alias_path="$(printf '%s\n' "$alias_command" | jq -r '.alias_cli_paths[0]')"
-	"$tmp/dws" schema "$canonical" --format json >"$tmp/canonical.json"
-	"$tmp/dws" schema --cli-path "$alias_path" --format json >"$tmp/alias.json"
+	"$BIN" schema "$canonical" --format json >"$tmp/canonical.json"
+	"$BIN" schema --cli-path "$alias_path" --format json >"$tmp/alias.json"
 	jq -S 'del(.cli_path, .is_alias)' "$tmp/canonical.json" >"$tmp/canonical-content.json"
 	jq -S 'del(.cli_path, .is_alias)' "$tmp/alias.json" >"$tmp/alias-content.json"
 	if ! cmp -s "$tmp/canonical-content.json" "$tmp/alias-content.json"; then

--- a/scripts/policy/check-schema-catalog.sh
+++ b/scripts/policy/check-schema-catalog.sh
@@ -4,6 +4,8 @@ set -eu
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$ROOT"
 . "$ROOT/scripts/policy/search.sh"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
 
 if [ -e internal/cli/schema_native_contracts.go ] ||
 	[ -e internal/cli/schema_native_contracts_generated.go ] ||

--- a/scripts/policy/check-schema-command-registry.sh
+++ b/scripts/policy/check-schema-command-registry.sh
@@ -8,6 +8,8 @@ set -eu
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 cd "$ROOT"
 . "$ROOT/scripts/policy/search.sh"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
 
 if [ -e internal/cli/schema_native_contracts.go ] ||
 	[ -e internal/cli/schema_native_contracts_generated.go ] ||

--- a/scripts/policy/check-skill-commands.sh
+++ b/scripts/policy/check-skill-commands.sh
@@ -2,10 +2,15 @@
 set -eu
 
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
-CHECKER="$(mktemp)"
-CHECK_HOME="$(mktemp -d)"
-trap 'rm -rf "$CHECKER" "$CHECK_HOME"' EXIT
-
 cd "$ROOT"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
+
+TMP_ROOT="$(policy_runtime_mktemp_dir dws-skill-command-check)"
+CHECKER="$TMP_ROOT/skill-command-check"
+CHECK_HOME="$TMP_ROOT/home"
+mkdir -p "$CHECK_HOME"
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
 go build -o "$CHECKER" ./scripts/policy/skill-command-check
 HOME="$CHECK_HOME" DWS_LANG=zh "$CHECKER"

--- a/scripts/policy/policy-runtime.sh
+++ b/scripts/policy/policy-runtime.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Shared runtime workspace for policy helpers that compile and execute Go
+# programs. Callers may override DWS_POLICY_TMPDIR and GOTMPDIR.
+policy_prepare_runtime() {
+	policy_root="$1"
+	DWS_POLICY_TMPDIR="${DWS_POLICY_TMPDIR:-$policy_root/.worktrees/policy-tmp}"
+	mkdir -p "$DWS_POLICY_TMPDIR/go"
+	DWS_POLICY_TMPDIR="$(CDPATH= cd -- "$DWS_POLICY_TMPDIR" && pwd)"
+	export DWS_POLICY_TMPDIR
+
+	if [ -z "${GOTMPDIR:-}" ]; then
+		GOTMPDIR="$DWS_POLICY_TMPDIR/go"
+	fi
+	mkdir -p "$GOTMPDIR"
+	GOTMPDIR="$(CDPATH= cd -- "$GOTMPDIR" && pwd)"
+	export GOTMPDIR
+}
+
+policy_runtime_mktemp_dir() {
+	prefix="$1"
+	mktemp -d "$DWS_POLICY_TMPDIR/${prefix}.XXXXXX"
+}

--- a/scripts/policy/run-platform-coverage-gate.sh
+++ b/scripts/policy/run-platform-coverage-gate.sh
@@ -39,12 +39,15 @@ done
 
 [ -n "$BASE_REF" ] && [ -n "$PROFILE" ] || { usage; exit 2; }
 cd "$ROOT"
+. "$ROOT/scripts/policy/policy-runtime.sh"
+policy_prepare_runtime "$ROOT"
+
 git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null || {
 	printf 'error: coverage base ref is not available locally: %s\n' "$BASE_REF" >&2
 	exit 2
 }
 
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dws-platform-coverage.XXXXXX")"
+TMP_ROOT="$(policy_runtime_mktemp_dir dws-platform-coverage)"
 PACKAGES="$TMP_ROOT/packages"
 SORTED_PACKAGES="$TMP_ROOT/packages.sorted"
 cleanup() {

--- a/test/scripts/install_script_test.go
+++ b/test/scripts/install_script_test.go
@@ -577,8 +577,8 @@ func TestBuildEntrypointsUseStripLdflags(t *testing.T) {
 			want:    `go build -ldflags="-s -w" -o $tmpBin "$Root/cmd"`,
 		},
 		{
-			relPath: filepath.Join("..", "..", "scripts", "policy", "check-command-surface.sh"),
-			want:    `go build -ldflags="-s -w" -o "$BIN_PATH" ./cmd`,
+			relPath: filepath.Join("..", "..", "scripts", "dev", "build.sh"),
+			want:    `-ldflags="-s -w"`,
 		},
 	}
 
@@ -595,6 +595,32 @@ func TestBuildEntrypointsUseStripLdflags(t *testing.T) {
 
 		if !strings.Contains(string(data), tc.want) {
 			t.Fatalf("%s missing stripped ldflags build invocation %q", scriptPath, tc.want)
+		}
+	}
+}
+
+func TestPolicyBinaryChecksReuseBuiltDWS(t *testing.T) {
+	t.Parallel()
+
+	for _, relPath := range []string{
+		filepath.Join("..", "..", "scripts", "policy", "check-command-surface.sh"),
+		filepath.Join("..", "..", "scripts", "policy", "check-schema-binary.sh"),
+	} {
+		scriptPath, err := filepath.Abs(relPath)
+		if err != nil {
+			t.Fatalf("Abs(%s) error = %v", relPath, err)
+		}
+		data, err := os.ReadFile(scriptPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", scriptPath, err)
+		}
+		text := string(data)
+		if !strings.Contains(text, `BIN="${DWS_BIN:-$ROOT/dws}"`) {
+			t.Fatalf("%s does not reuse DWS_BIN", scriptPath)
+		}
+		if strings.Contains(text, `go build -o "$tmp/dws" ./cmd`) ||
+			strings.Contains(text, `go build -ldflags="-s -w"`) {
+			t.Fatalf("%s unexpectedly rebuilds dws", scriptPath)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- reuse the CI-built `dws` binary in command-surface and Schema binary checks instead of rebuilding the CLI inside each script
- add a shared, configurable Policy runtime workspace for temporary Go executables and checker worktrees
- build Schema generators once per check and reuse them for deterministic repeated output validation
- remove the duplicated Generated Drift workflow step because `make policy` already runs it

## Behavior

- `make policy` now expects a current `dws` binary; run `make build` first or provide `DWS_BIN`
- historical Interface and Schema authority checks still build their referenced source revisions as required
- `DWS_POLICY_TMPDIR` and `POLICY_GOTMPDIR` can override the default Policy runtime workspace

## Verification

- `make build`
- `make policy` (verified the `dws` SHA-256 and mtime were unchanged across the Policy run)
- `make interface-integrity`
- `make skill-command-integrity`
- `make authoritative-interface-integrity BASE_REF=upstream/main^`
- `make schema-compatibility BASE_REF=upstream/main^`
- `make coverage-gate-platform BASE_REF=upstream/main PROFILE=<temp-profile>`
- `go test ./scripts/policy/... -count=1`
- `HOME=<isolated-home> go test ./test/scripts -count=1`
- shell syntax checks for every `scripts/policy/*.sh`
