### PR TITLE
test(cli): make permission test portable on Windows

### DIFF
--- a/internal/cli/stdin_test.go
+++ b/internal/cli/stdin_test.go
@@ -16,6 +16,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -201,6 +202,9 @@ func TestReadFileBoundedEmptyFile(t *testing.T) {
 
 func TestReadFileBoundedPermissionDenied(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows os.Chmod does not remove read permission, so mode 000 cannot exercise this error path")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "noperm.txt")
 	writeTestFile(t, path, []byte("secret"))


### PR DESCRIPTION
## Summary

- skip the POSIX chmod(000) permission-denied case on Windows
- keep production code and CI workflows unchanged
- isolate the remaining Windows Coverage baseline fix from PAT feature work

## Validation

- go test -count=1 ./internal/cli
- Windows amd64 test binary cross-build
- focused permission test on Darwin

This is intentionally separate from #628 and does not overlap its auth/app fixes.