### PR TITLE
ci: parallelize PR test and coverage jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint
@@ -54,10 +58,18 @@ jobs:
       - name: Check GitHub Actions workflows
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
-  test:
-    name: Test
+  test-race:
+    name: "Test (race: ${{ matrix.shard }})"
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - app
+          - generators
+          - helpers
+          - remaining
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -71,18 +83,84 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y zip unzip
 
       - name: Build
+        if: ${{ matrix.shard == 'remaining' }}
         run: make build
 
-      - name: Test with Race Detection
-        # The registry-first final-delivery gate validates all public commands
-        # and the complete generated Catalog under the race detector. Keep the
-        # package timeout aligned with the macOS race job so the Linux runner's
-        # five-minute default does not expire while that gate is still making
-        # progress.
-        run: go test -v -race -count=1 -timeout=10m ./cmd/... ./internal/...
+      - name: Test shard with Race Detection
+        env:
+          TEST_SHARD: ${{ matrix.shard }}
+        run: |
+          case "$TEST_SHARD" in
+            app)
+              packages=(./internal/app)
+              ;;
+            generators)
+              packages=(./internal/generator/...)
+              ;;
+            helpers)
+              packages=(./internal/helpers/...)
+              ;;
+            remaining)
+              mapfile -t packages < <(
+                go list ./cmd/... ./internal/... |
+                  grep -Ev '/internal/(app|generator|helpers)(/|$)'
+              )
+              ;;
+            *)
+              printf 'unknown test shard: %s\n' "$TEST_SHARD" >&2
+              exit 1
+              ;;
+          esac
+          test "${#packages[@]}" -gt 0
+          go test -v -race -count=1 -timeout=10m "${packages[@]}"
+
+  test-release-scripts:
+    name: Test (release scripts)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install archive tooling
+        run: sudo apt-get update && sudo apt-get install -y zip unzip
 
       - name: Test release scripts
         run: go test -v -count=1 -timeout=5m ./test/scripts
+
+  test:
+    name: Test
+    needs:
+      - test-race
+      - test-release-scripts
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Verify test shards
+        env:
+          RACE_RESULT: ${{ needs.test-race.result }}
+          RELEASE_SCRIPTS_RESULT: ${{ needs.test-release-scripts.result }}
+        run: |
+          failed=0
+          for shard in \
+            "race shards:$RACE_RESULT" \
+            "release scripts:$RELEASE_SCRIPTS_RESULT"
+          do
+            name="${shard%%:*}"
+            result="${shard#*:}"
+            printf '%s: %s\n' "$name" "$result"
+            if [ "$result" != "success" ]; then
+              failed=1
+            fi
+          done
+          test "$failed" -eq 0
 
   test-darwin:
     name: Test (macOS auth/keychain)
@@ -208,10 +286,80 @@ jobs:
           name: coverage-windows
           path: coverage-windows.txt
 
-  coverage:
-    name: Coverage
+  coverage-current:
+    name: Coverage (current)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install archive tooling
+        run: sudo apt-get update && sudo apt-get install -y zip unzip
+
+      - name: Build
+        run: make build
+
+      - name: Run current unit tests with coverage
+        run: |
+          go test -count=1 -p 1 -coverprofile=coverage.txt -covermode=atomic ./ ./cmd/... ./internal/... ./skills/...
+          go tool cover -func=coverage.txt
+
+      - name: Upload current coverage profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-current-profile
+          path: coverage.txt
+          retention-days: 1
+
+  coverage-supporting:
+    name: Coverage (supporting)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install archive tooling
+        run: sudo apt-get update && sudo apt-get install -y zip unzip
+
+      - name: Run policy and shortcut coverage
+        run: |
+          go test -count=1 -coverprofile=coverage-policy.txt -covermode=atomic ./pkg/... ./scripts/policy/...
+          go test -count=1 \
+            -run '^(TestAllShortcuts|TestCrossPlatformCoverage)' \
+            -coverpkg=./internal/app,./internal/helpers,./internal/shortcut/... \
+            -coverprofile=coverage-shortcut.txt \
+            -covermode=atomic \
+            ./internal/app ./internal/helpers ./internal/shortcut/...
+
+      - name: Upload supporting coverage profiles
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-supporting-profiles
+          path: |
+            coverage-policy.txt
+            coverage-shortcut.txt
+          retention-days: 1
+
+  coverage-baseline:
+    name: Coverage (baseline)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -226,9 +374,6 @@ jobs:
 
       - name: Install archive tooling
         run: sudo apt-get update && sudo apt-get install -y zip unzip
