### PR TITLE
docs(changelog): prepare v1.0.53-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.53-beta.2] - 2026-07-16
+
+This beta validates the accumulated post-v1.0.52 command surface, release automation, and runtime hardening changes, including enterprise contact onboarding, declarative shortcuts, Sheet/Aitable writes, multi-platform Homebrew formulas, and credential and target-validation fixes.
+
 ### Added
 
 - **Contact enterprise onboarding commands** — adds `contact org create`, `contact user invite`, and `contact account create` for creating a DingTalk enterprise, inviting an employee by mobile, and provisioning an enterprise login account, with reviewed Schema contracts and mono/multi Skill routing.


### PR DESCRIPTION
## Requirement and goal

Prepare the exact release-notes section required to validate and publish the next prerelease after `v1.0.53-beta.1`. The expected observable result is one non-empty `## [1.0.53-beta.2] - 2026-07-16` section with no `TODO` or `TBD`, while preserving an empty `## [Unreleased]` section for later work.

## Implementation

- Add the exact `1.0.53-beta.2` heading generated by `scripts/release/dws-release.sh v1.0.53-beta.2`.
- Move the existing post-`v1.0.52` Added, Changed, and Fixed entries under that version heading by placing it immediately before those existing sections.
- Replace the generated placeholder with a factual summary of the beta validation scope.

## Environment

- macOS 15.5, Darwin arm64
- Git 2.39.5 (Apple Git-154)
- Base: `main@34aad4596c6ff0da69e34cb3810b3144465e0e77`

## Verification

| ID | Acceptance criterion | Command | Expected result | Observed result | Status |
|---|---|---|---|---|---|
| V1 | Exact release heading exists once | `rg -c "^## \\[1\\.0\\.53-beta\\.2\\] - 2026-07-16$" CHANGELOG.md` | `1` | `1` | PASS |
| V2 | Release section contains no placeholder | `sed -n "/^## \\[1\\.0\\.53-beta\\.2\\]/,/^## \\[1\\.0\\.52\\]/p" CHANGELOG.md \\| rg "\\b(TODO\\|TBD)\\b"` | no matches | no matches | PASS |
| V3 | Patch is whitespace-clean | `git diff --check origin/main...HEAD` | exit 0 | exit 0 | PASS |
| V4 | Scope is CHANGELOG-only | `git diff --name-only origin/main...HEAD` | `CHANGELOG.md` | `CHANGELOG.md` | PASS |

Runtime and package-manager tests are N/A because this PR changes release notes only and does not change source, generated assets, dependencies, packaging templates, or workflows. The guarded `dws-release v1.0.53-beta.2` preflight will run only after this section is merged into clean `main`.

## Limitations and governance

- Publishing is intentionally not performed by this PR.
- The release preflight currently remains blocked until official repository immutable releases and `v*` tag governance are enabled.
- Historical `v1.0.53-beta.1` is not reused, moved, or repaired by this change.

## Risk and rollback

Risk is limited to release-note classification. Rollback is a revert of this single CHANGELOG commit. There is no runtime, data, wire-format, or migration impact.

## CHANGELOG policy

This PR is the release-time promotion of the existing `[Unreleased]` entries into the exact beta section, so it does not add another self-referential user-visible entry.