### PR TITLE
fix(chat): use openconversation_id for group message lists

### DIFF
--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -1351,10 +1351,9 @@ func newChatCommand() *cobra.Command {
 			timeVal := mustGetFlag(cmd, "time")
 			if groupID != "" {
 				toolArgs := map[string]any{
-					"openCid": groupID,
-					"cid":     groupID,
-					"time":    timeVal,
-					"forward": forward,
+					"openconversation_id": groupID,
+					"time":                timeVal,
+					"forward":             forward,
 				}
 				if v := chatIntFlagOrFallback(cmd, "limit", "size"); v > 0 {
 					toolArgs["limit"] = v

--- a/internal/helpers/chat_message_search_test.go
+++ b/internal/helpers/chat_message_search_test.go
@@ -161,7 +161,7 @@ func executeChatChangedContract(t *testing.T, caller *chatChangedContractCaller,
 	return cmd.Execute()
 }
 
-func TestCrossPlatformCoverageChatMessageListUsesObservedGroupKeys(t *testing.T) {
+func TestCrossPlatformCoverageChatMessageListUsesMCPMetadataGroupKey(t *testing.T) {
 	caller := &chatChangedContractCaller{}
 	err := executeChatChangedContract(t, caller,
 		"message", "list", "--group", "cid-1", "--time", "2026-07-15 09:00:00", "--limit", "50")
@@ -171,7 +171,7 @@ func TestCrossPlatformCoverageChatMessageListUsesObservedGroupKeys(t *testing.T)
 	if len(caller.calls) != 1 || caller.calls[0].toolName != "list_conversation_message_v2" {
 		t.Fatalf("calls = %#v", caller.calls)
 	}
-	want := map[string]any{"openCid": "cid-1", "cid": "cid-1", "time": "2026-07-15 09:00:00", "forward": true, "limit": 50}
+	want := map[string]any{"openconversation_id": "cid-1", "time": "2026-07-15 09:00:00", "forward": true, "limit": 50}
 	if !reflect.DeepEqual(caller.calls[0].args, want) {
 		t.Fatalf("tool args = %#v, want %#v", caller.calls[0].args, want)
 	}

--- a/internal/shortcut/chat/chat_message.go
+++ b/internal/shortcut/chat/chat_message.go
@@ -221,10 +221,9 @@ var MessagesList = shortcut.Shortcut{
 	Execute: func(rt *shortcut.RuntimeContext) error {
 		group := rt.StrFirst("group", "conversation-id", "id")
 		params := map[string]any{
-			"openCid": group,
-			"cid":     group,
-			"time":    rt.Str("time"),
-			"forward": rt.Bool("forward"),
+			"openconversation_id": group,
+			"time":                rt.Str("time"),
+			"forward":             rt.Bool("forward"),
 		}
 		if limit := rt.IntFirst("limit", "size"); limit > 0 {
 			params["limit"] = limit

--- a/internal/shortcut/chat/compatibility_coverage_test.go
+++ b/internal/shortcut/chat/compatibility_coverage_test.go
@@ -58,6 +58,7 @@ func TestCrossPlatformCoverageCompatibilityAliases(t *testing.T) {
 		wantProduct string
 		wantTool    string
 		wantArgs    map[string]any
+		wantAbsent  []string
 	}{
 		{
 			name:        "chat search keyword and size",
@@ -81,7 +82,8 @@ func TestCrossPlatformCoverageCompatibilityAliases(t *testing.T) {
 			},
 			wantProduct: "chat",
 			wantTool:    "list_conversation_message_v2",
-			wantArgs:    map[string]any{"openCid": "cid-1", "limit": 7},
+			wantArgs:    map[string]any{"openconversation_id": "cid-1", "limit": 7},
+			wantAbsent:  []string{"openCid", "cid"},
 		},
 		{
 			name: "direct messages size",
@@ -117,6 +119,11 @@ func TestCrossPlatformCoverageCompatibilityAliases(t *testing.T) {
 			for key, want := range tc.wantArgs {
 				if got := fake.args[key]; got != want {
 					t.Errorf("%s = %#v, want %#v", key, got, want)
+				}
+			}
+			for _, key := range tc.wantAbsent {
+				if _, ok := fake.args[key]; ok {
+					t.Errorf("unexpected legacy argument %q in %#v", key, fake.args)
 				}
 			}
 		})

--- a/internal/shortcut/smart/chat_messages.go
+++ b/internal/shortcut/smart/chat_messages.go
@@ -25,7 +25,7 @@ import (
 //
 // Steps:
 //  1. depending on whether --group or --user is given, call either
-//     list_conversation_message_v2 (group; param openCid) or
+//     list_conversation_message_v2 (group; param openconversation_id) or
 //     list_individual_chat_message (single chat; param userId) on the chat
 //     server — tool names and param keys copied verbatim from chat.go's
 //     `dws chat message list` call sites;
@@ -70,7 +70,7 @@ var ChatMessages = shortcut.Shortcut{
 	},
 	Execute: func(rt *shortcut.RuntimeContext) error {
 		// Step 1 — build params and pick the right tool. Param keys
-		// (openCid/cid / userId / time / forward / limit) match the MCP server
+		// (openconversation_id / userId / time / forward / limit) match the MCP server
 		// schema for group and direct message listing.
 		var tool string
 		params := map[string]any{}
@@ -95,8 +95,7 @@ var ChatMessages = shortcut.Shortcut{
 
 		if group := rt.StrFirst("group", "conversation-id", "id"); group != "" {
 			tool = "list_conversation_message_v2"
-			params["openCid"] = group
-			params["cid"] = group
+			params["openconversation_id"] = group
 		} else {
 			tool = "list_individual_chat_message"
 			params["userId"] = rt.Str("user")

--- a/internal/shortcut/smart/compatibility_coverage_test.go
+++ b/internal/shortcut/smart/compatibility_coverage_test.go
@@ -112,16 +112,18 @@ func TestCrossPlatformCoverageAIMessageTag(t *testing.T) {
 
 func TestCrossPlatformCoverageCompatibilityAliases(t *testing.T) {
 	tests := []struct {
-		name     string
-		argv     []string
-		wantTool string
-		wantArgs map[string]any
+		name       string
+		argv       []string
+		wantTool   string
+		wantArgs   map[string]any
+		wantAbsent []string
 	}{
 		{
-			name:     "chat messages id and size",
-			argv:     []string{"chat", "+chat-messages", "--id", "cid-1", "--size", "9", "--yes"},
-			wantTool: "list_conversation_message_v2",
-			wantArgs: map[string]any{"openCid": "cid-1", "limit": 9},
+			name:       "chat messages id and size",
+			argv:       []string{"chat", "+chat-messages", "--id", "cid-1", "--size", "9", "--yes"},
+			wantTool:   "list_conversation_message_v2",
+			wantArgs:   map[string]any{"openconversation_id": "cid-1", "limit": 9},
+			wantAbsent: []string{"openCid", "cid"},
 		},
 		{
 			name:     "search message id and keyword",
@@ -147,6 +149,11 @@ func TestCrossPlatformCoverageCompatibilityAliases(t *testing.T) {
 			for key, want := range tc.wantArgs {
 				if got := call.args[key]; got != want {
 					t.Errorf("%s = %#v, want %#v", key, got, want)
+				}
+			}
+			for _, key := range tc.wantAbsent {
+				if _, ok := call.args[key]; ok {
+					t.Errorf("unexpected legacy argument %q in %#v", key, call.args)
 				}
 			}
 		})


### PR DESCRIPTION
## What changed

- Send `openconversation_id` to `list_conversation_message_v2`.
- Apply the same mapping to `chat message list`, `chat +messages-list`, and `chat +chat-messages`.
- Add regression assertions that legacy `openCid` and `cid` are not sent.

## Root cause and impact

The CLI accepted the group ID through `--group` and its aliases, but forwarded it under legacy argument names. The current Open MCP metadata requires `openconversation_id`, so real group-message queries could not resolve the conversation correctly.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `make build`
- `make policy`
- Native changed-code coverage: 100.0% (10 executable statements; target 80.0%)