-
-      - name: Build
-        run: make build
 
       - name: Resolve authoritative coverage base
         env:
@@ -247,18 +392,9 @@ jobs:
           git rev-parse --verify "${base_ref}^{commit}" >/dev/null
           echo "COVERAGE_BASE_REF=$base_ref" >> "$GITHUB_ENV"
 
-      - name: Run current and baseline unit tests with coverage
+      - name: Run baseline unit tests with coverage
         run: |
           set -eu
-          go test -count=1 -p 1 -coverprofile=coverage.txt -covermode=atomic ./ ./cmd/... ./internal/... ./skills/...
-          go test -count=1 -coverprofile=coverage-policy.txt -covermode=atomic ./pkg/... ./scripts/policy/...
-          go test -count=1 \
-            -run '^(TestAllShortcuts|TestCrossPlatformCoverage)' \
-            -coverpkg=./internal/app,./internal/helpers,./internal/shortcut/... \
-            -coverprofile=coverage-shortcut.txt \
-            -covermode=atomic \
-            ./internal/app ./internal/helpers ./internal/shortcut/...
-
           base_worktree="$(mktemp -d "${RUNNER_TEMP}/dws-coverage-base.XXXXXX")"
           rmdir "$base_worktree"
           cleanup() {
@@ -274,7 +410,90 @@ jobs:
               -covermode=atomic \
               ./ ./cmd/... ./internal/... ./skills/...
           )
-          go tool cover -func=coverage.txt
+
+      - name: Upload baseline coverage profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-baseline-profile
+          path: coverage-base.txt
+          retention-days: 1
+
+  coverage:
+    name: Coverage
+    needs:
+      - coverage-current
+      - coverage-supporting
+      - coverage-baseline
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Verify coverage profile jobs
+        env:
+          CURRENT_RESULT: ${{ needs.coverage-current.result }}
+          SUPPORTING_RESULT: ${{ needs.coverage-supporting.result }}
+          BASELINE_RESULT: ${{ needs.coverage-baseline.result }}
+        run: |
+          failed=0
+          for profile in \
+            "current:$CURRENT_RESULT" \
+            "supporting:$SUPPORTING_RESULT" \
+            "baseline:$BASELINE_RESULT"
+          do
+            name="${profile%%:*}"
+            result="${profile#*:}"
+            printf '%s: %s\n' "$name" "$result"
+            if [ "$result" != "success" ]; then
+              failed=1
+            fi
+          done
+          test "$failed" -eq 0
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Resolve authoritative coverage base
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -eu
+          base_ref="$PUSH_BEFORE_SHA"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            base_ref="$(git merge-base "$PR_HEAD_SHA" "$PR_BASE_SHA")"
+          fi
+          if [ -z "$base_ref" ] || [ "$base_ref" = "0000000000000000000000000000000000000000" ]; then
+            base_ref="$(git rev-parse HEAD^)"
+          fi
+          git rev-parse --verify "${base_ref}^{commit}" >/dev/null
+          echo "COVERAGE_BASE_REF=$base_ref" >> "$GITHUB_ENV"
+
+      - name: Download current coverage profile
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-current-profile
+          path: .
+
+      - name: Download supporting coverage profiles
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-supporting-profiles
+          path: .
+
+      - name: Download baseline coverage profile
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-baseline-profile
+          path: .
 
       - name: Enforce coverage gate
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           case "$TEST_SHARD" in
             app)
-              packages=(./internal/app)
+              packages=(./internal/app/...)
               ;;
             generators)
               packages=(./internal/generator/...)

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -23,6 +23,11 @@ The repository defines five focused checks in addition to its existing CI:
   variance to avoid failing unchanged code on test-path noise. Set
   `COVERAGE_ENFORCE_OVERALL=true` once repository coverage reaches 80% to make
   the overall target fail closed as well.
