### PR TITLE
chore: update Homebrew beta formula for v1.0.53-beta.2

### DIFF
--- a/Formula/dingtalk-workspace-cli-beta.rb
+++ b/Formula/dingtalk-workspace-cli-beta.rb
@@ -1,33 +1,33 @@
 class DingtalkWorkspaceCliBeta < Formula
   desc "Automate DingTalk workspace tasks from the terminal (beta channel)"
   homepage "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli"
-  version "1.0.53-beta.1"
+  version "1.0.53-beta.2"
   license "Apache-2.0"
   keg_only "it is the beta channel and conflicts with dingtalk-workspace-cli"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.1/dws-darwin-arm64.tar.gz"
-      sha256 "7fef5add684189bfef16a1731fab4883fa096115dcd645c79bf9b3918758dbcb"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-darwin-arm64.tar.gz"
+      sha256 "08e4c0c5f40b720a823851073badcccda9c8ce9731f1f6f60bd2de3e9d3007ec"
     else
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.1/dws-darwin-amd64.tar.gz"
-      sha256 "8cde0fd62849dcb52bc053022361f983953bd5a4bac1edfc96076a84636debbe"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-darwin-amd64.tar.gz"
+      sha256 "306f301fabedf412c1326aa31343217d157df5c9485db32f8cbc8c33f592971a"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.1/dws-linux-arm64.tar.gz"
-      sha256 "17989f94b422d6490249c5e095049a9efc1c3861176fc249d5e7eea283f5e675"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-linux-arm64.tar.gz"
+      sha256 "6a6aaf9143ac63501f8104a76e4d8598a1330aab1ca287d31bcde73556ed8375"
     else
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.1/dws-linux-amd64.tar.gz"
-      sha256 "439d6a1ffc9572ed461b77a8bb27f6ddb4d4c9ce9d58474c0180955fc8a1d8d7"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-linux-amd64.tar.gz"
+      sha256 "7b22bc0790651c69051205a3621046973ee978a65572e3e33a69a245ec92ac61"
     end
   end
 
   resource "skills" do
-    url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.1/dws-skills.zip"
-    sha256 "a93ba8a73f2e319038a7bcb32038b9e7bd93d1e9af012a430ebf994498c140d4"
+    url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-skills.zip"
+    sha256 "cbfe8c3f8c60892b56a9c3f9090757f476112c7b556dccca2098148cdc387c1b"
   end
 
   def install

--- a/Formula/dingtalk-workspace-cli-beta.rb
+++ b/Formula/dingtalk-workspace-cli-beta.rb
@@ -8,26 +8,26 @@ class DingtalkWorkspaceCliBeta < Formula
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-darwin-arm64.tar.gz"
-      sha256 "08e4c0c5f40b720a823851073badcccda9c8ce9731f1f6f60bd2de3e9d3007ec"
+      sha256 "47d3f470003a309f4a93a4dfe55ab39240018b7c698f7863d85834e1f0a3affa"
     else
       url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-darwin-amd64.tar.gz"
-      sha256 "306f301fabedf412c1326aa31343217d157df5c9485db32f8cbc8c33f592971a"
+      sha256 "2dcf90b515d934e71715d95098d3b3cec34299cdbe6c858e1106a81d23d3d51a"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-linux-arm64.tar.gz"
-      sha256 "6a6aaf9143ac63501f8104a76e4d8598a1330aab1ca287d31bcde73556ed8375"
+      sha256 "b4692a3c2690460c039e641f75f6793daf3b8549b8c9a35d01153a908f6cc2b1"
     else
       url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-linux-amd64.tar.gz"
-      sha256 "7b22bc0790651c69051205a3621046973ee978a65572e3e33a69a245ec92ac61"
+      sha256 "000d29d4c81589553e5b23b573002b7014b16c073793b8d7c5617e9b89488175"
     end
   end
 
   resource "skills" do
     url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.2/dws-skills.zip"
-    sha256 "cbfe8c3f8c60892b56a9c3f9090757f476112c7b556dccca2098148cdc387c1b"
+    sha256 "b55a4eaaa63073147c3b9efff48b4713be75577c8a1d2dc8c6e11dc30b4f91c8"
   end
 
   def install


### PR DESCRIPTION
## Summary

- update the keg-only Homebrew beta Formula to v1.0.53-beta.2
- rebase the automation branch through current `main` at `642e676f`
- correct all five Formula SHA256 values to the immutable GitHub Release assets

## Problem found during review

The generated Formula URLs point to the GitHub v1.0.53-beta.2 Release, but the original five SHA256 values did not match that Release's published `checksums.txt` or asset digests. Merging the original branch would make Homebrew reject every supported macOS/Linux archive and the bundled Skills resource after download.

The corrected values are:

| Asset | SHA256 |
|---|---|
| `dws-darwin-amd64.tar.gz` | `2dcf90b515d934e71715d95098d3b3cec34299cdbe6c858e1106a81d23d3d51a` |
| `dws-darwin-arm64.tar.gz` | `47d3f470003a309f4a93a4dfe55ab39240018b7c698f7863d85834e1f0a3affa` |
| `dws-linux-amd64.tar.gz` | `000d29d4c81589553e5b23b573002b7014b16c073793b8d7c5617e9b89488175` |
| `dws-linux-arm64.tar.gz` | `b4692a3c2690460c039e641f75f6793daf3b8549b8c9a35d01153a908f6cc2b1` |
| `dws-skills.zip` | `b55a4eaaa63073147c3b9efff48b4713be75577c8a1d2dc8c6e11dc30b4f91c8` |

## Validation

| ID | Acceptance criterion | Command / evidence | Expected result | Observed result | Status |
|---|---|---|---|---|---|
| V1 | Formula matches the sealed GitHub assets | Download each release asset through the GitHub API with pipe-failure propagation and run `shasum -a 256` | All five hashes equal the Formula | All five matched exactly | PASS |
| V2 | Formula remains valid Ruby | `ruby -c Formula/dingtalk-workspace-cli-beta.rb` | `Syntax OK` | `Syntax OK` | PASS |
| V3 | Formula follows Homebrew style | `HOMEBREW_NO_AUTO_UPDATE=1 brew style Formula/dingtalk-workspace-cli-beta.rb` | No offenses | 1 file inspected, no offenses | PASS |
| V4 | Checked-in beta Formula contract remains valid | `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run 'TestCheckedInHomebrewBetaFormulaIsSeparateAndKegOnly|TestPostGoreleaserBuildsVersionedBetaFormula' -count=1` | Exit 0 | Exit 0 | PASS |
| V5 | CLI still compiles | `go build -o /dev/null ./cmd` | Exit 0 | Exit 0 | PASS |
| V6 | Patch has no whitespace errors | `git diff --check` | Exit 0 | Exit 0 | PASS |
| V7 | Repository CI | GitHub required checks on latest HEAD | All required checks succeed | 26 succeeded, 1 skipped, 0 failed on `f8e1be59` | PASS |

## Scope and follow-up

This PR only repairs delivery metadata for an already-published prerelease; it does not change product behavior, so no `CHANGELOG.md` entry is added. The release automation must separately prevent a generated Formula from diverging from the immutable GitHub assets; that release-governance follow-up stays outside this one-file delivery repair.
