### PR TITLE
fix(auth): refresh rejected tokens and retry once

### DIFF
--- a/internal/app/auth_refresh_retry.go
+++ b/internal/app/auth_refresh_retry.go
@@ -15,6 +15,16 @@ package app
 
 import (
 	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/authretry"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
 
 // authRetryingKey marks a context that has already attempted one
@@ -33,4 +43,115 @@ func IsAuthRetrying(ctx context.Context) bool {
 	}
 	v, _ := ctx.Value(authRetryingKey).(bool)
 	return v
+}
+
+func withAuthRetrying(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, authRetryingKey, true)
+}
+
+var forceRefreshRejectedTokenFunc = ForceRefreshRejectedToken
+
+func (r *runtimeRunner) maybeAuthRefreshRetry(
+	ctx context.Context,
+	endpoint string,
+	invocation executor.Invocation,
+	rejectedAccessToken string,
+	sourceErr error,
+	refresh *authretry.AuthRefreshRequired,
+) (executor.Result, error) {
+	originalErr := authRefreshCause(refresh, sourceErr)
+	if refresh == nil || !authRefreshAllowed(sourceErr, originalErr) {
+		return executor.Result{}, originalErr
+	}
+	if IsAuthRetrying(ctx) {
+		credentialDeleted, cleanupFailed := purgeCurrentAuthCredentials(ctx, rejectedAccessToken)
+		logAuthRefreshRecovery("retry_exhausted", invocation, credentialDeleted, cleanupFailed)
+		return executor.Result{}, originalErr
+	}
+
+	if _, err := forceRefreshRejectedTokenFunc(ctx, defaultConfigDir(), rejectedAccessToken); err != nil {
+		credentialDeleted, cleanupFailed := purgeCurrentAuthCredentials(ctx, rejectedAccessToken)
+		logAuthRefreshRecovery("refresh_failed", invocation, credentialDeleted, cleanupFailed)
+		return executor.Result{}, originalErr
+	}
+	invalidateAuthCaches()
+	return r.executeInvocation(withAuthRetrying(ctx), endpoint, invocation)
+}
+
+func authRefreshCause(refresh *authretry.AuthRefreshRequired, fallback error) error {
+	if refresh != nil && refresh.Cause != nil {
+		return refresh.Cause
+	}
+	if fallback != nil {
+		return fallback
+	}
+	return refresh
+}
+
+func authRefreshAllowed(sourceErr, originalErr error) bool {
+	if apperrors.AsPatAuthCheckError(sourceErr) != nil || apperrors.AsPatAuthCheckError(originalErr) != nil {
+		return false
+	}
+	var patScope *PatScopeError
+	if errors.As(sourceErr, &patScope) || errors.As(originalErr, &patScope) {
+		return false
+	}
+	if isPatScopeError(sourceErr) || isPatScopeError(originalErr) {
+		return false
+	}
+
+	if authRefreshDeniedByTypedError(sourceErr) || authRefreshDeniedByTypedError(originalErr) {
+		return false
+	}
+	return true
+}
+
+func authRefreshDeniedByTypedError(err error) bool {
+	var typed *apperrors.Error
+	if !errors.As(err, &typed) {
+		return false
+	}
+	if typed.Reason == "http_403" || typed.RPCCode == http.StatusForbidden {
+		return true
+	}
+	switch strings.ToUpper(strings.TrimSpace(typed.ServerDiag.ServerErrorCode)) {
+	case "CLI_ORG_NOT_AUTHORIZED", "AUTH_PERMISSION_DENIED", "PERMISSION_DENIED":
+		return true
+	default:
+		return false
+	}
+}
+
+func purgeCurrentAuthCredentials(ctx context.Context, expectedAccessToken string) (bool, bool) {
+	deleted, err := authpkg.DeleteTokenDataIfAccessTokenMatches(ctx, defaultConfigDir(), expectedAccessToken)
+	invalidateAuthCaches()
+	return deleted, err != nil
+}
+
+func invalidateAuthCaches() {
+	ResetRuntimeTokenCache()
+	if fn := edition.Get().InvalidateAuthCaches; fn != nil {
+		fn()
+	}
+}
+
+func logAuthRefreshRecovery(reason string, invocation executor.Invocation, credentialDeleted, cleanupFailed bool) {
+	slog.Warn("runtime.auth_refresh_recovery",
+		"reason", reason,
+		"product", invocation.CanonicalProduct,
+		"tool", invocation.Tool,
+		"profile_selected", strings.TrimSpace(authpkg.RuntimeProfile()) != "",
+		"credential_deleted", credentialDeleted,
+		"credential_cleanup_failed", cleanupFailed,
+	)
+}
+
+func (r *runtimeRunner) canAutoRefreshAuth(hasPluginAuth bool) bool {
+	if r == nil || hasPluginAuth {
+		return false
+	}
+	return r.globalFlags == nil || strings.TrimSpace(r.globalFlags.Token) == ""
 }

