### PR TITLE
fix(release): recognize reviewed stable recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This beta validates the accumulated post-v1.0.52 command surface, release automa
 ### Changed
 
 - **Guarded prerelease and stable automation** — adds the guided `dws-release` entry for one-command CHANGELOG preparation, validation-only and annotated-tag publication flows; promotes only an explicitly validated beta; verifies command-tree compatibility and all six packaged binaries; and serializes immutable GitHub Release, npm channel, OSS, Homebrew, and optional Gitee delivery with fail-closed recovery checks.
+- **Reviewed historical release recovery proofs** — release preflight can recognize an explicitly pinned successful recovery delivery for a historical stable tag while still rejecting arbitrary workflow dispatches, mismatched commits, and incomplete release, signing, or publication jobs.
 
 ### Fixed
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -86,7 +86,7 @@ dws-release v1.2.3 --from-beta v1.2.3-beta.1 --publish
 
 ## CI/CD 保证
 
-- 只接受 `vX.Y.Z-beta.N` 和 `vX.Y.Z`，且新版本必须高于上一正式版。这里的“上一正式版”必须同时具备公开非草稿 GitHub Release 和同 tag/commit 的成功 Release workflow；只有 tag、没有交付成功的孤儿版本会阻断后续发布，要求先重跑补齐。
+- 只接受 `vX.Y.Z-beta.N` 和 `vX.Y.Z`，且新版本必须高于上一正式版。这里的“上一正式版”必须同时具备公开非草稿 GitHub Release 和同 tag/commit 的成功 Release workflow；只有 tag、没有交付成功的孤儿版本会阻断后续发布，要求先重跑补齐。历史版本若曾通过专用 recovery workflow 完成交付，只能使用仓库内 `delivered-stable-recoveries.json` 中精确到 tag、commit、run、workflow SHA 与 attempt 的 reviewed 证据；验证仍要求 release、Darwin 签名和最终发布三个 job 全部成功，不能接受任意 workflow_dispatch。
 - tag 必须是 annotated tag；本地脚本在推送前重新确认 HEAD 与远端 `main` 完全一致，CI 允许其后 `main` 前进，但要求封板提交仍位于 `main` 历史中。
 - 日常 CI 和发布前都会对比“最新已交付正式版”的完整命令树；若长时间预检期间该 baseline 发生变化，会针对新的 baseline 重新比较。
 - GoReleaser 只构建；Darwin 重签、checksums 重算和 npm 安装验证通过后，才统一上传 GitHub Release 的最终产物。

--- a/scripts/release/delivered-stable-recoveries.json
+++ b/scripts/release/delivered-stable-recoveries.json
@@ -1,0 +1,14 @@
+{
+  "recoveries": [
+    {
+      "tag": "v1.0.52",
+      "commit": "4e59f9aa7ab057da8d5512ae9818fb66d4c6a045",
+      "run_id": 29380892754,
+      "workflow_sha": "434251695c19ebbfe2a2240d2eddce2d56af07b7",
+      "head_branch": "codex/recover-v1.0.52",
+      "run_attempt": 1,
+      "reviewed": true,
+      "review_reason": "The original stable tag push selected the colocated v1.0.52-beta.5 tag. This pinned workflow_dispatch run checked out the annotated v1.0.52 tag, required it to equal origin/main, built and signed that exact commit, published all channels, and completed every delivery job successfully."
+    }
+  ]
+}

--- a/scripts/release/verify-delivered-stable.sh
+++ b/scripts/release/verify-delivered-stable.sh
@@ -3,6 +3,7 @@ set -eu
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 . "$SCRIPT_DIR/release-lib.sh"
+RECOVERY_MANIFEST="$SCRIPT_DIR/delivered-stable-recoveries.json"
 
 TAG="${1:-}"
 EXPECTED_COMMIT="${2:-}"
@@ -75,10 +76,114 @@ for run in json.load(sys.stdin).get("workflow_runs", []):
 printf '%s\n' "$stable_runs" | awk -F '\t' -v sha="$EXPECTED_COMMIT" -v tag="$TAG" '
   $1 == sha && $2 == tag && $3 == "success" { found = 1 }
   END { exit(found ? 0 : 1) }