+  CI generates the candidate, supporting, and merge-base profiles on three
+  independent runners, then downloads all profiles into the aggregate
+  `Coverage` job and applies the same fail-closed gate. The split changes only
+  scheduling: the tested packages, profile contents, merge-base comparison,
+  and final coverage thresholds remain unchanged.
 - **CLI Smoke** builds the release binary, reads the root command list from the
   structured Interface contract, and renders offline help for every public
   top-level command. It rejects Cobra's unknown-command root-help fallback and
@@ -53,9 +58,10 @@ make coverage-gate-platform BASE_REF=<merge-base> PROFILE=<coverage-profile>
 ```
 
 `make coverage-gate` is the enforcement step, not a profile generator. It
-expects the candidate, policy, and merge-base profiles (`coverage.txt`,
-`coverage-policy.txt`, and `coverage-base.txt`) produced by the preceding CI
-steps. A clean local checkout can reproduce the Linux/overall CI gate with:
+expects the candidate, policy, shortcut, and merge-base profiles
+(`coverage.txt`, `coverage-policy.txt`, `coverage-shortcut.txt`, and
+`coverage-base.txt`) produced by the parallel CI profile jobs. A clean local
+checkout can reproduce the Linux/overall CI gate sequentially with:
 
 ```sh
 base_ref=$(git merge-base HEAD origin/main)
@@ -65,17 +71,25 @@ rmdir "$base_worktree"
 cleanup() { git worktree remove --force "$base_worktree" >/dev/null 2>&1 || true; }
 trap cleanup EXIT HUP INT TERM
 
-go test -count=1 -coverprofile=coverage.txt -covermode=atomic \
+go test -count=1 -p 1 -coverprofile=coverage.txt -covermode=atomic \
   ./ ./cmd/... ./internal/... ./skills/...
 go test -count=1 -coverprofile=coverage-policy.txt -covermode=atomic \
   ./pkg/... ./scripts/policy/...
+go test -count=1 \
+  -run '^(TestAllShortcuts|TestCrossPlatformCoverage)' \
+  -coverpkg=./internal/app,./internal/helpers,./internal/shortcut/... \
+  -coverprofile=coverage-shortcut.txt \
+  -covermode=atomic \
+  ./internal/app ./internal/helpers ./internal/shortcut/...
 git worktree add --detach "$base_worktree" "$base_ref"
 (
   cd "$base_worktree"
-  go test -count=1 -coverprofile="$root/coverage-base.txt" -covermode=atomic \
+  go test -count=1 -p 1 \
+    -coverprofile="$root/coverage-base.txt" -covermode=atomic \
     ./ ./cmd/... ./internal/... ./skills/...
 )
-make coverage-gate BASE_REF="$base_ref"
+COVERAGE_ADDITIONAL_PROFILE=coverage-shortcut.txt \
+  make coverage-gate BASE_REF="$base_ref"
 ```
 
 The native-platform target likewise expects `PROFILE` to have already been


### PR DESCRIPTION
## Summary

- split Linux race tests into four parallel matrix shards and run release-script tests independently
- generate current, supporting, and merge-base coverage profiles on three parallel runners, then enforce the unchanged gate in the aggregate `Coverage` job
- preserve the existing required check names `Test`, `Coverage`, and `CI Gate`
- cancel superseded runs for the same PR and document local coverage reproduction

## Why

Recent PR runs show:

- Coverage: 10m07s average, 14m32s P90
- Test: 8m54s average
- Test (macOS): 6m14s average

Coverage currently runs the current and merge-base suites sequentially with `-p 1`, so it has the clearest wall-clock parallelism opportunity. The Linux test job also serializes release-script tests behind the race suite.

The expected wall-clock target is roughly 8–9 minutes at Coverage P90 and 7–8 minutes for the average Linux Test job. macOS remains unchanged because its Go packages already run concurrently and the dominant `internal/app` package sets the critical path; adding macOS runners would add cost with little expected latency gain.

This trades additional concurrent Ubuntu runner usage and setup overhead for shorter PR feedback time.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- verified the four race shards cover exactly the original 68/68 packages
- `make build`
- `DWS_PACKAGE_VERSION=0.0.0-test go test ./scripts/policy/coverage-gate`
- isolated reruns of the two subprocess-based tests that were killed by local system resource pressure during the full suite both passed