--- a/internal/app/auth_refresh_retry_test.go
+++ b/internal/app/auth_refresh_retry_test.go
@@ -1,0 +1,496 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/transport"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/authretry"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
+)
+
+func TestRuntimeRunnerAuthRefreshFromHTTP401RetriesCurrentEndpoint(t *testing.T) {
+	configDir := setupRuntimeAuthRefreshTest(t, "corp-http-refresh", "old-access")
+	originalCause := errors.New("token rejected by HTTP 401")
+	var refreshes atomic.Int32
+	var invalidations atomic.Int32
+	var overlayTokenCache atomic.Value
+	overlayTokenCache.Store("old-access")
+	edition.Override(&edition.Hooks{
+		OnAuthError: func(_ string, err error) error {
+			var typed *apperrors.Error
+			if errors.As(err, &typed) && typed.Reason == "http_401" {
+				return &authretry.AuthRefreshRequired{Cause: originalCause}
+			}
+			return nil
+		},
+		TokenProvider: func(_ context.Context, fallback func() (string, error)) (string, error) {
+			if cached, _ := overlayTokenCache.Load().(string); cached != "" {
+				return cached, nil
+			}
+			token, err := fallback()
+			if err == nil {
+				overlayTokenCache.Store(token)
+			}
+			return token, err
+		},
+		InvalidateAuthCaches: func() {
+			overlayTokenCache.Store("")
+			invalidations.Add(1)
+		},
+	})
+	stubRejectedTokenRefresh(t, func(_ context.Context, gotConfigDir, rejected string) (string, error) {
+		refreshes.Add(1)
+		if gotConfigDir != configDir || rejected != "old-access" {
+			t.Fatalf("refresh args = (%q, %q), want (%q, old-access)", gotConfigDir, rejected, configDir)
+		}
+		return rotateRuntimeTestToken(t, gotConfigDir, "new-access"), nil
+	})
+
+	var calls atomic.Int32
+	server := newAuthRefreshMCPServer(t, func(token string) (int, map[string]any, bool) {
+		calls.Add(1)
+		if token == "old-access" {
+			return http.StatusUnauthorized, nil, false
+		}
+		if got := invalidations.Load(); got != 1 {
+			t.Errorf("cache invalidations before retry = %d, want 1", got)
+		}
+		return http.StatusOK, map[string]any{"success": true, "tokenGeneration": "new"}, false
+	})
+	defer server.Close()
+
+	result, err := newAuthRefreshRuntimeRunner(server).executeInvocation(context.Background(), server.URL, authRefreshTestInvocation())
+	if err != nil {
+		t.Fatalf("executeInvocation() error = %v", err)
+	}
+	if result.Response["endpoint"] != server.URL {
+		t.Fatalf("retry endpoint = %#v, want %q", result.Response["endpoint"], server.URL)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("MCP calls = %d, want 2", got)
+	}
+	if got := refreshes.Load(); got != 1 {
+		t.Fatalf("refreshes = %d, want 1", got)
+	}
+	if got := invalidations.Load(); got != 1 {
+		t.Fatalf("cache invalidations = %d, want 1", got)
+	}
+}
+
+func TestRuntimeRunnerAuthRefreshFromMCPBusinessMarker(t *testing.T) {
+	setupRuntimeAuthRefreshTest(t, "corp-mcp-refresh", "old-access")
+	originalCause := errors.New("TOKEN_VERIFIED_FAILED")
+	var refreshes atomic.Int32
+	edition.Override(&edition.Hooks{
+		ClassifyToolResult: func(content map[string]any) error {
+			if content["code"] == "TOKEN_VERIFIED_FAILED" {
+				return &authretry.AuthRefreshRequired{Cause: originalCause}
+			}
+			return nil
+		},
+	})
+	stubRejectedTokenRefresh(t, func(_ context.Context, configDir, rejected string) (string, error) {
+		refreshes.Add(1)
+		if rejected != "old-access" {
+			t.Fatalf("rejected token = %q, want old-access", rejected)
+		}
+		return rotateRuntimeTestToken(t, configDir, "new-access"), nil
+	})
+
+	var calls atomic.Int32
+	server := newAuthRefreshMCPServer(t, func(token string) (int, map[string]any, bool) {
+		calls.Add(1)
+		if token == "old-access" {
+			return http.StatusOK, map[string]any{"success": false, "code": "TOKEN_VERIFIED_FAILED"}, true
+		}
+		return http.StatusOK, map[string]any{"success": true}, false
+	})
+	defer server.Close()
+
+	if _, err := newAuthRefreshRuntimeRunner(server).executeInvocation(context.Background(), server.URL, authRefreshTestInvocation()); err != nil {
+		t.Fatalf("executeInvocation() error = %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("MCP calls = %d, want 2", got)
+	}
+	if got := refreshes.Load(); got != 1 {
+		t.Fatalf("refreshes = %d, want 1", got)
+	}
+}
+
+func TestRuntimeRunnerAuthRefreshFailurePurgesCredentialAndPreservesCause(t *testing.T) {
+	configDir := setupRuntimeAuthRefreshTest(t, "corp-refresh-failure", "old-access")
+	originalCause := errors.New("original auth failure")
+	edition.Override(&edition.Hooks{OnAuthError: func(_ string, _ error) error {
+		return &authretry.AuthRefreshRequired{Cause: originalCause}
+	}})
+	stubRejectedTokenRefresh(t, func(context.Context, string, string) (string, error) {
+		return "", errors.New("refresh exchange failed")
+	})
+
+	server := newAuthRefreshMCPServer(t, func(string) (int, map[string]any, bool) {
+		return http.StatusUnauthorized, nil, false
+	})
+	defer server.Close()
+
+	_, err := newAuthRefreshRuntimeRunner(server).executeInvocation(context.Background(), server.URL, authRefreshTestInvocation())
+	if !errors.Is(err, originalCause) {
+		t.Fatalf("executeInvocation() error = %v, want original cause", err)
+	}
+	if _, err := authpkg.LoadTokenData(configDir); err == nil {
+		t.Fatal("credential still exists after refresh failure")
+	}
+}
+
+func TestRuntimeRunnerAuthRefreshFailurePreservesConcurrentlyRotatedCredential(t *testing.T) {
+	configDir := setupRuntimeAuthRefreshTest(t, "corp-refresh-race", "old-access")
+	originalCause := errors.New("original auth failure")
+	edition.Override(&edition.Hooks{OnAuthError: func(_ string, _ error) error {
+		return &authretry.AuthRefreshRequired{Cause: originalCause}
+	}})
+	stubRejectedTokenRefresh(t, func(_ context.Context, gotConfigDir, rejected string) (string, error) {
+		if gotConfigDir != configDir || rejected != "old-access" {
+			t.Fatalf("refresh args = (%q, %q), want (%q, old-access)", gotConfigDir, rejected, configDir)
+		}
+		rotateRuntimeTestToken(t, gotConfigDir, "rotated-during-failure")
+		return "", errors.New("refresh response was ambiguous after persistence")
+	})
+
+	server := newAuthRefreshMCPServer(t, func(string) (int, map[string]any, bool) {
+		return http.StatusUnauthorized, nil, false
+	})
+	defer server.Close()
+
+	_, err := newAuthRefreshRuntimeRunner(server).executeInvocation(context.Background(), server.URL, authRefreshTestInvocation())
+	if !errors.Is(err, originalCause) {
+		t.Fatalf("executeInvocation() error = %v, want original cause", err)
+	}
+	stored, err := authpkg.LoadTokenData(configDir)
+	if err != nil {
+		t.Fatalf("LoadTokenData() after ambiguous refresh error = %v", err)
+	}
+	if stored.AccessToken != "rotated-during-failure" {
+		t.Fatalf("persisted access token = %q, want rotated-during-failure", stored.AccessToken)
+	}
+}
+
+func TestRuntimeRunnerAuthRefreshSecondMarkerDoesNotLoopAndPurges(t *testing.T) {
+	configDir := setupRuntimeAuthRefreshTest(t, "corp-retry-exhausted", "old-access")
+	originalCause := errors.New("token still rejected after refresh")
+	var refreshes atomic.Int32
+	edition.Override(&edition.Hooks{ClassifyToolResult: func(content map[string]any) error {
+		if content["code"] == "USER_TOKEN_ILLEGAL" {
+			return &authretry.AuthRefreshRequired{Cause: originalCause}
+		}
+		return nil
+	}})
+	stubRejectedTokenRefresh(t, func(_ context.Context, configDir, _ string) (string, error) {
+		refreshes.Add(1)
+		return rotateRuntimeTestToken(t, configDir, "new-access"), nil
+	})
+
+	var calls atomic.Int32
+	server := newAuthRefreshMCPServer(t, func(string) (int, map[string]any, bool) {
+		calls.Add(1)
+		return http.StatusOK, map[string]any{"success": false, "code": "USER_TOKEN_ILLEGAL"}, true
+	})
+	defer server.Close()
+
+	_, err := newAuthRefreshRuntimeRunner(server).executeInvocation(context.Background(), server.URL, authRefreshTestInvocation())
+	if !errors.Is(err, originalCause) {
+		t.Fatalf("executeInvocation() error = %v, want original cause", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("MCP calls = %d, want exactly 2", got)
+	}
+	if got := refreshes.Load(); got != 1 {
+		t.Fatalf("refreshes = %d, want exactly 1", got)
+	}
+	if _, err := authpkg.LoadTokenData(configDir); err == nil {
+		t.Fatal("credential still exists after retry exhaustion")
+	}
+}
+
+func TestRuntimeRunnerAuthRefreshSkipsHTTP403AndOrdinaryBusinessErrors(t *testing.T) {
+	t.Run("http 403 marker is rejected by core gate", func(t *testing.T) {
+		configDir := setupRuntimeAuthRefreshTest(t, "corp-http-forbidden", "old-access")
+		originalCause := errors.New("ordinary permission denied")
+		var refreshes atomic.Int32
+		edition.Override(&edition.Hooks{OnAuthError: func(_ string, _ error) error {
+			return &authretry.AuthRefreshRequired{Cause: originalCause}
+		}})
+		stubRejectedTokenRefresh(t, func(context.Context, string, string) (string, error) {
+			refreshes.Add(1)
+			return "", nil
+		})
+		server := newAuthRefreshMCPServer(t, func(string) (int, map[string]any, bool) {
+			return http.StatusForbidden, nil, false
+		})
+		defer server.Close()
+
+		_, err := newAuthRefreshRuntimeRunner(server).executeInvocation(context.Background(), server.URL, authRefreshTestInvocation())
+		if !errors.Is(err, originalCause) {
+			t.Fatalf("executeInvocation() error = %v, want permission cause", err)
+		}
+		if got := refreshes.Load(); got != 0 {
+			t.Fatalf("refreshes = %d, want 0", got)
+		}
+		if _, err := authpkg.LoadTokenData(configDir); err != nil {
+			t.Fatalf("credential was purged for HTTP 403: %v", err)
+		}
+	})
+
+	t.Run("ordinary MCP business error is not a marker", func(t *testing.T) {
+		configDir := setupRuntimeAuthRefreshTest(t, "corp-business-error", "old-access")
+		var refreshes atomic.Int32
+		edition.Override(&edition.Hooks{ClassifyToolResult: func(map[string]any) error {
+			return errors.New("ordinary business failure")
+		}})
+		stubRejectedTokenRefresh(t, func(context.Context, string, string) (string, error) {
+			refreshes.Add(1)
+			return "", nil
+		})
+		server := newAuthRefreshMCPServer(t, func(string) (int, map[string]any, bool) {
+			return http.StatusOK, map[string]any{"success": false, "code": "PARAM_ERROR"}, true
+		})
+		defer server.Close()
+
+		if _, err := newAuthRefreshRuntimeRunner(server).executeInvocation(context.Background(), server.URL, authRefreshTestInvocation()); err == nil || err.Error() != "ordinary business failure" {
+			t.Fatalf("executeInvocation() error = %v, want ordinary business failure", err)
+		}
+		if got := refreshes.Load(); got != 0 {
+			t.Fatalf("refreshes = %d, want 0", got)
+		}
+		if _, err := authpkg.LoadTokenData(configDir); err != nil {
+			t.Fatalf("credential was purged for business error: %v", err)
+		}
+	})
+}
+
+func TestAuthRefreshHTTP401SourceWithPermissionCauseDoesNotRefresh(t *testing.T) {
+	configDir := setupRuntimeAuthRefreshTest(t, "corp-permission-cause", "old-access")
+	var refreshes atomic.Int32
+	stubRejectedTokenRefresh(t, func(context.Context, string, string) (string, error) {
+		refreshes.Add(1)
+		return "", errors.New("refresh must not be attempted")
+	})
+	sourceErr := apperrors.NewAuth("token rejected", apperrors.WithReason("http_401"))
+	permissionCause := apperrors.NewAuth("permission denied", apperrors.WithReason("http_403"))
+
+	_, err := (&runtimeRunner{}).maybeAuthRefreshRetry(
+		context.Background(), "https://unused.invalid", authRefreshTestInvocation(), "old-access", sourceErr,
+		&authretry.AuthRefreshRequired{Cause: permissionCause},
+	)
+	if !errors.Is(err, permissionCause) {
+		t.Fatalf("maybeAuthRefreshRetry() error = %v, want permission cause", err)
+	}
+	if got := refreshes.Load(); got != 0 {
+		t.Fatalf("refreshes = %d, want 0", got)
+	}
+	if _, err := authpkg.LoadTokenData(configDir); err != nil {
+		t.Fatalf("credential was purged for permission cause: %v", err)
+	}
+}
+
+func TestAuthRefreshRetryExhaustionPreservesDifferentPersistedToken(t *testing.T) {
+	configDir := setupRuntimeAuthRefreshTest(t, "corp-retry-token-race", "persisted-newer")
+	var refreshes atomic.Int32
+	stubRejectedTokenRefresh(t, func(context.Context, string, string) (string, error) {
+		refreshes.Add(1)
+		return "", errors.New("second refresh must not be attempted")
+	})
+	originalCause := apperrors.NewAuth("retry token rejected", apperrors.WithReason("http_401"))
+
+	_, err := (&runtimeRunner{}).maybeAuthRefreshRetry(
+		withAuthRetrying(context.Background()), "https://unused.invalid", authRefreshTestInvocation(), "retry-token", originalCause,
+		&authretry.AuthRefreshRequired{Cause: originalCause},
+	)
+	if !errors.Is(err, originalCause) {
+		t.Fatalf("maybeAuthRefreshRetry() error = %v, want original cause", err)
+	}
+	if got := refreshes.Load(); got != 0 {
+		t.Fatalf("refreshes = %d, want 0", got)
+	}
+	stored, err := authpkg.LoadTokenData(configDir)
+	if err != nil {
+		t.Fatalf("LoadTokenData() after retry exhaustion = %v", err)
+	}
+	if stored.AccessToken != "persisted-newer" {
+		t.Fatalf("persisted access token = %q, want persisted-newer", stored.AccessToken)
+	}
+}
+
+func TestAuthRefreshPATMarkerDoesNotRefreshOrPurge(t *testing.T) {
+	configDir := setupRuntimeAuthRefreshTest(t, "corp-pat-error", "old-access")
+	var refreshes atomic.Int32
+	stubRejectedTokenRefresh(t, func(context.Context, string, string) (string, error) {
+		refreshes.Add(1)
+		return "", nil
+	})
+	patErr := &PatScopeError{ErrorType: "missing_scope", Message: "missing required scope(s): mail:send", MissingScope: "mail:send"}
+	runner := &runtimeRunner{}
+	_, err := runner.maybeAuthRefreshRetry(
+		context.Background(), "https://unused.invalid", authRefreshTestInvocation(), "old-access", patErr,
+		&authretry.AuthRefreshRequired{Cause: patErr},
+	)
+	if err != patErr {
+		t.Fatalf("maybeAuthRefreshRetry() error = %v, want original PAT error", err)
+	}
+	if got := refreshes.Load(); got != 0 {
+		t.Fatalf("refreshes = %d, want 0", got)
+	}
+	if _, err := authpkg.LoadTokenData(configDir); err != nil {
+		t.Fatalf("credential was purged for PAT error: %v", err)
+	}
+}
+
+func TestAuthRefreshFailurePurgesOnlyCurrentRuntimeProfile(t *testing.T) {
+	configDir := setupRuntimeAuthRefreshTest(t, "corp-profile-a", "token-a")
+	authpkg.SetRuntimeProfile("corp-profile-b")
+	if err := authpkg.SaveTokenData(configDir, runtimeAuthRefreshToken("corp-profile-b", "token-b")); err != nil {
+		t.Fatalf("SaveTokenData(profile B) error = %v", err)
+	}
+	authpkg.SetRuntimeProfile("corp-profile-a")
+	stubRejectedTokenRefresh(t, func(context.Context, string, string) (string, error) {
+		return "", errors.New("refresh failed")
+	})
+	originalCause := apperrors.NewAuth("profile A rejected", apperrors.WithReason("http_401"))
+
+	_, err := (&runtimeRunner{}).maybeAuthRefreshRetry(
+		context.Background(), "https://unused.invalid", authRefreshTestInvocation(), "token-a", originalCause,
+		&authretry.AuthRefreshRequired{Cause: originalCause},
+	)
+	if !errors.Is(err, originalCause) {
+		t.Fatalf("maybeAuthRefreshRetry() error = %v, want original cause", err)
+	}
+	if _, err := authpkg.LoadTokenDataForProfile(configDir, "corp-profile-a"); err == nil {
+		t.Fatal("failed profile A credential still exists")
+	}
+	profileB, err := authpkg.LoadTokenDataForProfile(configDir, "corp-profile-b")
+	if err != nil {
+		t.Fatalf("profile B credential was removed: %v", err)
+	}
+	if profileB.AccessToken != "token-b" {
+		t.Fatalf("profile B access token = %q, want token-b", profileB.AccessToken)
+	}
+}
+
+func setupRuntimeAuthRefreshTest(t *testing.T, corpID, accessToken string) string {
+	t.Helper()
+	previousHooks := edition.Get()
+	previousProfile := authpkg.RuntimeProfile()
+	originalRefresh := forceRefreshRejectedTokenFunc
+	t.Cleanup(func() {
+		forceRefreshRejectedTokenFunc = originalRefresh
+		edition.Override(previousHooks)
+		authpkg.SetRuntimeProfile(previousProfile)
+		ResetRuntimeTokenCache()
+	})
+	t.Setenv(keychain.DisableKeychainEnv, "1")
+	t.Setenv("DWS_ALLOW_HTTP_ENDPOINTS", "1")
+	t.Setenv("DWS_TRUSTED_DOMAINS", "127.0.0.1")
+	configDir := t.TempDir()
+	t.Setenv("DWS_CONFIG_DIR", configDir)
+	authpkg.SetRuntimeProfile("")
+	edition.Override(&edition.Hooks{})
+	ResetRuntimeTokenCache()
+	if err := authpkg.SaveTokenData(configDir, runtimeAuthRefreshToken(corpID, accessToken)); err != nil {
+		t.Fatalf("SaveTokenData() error = %v", err)
+	}
+	return configDir
+}
+
+func runtimeAuthRefreshToken(corpID, accessToken string) *authpkg.TokenData {
+	return &authpkg.TokenData{
+		AccessToken:  accessToken,
+		RefreshToken: "refresh-" + accessToken,
+		ExpiresAt:    time.Now().Add(2 * time.Hour),
+		RefreshExpAt: time.Now().Add(24 * time.Hour),
+		CorpID:       corpID,
+		CorpName:     corpID + " org",
+		ClientID:     "client-" + corpID,
+	}
+}
+
+func rotateRuntimeTestToken(t *testing.T, configDir, accessToken string) string {
+	t.Helper()
+	data, err := authpkg.LoadTokenData(configDir)
+	if err != nil {
+		t.Fatalf("LoadTokenData() before rotation error = %v", err)
+	}
+	data.AccessToken = accessToken
+	data.RefreshToken = "refresh-" + accessToken
+	data.ExpiresAt = time.Now().Add(2 * time.Hour)
+	data.RefreshExpAt = time.Now().Add(24 * time.Hour)
+	if err := authpkg.SaveTokenData(configDir, data); err != nil {
+		t.Fatalf("SaveTokenData() during rotation error = %v", err)
+	}
+	return accessToken
+}
+
+func stubRejectedTokenRefresh(t *testing.T, fn func(context.Context, string, string) (string, error)) {
+	t.Helper()
+	forceRefreshRejectedTokenFunc = fn
+}
+
+func authRefreshTestInvocation() executor.Invocation {
+	return executor.Invocation{
+		Kind:             "dynamic_tool",
+		CanonicalProduct: "auth-refresh-test",
+		Tool:             "auth.refresh_test",
+		Params:           map[string]any{"value": "same-invocation"},
+	}
+}
+
+func newAuthRefreshRuntimeRunner(server *httptest.Server) *runtimeRunner {
+	client := transport.NewClient(server.Client())
+	client.MaxRetries = 0
+	return &runtimeRunner{
+		transport:   client,
+		globalFlags: &GlobalFlags{Timeout: 5},
+		fallback:    executor.EchoRunner{},
+	}
+}
+
+func newAuthRefreshMCPServer(t *testing.T, response func(token string) (int, map[string]any, bool)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		token := strings.TrimSpace(strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer "))
+		status, content, isError := response(token)
+		if status != http.StatusOK {
+			http.Error(w, http.StatusText(status), status)
+			return
+		}
+		var request struct {
+			ID any `json:"id"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			t.Errorf("decode MCP request: %v", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request.ID,
+			"result": map[string]any{
+				"content": content,
+				"isError": isError,
+			},
+		}); err != nil {
+			t.Errorf("encode MCP response: %v", err)
+		}
+	}))
+}

--- a/internal/app/force_refresh.go
+++ b/internal/app/force_refresh.go
@@ -23,33 +23,30 @@ import (
 	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
 )
 
-// ForceRefreshAccessToken forces a single refresh_token exchange and returns
-// the new access_token. It is intended for callers that have observed a
-// server-side rejection (HTTP 401 or business code such as
-// TOKEN_VERIFIED_FAILED) on what locally appeared to be a still-valid token.
-//
-// Steps:
-//  1. MarkAccessTokenStale rewrites ExpiresAt to a past instant so
-//     OAuthProvider.GetAccessToken's fast-path will miss.
-//  2. NewOAuthProvider + GetAccessToken triggers lockedRefresh, which uses the
-//     existing dual-layer lock (process + file) to serialize concurrent
-//     refresh attempts across goroutines and processes.
-//  3. ResetRuntimeTokenCache clears the per-process sync.Once cache so the
-//     next resolveAuthToken call re-reads from disk.
-//
-// Existing OAuthProvider.GetAccessToken behaviour is unchanged; this helper
-// is the only entry point that orchestrates "force refresh" semantics.
+// ForceRefreshAccessToken preserves the original force-refresh entry point.
+// New recovery paths should pass the token rejected by the server to
+// ForceRefreshRejectedToken so concurrent refreshes can be deduplicated.
 func ForceRefreshAccessToken(ctx context.Context, configDir string) (string, error) {
 	if strings.TrimSpace(configDir) == "" {
 		return "", fmt.Errorf("config directory is empty")
 	}
-	if err := authpkg.MarkAccessTokenStale(configDir); err != nil {
-		return "", fmt.Errorf("mark access token stale: %w", err)
+	data, err := authpkg.LoadTokenData(configDir)
+	if err != nil {
+		return "", err
+	}
+	return ForceRefreshRejectedToken(ctx, configDir, data.AccessToken)
+}
+
+// ForceRefreshRejectedToken atomically refreshes rejectedAccessToken, or
+// reuses the persisted token if another goroutine/process already rotated it.
+func ForceRefreshRejectedToken(ctx context.Context, configDir, rejectedAccessToken string) (string, error) {
+	if strings.TrimSpace(configDir) == "" {
+		return "", fmt.Errorf("config directory is empty")
 	}
 	disc := slog.New(slog.NewTextHandler(io.Discard, nil))
 	provider := authpkg.NewOAuthProvider(configDir, disc)
 	configureOAuthProviderCompatibility(provider, configDir)
-	tok, err := provider.GetAccessToken(ctx)
+	tok, err := provider.ForceRefreshRejectedToken(ctx, rejectedAccessToken)
 	if err != nil {
 		return "", err
 	}

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -35,6 +35,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/logging"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/safety"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/transport"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/authretry"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/configmeta"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
@@ -588,6 +589,16 @@ func (r *runtimeRunner) executeInvocation(ctx context.Context, endpoint string, 
 		if isAuthError(err) {
 			if fn := edition.Get().OnAuthError; fn != nil {
 				if overrideErr := fn(defaultConfigDir(), err); overrideErr != nil {
+					if refresh, ok := authretry.As(overrideErr); ok {
+						if !r.canAutoRefreshAuth(hasPluginAuth) {
+							return executor.Result{}, authRefreshCause(refresh, err)
+						}
+						result, retryErr := r.maybeAuthRefreshRetry(ctx, endpoint, invocation, authToken, err, refresh)
+						if retryErr != nil {
+							captureRuntimeFailure(invocation, err, retryErr)
+						}
+						return result, retryErr
+					}
 					captureRuntimeFailure(invocation, err, overrideErr)
 					return executor.Result{}, overrideErr
 				}
@@ -612,6 +623,16 @@ func (r *runtimeRunner) executeInvocation(ctx context.Context, endpoint string, 
 				}
 				return handlePatAuthCheck(ctx, r, invocation, patCheck, defaultConfigDir(), os.Stderr)
 			}
+			if refresh, ok := authretry.As(editionErr); ok {
+				if !r.canAutoRefreshAuth(hasPluginAuth) {
+					return executor.Result{}, authRefreshCause(refresh, editionErr)
+				}
+				result, retryErr := r.maybeAuthRefreshRetry(ctx, endpoint, invocation, authToken, editionErr, refresh)
+				if retryErr != nil {
+					captureRuntimeFailure(invocation, editionErr, retryErr)
+				}
+				return result, retryErr
+			}
 			return executor.Result{}, editionErr
 		}
 	}
@@ -627,15 +648,6 @@ func (r *runtimeRunner) executeInvocation(ctx context.Context, endpoint string, 
 	if callResult.IsError {
 		diag := transport.ExtractServerDiagnosticsFromMap(callResult.Content)
 		logBusinessError(r.transport.FileLogger, "mcp_tool_error", invocation, callResult.Content, diag)
-
-		// ClassifyToolResult hook: let the overlay intercept known error
-		// patterns (PAT permission, gateway-auth) before generic handling.
-		if classify := edition.Get().ClassifyToolResult; classify != nil {
-			if hookErr := classify(callResult.Content); hookErr != nil {
-				captureRuntimeFailure(invocation, hookErr, hookErr)
-				return executor.Result{}, hookErr
-			}
-		}
 
 		mcpErr := apperrors.NewAPI(
 			extractMCPErrorMessage(callResult),

--- a/internal/auth/rejected_token_refresh.go
+++ b/internal/auth/rejected_token_refresh.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
+)
+
+// ForceRefreshRejectedToken refreshes an access token that was rejected by the
+// server even though it may still look valid locally. The rejected-token check
+// and refresh exchange share the same process + file lock so concurrent callers
+// cannot invalidate a token that another caller has already rotated.
+func (p *OAuthProvider) ForceRefreshRejectedToken(ctx context.Context, rejectedAccessToken string) (string, error) {
+	if p == nil || strings.TrimSpace(p.configDir) == "" {
+		return "", fmt.Errorf("config directory is empty")
+	}
+	rejectedAccessToken = strings.TrimSpace(rejectedAccessToken)
+	if rejectedAccessToken == "" {
+		return "", fmt.Errorf("rejected access token is empty")
+	}
+
+	lock, err := AcquireDualLock(ctx, p.configDir)
+	if err != nil {
+		return "", fmt.Errorf("acquiring dual lock: %w", err)
+	}
+	defer lock.Release()
+
+	data, err := LoadTokenData(p.configDir)
+	if err != nil {
+		return "", err
+	}
+	currentAccessToken := strings.TrimSpace(data.AccessToken)
+	if currentAccessToken == "" {
+		return "", fmt.Errorf("stored access token is empty")
+	}
+	if currentAccessToken != rejectedAccessToken {
+		if p.logger != nil {
+			p.logger.Debug("rejected token already rotated by another goroutine/process")
+		}
+		return currentAccessToken, nil
+	}
+
+	if !data.IsRefreshTokenValid() {
+		return "", fmt.Errorf("refresh_token 已过期")
+	}
+	if err := preflightTokenRefreshPersistence(data); err != nil {
+		return "", fmt.Errorf("本地登录态无法安全更新: %w", err)
+	}
+	refreshed, err := p.refreshWithRefreshToken(ctx, data)
+	if err != nil {
+		return "", err
+	}
+	accessToken := strings.TrimSpace(refreshed.AccessToken)
+	if accessToken == "" {
+		return "", fmt.Errorf("force refresh returned empty access token")
+	}
+	return accessToken, nil
+}
+
+// DeleteTokenDataIfAccessTokenMatches removes only the current runtime
+// profile's credential and only while its persisted access token still equals
+// expectedAccessToken. The compare and delete share the auth dual lock so a
+// concurrently rotated token cannot be removed by stale failure cleanup.
+func DeleteTokenDataIfAccessTokenMatches(ctx context.Context, configDir, expectedAccessToken string) (bool, error) {
+	expectedAccessToken = strings.TrimSpace(expectedAccessToken)
+	if strings.TrimSpace(configDir) == "" {
+		return false, fmt.Errorf("config directory is empty")
+	}
+	if expectedAccessToken == "" {
+		return false, fmt.Errorf("expected access token is empty")
+	}
+	profile := strings.TrimSpace(RuntimeProfile())
+
+	lock, err := AcquireDualLock(ctx, configDir)
+	if err != nil {
+		return false, fmt.Errorf("acquiring dual lock: %w", err)
+	}
+	defer lock.Release()
+
+	data, err := LoadTokenDataForProfile(configDir, profile)
+	if err != nil {
+		return false, err
+	}
+	if data == nil || strings.TrimSpace(data.AccessToken) != expectedAccessToken {
+		return false, nil
+	}
+
+	hooks := edition.Get()
+	if hooks.DeleteToken != nil {
+		if profile != "" {
+			return false, fmt.Errorf("profile selection is not supported by the current auth backend")
+		}
+		if err := hooks.DeleteToken(configDir); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if err := deleteTokenDataForProfileLocked(configDir, profile); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/auth/rejected_token_refresh_test.go
+++ b/internal/auth/rejected_token_refresh_test.go
@@ -1,0 +1,297 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
+)
+
+type rejectedTokenRoundTripper func(*http.Request) (*http.Response, error)
+
+func (fn rejectedTokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestForceRefreshRejectedTokenConcurrentCallersExchangeOnce(t *testing.T) {
+	cleanupKeychain(t)
+	t.Setenv(keychain.DisableKeychainEnv, "1")
+	setPreflightTestCredentials(t)
+	configDir := t.TempDir()
+	data := testToken("old-access", "corp-concurrent-refresh", "Concurrent Refresh Org")
+	if err := SaveTokenData(configDir, data); err != nil {
+		t.Fatalf("SaveTokenData() error = %v", err)
+	}
+
+	var exchanges atomic.Int32
+	provider := NewOAuthProvider(configDir, nil)
+	provider.httpClient = &http.Client{Transport: rejectedTokenRoundTripper(func(*http.Request) (*http.Response, error) {
+		exchanges.Add(1)
+		time.Sleep(10 * time.Millisecond)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body: io.NopCloser(strings.NewReader(
+				`{"accessToken":"new-access","refreshToken":"new-refresh","expiresIn":7200,"corpId":"corp-concurrent-refresh"}`,
+			)),
+		}, nil
+	})}
+
+	const callers = 20
+	start := make(chan struct{})
+	results := make(chan string, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			token, err := provider.ForceRefreshRejectedToken(context.Background(), "old-access")
+			results <- token
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("ForceRefreshRejectedToken() error = %v", err)
+		}
+	}
+	for token := range results {
+		if token != "new-access" {
+			t.Fatalf("ForceRefreshRejectedToken() token = %q, want new-access", token)
+		}
+	}
+	if got := exchanges.Load(); got != 1 {
+		t.Fatalf("refresh exchanges = %d, want 1", got)
+	}
+}
+
+func TestForceRefreshRejectedTokenReusesAlreadyRotatedToken(t *testing.T) {
+	cleanupKeychain(t)
+	t.Setenv(keychain.DisableKeychainEnv, "1")
+	configDir := t.TempDir()
+	if err := SaveTokenData(configDir, testToken("already-new", "corp-already-rotated", "Already Rotated Org")); err != nil {
+		t.Fatalf("SaveTokenData() error = %v", err)
+	}
+
+	var exchanges atomic.Int32
+	provider := NewOAuthProvider(configDir, nil)
+	provider.httpClient = &http.Client{Transport: rejectedTokenRoundTripper(func(*http.Request) (*http.Response, error) {
+		exchanges.Add(1)
+		return nil, errors.New("unexpected refresh exchange")
+	})}
+
+	token, err := provider.ForceRefreshRejectedToken(context.Background(), "old-rejected")
+	if err != nil {
+		t.Fatalf("ForceRefreshRejectedToken() error = %v", err)
+	}
+	if token != "already-new" {
+		t.Fatalf("ForceRefreshRejectedToken() token = %q, want already-new", token)
+	}
+	if got := exchanges.Load(); got != 0 {
+		t.Fatalf("refresh exchanges = %d, want 0", got)
+	}
+}
+
+func TestDeleteTokenDataIfAccessTokenMatchesDeletesMatchingCredential(t *testing.T) {
+	cleanupKeychain(t)
+	t.Setenv(keychain.DisableKeychainEnv, "1")
+	configDir := t.TempDir()
+	if err := SaveTokenData(configDir, testToken("rejected-access", "corp-delete-match", "Delete Match Org")); err != nil {
+		t.Fatalf("SaveTokenData() error = %v", err)
+	}
+
+	deleted, err := DeleteTokenDataIfAccessTokenMatches(context.Background(), configDir, "rejected-access")
+	if err != nil {
+		t.Fatalf("DeleteTokenDataIfAccessTokenMatches() error = %v", err)
+	}
+	if !deleted {
+		t.Fatal("DeleteTokenDataIfAccessTokenMatches() deleted = false, want true")
+	}
+	if _, err := LoadTokenData(configDir); err == nil {
+		t.Fatal("matching credential still exists after conditional delete")
+	}
+}
+
+func TestDeleteTokenDataIfAccessTokenMatchesPreservesDifferentCredential(t *testing.T) {
+	cleanupKeychain(t)
+	t.Setenv(keychain.DisableKeychainEnv, "1")
+	configDir := t.TempDir()
+	if err := SaveTokenData(configDir, testToken("rotated-access", "corp-delete-mismatch", "Delete Mismatch Org")); err != nil {
+		t.Fatalf("SaveTokenData() error = %v", err)
+	}
+
+	deleted, err := DeleteTokenDataIfAccessTokenMatches(context.Background(), configDir, "rejected-access")
+	if err != nil {
+		t.Fatalf("DeleteTokenDataIfAccessTokenMatches() error = %v", err)
+	}
+	if deleted {
+		t.Fatal("DeleteTokenDataIfAccessTokenMatches() deleted = true, want false")
+	}
+	stored, err := LoadTokenData(configDir)
+	if err != nil {
+		t.Fatalf("LoadTokenData() error = %v", err)
+	}
+	if stored.AccessToken != "rotated-access" {
+		t.Fatalf("persisted access token = %q, want rotated-access", stored.AccessToken)
+	}
+}
+
+func TestDeleteTokenDataIfAccessTokenMatchesConcurrentRotationPreservesNewToken(t *testing.T) {
+	cleanupKeychain(t)
+	t.Setenv(keychain.DisableKeychainEnv, "1")
+	configDir := t.TempDir()
+	const iterations = 50
+	for i := range iterations {
+		corpID := "corp-delete-race"
+		if err := SaveTokenData(configDir, testToken("rejected-access", corpID, "Delete Race Org")); err != nil {
+			t.Fatalf("iteration %d SaveTokenData(old) error = %v", i, err)
+		}
+
+		start := make(chan struct{})
+		errs := make(chan error, 2)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := DeleteTokenDataIfAccessTokenMatches(context.Background(), configDir, "rejected-access")
+			errs <- err
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- SaveTokenData(configDir, testToken("rotated-access", corpID, "Delete Race Org"))
+		}()
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("iteration %d concurrent operation error = %v", i, err)
+			}
+		}
+
+		stored, err := LoadTokenData(configDir)
+		if err != nil {
+			t.Fatalf("iteration %d LoadTokenData() error = %v", i, err)
+		}
+		if stored.AccessToken != "rotated-access" {
+			t.Fatalf("iteration %d persisted access token = %q, want rotated-access", i, stored.AccessToken)
+		}
+	}
+}
+
+func TestDeleteTokenDataIfAccessTokenMatchesHookBackend(t *testing.T) {
+	cleanupKeychain(t)
+	t.Setenv(keychain.DisableKeychainEnv, "1")
+	configDir := t.TempDir()
+
+	var storeMu sync.Mutex
+	var stored []byte
+	deleteCalls := 0
+	previousHooks := edition.Get()
+	edition.Override(&edition.Hooks{
+		SaveToken: func(_ string, data []byte) error {
+			storeMu.Lock()
+			defer storeMu.Unlock()
+			stored = append([]byte(nil), data...)
+			return nil
+		},
+		LoadToken: func(string) ([]byte, error) {
+			storeMu.Lock()
+			defer storeMu.Unlock()
+			if len(stored) == 0 {
+				return nil, ErrTokenDataNotFound
+			}
+			return append([]byte(nil), stored...), nil
+		},
+		DeleteToken: func(string) error {
+			storeMu.Lock()
+			defer storeMu.Unlock()
+			deleteCalls++
+			stored = nil
+			return nil
+		},
+	})
+	t.Cleanup(func() { edition.Override(previousHooks) })
+
+	callWithDeadlockGuard := func(expectedAccessToken string) (bool, error) {
+		t.Helper()
+		type result struct {
+			deleted bool
+			err     error
+		}
+		done := make(chan result, 1)
+		go func() {
+			deleted, err := DeleteTokenDataIfAccessTokenMatches(context.Background(), configDir, expectedAccessToken)
+			done <- result{deleted: deleted, err: err}
+		}()
+		select {
+		case got := <-done:
+			return got.deleted, got.err
+		case <-time.After(2 * time.Second):
+			t.Fatal("DeleteTokenDataIfAccessTokenMatches() deadlocked with hook-backed storage")
+			return false, nil
+		}
+	}
+
+	if err := SaveTokenData(configDir, testToken("rejected-hook-access", "corp-hook-delete", "Hook Delete Org")); err != nil {
+		t.Fatalf("SaveTokenData(matching) error = %v", err)
+	}
+	deleted, err := callWithDeadlockGuard("rejected-hook-access")
+	if err != nil {
+		t.Fatalf("DeleteTokenDataIfAccessTokenMatches(matching) error = %v", err)
+	}
+	if !deleted {
+		t.Fatal("DeleteTokenDataIfAccessTokenMatches(matching) deleted = false, want true")
+	}
+	storeMu.Lock()
+	matchingDeleteCalls := deleteCalls
+	matchingStoreEmpty := len(stored) == 0
+	storeMu.Unlock()
+	if matchingDeleteCalls != 1 {
+		t.Fatalf("matching DeleteToken hook calls = %d, want 1", matchingDeleteCalls)
+	}
+	if !matchingStoreEmpty {
+		t.Fatal("matching credential still exists in hook-backed storage")
+	}
+
+	if err := SaveTokenData(configDir, testToken("rotated-hook-access", "corp-hook-delete", "Hook Delete Org")); err != nil {
+		t.Fatalf("SaveTokenData(rotated) error = %v", err)
+	}
+	deleted, err = callWithDeadlockGuard("rejected-hook-access")
+	if err != nil {
+		t.Fatalf("DeleteTokenDataIfAccessTokenMatches(rotated) error = %v", err)
+	}
+	if deleted {
+		t.Fatal("DeleteTokenDataIfAccessTokenMatches(rotated) deleted = true, want false")
+	}
+	storeMu.Lock()
+	rotatedDeleteCalls := deleteCalls
+	storeMu.Unlock()
+	if rotatedDeleteCalls != 1 {
+		t.Fatalf("DeleteToken hook calls after mismatch = %d, want 1", rotatedDeleteCalls)
+	}
+	loaded, err := LoadTokenData(configDir)
+	if err != nil {
+		t.Fatalf("LoadTokenData(rotated) error = %v", err)
+	}
+	if loaded.AccessToken != "rotated-hook-access" {
+		t.Fatalf("hook-backed access token = %q, want rotated-hook-access", loaded.AccessToken)
+	}
+}

--- a/pkg/edition/edition.go
+++ b/pkg/edition/edition.go
@@ -103,6 +103,9 @@ type Hooks struct {
 	AuthClientFromMCP bool   // true → fetch client ID from MCP at runtime
 	OnAuthError       func(configDir string, err error) error
 	TokenProvider     func(ctx context.Context, fallback func() (string, error)) (string, error)
+	// InvalidateAuthCaches clears edition-owned token and discovery header
+	// snapshots after persisted credentials change. It must not log token data.
+	InvalidateAuthCaches func()
 
 	// --- token persistence (overlay-managed keychain / encrypted storage) ---
 	SaveToken   func(configDir string, data []byte) error // persist token blob


### PR DESCRIPTION
## Summary

- consume `AuthRefreshRequired` from both transport auth errors and MCP tool-result classification
- atomically refresh the exact access token rejected by the server, reusing a token already rotated by another goroutine or process
- retry only the current endpoint and invocation once, without replaying multi-profile dispatch
- conditionally remove only the current profile credential after refresh failure or retry exhaustion
- invalidate core and edition-owned token caches before retrying
- keep ordinary HTTP 403, PAT scope, permission, and business errors out of the refresh path

## Root cause

The Wukong overlay already returned an `AuthRefreshRequired` marker for explicit token failures, but the core runner treated that marker as a terminal business error. The previous refresh helper had also been removed, so no refresh, retry, or credential cleanup happened.

## Safety

- refresh and rejected-token comparison share the existing process and file lock
- cleanup uses compare-and-delete so a stale request cannot remove a newly rotated credential
- explicit `--token` and plugin-auth invocations are not auto-refreshed
- logs include structured recovery reasons but never token values

## Validation

- `go test -race ./internal/auth -run 'TestForceRefreshRejectedToken|TestDeleteTokenDataIfAccessTokenMatches' -count=1`
- `go test -race ./internal/app -run 'TestRuntimeRunnerAuthRefresh|TestAuthRefresh' -count=1`
- `go test ./internal/app ./internal/auth ./pkg/authretry -count=1`
- `go test ./...`
- `git diff --check`

## Downstream integration

Companion Wukong CR: https://code.alibaba-inc.com/dingtalk-workspace/dws-wukong/codereview/28610386

It registers the new `InvalidateAuthCaches` hook, narrows generic auth-service classification, and adds the cache/classification regression tests. After this PR is merged and tagged, Wukong still needs to bump `CLI_UPSTREAM_TAG` as a release step.