-' || {
-  printf 'Release workflow did not complete successfully for stable baseline %s at %s\n' \
-    "$TAG" "$EXPECTED_COMMIT" >&2
-  exit 1
+' && delivered_by_push=1 || delivered_by_push=0
+
+if [ "$delivered_by_push" -ne 1 ]; then
+  recovery_proof="$(
+    python3 - "$RECOVERY_MANIFEST" "$TAG" "$EXPECTED_COMMIT" <<'PY'
+import json
+import sys
+
+path, tag, commit = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+if set(payload) != {"recoveries"} or not isinstance(payload["recoveries"], list):
+    raise SystemExit("invalid delivered stable recovery manifest")
+
+required = {
+    "tag", "commit", "run_id", "workflow_sha", "head_branch",
+    "run_attempt", "reviewed", "review_reason",
 }
+matches = []
+identities = set()
+for entry in payload["recoveries"]:
+    if not isinstance(entry, dict) or set(entry) != required:
+        raise SystemExit("invalid delivered stable recovery entry")
+    identity = (entry["tag"], entry["commit"])
+    if identity in identities:
+        raise SystemExit("duplicate delivered stable recovery entry")
+    identities.add(identity)
+    if (
+        not isinstance(entry["tag"], str)
+        or not isinstance(entry["commit"], str)
+        or not isinstance(entry["run_id"], int)
+        or entry["run_id"] <= 0
+        or not isinstance(entry["workflow_sha"], str)
+        or not isinstance(entry["head_branch"], str)
+        or not isinstance(entry["run_attempt"], int)
+        or entry["run_attempt"] <= 0
+        or entry["reviewed"] is not True
+        or not isinstance(entry["review_reason"], str)
+        or not entry["review_reason"].strip()
+    ):
+        raise SystemExit("invalid delivered stable recovery evidence")
+    if identity == (tag, commit):
+        matches.append(entry)
+
+if len(matches) > 1:
+    raise SystemExit("ambiguous delivered stable recovery evidence")
+if matches:
+    entry = matches[0]
+    print(entry["run_id"])
+    print(entry["workflow_sha"])
+    print(entry["head_branch"])
+    print(entry["run_attempt"])
+PY
+  )" || exit 1
+  [ -n "$recovery_proof" ] || {
+    printf 'Release workflow did not complete successfully for stable baseline %s at %s\n' \
+      "$TAG" "$EXPECTED_COMMIT" >&2
+    exit 1
+  }
+
+  recovery_run_id="$(printf '%s\n' "$recovery_proof" | sed -n '1p')"
+  recovery_workflow_sha="$(printf '%s\n' "$recovery_proof" | sed -n '2p')"
+  recovery_head_branch="$(printf '%s\n' "$recovery_proof" | sed -n '3p')"
+  recovery_run_attempt="$(printf '%s\n' "$recovery_proof" | sed -n '4p')"
+  recovery_run_state="$(
+    github_get "repos/$REPOSITORY/actions/runs/$recovery_run_id" \
+      | python3 -c 'import json,sys
+r=json.load(sys.stdin)
+print("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (
+    r.get("event", ""), r.get("status", ""), r.get("conclusion", ""),
+    r.get("head_sha", ""), r.get("head_branch", ""), r.get("run_attempt", ""),
+    r.get("path", ""), r.get("repository", {}).get("full_name", "")))'
+  )" || {
+    printf 'could not query reviewed recovery run %s for %s\n' "$recovery_run_id" "$TAG" >&2
+    exit 1
+  }
+  expected_recovery_state="$(printf 'workflow_dispatch\tcompleted\tsuccess\t%s\t%s\t%s\t.github/workflows/release.yml\t%s' \
+    "$recovery_workflow_sha" "$recovery_head_branch" "$recovery_run_attempt" "$REPOSITORY")"
+  [ "$recovery_run_state" = "$expected_recovery_state" ] || {
+    printf 'reviewed recovery run %s does not match the pinned delivery proof for %s\n' \
+      "$recovery_run_id" "$TAG" >&2
+    exit 1
+  }
+
+  recovery_jobs="$(
+    github_get "repos/$REPOSITORY/actions/runs/$recovery_run_id/jobs?per_page=100" \
+      | python3 -c 'import json,sys
+for job in json.load(sys.stdin).get("jobs", []):
+    print("%s\t%s\t%s\t%s" % (
+        job.get("name", ""), job.get("status", ""),
+        job.get("conclusion", ""), job.get("head_sha", "")))'
+  )" || {
+    printf 'could not query reviewed recovery jobs for %s\n' "$TAG" >&2
+    exit 1
+  }
+  for recovery_job in release verify-darwin-signatures publish-release; do
+    printf '%s\n' "$recovery_jobs" | awk -F '\t' -v name="$recovery_job" -v sha="$recovery_workflow_sha" '
+      $1 == name && $2 == "completed" && $3 == "success" && $4 == sha { found++ }
+      END { exit(found == 1 ? 0 : 1) }
+    ' || {
+      printf 'reviewed recovery run %s is missing successful job %s for %s\n' \
+        "$recovery_run_id" "$recovery_job" "$TAG" >&2
+      exit 1
+    }
+  done
+  printf 'Delivered stable baseline verified through reviewed recovery run %s: %s -> %s\n' \
+    "$recovery_run_id" "$TAG" "$EXPECTED_COMMIT"
+  exit 0
+fi
 
 printf 'Delivered stable baseline verified: %s -> %s\n' "$TAG" "$EXPECTED_COMMIT"

