### PR TITLE
chore(lint): fix pre-existing ST1005 capitalized error string

### DIFF
--- a/internal/generator/agentmetadata/manual_hints_test.go
+++ b/internal/generator/agentmetadata/manual_hints_test.go
@@ -101,7 +101,7 @@ func TestGenerateRejectsIncompleteSelectionCoverage(t *testing.T) {
 
 func TestGenerateRequiresAgentHintDirectory(t *testing.T) {
 	_, _, err := Generate(Options{})
-	if err == nil || !strings.Contains(err.Error(), "Agent hint directory is required") {
+	if err == nil || !strings.Contains(err.Error(), "agent hint directory is required") {
 		t.Fatalf("Generate() error = %v", err)
 	}
 }

--- a/internal/generator/agentmetadata/metadata.go
+++ b/internal/generator/agentmetadata/metadata.go
@@ -369,7 +369,7 @@ var (
 
 func Generate(opts Options) (File, Stats, error) {
 	if strings.TrimSpace(opts.HintsDir) == "" {
-		return File{}, Stats{}, fmt.Errorf("Agent hint directory is required")
+		return File{}, Stats{}, fmt.Errorf("agent hint directory is required")
 	}
 	if len(opts.CanonicalToolPaths) == 0 || len(opts.ToolPaths) == 0 || len(opts.ProductIDs) == 0 {
 		return File{}, Stats{}, fmt.Errorf("complete Effective CommandRegistry projection is required")


### PR DESCRIPTION
## Summary

- **What changed:** Lowercased one error string flagged by staticcheck ST1005 in `internal/generator/agentmetadata/metadata.go`: `"Agent hint directory is required"` → `"agent hint directory is required"`. Updated the one test (`TestGenerateRequiresAgentHintDirectory`) that asserts on this text.
- **Why:** This is the only staticcheck finding on `main`. It is unrelated to any feature PR and CI does not currently enforce staticcheck (golangci-lint is disabled in `ci.yml` due to a Go-version incompatibility), so it has been lingering. Fixing it lets local `make lint` go fully green and re-enables the lint checklist item for contributors.

## Verification

- [x] `make lint` — gofmt + go vet + staticcheck all pass (was: 1 ST1005 finding)
- [x] `go test ./internal/generator/agentmetadata/` — `TestGenerateRequiresAgentHintDirectory` passes

## Notes

- Trivial, no behavior change (error string wording only).
- Spotted while running `make lint` locally for #656; kept separate to avoid scope creep there.