### PR TITLE
fix: accept uploaded media IDs for group icons

### DIFF
--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -188,10 +187,6 @@ func isNumericUserID(value string) bool {
 	}
 	return true
 }
-
-// dingTalkMediaIDPattern 匹配钉钉媒体 ID（上传接口返回），固定以 @ 开头，
-// 后跟 base64 风格字符（如 @lADPfake、@lQDPM4DCjE1Mk_nNBInNBImw...）。
-var dingTalkMediaIDPattern = regexp.MustCompile(`^@[A-Za-z0-9_\-+/=.]{4,}$`)
 
 func isOpenDingTalkID(value string) bool {
 	value = strings.TrimSpace(value)
@@ -3366,10 +3361,8 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 				return err
 			}
 			iconMediaID := strings.TrimSpace(mustGetFlag(cmd, "icon-media-id"))
-			// 客户端预校验：钉钉媒体 ID 由上传接口（如 dt_media_upload）返回，
-			// 固定以 @ 开头（形如 @lADP.../@lQDP...）。明显非法的值本地直接报错。
-			if !dingTalkMediaIDPattern.MatchString(iconMediaID) {
-				return fmt.Errorf("invalid --icon-media-id %q: 钉钉媒体 ID 应以 @ 开头（如 @lADP...）\n  hint: 先通过媒体上传命令（dt_media_upload）上传图片，使用返回的 mediaId", iconMediaID)
+			if iconMediaID == "" {
+				return fmt.Errorf("invalid --icon-media-id: mediaId 不能为空\n  hint: 先通过媒体上传命令（dt_media_upload）上传图片，使用返回的 mediaId")
 			}
 			return callMCPToolOnServer("im", "update_group_icon", map[string]any{
 				"openConversationId": mustGetFlag(cmd, "group"),

--- a/internal/helpers/chat_command_edges_test.go
+++ b/internal/helpers/chat_command_edges_test.go
@@ -43,6 +43,48 @@ func runChatCoverageDirect(t *testing.T, path []string, flags map[string]string)
 	return command.RunE(command, nil)
 }
 
+func TestChatGroupUpdateIconAcceptsUploadedMediaIDPrefixes(t *testing.T) {
+	previousDeps, previousArgs := deps, os.Args
+	os.Args = []string{"dws", "chat"}
+	t.Cleanup(func() { deps, os.Args = previousDeps, previousArgs })
+
+	for _, tc := range []struct {
+		name    string
+		mediaID string
+	}{
+		{name: "at prefix", mediaID: "@lADPvalidMediaID"},
+		{name: "dollar prefix", mediaID: "$iAEvalidMediaID"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &productExampleCaller{}
+			err := runChatCoverageCommand(t, caller,
+				"group", "update-icon", "--group=cid", "--icon-media-id="+tc.mediaID)
+			if err != nil {
+				t.Fatalf("update group icon with uploaded media ID %q: %v", tc.mediaID, err)
+			}
+			if caller.calls != 1 {
+				t.Fatalf("tool calls = %d, want 1", caller.calls)
+			}
+		})
+	}
+}
+
+func TestChatGroupUpdateIconRejectsBlankMediaID(t *testing.T) {
+	previousDeps, previousArgs := deps, os.Args
+	os.Args = []string{"dws", "chat"}
+	t.Cleanup(func() { deps, os.Args = previousDeps, previousArgs })
+
+	caller := &productExampleCaller{}
+	err := runChatCoverageCommand(t, caller,
+		"group", "update-icon", "--group=cid", "--icon-media-id=   ")
+	if err == nil {
+		t.Fatal("update group icon with a blank media ID succeeded, want validation error")
+	}
+	if caller.calls != 0 {
+		t.Fatalf("tool calls = %d, want 0", caller.calls)
+	}
+}
+
 func TestCrossPlatformCoverageChatCommandValidationAndSuccessEdges(t *testing.T) {
 	previousDeps, previousArgs := deps, os.Args
 	os.Args = []string{"dws", "chat"}

--- a/internal/helpers/chat_command_edges_test.go
+++ b/internal/helpers/chat_command_edges_test.go
@@ -43,7 +43,7 @@ func runChatCoverageDirect(t *testing.T, path []string, flags map[string]string)
 	return command.RunE(command, nil)
 }
 
-func TestChatGroupUpdateIconAcceptsUploadedMediaIDPrefixes(t *testing.T) {
+func TestCrossPlatformCoverageChatGroupUpdateIconAcceptsUploadedMediaIDPrefixes(t *testing.T) {
 	previousDeps, previousArgs := deps, os.Args
 	os.Args = []string{"dws", "chat"}
 	t.Cleanup(func() { deps, os.Args = previousDeps, previousArgs })
@@ -69,7 +69,7 @@ func TestChatGroupUpdateIconAcceptsUploadedMediaIDPrefixes(t *testing.T) {
 	}
 }
 
-func TestChatGroupUpdateIconRejectsBlankMediaID(t *testing.T) {
+func TestCrossPlatformCoverageChatGroupUpdateIconRejectsBlankMediaID(t *testing.T) {
 	previousDeps, previousArgs := deps, os.Args
 	os.Args = []string{"dws", "chat"}
 	t.Cleanup(func() { deps, os.Args = previousDeps, previousArgs })


### PR DESCRIPTION
## Summary

- Treat `chat group update-icon --icon-media-id` as a server-issued opaque identifier instead of requiring an `@` prefix.
- Keep trimmed non-empty validation and add regression coverage for both `@...` and `$...` upload results.

DingTalk media upload can return media IDs beginning with `$`. The CLI previously rejected those IDs before calling `im/update_group_icon` because it hard-coded an `@`-only regular expression. Passing the non-empty identifier through aligns this command with the other media-ID consumers.

## Verification

- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/helpers -run 'Chat' -count=1`
- [x] `go vet ./...`
- [x] `go build -trimpath -o /tmp/dws-chat-media-id-fix ./cmd`
- [x] `./scripts/policy/check-generated-drift.sh`
- [x] Local binary dry-run with both `@...` and `$...` media IDs; both reached `im/update_group_icon` without a real write
- [ ] `make test` — not marked complete: a full run hit existing `internal/auth` OAuth callback timeouts, while the changed `internal/helpers` package passed
- [ ] `make policy` — not run

## Notes

- No command surface or generated Schema input changed.
- Existing Skill/shortcut prose that describes media IDs as `@`-prefixed is intentionally outside this focused CLI regression fix and should be reviewed separately.