--- a/test/scripts/release_script_test.go
+++ b/test/scripts/release_script_test.go
@@ -331,6 +331,67 @@ esac
 	}
 }
 
+func TestReleaseDeliveredStableAcceptsOnlyPinnedSuccessfulRecovery(t *testing.T) {
+	const (
+		tag         = "v1.0.52"
+		commit      = "4e59f9aa7ab057da8d5512ae9818fb66d4c6a045"
+		runID       = "29380892754"
+		workflowSHA = "434251695c19ebbfe2a2240d2eddce2d56af07b7"
+	)
+	sourceRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("Abs(repo root) error = %v", err)
+	}
+	root := t.TempDir()
+	mustRun(t, root, "git", "init")
+	binDir := t.TempDir()
+	fakeCurl := filepath.Join(binDir, "curl")
+	mustWriteFile(t, fakeCurl, []byte(`#!/bin/sh
+set -eu
+for arg in "$@"; do last="$arg"; done
+case "$last" in
+  */releases/tags/*)
+    printf '{"tag_name":"v1.0.52","draft":false,"prerelease":false}\n'
+    ;;
+  */actions/workflows/release.yml/runs*)
+    printf '{"workflow_runs":[]}\n'
+    ;;
+  */actions/runs/29380892754/jobs*)
+    printf '{"jobs":[{"name":"release","status":"completed","conclusion":"success","head_sha":"%s"},{"name":"verify-darwin-signatures","status":"completed","conclusion":"success","head_sha":"%s"},{"name":"publish-release","status":"completed","conclusion":"%s","head_sha":"%s"}]}\n' "$WORKFLOW_SHA" "$WORKFLOW_SHA" "$PUBLISH_CONCLUSION" "$WORKFLOW_SHA"
+    ;;
+  */actions/runs/29380892754)
+    printf '{"event":"workflow_dispatch","status":"completed","conclusion":"success","head_sha":"%s","head_branch":"codex/recover-v1.0.52","run_attempt":1,"path":".github/workflows/release.yml","repository":{"full_name":"owner/repo"}}\n' "$RUN_HEAD_SHA"
+    ;;
+  *) exit 1 ;;
+esac
+`), 0o755)
+	script := filepath.Join(sourceRoot, "scripts", "release", "verify-delivered-stable.sh")
+	run := func(runHeadSHA, publishConclusion string) (string, error) {
+		cmd := exec.Command("sh", script, tag, commit)
+		cmd.Dir = root
+		cmd.Env = []string{
+			"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+			"HOME=" + t.TempDir(),
+			"DWS_RELEASE_OFFICIAL_REPOSITORY=owner/repo",
+			"WORKFLOW_SHA=" + workflowSHA,
+			"RUN_HEAD_SHA=" + runHeadSHA,
+			"PUBLISH_CONCLUSION=" + publishConclusion,
+		}
+		output, err := cmd.CombinedOutput()
+		return string(output), err
+	}
+
+	if output, err := run(workflowSHA, "success"); err != nil || !strings.Contains(output, "reviewed recovery run "+runID) {
+		t.Fatalf("pinned stable recovery was rejected: err=%v\noutput:\n%s", err, output)
+	}
+	if output, err := run(strings.Repeat("0", 40), "success"); err == nil || !strings.Contains(output, "does not match the pinned delivery proof") {
+		t.Fatalf("mismatched recovery workflow passed: err=%v\noutput:\n%s", err, output)
+	}
+	if output, err := run(workflowSHA, "failure"); err == nil || !strings.Contains(output, "missing successful job publish-release") {
+		t.Fatalf("failed recovery delivery job passed: err=%v\noutput:\n%s", err, output)
+	}
+}
+
 func releaseChangelog(sections ...string) string {
 	text := "# Changelog\n\n## [Unreleased]\n\n"
 	for _, section := range sections {


### PR DESCRIPTION
## Requirement and goal

Unblock the guarded v1.0.53-beta.2 preflight without moving, deleting, reusing, or bypassing any published tag. The previous stable v1.0.52 was delivered by the repository recovery workflow after its original tag-push run selected the colocated beta.5 tag and failed on duplicate assets.

## Expected behavior

A successful exact-tag push Release run remains the default proof. A historical workflow_dispatch counts only when a reviewed repository manifest pins the exact stable tag, tag commit, recovery run ID, workflow SHA, branch and attempt, and the release, Darwin signature verification, and final publication jobs each completed successfully at that SHA. Arbitrary dispatches, mismatched SHAs and incomplete jobs remain fail-closed.

## Implementation

- Add one closed reviewed proof for v1.0.52 and recovery run 29380892754.
- Validate manifest shape, uniqueness and reviewed reason.
- Query the pinned run and jobs from GitHub and require exact identity plus all three delivery jobs.
- Keep the existing exact-tag push path unchanged.
- Document the narrow historical recovery rule and include it in the beta.2 release notes.

## Verification

| ID | Acceptance criterion | Command | Expected result | Observed result | Status |
|---|---|---|---|---|---|
| V1 | Exact push delivery still passes and failed push without proof fails | go test ./test/scripts -run '^TestReleaseDeliveredStable' -count=1 | pass | pass | PASS |
| V2 | Pinned recovery passes; wrong workflow SHA and failed publish job fail closed | same focused test | pass | pass | PASS |
| V3 | Real v1.0.52 recovery evidence resolves through GitHub API | scripts/release/verify-delivered-stable.sh v1.0.52 4e59f9aa7ab057da8d5512ae9818fb66d4c6a045 | reviewed recovery run 29380892754 verified | observed exact success output | PASS |
| V4 | Full release/package script regression suite | go test ./test/scripts -count=1 | pass | pass in 255.795s | PASS |
| V5 | Public asset audit and whitespace | ./scripts/policy/check-open-source-assets.sh and git diff --check | pass | pass | PASS |

Full repository CI is delegated to the canonical PR because this high-risk release-infrastructure change is developed in an isolated temporary fork worktree where executing locally built DWS binaries is prohibited by repository guidance.

## Risk and rollback

The risk is limited to stable-baseline evidence selection. The recovery path is exact and reviewed, cannot be supplied by environment variables, and still verifies public release state plus pinned workflow/job identities. Rollback is a revert of this PR; no tag or release state is mutated by this change.