### PR TITLE
ci(schema): support jq 1.8 policy evaluation

### DIFF
--- a/scripts/policy/check-schema-catalog.sh
+++ b/scripts/policy/check-schema-catalog.sh
@@ -196,6 +196,10 @@ fi
 binding_count="$(jq '[.bindings[] | length] | add' internal/cli/schema_parameter_bindings.json)"
 if ! jq -e --slurpfile bindings internal/cli/schema_parameter_bindings.json '
   . as $catalog |
+  ([$bindings[0].bindings | to_entries[] |
+    .key as $tool | .value | to_entries[] |
+    {tool: $tool, flag: .key, property: .value}
+  ]) as $expected |
   $bindings[0].version == 3 and
   $bindings[0].baseline.manifest == "schema-parameter-bindings-v3" and
   ($bindings[0].baseline.sha256 | test("^sha256:[0-9a-f]{64}$")) and
@@ -218,10 +222,6 @@ if ! jq -e --slurpfile bindings internal/cli/schema_parameter_bindings.json '
   all(($bindings[0].mapping_exclusions // {} | to_entries)[];
     (.key | length) > 0 and (.value | length) > 0
   ) and
-  ([$bindings[0].bindings | to_entries[] |
-    .key as $tool | .value | to_entries[] |
-    {tool: $tool, flag: .key, property: .value}
-  ]) as $expected |
   all($expected[];
     . as $binding |
     $catalog.tools[$binding.tool].parameters[$binding.flag].property == $binding.property


### PR DESCRIPTION
## Summary

- bind the generated parameter mapping before the boolean validation chain
- avoid jq 1.8 parsing the late `as $expected` expression against the boolean pipeline result
- keep the validated catalog/binding contract unchanged

## Why this is separate

This is a pre-existing engineering-gate portability bug exposed while validating the PAT authorization PR. It is isolated from product behavior and from the schema migration governance PR.

## Verification

- `jq --version` → `jq-1.8.1`
- `sh -n scripts/policy/check-schema-catalog.sh`
- `./scripts/policy/check-schema-catalog.sh`
- `make policy`
- `git diff --check`
