### PR TITLE
ci: align Code Admission gates and trusted changelog fast path

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ other pull request, mark the targeted check `N/A` and complete the applicable
 full-suite checks.
 
 - [ ] Exact `CHANGELOG.md`-only check (otherwise `N/A`):
-  `./scripts/policy/check-changelog-pr.sh "$(git merge-base HEAD origin/main)" HEAD`
+  `./scripts/policy/check-changelog-pr.sh --fast-path "$(git merge-base HEAD origin/main)" HEAD`
 - [ ] `make build`
 - [ ] `make lint`
 - [ ] `make test`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,13 @@
 
 ## Verification
 
+For an exact in-place `CHANGELOG.md`-only pull request, the full-suite checks
+may be marked `N/A`, but the targeted CHANGELOG check is required. For every
+other pull request, mark the targeted check `N/A` and complete the applicable
+full-suite checks.
+
+- [ ] Exact `CHANGELOG.md`-only check (otherwise `N/A`):
+  `./scripts/policy/check-changelog-pr.sh "$(git merge-base HEAD origin/main)" HEAD`
 - [ ] `make build`
 - [ ] `make lint`
 - [ ] `make test`

--- a/.github/workflows/ai-behavior-check.yml
+++ b/.github/workflows/ai-behavior-check.yml
@@ -1,8 +1,11 @@
-name: AI Behavior Check
+name: Code Admission — AI Behavior
 
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read
@@ -11,7 +14,7 @@ permissions:
 
 jobs:
   ai-behavior-check:
-    name: AI Behavior Policy Evaluator
+    name: AI Behavior
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -21,75 +24,107 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const sha = context.payload.pull_request.head.sha;
+            const pullRequest = context.payload.pull_request;
+            const sha = context.eventName === 'push' ? context.sha : pullRequest.head.sha;
             const setStatus = (state, description) =>
               github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 sha,
                 state,
-                context: 'AI Behavior Check',
+                context: 'AI Behavior',
                 description,
               });
 
             await setStatus('pending', 'Evaluating AI-generated PR boundaries');
 
-            const labels = context.payload.pull_request.labels.map(({ name }) => name);
-            if (!labels.includes('ai-generated')) {
-              await setStatus('success', 'Not labeled ai-generated');
-              core.notice('Not an ai-generated PR; no AI-only policy applied.');
+            if (context.eventName === 'push') {
+              await setStatus('success', 'Not applicable to the protected main push');
+              core.notice('AI Behavior is a PR policy; the main push context is sealed.');
               return;
             }
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              per_page: 100,
-            });
+            try {
+              const expectedHead = pullRequest.head.sha;
+              const expectedBase = pullRequest.base.sha;
+              const currentPull = async (phase) => {
+                const { data: pull } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number,
+                });
+                if (pull.head.sha !== expectedHead || pull.base.sha !== expectedBase) {
+                  throw new Error(
+                    `Pull request revision changed during ${phase}: ` +
+                    `expected base/head ${expectedBase}/${expectedHead}, ` +
+                    `got ${pull.base.sha}/${pull.head.sha}`
+                  );
+                }
+                return pull;
+              };
 
-            const maxChangedFiles = 30;
-            if (files.length > maxChangedFiles) {
+              const before = await currentPull('pre-policy check');
+              const labels = before.labels.map(({ name }) => name);
+              if (!labels.includes('ai-generated')) {
+                await setStatus('success', 'Not labeled ai-generated');
+                core.notice('Not an ai-generated PR; no AI-only policy applied.');
+                return;
+              }
+
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              });
+              await currentPull('post-policy check');
+
+              const maxChangedFiles = 30;
+              if (files.length > maxChangedFiles) {
+                await setStatus(
+                  'failure',
+                  `Changes ${files.length} files; limit is ${maxChangedFiles}`
+                );
+                core.setFailed(
+                  `AI-generated PR changes ${files.length} files; limit is ${maxChangedFiles}.`
+                );
+                return;
+              }
+
+              const isProtectedPath = (filename) =>
+                typeof filename === 'string' &&
+                (
+                  filename.startsWith('.github/workflows/') ||
+                  filename.startsWith('scripts/policy/') ||
+                  filename.startsWith('scripts/release/') ||
+                  filename === 'test/fixtures/cli-interface-baseline.txt' ||
+                  filename === '.goreleaser.yaml' ||
+                  filename === 'Makefile'
+                );
+              const protectedPaths = [...new Set(
+                files
+                  .flatMap(({ filename, previous_filename }) => [filename, previous_filename])
+                  .filter(isProtectedPath)
+              )];
+
+              if (protectedPaths.length > 0) {
+                await setStatus('failure', 'Modifies protected release/CI infrastructure');
+                core.setFailed(
+                  'AI-generated PR modifies protected release/CI infrastructure:\n' +
+                  protectedPaths.map((filename) => `  - ${filename}`).join('\n') +
+                  '\nSplit these changes into a human-owned PR with explicit review.'
+                );
+                return;
+              }
+
               await setStatus(
-                'failure',
-                `Changes ${files.length} files; limit is ${maxChangedFiles}`
+                'success',
+                `Passed with ${files.length} changed files (limit ${maxChangedFiles})`
               );
-              core.setFailed(
-                `AI-generated PR changes ${files.length} files; limit is ${maxChangedFiles}.`
+              core.notice(
+                `AI behavior check passed (${files.length} changed files; limit ${maxChangedFiles}).`
               );
-              return;
+            } catch (error) {
+              await setStatus('error', 'Could not evaluate the exact pull request revision');
+              throw error;
             }
-
-            const isProtectedPath = (filename) =>
-              typeof filename === 'string' &&
-              (
-                filename.startsWith('.github/workflows/') ||
-                filename.startsWith('scripts/policy/') ||
-                filename.startsWith('scripts/release/') ||
-                filename === 'test/fixtures/cli-interface-baseline.txt' ||
-                filename === '.goreleaser.yaml' ||
-                filename === 'Makefile'
-              );
-            const protectedPaths = [...new Set(
-              files
-                .flatMap(({ filename, previous_filename }) => [filename, previous_filename])
-                .filter(isProtectedPath)
-            )];
-
-            if (protectedPaths.length > 0) {
-              await setStatus('failure', 'Modifies protected release/CI infrastructure');
-              core.setFailed(
-                'AI-generated PR modifies protected release/CI infrastructure:\n' +
-                protectedPaths.map((filename) => `  - ${filename}`).join('\n') +
-                '\nSplit these changes into a human-owned PR with explicit review.'
-              );
-              return;
-            }
-
-            await setStatus(
-              'success',
-              `Passed with ${files.length} changed files (limit ${maxChangedFiles})`
-            );
-            core.notice(
-              `AI behavior check passed (${files.length} changed files; limit ${maxChangedFiles}).`
-            );

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,71 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  scope:
+    name: Classify PR changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      changelog_only: ${{ steps.classify.outputs.changelog_only }}
+    steps:
+      - name: Classify exact CHANGELOG-only pull requests
+        id: classify
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let changelogOnly = false;
+            let files = [];
+
+            if (context.eventName === 'pull_request') {
+              files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+              });
+              changelogOnly =
+                files.length === 1 &&
+                files[0].filename === 'CHANGELOG.md' &&
+                files[0].status === 'modified' &&
+                !files[0].previous_filename;
+            }
+
+            core.setOutput('changelog_only', String(changelogOnly));
+            await core.summary
+              .addHeading('PR change classification')
+              .addRaw(`- Event: \`${context.eventName}\`\n`)
+              .addRaw(`- Exact modified CHANGELOG only: \`${changelogOnly}\`\n`)
+              .addRaw(`- Changed files: \`${files.length}\`\n`)
+              .write();
+
+  changelog-check:
+    name: Changelog Check
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Check out pull request head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate exact CHANGELOG change
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: ./scripts/policy/check-changelog-pr.sh "$PR_BASE_SHA" "$PR_HEAD_SHA"
+
   lint:
     name: Lint
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -44,6 +107,8 @@ jobs:
 
   actionlint:
     name: Actionlint
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -60,6 +125,8 @@ jobs:
 
   test-race:
     name: "Test (race: ${{ matrix.shard }})"
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -116,6 +183,8 @@ jobs:
 
   test-release-scripts:
     name: Test (release scripts)
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -136,9 +205,10 @@ jobs:
   test:
     name: Test
     needs:
+      - scope
       - test-race
       - test-release-scripts
-    if: ${{ always() }}
+    if: ${{ always() && needs.scope.result == 'success' && needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
@@ -164,6 +234,8 @@ jobs:
 
   test-darwin:
     name: Test (macOS auth/keychain)
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
@@ -180,6 +252,8 @@ jobs:
 
   test-windows:
     name: Test (Windows)
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
@@ -202,6 +276,8 @@ jobs:
 
   coverage-darwin:
     name: Coverage (macOS)
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
@@ -244,6 +320,8 @@ jobs:
 
   coverage-windows:
     name: Coverage (Windows)
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
@@ -288,6 +366,8 @@ jobs:
 
   coverage-current:
     name: Coverage (current)
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -321,6 +401,8 @@ jobs:
 
   coverage-supporting:
     name: Coverage (supporting)
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -358,6 +440,8 @@ jobs:
 
   coverage-baseline:
     name: Coverage (baseline)
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -421,10 +505,11 @@ jobs:
   coverage:
     name: Coverage
     needs:
+      - scope
       - coverage-current
       - coverage-supporting
       - coverage-baseline
-    if: ${{ always() }}
+    if: ${{ always() && needs.scope.result == 'success' && needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -517,6 +602,8 @@ jobs:
 
   policy:
     name: Policy Check
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -536,6 +623,8 @@ jobs:
 
   interface-integrity:
     name: Interface Integrity
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -594,6 +683,8 @@ jobs:
 
   cli-smoke:
     name: CLI Smoke
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -613,6 +704,8 @@ jobs:
 
   mock-mcp-smoke:
     name: Mock MCP Smoke
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -629,6 +722,8 @@ jobs:
 
   edition-tests:
     name: Edition Contract Tests
+    needs: scope
+    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -646,6 +741,8 @@ jobs:
   ci-gate:
     name: CI Gate
     needs:
+      - scope
+      - changelog-check
       - lint
       - actionlint
       - test
@@ -666,6 +763,9 @@ jobs:
     steps:
       - name: Verify required checks
         env:
+          SCOPE_RESULT: ${{ needs.scope.result }}
+          CHANGELOG_ONLY: ${{ needs.scope.outputs.changelog_only }}
+          CHANGELOG_RESULT: ${{ needs.changelog-check.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
           TEST_RESULT: ${{ needs.test.result }}
@@ -681,6 +781,33 @@ jobs:
           EDITION_TESTS_RESULT: ${{ needs.edition-tests.result }}
         run: |
           failed=0
+          if [ "$SCOPE_RESULT" != "success" ]; then
+            printf 'Classify PR changes: %s\n' "$SCOPE_RESULT"
+            failed=1
+          fi
+
+          case "$CHANGELOG_ONLY" in
+            true)
+              expected_heavy_result=skipped
+              expected_changelog_result=success
+              ;;
+            false)
+              expected_heavy_result=success
+              expected_changelog_result=skipped
+              ;;
+            *)
+              printf 'invalid changelog_only classification: %s\n' "$CHANGELOG_ONLY"
+              failed=1
+              expected_heavy_result=invalid
+              expected_changelog_result=invalid
+              ;;
+          esac
+
+          printf 'Changelog Check: %s\n' "$CHANGELOG_RESULT"
+          if [ "$CHANGELOG_RESULT" != "$expected_changelog_result" ]; then
+            failed=1
+          fi
+
           for check in \
             "Lint:$LINT_RESULT" \
             "Actionlint:$ACTIONLINT_RESULT" \
@@ -699,7 +826,7 @@ jobs:
             name="${check%%:*}"
             result="${check#*:}"
             printf '%s: %s\n' "$name" "$result"
-            if [ "$result" != "success" ]; then
+            if [ "$result" != "$expected_heavy_result" ]; then
               failed=1
             fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Code Admission — PR 合入门禁
 
 on:
   push:
@@ -14,119 +14,140 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  scope:
-    name: Classify PR changes
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
     outputs:
       changelog_only: ${{ steps.classify.outputs.changelog_only }}
+      changelog_changed: ${{ steps.classify.outputs.changelog_changed }}
+      platform_sensitive: ${{ steps.classify.outputs.platform_sensitive }}
     steps:
-      - name: Classify exact CHANGELOG-only pull requests
+      - name: Classify pull request scope
         id: classify
         uses: actions/github-script@v7
         with:
           script: |
             let changelogOnly = false;
+            let changelogChanged = false;
+            let platformSensitive = context.eventName === 'push';
             let files = [];
 
             if (context.eventName === 'pull_request') {
+              const expectedHead = context.payload.pull_request.head.sha;
+              const expectedBase = context.payload.pull_request.base.sha;
+              const assertCurrentRevision = async (phase) => {
+                const { data: pull } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number,
+                });
+                if (pull.head.sha !== expectedHead || pull.base.sha !== expectedBase) {
+                  throw new Error(
+                    `Pull request revision changed during ${phase}: ` +
+                    `expected base/head ${expectedBase}/${expectedHead}, ` +
+                    `got ${pull.base.sha}/${pull.head.sha}`
+                  );
+                }
+                return pull;
+              };
+
+              const before = await assertCurrentRevision('pre-classification');
               files = await github.paginate(github.rest.pulls.listFiles, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.issue.number,
                 per_page: 100,
               });
+              const after = await assertCurrentRevision('post-classification');
+              if (
+                before.changed_files !== files.length ||
+                after.changed_files !== files.length
+              ) {
+                throw new Error(
+                  `Pull request file list is incomplete: API reports ` +
+                  `${after.changed_files} changed files, pagination returned ${files.length}`
+                );
+              }
+
               changelogOnly =
                 files.length === 1 &&
                 files[0].filename === 'CHANGELOG.md' &&
                 files[0].status === 'modified' &&
                 !files[0].previous_filename;
+              changelogChanged = files.some(
+                ({ filename, previous_filename }) =>
+                  filename === 'CHANGELOG.md' ||
+                  previous_filename === 'CHANGELOG.md'
+              );
+
+              const isPlatformSensitive = (filename) =>
+                typeof filename === 'string' &&
+                (
+                  filename.startsWith('internal/auth/') ||
+                  filename.startsWith('internal/keychain/') ||
+                  /_(darwin|windows|linux|unix)\.go$/.test(filename) ||
+                  filename.startsWith('scripts/release/') ||
+                  filename.startsWith('scripts/install') ||
+                  filename.startsWith('Formula/') ||
+                  filename.startsWith('build/npm/') ||
+                  filename === '.goreleaser.yaml' ||
+                  filename === '.github/workflows/release.yml'
+                );
+              platformSensitive = files.some(
+                ({ filename, previous_filename }) =>
+                  isPlatformSensitive(filename) ||
+                  isPlatformSensitive(previous_filename)
+              );
             }
 
             core.setOutput('changelog_only', String(changelogOnly));
+            core.setOutput('changelog_changed', String(changelogChanged));
+            core.setOutput('platform_sensitive', String(platformSensitive));
             await core.summary
-              .addHeading('PR change classification')
+              .addHeading('Code Admission scope')
               .addRaw(`- Event: \`${context.eventName}\`\n`)
               .addRaw(`- Exact modified CHANGELOG only: \`${changelogOnly}\`\n`)
+              .addRaw(`- CHANGELOG touched: \`${changelogChanged}\`\n`)
+              .addRaw(`- Native-platform risk paths touched: \`${platformSensitive}\`\n`)
               .addRaw(`- Changed files: \`${files.length}\`\n`)
               .write();
 
-  changelog-check:
-    name: Changelog Check
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    steps:
-      - name: Check out pull request head
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Record CHANGELOG-only fast path
+        if: steps.classify.outputs.changelog_only == 'true'
+        run: echo "Lint is satisfied by the trusted CHANGELOG-only Policy path." >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Validate exact CHANGELOG change
-        env:
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: ./scripts/policy/check-changelog-pr.sh "$PR_BASE_SHA" "$PR_HEAD_SHA"
-
-  lint:
-    name: Lint
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
       - name: Check out repository
+        if: steps.classify.outputs.changelog_only != 'true'
         uses: actions/checkout@v4
 
       - name: Set up Go
+        if: steps.classify.outputs.changelog_only != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Format Check
+        if: steps.classify.outputs.changelog_only != 'true'
         run: |
           unformatted="$(find cmd internal test scripts/policy -name '*.go' -print0 | xargs -0r gofmt -l)"
           test -z "$unformatted" || (printf '%s\n' "$unformatted" && exit 1)
 
       - name: Go Vet
+        if: steps.classify.outputs.changelog_only != 'true'
         run: go vet ./...
 
-      # golangci-lint temporarily disabled: v1.64.8 built with Go 1.24 is incompatible with Go 1.25
-      # - name: golangci-lint
-      #   uses: golangci/golangci-lint-action@v6
-      #   with:
-      #     version: v1.64.8
-      #     args: ./...
-
-  actionlint:
-    name: Actionlint
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
       - name: Check GitHub Actions workflows
+        if: steps.classify.outputs.changelog_only != 'true'
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
   test-race:
     name: "Test (race: ${{ matrix.shard }})"
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -183,8 +204,8 @@ jobs:
 
   test-release-scripts:
     name: Test (release scripts)
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -202,26 +223,85 @@ jobs:
       - name: Test release scripts
         run: go test -v -count=1 -timeout=5m ./test/scripts
 
+  test-cross-platform:
+    name: Test (cross-platform compile)
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Compile supported operating systems
+        shell: bash
+        run: |
+          set -eu
+          for target in darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
+            goos="${target%/*}"
+            goarch="${target#*/}"
+            output="$RUNNER_TEMP/dws-${goos}-${goarch}"
+            if [ "$goos" = windows ]; then
+              output="${output}.exe"
+            fi
+            printf 'compile %s/%s\n' "$goos" "$goarch"
+            CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+              go build -o "$output" ./cmd
+          done
+
   test:
     name: Test
     needs:
-      - scope
+      - lint
       - test-race
       - test-release-scripts
-    if: ${{ always() && needs.scope.result == 'success' && needs.scope.outputs.changelog_only != 'true' }}
+      - test-cross-platform
+      - test-darwin
+      - test-windows
+    if: ${{ always() && needs.lint.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
     steps:
       - name: Verify test shards
         env:
+          CHANGELOG_ONLY: ${{ needs.lint.outputs.changelog_only }}
+          PLATFORM_SENSITIVE: ${{ needs.lint.outputs.platform_sensitive }}
           RACE_RESULT: ${{ needs.test-race.result }}
           RELEASE_SCRIPTS_RESULT: ${{ needs.test-release-scripts.result }}
+          CROSS_PLATFORM_RESULT: ${{ needs.test-cross-platform.result }}
+          DARWIN_RESULT: ${{ needs.test-darwin.result }}
+          WINDOWS_RESULT: ${{ needs.test-windows.result }}
         run: |
           failed=0
+          if [ "$CHANGELOG_ONLY" = true ]; then
+            for shard in \
+              "race shards:$RACE_RESULT" \
+              "release scripts:$RELEASE_SCRIPTS_RESULT" \
+              "cross-platform compile:$CROSS_PLATFORM_RESULT" \
+              "macOS native:$DARWIN_RESULT" \
+              "Windows native:$WINDOWS_RESULT"
+            do
+              name="${shard%%:*}"
+              result="${shard#*:}"
+              printf '%s: %s\n' "$name" "$result"
+              if [ "$result" != skipped ]; then
+                failed=1
+              fi
+            done
+            test "$failed" -eq 0
+            exit
+          fi
+
           for shard in \
             "race shards:$RACE_RESULT" \
-            "release scripts:$RELEASE_SCRIPTS_RESULT"
+            "release scripts:$RELEASE_SCRIPTS_RESULT" \
+            "cross-platform compile:$CROSS_PLATFORM_RESULT"
           do
             name="${shard%%:*}"
             result="${shard#*:}"
@@ -230,12 +310,28 @@ jobs:
               failed=1
             fi
           done
+
+          native_expected=skipped
+          if [ "$PLATFORM_SENSITIVE" = true ]; then
+            native_expected=success
+          fi
+          for native in \
+            "macOS native:$DARWIN_RESULT" \
+            "Windows native:$WINDOWS_RESULT"
+          do
+            name="${native%%:*}"
+            result="${native#*:}"
+            printf '%s: %s\n' "$name" "$result"
+            if [ "$result" != "$native_expected" ]; then
+              failed=1
+            fi
+          done
           test "$failed" -eq 0
 
   test-darwin:
     name: Test (macOS auth/keychain)
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.platform_sensitive == 'true' }}
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
@@ -252,8 +348,8 @@ jobs:
 
   test-windows:
     name: Test (Windows)
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.platform_sensitive == 'true' }}
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
@@ -276,8 +372,8 @@ jobs:
 
   coverage-darwin:
     name: Coverage (macOS)
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.platform_sensitive == 'true' }}
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
@@ -320,8 +416,8 @@ jobs:
 
   coverage-windows:
     name: Coverage (Windows)
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.platform_sensitive == 'true' }}
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
@@ -366,8 +462,8 @@ jobs:
 
   coverage-current:
     name: Coverage (current)
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -401,8 +497,8 @@ jobs:
 
   coverage-supporting:
     name: Coverage (supporting)
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -440,8 +536,8 @@ jobs:
 
   coverage-baseline:
     name: Coverage (baseline)
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
+    if: ${{ needs.lint.outputs.changelog_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -505,21 +601,35 @@ jobs:
   coverage:
     name: Coverage
     needs:
-      - scope
+      - lint
       - coverage-current
       - coverage-supporting
       - coverage-baseline
-    if: ${{ always() && needs.scope.result == 'success' && needs.scope.outputs.changelog_only != 'true' }}
+      - coverage-darwin
+      - coverage-windows
+    if: ${{ always() && needs.lint.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Verify coverage profile jobs
         env:
+          CHANGELOG_ONLY: ${{ needs.lint.outputs.changelog_only }}
+          PLATFORM_SENSITIVE: ${{ needs.lint.outputs.platform_sensitive }}
           CURRENT_RESULT: ${{ needs.coverage-current.result }}
           SUPPORTING_RESULT: ${{ needs.coverage-supporting.result }}
           BASELINE_RESULT: ${{ needs.coverage-baseline.result }}
+          DARWIN_RESULT: ${{ needs.coverage-darwin.result }}
+          WINDOWS_RESULT: ${{ needs.coverage-windows.result }}
         run: |
           failed=0
+          expected=success
+          native_expected=skipped
+          if [ "$CHANGELOG_ONLY" = true ]; then
+            expected=skipped
+          elif [ "$PLATFORM_SENSITIVE" = true ]; then
+            native_expected=success
+          fi
+
           for profile in \
             "current:$CURRENT_RESULT" \
             "supporting:$SUPPORTING_RESULT" \
@@ -528,24 +638,42 @@ jobs:
             name="${profile%%:*}"
             result="${profile#*:}"
             printf '%s: %s\n' "$name" "$result"
-            if [ "$result" != "success" ]; then
+            if [ "$result" != "$expected" ]; then
+              failed=1
+            fi
+          done
+
+          for native in \
+            "macOS native:$DARWIN_RESULT" \
+            "Windows native:$WINDOWS_RESULT"
+          do
+            name="${native%%:*}"
+            result="${native#*:}"
+            printf '%s: %s\n' "$name" "$result"
+            if [ "$CHANGELOG_ONLY" = true ]; then
+              native_expected=skipped
+            fi
+            if [ "$result" != "$native_expected" ]; then
               failed=1
             fi
           done
           test "$failed" -eq 0
 
       - name: Check out repository
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Go
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Resolve authoritative coverage base
+        if: needs.lint.outputs.changelog_only != 'true'
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -563,33 +691,39 @@ jobs:
           echo "COVERAGE_BASE_REF=$base_ref" >> "$GITHUB_ENV"
 
       - name: Download current coverage profile
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/download-artifact@v4
         with:
           name: coverage-current-profile
           path: .
 
       - name: Download supporting coverage profiles
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/download-artifact@v4
         with:
           name: coverage-supporting-profiles
           path: .
 
       - name: Download baseline coverage profile
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/download-artifact@v4
         with:
           name: coverage-baseline-profile
           path: .
 
       - name: Enforce coverage gate
+        if: needs.lint.outputs.changelog_only != 'true'
         env:
           COVERAGE_TARGET: "80"
           COVERAGE_ENFORCE_OVERALL: "false"
         run: COVERAGE_ADDITIONAL_PROFILE=coverage-shortcut.txt make coverage-gate BASE_REF="$COVERAGE_BASE_REF"
 
       - name: Generate coverage report
+        if: needs.lint.outputs.changelog_only != 'true'
         run: go tool cover -html=coverage.txt -o coverage.html
 
       - name: Upload coverage artifact
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
@@ -601,48 +735,114 @@ jobs:
             coverage.html
 
   policy:
-    name: Policy Check
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    name: Policy
+    needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
+      - name: Verify pull request merge revision
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          test "$(git rev-parse HEAD^1)" = "$PR_BASE_SHA" || {
+            echo "checked-out merge first parent does not match event base" >&2
+            exit 1
+          }
+          test "$(git rev-parse HEAD^2)" = "$PR_HEAD_SHA" || {
+            echo "checked-out merge second parent does not match event head" >&2
+            exit 1
+          }
+
+      - name: Validate changed CHANGELOG content
+        if: github.event_name == 'pull_request'
+        env:
+          CLASSIFIED_CHANGELOG_CHANGED: ${{ needs.lint.outputs.changelog_changed }}
+          CHANGELOG_ONLY: ${{ needs.lint.outputs.changelog_only }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -eu
+          merge_changelog_changed=false
+          if git diff --no-ext-diff --find-renames --name-status \
+            "$PR_BASE_SHA" HEAD |
+            awk -F '\t' '
+              {
+                for (field = 2; field <= NF; field++) {
+                  if ($field == "CHANGELOG.md") found = 1
+                }
+              }
+              END { exit !found }
+            '
+          then
+            merge_changelog_changed=true
+          fi
+          test "$merge_changelog_changed" = "$CLASSIFIED_CHANGELOG_CHANGED" || {
+            echo "Files API and synthetic merge tree disagree on CHANGELOG scope" >&2
+            exit 1
+          }
+          if [ "$merge_changelog_changed" != true ]; then
+            exit 0
+          fi
+
+          mode=--content-only
+          if [ "$CHANGELOG_ONLY" = true ]; then
+            mode=--fast-path
+          fi
+          ./scripts/policy/check-changelog-pr.sh \
+            "$mode" "$PR_BASE_SHA" HEAD
+
+      - name: Record CHANGELOG-only fast path
+        if: needs.lint.outputs.changelog_only == 'true'
+        run: |
+          echo "Only the base-equivalent CHANGELOG validator ran; full Policy resumes on main." \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Build
+        if: needs.lint.outputs.changelog_only != 'true'
         run: make build
 
       - name: Policy
+        if: needs.lint.outputs.changelog_only != 'true'
         run: make policy
 
   interface-integrity:
     name: Interface Integrity
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Check out repository
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Go
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Build
+        if: needs.lint.outputs.changelog_only != 'true'
         run: make build
 
       - name: Resolve authoritative compatibility merge-base
+        if: needs.lint.outputs.changelog_only != 'true'
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -667,6 +867,7 @@ jobs:
           echo "COMPATIBILITY_STABLE_REF=$stable_ref" >> "$GITHUB_ENV"
 
       - name: Check historical commands and help compatibility
+        if: needs.lint.outputs.changelog_only != 'true'
         run: |
           make authoritative-interface-integrity \
             BASE_REF="$COMPATIBILITY_BASE_REF"
@@ -676,181 +877,89 @@ jobs:
           fi
 
       - name: Check complete Schema compatibility
+        if: needs.lint.outputs.changelog_only != 'true'
         run: make schema-compatibility BASE_REF="$COMPATIBILITY_BASE_REF"
 
       - name: Check skill command references
+        if: needs.lint.outputs.changelog_only != 'true'
         run: make skill-command-integrity
+
+      - name: Record CHANGELOG-only fast path
+        if: needs.lint.outputs.changelog_only == 'true'
+        run: echo "Interface Integrity is unaffected by an exact CHANGELOG-only diff." >> "$GITHUB_STEP_SUMMARY"
 
   cli-smoke:
     name: CLI Smoke
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Check out repository
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/checkout@v4
 
       - name: Set up Go
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Build
+        if: needs.lint.outputs.changelog_only != 'true'
         run: make build
 
       - name: Check public top-level commands
+        if: needs.lint.outputs.changelog_only != 'true'
         run: make cli-smoke
 
+      - name: Record CHANGELOG-only fast path
+        if: needs.lint.outputs.changelog_only == 'true'
+        run: echo "CLI Smoke is unaffected by an exact CHANGELOG-only diff." >> "$GITHUB_STEP_SUMMARY"
+
   mock-mcp-smoke:
-    name: Mock MCP Smoke
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    name: Mock MCP
+    needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Check out repository
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/checkout@v4
 
       - name: Set up Go
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Check HTTP and stdio MCP transport
+        if: needs.lint.outputs.changelog_only != 'true'
         run: make mock-mcp-smoke
 
+      - name: Record CHANGELOG-only fast path
+        if: needs.lint.outputs.changelog_only == 'true'
+        run: echo "Mock MCP is unaffected by an exact CHANGELOG-only diff." >> "$GITHUB_STEP_SUMMARY"
+
   edition-tests:
-    name: Edition Contract Tests
-    needs: scope
-    if: ${{ needs.scope.outputs.changelog_only != 'true' }}
+    name: Edition
+    needs: lint
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Check out repository
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/checkout@v4
 
       - name: Set up Go
+        if: needs.lint.outputs.changelog_only != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Run edition contract tests
+        if: needs.lint.outputs.changelog_only != 'true'
         run: go test -v -count=1 ./pkg/editiontest/...
 
-  ci-gate:
-    name: CI Gate
-    needs:
-      - scope
-      - changelog-check
-      - lint
-      - actionlint
-      - test
-      - test-darwin
-      - test-windows
-      - coverage
-      - coverage-darwin
-      - coverage-windows
-      - policy
-      - interface-integrity
-      - cli-smoke
-      - mock-mcp-smoke
-      - edition-tests
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions: {}
-    steps:
-      - name: Verify required checks
-        env:
-          SCOPE_RESULT: ${{ needs.scope.result }}
-          CHANGELOG_ONLY: ${{ needs.scope.outputs.changelog_only }}
-          CHANGELOG_RESULT: ${{ needs.changelog-check.result }}
-          LINT_RESULT: ${{ needs.lint.result }}
-          ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
-          TEST_RESULT: ${{ needs.test.result }}
-          TEST_DARWIN_RESULT: ${{ needs.test-darwin.result }}
-          TEST_WINDOWS_RESULT: ${{ needs.test-windows.result }}
-          COVERAGE_RESULT: ${{ needs.coverage.result }}
-          COVERAGE_DARWIN_RESULT: ${{ needs.coverage-darwin.result }}
-          COVERAGE_WINDOWS_RESULT: ${{ needs.coverage-windows.result }}
-          POLICY_RESULT: ${{ needs.policy.result }}
-          INTERFACE_INTEGRITY_RESULT: ${{ needs.interface-integrity.result }}
-          CLI_SMOKE_RESULT: ${{ needs.cli-smoke.result }}
-          MOCK_MCP_SMOKE_RESULT: ${{ needs.mock-mcp-smoke.result }}
-          EDITION_TESTS_RESULT: ${{ needs.edition-tests.result }}
-        run: |
-          failed=0
-          if [ "$SCOPE_RESULT" != "success" ]; then
-            printf 'Classify PR changes: %s\n' "$SCOPE_RESULT"
-            failed=1
-          fi
-
-          case "$CHANGELOG_ONLY" in
-            true)
-              expected_heavy_result=skipped
-              expected_changelog_result=success
-              ;;
-            false)
-              expected_heavy_result=success
-              expected_changelog_result=skipped
-              ;;
-            *)
-              printf 'invalid changelog_only classification: %s\n' "$CHANGELOG_ONLY"
-              failed=1
-              expected_heavy_result=invalid
-              expected_changelog_result=invalid
-              ;;
-          esac
-
-          printf 'Changelog Check: %s\n' "$CHANGELOG_RESULT"
-          if [ "$CHANGELOG_RESULT" != "$expected_changelog_result" ]; then
-            failed=1
-          fi
-
-          for check in \
-            "Lint:$LINT_RESULT" \
-            "Actionlint:$ACTIONLINT_RESULT" \
-            "Test:$TEST_RESULT" \
-            "Test (macOS auth/keychain):$TEST_DARWIN_RESULT" \
-            "Test (Windows):$TEST_WINDOWS_RESULT" \
-            "Coverage:$COVERAGE_RESULT" \
-            "Coverage (macOS):$COVERAGE_DARWIN_RESULT" \
-            "Coverage (Windows):$COVERAGE_WINDOWS_RESULT" \
-            "Policy Check:$POLICY_RESULT" \
-            "Interface Integrity:$INTERFACE_INTEGRITY_RESULT" \
-            "CLI Smoke:$CLI_SMOKE_RESULT" \
-            "Mock MCP Smoke:$MOCK_MCP_SMOKE_RESULT" \
-            "Edition Contract Tests:$EDITION_TESTS_RESULT"
-          do
-            name="${check%%:*}"
-            result="${check#*:}"
-            printf '%s: %s\n' "$name" "$result"
-            if [ "$result" != "$expected_heavy_result" ]; then
-              failed=1
-            fi
-          done
-          test "$failed" -eq 0
-
-  notify-downstream:
-    name: Notify Wukong Overlay
-    needs: [ci-gate]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    permissions: {}
-    steps:
-      - name: Trigger downstream CI
-        run: |
-          # Trigger internal GitLab CI pipeline via webhook.
-          # WUKONG_TRIGGER_TOKEN is a repository secret.
-          if [ -n "${{ secrets.WUKONG_TRIGGER_TOKEN }}" ]; then
-            curl --fail --silent --show-error \
-              -X POST \
-              -F "token=${{ secrets.WUKONG_TRIGGER_TOKEN }}" \
-              -F "ref=main" \
-              -F "variables[UPSTREAM_SHA]=${{ github.sha }}" \
-              "${{ secrets.WUKONG_TRIGGER_URL }}"
-            echo "Downstream CI triggered."
-          else
-            echo "No WUKONG_TRIGGER_TOKEN configured, skipping downstream notification."
-          fi
+      - name: Record CHANGELOG-only fast path
+        if: needs.lint.outputs.changelog_only == 'true'
+        run: echo "Edition is unaffected by an exact CHANGELOG-only diff." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/multi-profile-e2e.yml
+++ b/.github/workflows/multi-profile-e2e.yml
@@ -1,7 +1,6 @@
-name: Multi Profile E2E
+name: Main Integration — 主干集成
 
 on:
-  pull_request:
   push:
     branches:
       - main
@@ -9,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: multi-profile-e2e-${{ github.ref }}
@@ -17,70 +15,36 @@ concurrency:
 
 jobs:
   multi-profile-e2e:
-    name: Multi Profile E2E
+    name: Multi-profile E2E
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       MULTI_PROFILE_E2E_LOG: .tmp-bin/multi-profile-e2e.log
 
     steps:
-      - name: Classify pull request changes
-        id: changes
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              per_page: 100,
-            });
-            const changelogOnly =
-              files.length === 1 &&
-              files[0].filename === 'CHANGELOG.md' &&
-              files[0].status === 'modified' &&
-              !files[0].previous_filename;
-
-            core.setOutput('changelog_only', String(changelogOnly));
-
-      - name: Record changelog-only fast path
-        if: github.event_name == 'pull_request' && steps.changes.outputs.changelog_only == 'true'
-        shell: bash
-        run: |
-          {
-            echo "### Multi Profile E2E"
-            echo "- Scope: exact in-place modification of \`CHANGELOG.md\`"
-            echo "- Result: skipped by the changelog-only pull request fast path"
-            echo "- Full E2E: runs after merge on the \`main\` push"
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Check out repository
-        if: steps.changes.outputs.changelog_only != 'true'
         uses: actions/checkout@v4
 
       - name: Set up Go
-        if: steps.changes.outputs.changelog_only != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Run isolated multi-profile chain
-        if: steps.changes.outputs.changelog_only != 'true'
         shell: bash
         run: |
           set -o pipefail
           mkdir -p .tmp-bin
           bash scripts/dev/test-multi-profile-e2e.sh --keep-workdir | tee "$MULTI_PROFILE_E2E_LOG"
           {
-            echo "### Multi Profile E2E"
+            echo "### Multi-profile E2E"
             echo "- Command: \`bash scripts/dev/test-multi-profile-e2e.sh --keep-workdir\`"
             echo "- Scope: isolated auth/profile storage, profile switch/use, one-shot profile override, CSV multi-profile aggregation, legacy migration"
             echo "- Result: passed"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload debug artifacts
-        if: failure() && steps.changes.outputs.changelog_only != 'true'
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: multi-profile-e2e-debug

--- a/.github/workflows/multi-profile-e2e.yml
+++ b/.github/workflows/multi-profile-e2e.yml
@@ -3,10 +3,13 @@ name: Multi Profile E2E
 on:
   pull_request:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: multi-profile-e2e-${{ github.ref }}
@@ -21,15 +24,49 @@ jobs:
       MULTI_PROFILE_E2E_LOG: .tmp-bin/multi-profile-e2e.log
 
     steps:
+      - name: Classify pull request changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+            const changelogOnly =
+              files.length === 1 &&
+              files[0].filename === 'CHANGELOG.md' &&
+              files[0].status === 'modified' &&
+              !files[0].previous_filename;
+
+            core.setOutput('changelog_only', String(changelogOnly));
+
+      - name: Record changelog-only fast path
+        if: github.event_name == 'pull_request' && steps.changes.outputs.changelog_only == 'true'
+        shell: bash
+        run: |
+          {
+            echo "### Multi Profile E2E"
+            echo "- Scope: exact in-place modification of \`CHANGELOG.md\`"
+            echo "- Result: skipped by the changelog-only pull request fast path"
+            echo "- Full E2E: runs after merge on the \`main\` push"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check out repository
+        if: steps.changes.outputs.changelog_only != 'true'
         uses: actions/checkout@v4
 
       - name: Set up Go
+        if: steps.changes.outputs.changelog_only != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Run isolated multi-profile chain
+        if: steps.changes.outputs.changelog_only != 'true'
         shell: bash
         run: |
           set -o pipefail
@@ -43,7 +80,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload debug artifacts
-        if: failure()
+        if: failure() && steps.changes.outputs.changelog_only != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: multi-profile-e2e-debug

--- a/.github/workflows/notify-wukong.yml
+++ b/.github/workflows/notify-wukong.yml
@@ -1,0 +1,38 @@
+name: Main Integration — Wukong Overlay
+
+on:
+  workflow_run:
+    workflows:
+      - Code Admission — PR 合入门禁
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  notify-downstream:
+    name: Notify Wukong Overlay
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger downstream CI
+        env:
+          UPSTREAM_SHA: ${{ github.event.workflow_run.head_sha }}
+          WUKONG_TRIGGER_TOKEN: ${{ secrets.WUKONG_TRIGGER_TOKEN }}
+          WUKONG_TRIGGER_URL: ${{ secrets.WUKONG_TRIGGER_URL }}
+        run: |
+          if [ -n "$WUKONG_TRIGGER_TOKEN" ]; then
+            curl --fail --silent --show-error \
+              -X POST \
+              -F "token=$WUKONG_TRIGGER_TOKEN" \
+              -F "ref=main" \
+              -F "variables[UPSTREAM_SHA]=$UPSTREAM_SHA" \
+              "$WUKONG_TRIGGER_URL"
+            echo "Downstream CI triggered."
+          else
+            echo "No WUKONG_TRIGGER_TOKEN configured, skipping downstream notification."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,26 +235,56 @@ jobs:
             exit 1
           }
 
-      - name: Require successful CI Gate on the preflight commit
+      - name: Require successful Code Admission contexts on the preflight commit
         uses: actions/github-script@v7
         env:
           PREFLIGHT_COMMIT: ${{ inputs.governance_preflight_commit }}
         with:
           script: |
             const { owner, repo } = context.repo;
-            const { data } = await github.rest.checks.listForRef({
+            const sha = process.env.PREFLIGHT_COMMIT;
+            const requiredContexts = [
+              "Lint",
+              "Test",
+              "Coverage",
+              "Policy",
+              "Edition",
+              "Interface Integrity",
+              "AI Behavior",
+              "CLI Smoke",
+              "Mock MCP",
+            ];
+            const runs = await github.paginate(github.rest.checks.listForRef, {
               owner,
               repo,
-              ref: process.env.PREFLIGHT_COMMIT,
-              check_name: "CI Gate",
+              ref: sha,
               filter: "latest",
               per_page: 100,
             });
-            const passed = data.check_runs.some(
-              (run) => run.name === "CI Gate" && run.conclusion === "success",
-            );
-            if (!passed) {
-              core.setFailed(`CI Gate has not succeeded for ${process.env.PREFLIGHT_COMMIT}`);
+            const latestByName = new Map();
+            for (const run of runs) {
+              if (run.head_sha !== sha || !requiredContexts.includes(run.name)) {
+                continue;
+              }
+              const current = latestByName.get(run.name);
+              if (!current || run.id > current.id) {
+                latestByName.set(run.name, run);
+              }
+            }
+            const missing = requiredContexts.filter((name) => !latestByName.has(name));
+            const nonSuccess = requiredContexts.flatMap((name) => {
+              const run = latestByName.get(name);
+              if (!run || run.conclusion === "success") {
+                return [];
+              }
+              return [`${name}=${run.conclusion || run.status || "unknown"}`];
+            });
+            if (missing.length > 0 || nonSuccess.length > 0) {
+              core.setFailed(
+                `Code Admission contexts are not all successful for ${sha}; ` +
+                `missing: ${missing.length > 0 ? missing.join(", ") : "none"}; ` +
+                `non-success: ${nonSuccess.length > 0 ? nonSuccess.join(", ") : "none"}`,
+              );
             }
 
       - name: Check out trusted preflight tooling
@@ -502,26 +532,56 @@ jobs:
           "$GITHUB_WORKSPACE/tmp/trusted-release-tooling/scripts/release/verify-github-tag-authority.sh" \
             "$RELEASE_VERSION" "$RELEASE_COMMIT" "$RELEASE_TAG_OBJECT"
 
-      - name: Require successful CI Gate on the sealed commit
+      - name: Require successful Code Admission contexts on the sealed commit
         uses: actions/github-script@v7
         env:
           RELEASE_COMMIT: ${{ steps.target.outputs.release_commit }}
         with:
           script: |
             const { owner, repo } = context.repo;
-            const { data } = await github.rest.checks.listForRef({
+            const sha = process.env.RELEASE_COMMIT;
+            const requiredContexts = [
+              "Lint",
+              "Test",
+              "Coverage",
+              "Policy",
+              "Edition",
+              "Interface Integrity",
+              "AI Behavior",
+              "CLI Smoke",
+              "Mock MCP",
+            ];
+            const runs = await github.paginate(github.rest.checks.listForRef, {
               owner,
               repo,
-              ref: process.env.RELEASE_COMMIT,
-              check_name: "CI Gate",
+              ref: sha,
               filter: "latest",
               per_page: 100,
             });
-            const passed = data.check_runs.some(
-              (run) => run.name === "CI Gate" && run.conclusion === "success",
-            );
-            if (!passed) {
-              core.setFailed(`CI Gate has not succeeded for ${process.env.RELEASE_COMMIT}`);
+            const latestByName = new Map();
+            for (const run of runs) {
+              if (run.head_sha !== sha || !requiredContexts.includes(run.name)) {
+                continue;
+              }
+              const current = latestByName.get(run.name);
+              if (!current || run.id > current.id) {
+                latestByName.set(run.name, run);
+              }
+            }
+            const missing = requiredContexts.filter((name) => !latestByName.has(name));
+            const nonSuccess = requiredContexts.flatMap((name) => {
+              const run = latestByName.get(name);
+              if (!run || run.conclusion === "success") {
+                return [];
+              }
+              return [`${name}=${run.conclusion || run.status || "unknown"}`];
+            });
+            if (missing.length > 0 || nonSuccess.length > 0) {
+              core.setFailed(
+                `Code Admission contexts are not all successful for ${sha}; ` +
+                `missing: ${missing.length > 0 ? missing.join(", ") : "none"}; ` +
+                `non-success: ${nonSuccess.length > 0 ? nonSuccess.join(", ") : "none"}`,
+              );
             }
 
       - name: Require delivered previous stable baseline
@@ -721,7 +781,7 @@ jobs:
       - name: Install archive tooling
         run: sudo apt-get update && sudo apt-get install -y zip unzip
 
-      - name: Multi Profile E2E
+      - name: Multi-profile E2E
         run: bash scripts/dev/test-multi-profile-e2e.sh
 
       - name: Install rcodesign (sign darwin binaries from Linux)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,3 +43,38 @@
 - `skills/`: bundled agent skills (mono/ and multi/ layouts)
 - `test/`: CLI, integration, contract, unit, and skill E2E tests
 - `scripts/`: install scripts, policy checks, and CI helpers
+
+## Quality Pipeline
+
+Quality enforcement is layered so a pull request receives fast, deterministic
+admission feedback without pretending that downstream integration has already
+run.
+
+```mermaid
+flowchart TB
+  PR["Pull request"] --> CA["Code Admission — PR 合入门禁"]
+  subgraph CA_CHECKS["Nine required contexts"]
+    L["Lint"]
+    T["Test"]
+    C["Coverage"]
+    P["Policy"]
+    E["Edition"]
+    I["Interface Integrity"]
+    A["AI Behavior"]
+    S["CLI Smoke"]
+    M["Mock MCP"]
+  end
+  CA --> CA_CHECKS
+  CA_CHECKS --> MAIN["Protected main"]
+  MAIN --> MP["Main Integration — 主干集成<br/>Multi-profile E2E"]
+  MAIN --> PLATFORM["Risk-selected / release native platform validation"]
+  MP --> RELEASE["Release delivery"]
+  PLATFORM --> RELEASE
+```
+
+Complete Multi-profile E2E and the ordinary full native-platform matrix are
+downstream of PR admission. PRs still run primary-environment assurance and
+fast cross-platform compilation; auth, keychain, OS-specific, installer, and
+release changes additionally select native platform tests before merge. See
+[`docs/ci-pr-gates.md`](ci-pr-gates.md) for the exact context and ruleset
+contract.

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -1,163 +1,152 @@
-# Pull request quality gates
+# Code Admission — PR 合入门禁
 
-The repository defines five focused checks in addition to its existing CI:
+The pull-request admission layer has exactly nine required external contexts:
 
-- **Interface Integrity** enforces backwards compatibility. Every historical
-  command path and alias must still resolve, every historical command must
-  still render `-h`, and historical flags must keep their type and shorthand.
-  New commands, aliases, and flags are allowed. The same job compares the full
-  complete `dws schema --all` contract with the PR merge-base, blocking removed
-  products/tools/parameters, incompatible parameter or interface mappings,
-  constraint drift, and safety-semantic drift. It also checks that executable
-  `dws ...` references in `skills/**/*.md` resolve to real commands.
-  Help compatibility covers command/alias/flag spelling, flag type and
-  shorthand; descriptive prose may evolve without breaking the gate.
-- **Coverage** runs unit tests on every pull request and prints both overall and
-  changed-code statement coverage. During the migration to the 80% repository
-  target, overall coverage may not regress from a profile generated from the
-  merge-base with the same test command, while changed production Go
-  statements must meet 80%. Linux, Windows, and macOS each generate a native
-  coverage profile for changed packages and enforce the threshold against
-  changed files buildable on that platform, so build-tagged source cannot be
-  hidden by an Ubuntu-only profile. Overall non-regression allows 0.1 percentage point of measurement
-  variance to avoid failing unchanged code on test-path noise. Set
-  `COVERAGE_ENFORCE_OVERALL=true` once repository coverage reaches 80% to make
-  the overall target fail closed as well.
-  CI generates the candidate, supporting, and merge-base profiles on three
-  independent runners, then downloads all profiles into the aggregate
-  `Coverage` job and applies the same fail-closed gate. The split changes only
-  scheduling: the tested packages, profile contents, merge-base comparison,
-  and final coverage thresholds remain unchanged.
-- **CLI Smoke** builds the release binary, reads the root command list from the
-  structured Interface contract, and renders offline help for every public
-  top-level command. It rejects Cobra's unknown-command root-help fallback and
-  fails when the checked-in development fixture is stale.
-- **Mock MCP Smoke** runs the existing HTTP and stdio MCP lifecycle tests
-  (`Initialize -> ListTools -> CallTool`).
-- **AI Behavior Check** applies to pull requests labeled `ai-generated`. It
-  limits the change to 30 files and blocks release/CI infrastructure changes,
-  including policy implementations and the checked-in Interface fixture.
-  It uses `pull_request_target` without checking out PR code, so the policy
-  cannot be bypassed by changing the workflow in the same pull request. The
-  evaluator writes an `AI Behavior Check` commit status to the PR head SHA so
-  GitHub rulesets can require it.
+| Required context | Contract |
+|---|---|
+| `Lint` | Stable PR revision classification, formatting, `go vet`, and Actionlint |
+| `Test` | Race/unit/release-script tests plus fast cross-platform compilation |
+| `Coverage` | Overall non-regression and changed-code coverage |
+| `Policy` | Repository policy and the fail-closed CHANGELOG contract |
+| `Edition` | Edition contract tests |
+| `Interface Integrity` | CLI, Schema, Skill, and stable-release compatibility |
+| `AI Behavior` | Base-owned policy for PRs labeled `ai-generated` |
+| `CLI Smoke` | Offline help for every public top-level command |
+| `Mock MCP` | HTTP and stdio MCP lifecycle smoke tests |
+
+The workflow display name is `Code Admission — PR 合入门禁`. Parallel helper
+jobs may implement `Test` and `Coverage`, but they are not ruleset contexts.
+Do not require an aggregate alias or a downstream integration check in place of
+the nine contracts above.
+
+`AI Behavior` is evaluated by a `pull_request_target` workflow that never
+checks out or executes PR code. It writes the exact `AI Behavior` status to the
+current PR head. Its Files API read is bracketed by base/head revision checks,
+so a synchronize race fails closed. The same workflow supplies a successful
+`AI Behavior` check run on protected `main` pushes for release governance.
 
 ## Exact CHANGELOG-only fast path
 
-A pull request qualifies for the fast path only when GitHub reports exactly
-one changed file and that file is an in-place modification of
-`CHANGELOG.md`. Adding, deleting, or renaming the file does not qualify, and
-neither does changing any second file.
+A pull request qualifies only when GitHub reports exactly one changed file,
+that file is an in-place modification of `CHANGELOG.md`, and the base and head
+both retain it as a regular non-executable `100644` blob. Add, delete, rename,
+symlink, executable-mode, and second-file changes do not qualify.
 
-The workflow classifies the pull request through GitHub's pull-request files
-API before checking out or executing pull-request code. Qualifying changes run
-the targeted CHANGELOG contract check. Because classification rejects any
-second file, the validator itself is the reviewed version from the base:
+`Lint` classifies the Files API result only after verifying that the API's base
+and head equal the event revision both before and after pagination. `Policy`
+checks out GitHub's PR merge ref and verifies its parents:
 
-```sh
-base_ref=$(git merge-base HEAD origin/main)
-./scripts/policy/check-changelog-pr.sh "$base_ref" HEAD
+```text
+HEAD^1 = pull_request.base.sha
+HEAD^2 = pull_request.head.sha
 ```
 
-The `CI Gate` remains present and succeeds only after that targeted check
-passes. `Multi Profile E2E` also remains present as a required successful job,
-but records the fast-path decision in its job summary instead of checking out
-the repository, setting up Go, or running the E2E chain. The workflows use
-job/step conditions rather than workflow-level `paths-ignore`, so required
-checks are never left pending.
+It then runs:
 
-All other pull requests run the normal full gates. After a qualifying pull
-request is merged, the `main` push runs the complete CI and Multi Profile E2E
-again; the fast path never applies to a push. Multi Profile E2E listens only
-for pushes to `main`, avoiding a duplicate branch-push run for same-repository
-pull requests.
+```sh
+./scripts/policy/check-changelog-pr.sh \
+  --fast-path "$PR_BASE_SHA" HEAD
+```
 
-## Running the compatibility gates
+Because the verified PR diff contains only `CHANGELOG.md`, the validator and
+its policy dependencies in that merge tree are byte-for-byte the current base
+versions. Validation targets the synthetic merge tree, not the feature-branch
+tree, so a stale branch cannot supply an older validator or combine with newer
+base notes into an invalid final CHANGELOG.
 
-Run:
+All nine admission contexts are still emitted and must succeed. Expensive
+implementation helpers are skipped; the named contexts record that their code
+surface is unaffected. After merge, the protected `main` push executes the
+full admission suite.
+
+Any PR that touches `CHANGELOG.md` but also changes another file runs the same
+content contract in `Policy` with `--content-only`. That mode permits the
+second file but still rejects invalid dates or versions, missing bullets,
+placeholder `TODO`/`TBD`, unmanaged-section changes, and unsafe tree modes.
+Adding a second file therefore cannot bypass CHANGELOG validation.
+
+## Platform and downstream boundaries
+
+Ordinary PRs run the primary Linux assurance plus fast Darwin/Windows compile
+checks. Full native macOS/Windows tests and platform coverage run on a PR only
+when its diff touches auth, keychain, OS-specific Go files, installers,
+packaging, Formulae, or release automation. Protected `main` pushes run the
+complete native matrix.
+
+Complete `Multi-profile E2E` is not a PR admission context. It belongs to the
+`Main Integration — 主干集成` workflow and runs only after a push to `main` (or
+an explicit manual dispatch). A failing downstream run remains a real
+regression and must be repaired, but it must not be represented by a synthetic
+successful PR check.
+
+```mermaid
+flowchart TB
+  PR["Pull request"] --> ADMISSION["Code Admission — PR 合入门禁"]
+  ADMISSION --> L["Lint"]
+  ADMISSION --> T["Test"]
+  ADMISSION --> C["Coverage"]
+  ADMISSION --> P["Policy"]
+  ADMISSION --> E["Edition"]
+  ADMISSION --> I["Interface Integrity"]
+  ADMISSION --> A["AI Behavior"]
+  ADMISSION --> S["CLI Smoke"]
+  ADMISSION --> M["Mock MCP"]
+  ADMISSION --> MAIN["Protected main"]
+  MAIN --> NATIVE["Full native platform matrix"]
+  MAIN --> E2E["Multi-profile E2E"]
+  MAIN --> RELEASE["Release delivery"]
+```
+
+## Running focused gates locally
+
+Run the contracts relevant to the change:
 
 ```sh
 make build
+make policy
 make interface-integrity
 make authoritative-interface-integrity BASE_REF=<merge-base>
 make schema-compatibility BASE_REF=<merge-base>
 make skill-command-integrity
 make cli-smoke
-# Run on the corresponding native runner with its generated profile:
-make coverage-gate-platform BASE_REF=<merge-base> PROFILE=<coverage-profile>
+make mock-mcp-smoke
+go test -v -count=1 ./pkg/editiontest/...
 ```
 
-`make coverage-gate` is the enforcement step, not a profile generator. It
-expects the candidate, policy, shortcut, and merge-base profiles
-(`coverage.txt`, `coverage-policy.txt`, `coverage-shortcut.txt`, and
-`coverage-base.txt`) produced by the parallel CI profile jobs. A clean local
-checkout can reproduce the Linux/overall CI gate sequentially with:
+For an exact CHANGELOG-only branch:
 
 ```sh
 base_ref=$(git merge-base HEAD origin/main)
-root=$(pwd)
-base_worktree=$(mktemp -d "${TMPDIR:-/tmp}/dws-coverage-base.XXXXXX")
-rmdir "$base_worktree"
-cleanup() { git worktree remove --force "$base_worktree" >/dev/null 2>&1 || true; }
-trap cleanup EXIT HUP INT TERM
-
-go test -count=1 -p 1 -coverprofile=coverage.txt -covermode=atomic \
-  ./ ./cmd/... ./internal/... ./skills/...
-go test -count=1 -coverprofile=coverage-policy.txt -covermode=atomic \
-  ./pkg/... ./scripts/policy/...
-go test -count=1 \
-  -run '^(TestAllShortcuts|TestCrossPlatformCoverage)' \
-  -coverpkg=./internal/app,./internal/helpers,./internal/shortcut/... \
-  -coverprofile=coverage-shortcut.txt \
-  -covermode=atomic \
-  ./internal/app ./internal/helpers ./internal/shortcut/...
-git worktree add --detach "$base_worktree" "$base_ref"
-(
-  cd "$base_worktree"
-  go test -count=1 -p 1 \
-    -coverprofile="$root/coverage-base.txt" -covermode=atomic \
-    ./ ./cmd/... ./internal/... ./skills/...
-)
-COVERAGE_ADDITIONAL_PROFILE=coverage-shortcut.txt \
-  make coverage-gate BASE_REF="$base_ref"
+./scripts/policy/check-changelog-pr.sh --fast-path "$base_ref" HEAD
 ```
 
-The native-platform target likewise expects `PROFILE` to have already been
-generated on that operating system. CI owns those generation steps; copying
-only either enforcement command into a clean checkout is intentionally an
-incomplete invocation.
+`make coverage-gate` is an enforcement step, not a profile generator. CI
+generates the candidate, supporting, merge-base, and (when risk-selected)
+native profiles before the aggregate `Coverage` context evaluates them.
 
-CI derives the authoritative Interface snapshots from both the PR merge-base
-and the latest reachable stable release tag. The complete Schema snapshot comes
-from the PR merge-base, which contains the registry-first Schema introduced on
-`main`. The candidate branch cannot bless a breaking change by editing a
-fixture. Schema additions are allowed; historical products, tools, parameters,
-parameter mappings, positional execution fields, constraints, and safety
-semantics remain protected. Positional descriptions are documentation and may
-change without breaking compatibility.
-
-`make update-interface-baseline` still extends the local checked-in Interface
-fixture used by `make interface-integrity`. Updates are monotonic: they add new
-commands and flags without removing history.
-
-For an intentional compatibility reset at a major-version boundary, run
-`make reset-interface-baseline`. This replaces all CLI compatibility history
-with the current command tree and must receive explicit human review.
+Compatibility checks derive authoritative Interface snapshots from the PR
+merge-base and the latest reachable stable release. The candidate cannot bless
+a breaking change by editing a fixture. Schema additions are allowed;
+historical products, tools, parameters, mappings, positional execution fields,
+constraints, and safety semantics remain protected.
 
 ## Required GitHub repository settings
 
-Create a ruleset for `main` that requires pull requests and code-owner review,
-then mark these aggregate status checks as required:
+The `main` quality ruleset must enable strict required-status-check policy
+(`strict_required_status_checks_policy=true`) so a PR is revalidated whenever
+`main` advances. It must require these exact contexts and no legacy aliases:
 
-- `CI Gate`
-- `Multi Profile E2E`
-- `AI Behavior Check`
+- `Lint`
+- `Test`
+- `Coverage`
+- `Policy`
+- `Edition`
+- `Interface Integrity`
+- `AI Behavior`
+- `CLI Smoke`
+- `Mock MCP`
 
-`CI Gate` fails closed unless every first-layer CI job succeeds, including
-lint, tests, native Linux/Windows/macOS coverage, policy,
-Interface/Schema/Skill integrity, and smoke tests. Requiring the aggregate
-check keeps repository rules stable when an internal job is renamed or split.
-
-The `ai-generated` label must be applied by the PR-creation automation or by a
-maintainer; GitHub cannot infer reliably whether a human-authored PR contains
-AI-generated code.
+Do not require helper jobs, `Multi-profile E2E`, or an aggregate admission
+alias. Update ruleset contexts only after the new names have appeared on the
+protected branch, so a rename cannot silently remove enforcement or leave an
+unproducible required context.

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -42,6 +42,36 @@ The repository defines five focused checks in addition to its existing CI:
   evaluator writes an `AI Behavior Check` commit status to the PR head SHA so
   GitHub rulesets can require it.
 
+## Exact CHANGELOG-only fast path
+
+A pull request qualifies for the fast path only when GitHub reports exactly
+one changed file and that file is an in-place modification of
+`CHANGELOG.md`. Adding, deleting, or renaming the file does not qualify, and
+neither does changing any second file.
+
+The workflow classifies the pull request through GitHub's pull-request files
+API before checking out or executing pull-request code. Qualifying changes run
+the targeted CHANGELOG contract check. Because classification rejects any
+second file, the validator itself is the reviewed version from the base:
+
+```sh
+base_ref=$(git merge-base HEAD origin/main)
+./scripts/policy/check-changelog-pr.sh "$base_ref" HEAD
+```
+
+The `CI Gate` remains present and succeeds only after that targeted check
+passes. `Multi Profile E2E` also remains present as a required successful job,
+but records the fast-path decision in its job summary instead of checking out
+the repository, setting up Go, or running the E2E chain. The workflows use
+job/step conditions rather than workflow-level `paths-ignore`, so required
+checks are never left pending.
+
+All other pull requests run the normal full gates. After a qualifying pull
+request is merged, the `main` push runs the complete CI and Multi Profile E2E
+again; the fast path never applies to a push. Multi Profile E2E listens only
+for pushes to `main`, avoiding a duplicate branch-push run for same-repository
+pull requests.
+
 ## Running the compatibility gates
 
 Run:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,7 +2,7 @@
 
 发布只走一条链路：本地脚本负责封板、验证并推送 annotated tag；GitHub Actions 负责构建和发布最终产物。不要直接运行 `goreleaser release`，也不要手工补打或移动 tag。
 
-发布前必须完成平台治理：目标 GitHub 仓库已启用 immutable releases，`main` 要求 `CI Gate`，操作机已安装并登录 `gh`。本地脚本会在封 tag 前通过 API 检查 immutable releases、当前 SHA 的 `CI Gate` 和在途 Release；`v*` tag ruleset 仍需仓库管理员预先配置并由操作人确认。
+发布前必须完成平台治理：目标 GitHub 仓库已启用 immutable releases，`main` 精确要求 `Code Admission — PR 合入门禁` 的九个 context：`Lint`、`Test`、`Coverage`、`Policy`、`Edition`、`Interface Integrity`、`AI Behavior`、`CLI Smoke`、`Mock MCP`，操作机已安装并登录 `gh`。本地脚本会在封 tag 前通过 API 检查 immutable releases、当前 SHA 的全部九个 context 和在途 Release；`v*` tag ruleset 仍需仓库管理员预先配置并由操作人确认。
 
 ## 日常只用一个入口
 
@@ -45,7 +45,7 @@ dws-release v1.2.3-beta.1
 dws-release v1.2.3-beta.1
 ```
 
-预检包含测试、策略检查、旧正式版命令树兼容检查、全平台打包、npm 安装验证，以及 macOS 环境下的 Homebrew 安装验证。它还会从默认分支触发一次无发布权限的 `Release governance preflight`，用正式流水线相同的身份检查 `CI Gate` 和 immutable releases。通过后会在当前 Git worktree 的私有 Git 状态目录写入一个有效期六小时的证明，绑定版本、精确 commit、发布仓库、beta/stable 基线和远端 `main`：
+预检包含测试、策略检查、旧正式版命令树兼容检查、全平台打包、npm 安装验证，以及 macOS 环境下的 Homebrew 安装验证。它还会从默认分支触发一次无发布权限的 `Release governance preflight`，用正式流水线相同的身份检查该精确 commit 的九个 Code Admission context 和 immutable releases。通过后会在当前 Git worktree 的私有 Git 状态目录写入一个有效期六小时的证明，绑定版本、精确 commit、发布仓库、beta/stable 基线和远端 `main`：
 
 ```bash
 dws-release v1.2.3-beta.1 --publish
@@ -125,10 +125,10 @@ Homebrew 当前只属于本机预检/手工公式通道：预检会在当前 mac
 
 仓库管理员还需要在 GitHub 平台配置以下不可由脚本替代的规则：
 
-- `main` 必须要求精确的 `CI Gate`；tag workflow 也会通过 Checks API 再确认该封板 SHA 已通过。
+- `main` 必须精确要求 `Lint`、`Test`、`Coverage`、`Policy`、`Edition`、`Interface Integrity`、`AI Behavior`、`CLI Smoke`、`Mock MCP` 九个 Code Admission context；tag workflow 也会通过 Checks API 再确认该封板 SHA 上九项全部成功。
 - 必须启用 immutable releases；它只保护启用后发布的 release，因此应在第一次使用新流水线前配置。为 `v*` 增加 tag ruleset，限制创建权限，并在 release 发布前保护 tag 的短暂窗口。
 - 配置 `RELEASE_GOVERNANCE_TOKEN` Actions secret，只授予目标仓库 `Administration: read`；内置 `GITHUB_TOKEN` 不具备 immutable-releases API 所需的仓库治理权限。每次本地预检和 tag workflow 都使用这一个身份进行 fail-closed 验证。
 - 单独配置 `HOMEBREW_PR_TOKEN`，优先使用仅授权本仓库且具备 `Contents: write`、`Pull requests: write` 的 fine-grained PAT；若组织策略不允许该账号使用 fine-grained PAT，则回退到仅带 `public_repo` scope 的专用 classic PAT。治理预检和 tag contract 会验证 token 身份、classic scope，并用 `[skip ci]` 临时分支和 draft PR 完成真实写权限 canary，随后立即关闭 PR、删除分支；任何清理失败都会 fail closed。门禁也会拒绝与治理 token 复用。
 - 创建 `release-recovery` environment，只允许受保护分支，设置 required reviewer、禁止自审并关闭管理员绕过。workflow 会读取 environment 的 required-reviewer、prevent-self-review 和 protected-branch 规则；规则缺失时紧急恢复会失败，正常 beta/stable tag 发布不受影响。
 
-immutable releases 或 `CI Gate` 缺失时，发布脚本会自动拒绝封 tag。tag ruleset 可能来自组织层，脚本不自动推断其最终作用范围；管理员确认不能省略，脚本约定也不能替代平台强制。
+immutable releases，或任一 Code Admission context 缺失、未成功时，发布脚本会自动拒绝封 tag。tag ruleset 可能来自组织层，脚本不自动推断其最终作用范围；管理员确认不能省略，脚本约定也不能替代平台强制。

--- a/scripts/policy/check-changelog-pr.sh
+++ b/scripts/policy/check-changelog-pr.sh
@@ -1,23 +1,37 @@
 #!/bin/sh
 set -eu
 
-# Validate the narrow PR fast path. The diff must be exactly one in-place
-# CHANGELOG.md modification, and every touched release section must still
-# satisfy the release contract.
+# Validate CHANGELOG.md changes against the release contract.
+#
+# --fast-path additionally requires the complete PR diff to be exactly one
+# in-place CHANGELOG.md modification. --content-only validates CHANGELOG.md
+# while allowing other files to change in the same PR.
 
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 
 usage() {
-	printf '%s\n' "usage: $0 BASE HEAD" >&2
+	printf '%s\n' "usage: $0 (--fast-path|--content-only) BASE HEAD" >&2
 }
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
 	usage
 	exit 2
 fi
 
-BASE_REF="$1"
-HEAD_REF="$2"
+case "$1" in
+--fast-path)
+	VALIDATION_MODE="fast-path"
+	;;
+--content-only)
+	VALIDATION_MODE="content-only"
+	;;
+*)
+	usage
+	exit 2
+	;;
+esac
+BASE_REF="$2"
+HEAD_REF="$3"
 
 cd "$ROOT"
 
@@ -44,18 +58,69 @@ if [ "$merge_base_count" -ne 1 ]; then
 fi
 IFS= read -r MERGE_BASE <"$TMP_ROOT/merge-bases"
 
+require_regular_changelog() {
+	_rrc_label="$1"
+	_rrc_commit="$2"
+	if ! git ls-tree "$_rrc_commit" -- CHANGELOG.md |
+		awk '
+			NR == 1 &&
+				$1 == "100644" &&
+				$2 == "blob" &&
+				$4 == "CHANGELOG.md" {
+				valid = 1
+			}
+			END {
+				exit !(NR == 1 && valid)
+			}
+		'; then
+		printf 'error: CHANGELOG.md must be a regular 100644 blob at %s\n' \
+			"$_rrc_label" >&2
+		exit 1
+	fi
+}
+
+# The merge base is the effective base of the PR diff. Also validate the
+# caller-provided base commit so a stale or malformed target ref fails closed.
+require_regular_changelog "base" "$BASE_COMMIT"
+if [ "$MERGE_BASE" != "$BASE_COMMIT" ]; then
+	require_regular_changelog "merge base" "$MERGE_BASE"
+fi
+require_regular_changelog "head" "$HEAD_COMMIT"
+
 git diff --no-ext-diff --find-renames --name-status \
 	"$MERGE_BASE" "$HEAD_COMMIT" >"$TMP_ROOT/name-status"
-printf 'M\tCHANGELOG.md\n' >"$TMP_ROOT/expected-name-status"
-if ! cmp -s "$TMP_ROOT/expected-name-status" "$TMP_ROOT/name-status"; then
-	printf '%s\n' 'error: fast path requires exactly one in-place modification: CHANGELOG.md' >&2
-	if [ -s "$TMP_ROOT/name-status" ]; then
-		sed 's/^/  /' "$TMP_ROOT/name-status" >&2
-	else
-		printf '%s\n' '  (no changed files)' >&2
+case "$VALIDATION_MODE" in
+fast-path)
+	printf 'M\tCHANGELOG.md\n' >"$TMP_ROOT/expected-name-status"
+	if ! cmp -s "$TMP_ROOT/expected-name-status" "$TMP_ROOT/name-status"; then
+		printf '%s\n' 'error: fast path requires exactly one in-place modification: CHANGELOG.md' >&2
+		if [ -s "$TMP_ROOT/name-status" ]; then
+			sed 's/^/  /' "$TMP_ROOT/name-status" >&2
+		else
+			printf '%s\n' '  (no changed files)' >&2
+		fi
+		exit 1
 	fi
-	exit 1
-fi
+	;;
+content-only)
+	if ! awk -F '	' '
+		$1 == "M" && $2 == "CHANGELOG.md" && NF == 2 {
+			count++
+		}
+		END {
+			exit count != 1
+		}
+	' "$TMP_ROOT/name-status"; then
+		printf '%s\n' 'error: content-only validation requires an in-place modification: CHANGELOG.md' >&2
+		if [ -s "$TMP_ROOT/name-status" ]; then
+			sed 's/^/  /' "$TMP_ROOT/name-status" >&2
+		else
+			printf '%s\n' '  (no changed files)' >&2
+		fi
+		exit 1
+	fi
+	;;
+esac
 
 if ! git diff --no-ext-diff --check "$MERGE_BASE" "$HEAD_COMMIT" -- CHANGELOG.md; then
 	printf '%s\n' 'error: CHANGELOG diff contains whitespace errors' >&2
@@ -200,7 +265,7 @@ validate_release_notes() {
 extract_unmanaged_content "$TMP_ROOT/base-changelog" >"$TMP_ROOT/base-unmanaged"
 extract_unmanaged_content "$TMP_ROOT/head-changelog" >"$TMP_ROOT/head-unmanaged"
 if ! cmp -s "$TMP_ROOT/base-unmanaged" "$TMP_ROOT/head-unmanaged"; then
-	printf '%s\n' 'error: fast path only permits notes inside Unreleased or versioned release sections' >&2
+	printf '%s\n' 'error: CHANGELOG validation only permits notes inside Unreleased or versioned release sections' >&2
 	exit 1
 fi
 
@@ -270,5 +335,5 @@ if [ "$changed_release_count" -eq 0 ] && [ "$unreleased_changed" -eq 0 ]; then
 	exit 1
 fi
 
-printf 'CHANGELOG PR check: ok (release_sections=%s unreleased_changed=%s)\n' \
-	"$changed_release_count" "$unreleased_changed"
+printf 'CHANGELOG PR check: ok (mode=%s release_sections=%s unreleased_changed=%s)\n' \
+	"$VALIDATION_MODE" "$changed_release_count" "$unreleased_changed"

--- a/scripts/policy/check-changelog-pr.sh
+++ b/scripts/policy/check-changelog-pr.sh
@@ -1,0 +1,274 @@
+#!/bin/sh
+set -eu
+
+# Validate the narrow PR fast path. The diff must be exactly one in-place
+# CHANGELOG.md modification, and every touched release section must still
+# satisfy the release contract.
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+
+usage() {
+	printf '%s\n' "usage: $0 BASE HEAD" >&2
+}
+
+if [ "$#" -ne 2 ]; then
+	usage
+	exit 2
+fi
+
+BASE_REF="$1"
+HEAD_REF="$2"
+
+cd "$ROOT"
+
+BASE_COMMIT="$(git rev-parse --verify --quiet "${BASE_REF}^{commit}")" || {
+	printf 'error: CHANGELOG base ref is not an available commit: %s\n' "$BASE_REF" >&2
+	exit 2
+}
+HEAD_COMMIT="$(git rev-parse --verify --quiet "${HEAD_REF}^{commit}")" || {
+	printf 'error: CHANGELOG head ref is not an available commit: %s\n' "$HEAD_REF" >&2
+	exit 2
+}
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dws-changelog-pr.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+if ! git merge-base --all "$BASE_COMMIT" "$HEAD_COMMIT" >"$TMP_ROOT/merge-bases"; then
+	printf 'error: CHANGELOG base and head commits have no merge base\n' >&2
+	exit 2
+fi
+merge_base_count="$(wc -l <"$TMP_ROOT/merge-bases" | tr -d '[:space:]')"
+if [ "$merge_base_count" -ne 1 ]; then
+	printf 'error: expected exactly one merge base, found %s\n' "$merge_base_count" >&2
+	exit 2
+fi
+IFS= read -r MERGE_BASE <"$TMP_ROOT/merge-bases"
+
+git diff --no-ext-diff --find-renames --name-status \
+	"$MERGE_BASE" "$HEAD_COMMIT" >"$TMP_ROOT/name-status"
+printf 'M\tCHANGELOG.md\n' >"$TMP_ROOT/expected-name-status"
+if ! cmp -s "$TMP_ROOT/expected-name-status" "$TMP_ROOT/name-status"; then
+	printf '%s\n' 'error: fast path requires exactly one in-place modification: CHANGELOG.md' >&2
+	if [ -s "$TMP_ROOT/name-status" ]; then
+		sed 's/^/  /' "$TMP_ROOT/name-status" >&2
+	else
+		printf '%s\n' '  (no changed files)' >&2
+	fi
+	exit 1
+fi
+
+if ! git diff --no-ext-diff --check "$MERGE_BASE" "$HEAD_COMMIT" -- CHANGELOG.md; then
+	printf '%s\n' 'error: CHANGELOG diff contains whitespace errors' >&2
+	exit 1
+fi
+
+"$ROOT/scripts/policy/open-source-audit.sh"
+
+if ! git show "${MERGE_BASE}:CHANGELOG.md" >"$TMP_ROOT/base-changelog" ||
+	! git show "${HEAD_COMMIT}:CHANGELOG.md" >"$TMP_ROOT/head-changelog"; then
+	printf '%s\n' 'error: could not read CHANGELOG.md from both commits' >&2
+	exit 2
+fi
+
+git diff --no-ext-diff --unified=0 \
+	"$MERGE_BASE" "$HEAD_COMMIT" -- CHANGELOG.md >"$TMP_ROOT/changelog.patch"
+if grep -q '^Binary files ' "$TMP_ROOT/changelog.patch"; then
+	printf '%s\n' 'error: CHANGELOG.md must remain a text file' >&2
+	exit 1
+fi
+if ! awk '
+	/^\+\+\+ / { next }
+	/^\+/ {
+		line = substr($0, 2)
+		if (line ~ /(^|[^[:alnum:]_])(TODO|TBD)([^[:alnum:]_]|$)/) {
+			bad = 1
+		}
+	}
+	END { exit bad }
+' "$TMP_ROOT/changelog.patch"; then
+	printf '%s\n' 'error: changed CHANGELOG additions must not contain TODO/TBD placeholders' >&2
+	exit 1
+fi
+
+. "$ROOT/scripts/release/release-lib.sh"
+
+extract_labeled_section() {
+	_els_file="$1"
+	_els_wanted="$2"
+	awk -v wanted="$_els_wanted" '
+		/^## / {
+			active = 0
+			if (substr($0, 1, 4) == "## [") {
+				rest = substr($0, 5)
+				close_pos = index(rest, "]")
+				if (close_pos > 1 && substr(rest, 1, close_pos - 1) == wanted) {
+					active = 1
+				}
+			}
+		}
+		active { print }
+	' "$_els_file"
+}
+
+extract_unmanaged_content() {
+	_euc_file="$1"
+	awk '
+		BEGIN { active = 1 }
+		/^## / {
+			active = 1
+			if (substr($0, 1, 4) == "## [") {
+				rest = substr($0, 5)
+				close_pos = index(rest, "]")
+				if (close_pos > 1) {
+					active = 0
+				}
+			}
+		}
+		active { print }
+	' "$_euc_file"
+}
+
+label_heading_count() {
+	_lhc_file="$1"
+	_lhc_wanted="$2"
+	awk -v wanted="$_lhc_wanted" '
+		/^## / && substr($0, 1, 4) == "## [" {
+			rest = substr($0, 5)
+			close_pos = index(rest, "]")
+			if (close_pos > 1 && substr(rest, 1, close_pos - 1) == wanted) count++
+		}
+		END { print count + 0 }
+	' "$_lhc_file"
+}
+
+calendar_date_is_valid() {
+	_cdiv_date="$1"
+	awk -v date="$_cdiv_date" 'BEGIN {
+		if (date !~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/) exit 1
+		split(date, part, "-")
+		year = part[1] + 0
+		month = part[2] + 0
+		day = part[3] + 0
+		if (year < 1 || month < 1 || month > 12 || day < 1) exit 1
+		days = 31
+		if (month == 4 || month == 6 || month == 9 || month == 11) days = 30
+		if (month == 2) {
+			days = 28
+			if ((year % 4 == 0 && year % 100 != 0) || year % 400 == 0) days = 29
+		}
+		exit day > days
+	}'
+}
+
+release_heading_date() {
+	_rhd_file="$1"
+	_rhd_version="$2"
+	awk -v wanted="$_rhd_version" '
+		BEGIN { prefix = "## [" wanted "] - " }
+		index($0, prefix) == 1 {
+			print substr($0, length(prefix) + 1)
+		}
+	' "$_rhd_file"
+}
+
+validate_release_notes() {
+	_vrn_file="$1"
+	set +e
+	awk '
+		NR == 1 { next }
+		{
+			if ($0 ~ /[^[:space:]]/) meaningful = 1
+			if ($0 ~ /^- /) bullet = 1
+			if ($0 ~ /(^|[^[:alnum:]_])(TODO|TBD)([^[:alnum:]_]|$)/) placeholder = 1
+		}
+		END {
+			if (!meaningful || !bullet) exit 43
+			if (placeholder) exit 44
+		}
+	' "$_vrn_file"
+	_vrn_status=$?
+	set -e
+	case "$_vrn_status" in
+	0) return 0 ;;
+	43) printf '%s\n' 'error: changed release section must contain notes and at least one bullet' >&2 ;;
+	44) printf '%s\n' 'error: changed release section still contains TODO/TBD placeholders' >&2 ;;
+	*) printf '%s\n' 'error: failed to validate changed release notes' >&2 ;;
+	esac
+	return "$_vrn_status"
+}
+
+extract_unmanaged_content "$TMP_ROOT/base-changelog" >"$TMP_ROOT/base-unmanaged"
+extract_unmanaged_content "$TMP_ROOT/head-changelog" >"$TMP_ROOT/head-unmanaged"
+if ! cmp -s "$TMP_ROOT/base-unmanaged" "$TMP_ROOT/head-unmanaged"; then
+	printf '%s\n' 'error: fast path only permits notes inside Unreleased or versioned release sections' >&2
+	exit 1
+fi
+
+unreleased_count="$(label_heading_count "$TMP_ROOT/head-changelog" Unreleased)"
+unreleased_exact_count="$(awk '$0 == "## [Unreleased]" { count++ } END { print count + 0 }' \
+	"$TMP_ROOT/head-changelog")"
+if [ "$unreleased_count" -ne 1 ] || [ "$unreleased_exact_count" -ne 1 ]; then
+	printf 'error: CHANGELOG must contain exactly one heading: ## [Unreleased]\n' >&2
+	exit 1
+fi
+
+extract_labeled_section "$TMP_ROOT/base-changelog" Unreleased >"$TMP_ROOT/base-unreleased"
+extract_labeled_section "$TMP_ROOT/head-changelog" Unreleased >"$TMP_ROOT/head-unreleased"
+unreleased_changed=0
+if ! cmp -s "$TMP_ROOT/base-unreleased" "$TMP_ROOT/head-unreleased"; then
+	unreleased_changed=1
+fi
+
+awk '
+	/^## / && substr($0, 1, 4) == "## [" {
+		rest = substr($0, 5)
+		close_pos = index(rest, "]")
+		if (close_pos > 1) {
+			label = substr(rest, 1, close_pos - 1)
+			if (label != "Unreleased") print label
+		}
+	}
+' "$TMP_ROOT/base-changelog" "$TMP_ROOT/head-changelog" |
+	LC_ALL=C sort -u >"$TMP_ROOT/release-labels"
+
+changed_release_count=0
+section_index=0
+while IFS= read -r version; do
+	[ -n "$version" ] || continue
+	section_index=$((section_index + 1))
+	base_section="$TMP_ROOT/base-release-$section_index"
+	head_section="$TMP_ROOT/head-release-$section_index"
+	extract_labeled_section "$TMP_ROOT/base-changelog" "$version" >"$base_section"
+	extract_labeled_section "$TMP_ROOT/head-changelog" "$version" >"$head_section"
+	if cmp -s "$base_section" "$head_section"; then
+		continue
+	fi
+
+	changed_release_count=$((changed_release_count + 1))
+	if ! release_channel_for_version "v$version" >/dev/null 2>&1; then
+		printf 'error: changed CHANGELOG release heading has an invalid version: %s\n' "$version" >&2
+		exit 1
+	fi
+	if [ "$(label_heading_count "$TMP_ROOT/head-changelog" "$version")" -ne 1 ]; then
+		printf 'error: CHANGELOG must contain exactly one well-formed section for %s\n' \
+			"$version" >&2
+		exit 1
+	fi
+	if ! validate_release_notes "$head_section"; then
+		exit 1
+	fi
+	release_date="$(release_heading_date "$TMP_ROOT/head-changelog" "$version")"
+	if ! calendar_date_is_valid "$release_date"; then
+		printf 'error: CHANGELOG section for %s has an invalid calendar date: %s\n' \
+			"$version" "$release_date" >&2
+		exit 1
+	fi
+done <"$TMP_ROOT/release-labels"
+
+if [ "$changed_release_count" -eq 0 ] && [ "$unreleased_changed" -eq 0 ]; then
+	printf '%s\n' 'error: CHANGELOG modification did not change an eligible notes section' >&2
+	exit 1
+fi
+
+printf 'CHANGELOG PR check: ok (release_sections=%s unreleased_changed=%s)\n' \
+	"$changed_release_count" "$unreleased_changed"

--- a/scripts/release/release-lib.sh
+++ b/scripts/release/release-lib.sh
@@ -130,8 +130,7 @@ release_extract_changelog() {
       print
       if ($0 ~ /[^[:space:]]/) meaningful = 1
       if ($0 ~ /^- /) bullet = 1
-      lowered = tolower($0)
-      if (lowered ~ /todo|tbd/) placeholder = 1
+      if ($0 ~ /(^|[^[:alnum:]_])(TODO|TBD)([^[:alnum:]_]|$)/) placeholder = 1
     }
     END {
       if (found != 1) exit 41

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -134,16 +134,44 @@ require_github_publication_authority() {
   }
 
   sealed_commit="$(git rev-parse HEAD)"
-  passed_gate="$(
+  admission_check_runs="$(
     gh api -H 'Accept: application/vnd.github+json' \
-      "repos/$github_repository/commits/$sealed_commit/check-runs?check_name=CI%20Gate&filter=latest&per_page=100" \
-      --jq '[.check_runs[] | select(.name == "CI Gate" and .conclusion == "success")] | length'
+      "repos/$github_repository/commits/$sealed_commit/check-runs?filter=latest&per_page=100" \
+      --jq '.check_runs | group_by(.name) | map(max_by(.id)) | .[] | [.name, (.conclusion // .status // "unknown")] | @tsv'
   )" || {
-    printf 'could not query CI Gate for %s\n' "$sealed_commit" >&2
+    printf 'could not query Code Admission contexts for %s\n' "$sealed_commit" >&2
     return 1
   }
-  [ "$passed_gate" -gt 0 ] || {
-    printf 'CI Gate has not succeeded for sealed commit %s in %s\n' "$sealed_commit" "$github_repository" >&2
+
+  missing_contexts=""
+  non_success_contexts=""
+  while IFS= read -r required_context; do
+    context_state="$(
+      printf '%s\n' "$admission_check_runs" |
+        awk -F '\t' -v required="$required_context" '$1 == required { state = $2 } END { print state }'
+    )"
+    if [ -z "$context_state" ]; then
+      missing_contexts="${missing_contexts}${missing_contexts:+, }$required_context"
+    elif [ "$context_state" != "success" ]; then
+      non_success_contexts="${non_success_contexts}${non_success_contexts:+, }$required_context=$context_state"
+    fi
+  done <<'ADMISSION_CONTEXTS'
+Lint
+Test
+Coverage
+Policy
+Edition
+Interface Integrity
+AI Behavior
+CLI Smoke
+Mock MCP
+ADMISSION_CONTEXTS
+  [ -z "$missing_contexts" ] && [ -z "$non_success_contexts" ] || {
+    printf 'Code Admission contexts are not all successful for sealed commit %s in %s; missing: %s; non-success: %s\n' \
+      "$sealed_commit" \
+      "$github_repository" \
+      "${missing_contexts:-none}" \
+      "${non_success_contexts:-none}" >&2
     return 1
   }
 

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -1,0 +1,376 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type changelogGateRepo struct {
+	root string
+	gate string
+	base string
+}
+
+const changelogGateBase = `# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2026-07-01
+
+### Added
+
+- Initial release.
+`
+
+func newChangelogGateRepo(t *testing.T) *changelogGateRepo {
+	t.Helper()
+
+	sourceRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("Abs(repo root) error = %v", err)
+	}
+	root := t.TempDir()
+
+	for _, path := range []string{
+		"LICENSE",
+		"NOTICE",
+		"README.md",
+		"CONTRIBUTING.md",
+		"SECURITY.md",
+		"CODE_OF_CONDUCT.md",
+		".env.example",
+		".github/workflows/ci.yml",
+		".github/PULL_REQUEST_TEMPLATE.md",
+		"docs/architecture.md",
+		"scripts/README.md",
+		"build/README.md",
+	} {
+		changelogGateWrite(t, root, path, "fixture\n", 0o644)
+	}
+	for _, path := range []string{
+		"scripts/policy/check-changelog-pr.sh",
+		"scripts/policy/open-source-audit.sh",
+		"scripts/release/release-lib.sh",
+	} {
+		data, err := os.ReadFile(filepath.Join(sourceRoot, path))
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", path, err)
+		}
+		mode := os.FileMode(0o644)
+		if strings.HasSuffix(path, ".sh") {
+			mode = 0o755
+		}
+		changelogGateWrite(t, root, path, string(data), mode)
+	}
+	changelogGateWrite(t, root, "CHANGELOG.md", changelogGateBase, 0o644)
+
+	changelogGateGit(t, root, "init", "-b", "main")
+	changelogGateGit(t, root, "config", "user.name", "Changelog Gate Test")
+	changelogGateGit(t, root, "config", "user.email", "changelog-gate@example.com")
+	changelogGateGit(t, root, "add", ".")
+	changelogGateGit(t, root, "commit", "-m", "seed repository")
+
+	return &changelogGateRepo{
+		root: root,
+		gate: filepath.Join(root, "scripts", "policy", "check-changelog-pr.sh"),
+		base: strings.TrimSpace(changelogGateGit(t, root, "rev-parse", "HEAD")),
+	}
+}
+
+func changelogGateWrite(t *testing.T, root, path, content string, mode os.FileMode) {
+	t.Helper()
+	full := filepath.Join(root, path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", filepath.Dir(full), err)
+	}
+	if err := os.WriteFile(full, []byte(content), mode); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", full, err)
+	}
+}
+
+func changelogGateGit(t *testing.T, root string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s error = %v\noutput:\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+func (r *changelogGateRepo) commit(t *testing.T, message string) {
+	t.Helper()
+	changelogGateGit(t, r.root, "add", "-A")
+	changelogGateGit(t, r.root, "commit", "-m", message)
+}
+
+func (r *changelogGateRepo) run(t *testing.T) (string, error) {
+	t.Helper()
+	cmd := exec.Command("sh", r.gate, r.base, "HEAD")
+	cmd.Dir = r.root
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func TestChangelogPRGateAcceptsTargetedChanges(t *testing.T) {
+	tests := []struct {
+		name      string
+		changelog string
+	}{
+		{
+			name: "new release section with lowercase todo product",
+			changelog: `# Changelog
+
+## [Unreleased]
+
+## [1.0.1-beta.1] - 2026-07-17
+
+### Changed
+
+- Improve the lowercase todo command family without leaving a placeholder.
+
+## [1.0.0] - 2026-07-01
+
+### Added
+
+- Initial release.
+`,
+		},
+		{
+			name: "unreleased note",
+			changelog: `# Changelog
+
+## [Unreleased]
+
+### Changed
+
+- Document the next release candidate.
+
+## [1.0.0] - 2026-07-01
+
+### Added
+
+- Initial release.
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo := newChangelogGateRepo(t)
+			changelogGateWrite(t, repo.root, "CHANGELOG.md", test.changelog, 0o644)
+			repo.commit(t, test.name)
+
+			output, err := repo.run(t)
+			if err != nil {
+				t.Fatalf("gate error = %v\noutput:\n%s", err, output)
+			}
+			if !strings.Contains(output, "CHANGELOG PR check: ok") {
+				t.Fatalf("gate output missing success marker:\n%s", output)
+			}
+		})
+	}
+}
+
+func TestReleaseChangelogExtractionAllowsLowercaseTodoProductName(t *testing.T) {
+	sourceRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("Abs(repo root) error = %v", err)
+	}
+	changelog := filepath.Join(t.TempDir(), "CHANGELOG.md")
+	changelogGateWrite(t, filepath.Dir(changelog), filepath.Base(changelog), `# Changelog
+
+## [1.0.1-beta.1] - 2026-07-17
+
+### Changed
+
+- Improve the lowercase todo command family.
+`, 0o644)
+
+	cmd := exec.Command(
+		"sh",
+		"-c",
+		`. "$1"; release_extract_changelog "$2" 1.0.1-beta.1 -`,
+		"sh",
+		filepath.Join(sourceRoot, "scripts", "release", "release-lib.sh"),
+		changelog,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("release_extract_changelog error = %v\noutput:\n%s", err, output)
+	}
+}
+
+func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("Abs(repo root) error = %v", err)
+	}
+	workflows := map[string][]string{
+		".github/workflows/ci.yml": {
+			"name: Classify PR changes",
+			"name: Changelog Check",
+			`run: ./scripts/policy/check-changelog-pr.sh "$PR_BASE_SHA" "$PR_HEAD_SHA"`,
+			"expected_heavy_result=skipped",
+			"name: CI Gate",
+		},
+		".github/workflows/multi-profile-e2e.yml": {
+			"branches:",
+			"- main",
+			"Record changelog-only fast path",
+			"Full E2E: runs after merge",
+		},
+	}
+	classifierContract := []string{
+		"files.length === 1",
+		"files[0].filename === 'CHANGELOG.md'",
+		"files[0].status === 'modified'",
+		"!files[0].previous_filename",
+	}
+
+	for path, required := range workflows {
+		data, err := os.ReadFile(filepath.Join(root, path))
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", path, err)
+		}
+		workflow := string(data)
+		for _, want := range append(classifierContract, required...) {
+			if !strings.Contains(workflow, want) {
+				t.Errorf("%s missing fast-path contract %q", path, want)
+			}
+		}
+		if strings.Contains(workflow, "paths-ignore:") {
+			t.Errorf("%s must not skip the required workflow with paths-ignore", path)
+		}
+	}
+}
+
+func TestChangelogPRGateRejectsUnsafeChanges(t *testing.T) {
+	validRelease := `# Changelog
+
+## [Unreleased]
+
+## [1.0.1-beta.1] - 2026-07-17
+
+### Changed
+
+- Valid release note.
+
+## [1.0.0] - 2026-07-01
+
+### Added
+
+- Initial release.
+`
+	tests := []struct {
+		name       string
+		changelog  string
+		mutate     func(*testing.T, *changelogGateRepo)
+		wantOutput string
+	}{
+		{
+			name:      "second changed file",
+			changelog: validRelease,
+			mutate: func(t *testing.T, repo *changelogGateRepo) {
+				changelogGateWrite(t, repo.root, "extra.txt", "extra\n", 0o644)
+			},
+			wantOutput: "exactly one in-place modification",
+		},
+		{
+			name: "invalid calendar date",
+			changelog: strings.Replace(
+				validRelease,
+				"2026-07-17",
+				"2026-02-30",
+				1,
+			),
+			wantOutput: "invalid calendar date",
+		},
+		{
+			name: "duplicate release heading",
+			changelog: strings.Replace(
+				validRelease,
+				"## [1.0.0] - 2026-07-01",
+				"## [1.0.1-beta.1] - 2026-07-17\n\n- Duplicate.\n\n## [1.0.0] - 2026-07-01",
+				1,
+			),
+			wantOutput: "exactly one well-formed section",
+		},
+		{
+			name: "missing bullet",
+			changelog: strings.Replace(
+				validRelease,
+				"- Valid release note.",
+				"Valid release note.",
+				1,
+			),
+			wantOutput: "at least one bullet",
+		},
+		{
+			name: "placeholder",
+			changelog: strings.Replace(
+				validRelease,
+				"- Valid release note.",
+				"- TODO: write release notes.",
+				1,
+			),
+			wantOutput: "must not contain TODO/TBD",
+		},
+		{
+			name: "malformed duplicate unreleased heading",
+			changelog: strings.Replace(
+				validRelease,
+				"## [Unreleased]",
+				"## [Unreleased]\n\n## [Unreleased] junk",
+				1,
+			),
+			wantOutput: "exactly one heading",
+		},
+		{
+			name: "preamble change",
+			changelog: strings.Replace(
+				validRelease,
+				"# Changelog",
+				"# Release history",
+				1,
+			),
+			wantOutput: "only permits notes inside",
+		},
+		{
+			name:      "rename changelog",
+			changelog: changelogGateBase,
+			mutate: func(t *testing.T, repo *changelogGateRepo) {
+				if err := os.Rename(
+					filepath.Join(repo.root, "CHANGELOG.md"),
+					filepath.Join(repo.root, "CHANGES.md"),
+				); err != nil {
+					t.Fatalf("Rename CHANGELOG.md error = %v", err)
+				}
+			},
+			wantOutput: "exactly one in-place modification",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo := newChangelogGateRepo(t)
+			changelogGateWrite(t, repo.root, "CHANGELOG.md", test.changelog, 0o644)
+			if test.mutate != nil {
+				test.mutate(t, repo)
+			}
+			repo.commit(t, test.name)
+
+			output, err := repo.run(t)
+			if err == nil {
+				t.Fatalf("unsafe change unexpectedly passed:\n%s", output)
+			}
+			if !strings.Contains(output, test.wantOutput) {
+				t.Fatalf("gate output missing %q:\n%s", test.wantOutput, output)
+			}
+		})
+	}
+}

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -25,6 +25,23 @@ const changelogGateBase = `# Changelog
 - Initial release.
 `
 
+const changelogGateValidRelease = `# Changelog
+
+## [Unreleased]
+
+## [1.0.1-beta.1] - 2026-07-17
+
+### Changed
+
+- Valid release note.
+
+## [1.0.0] - 2026-07-01
+
+### Added
+
+- Initial release.
+`
+
 func newChangelogGateRepo(t *testing.T) *changelogGateRepo {
 	t.Helper()
 
@@ -110,7 +127,17 @@ func (r *changelogGateRepo) commit(t *testing.T, message string) {
 
 func (r *changelogGateRepo) run(t *testing.T) (string, error) {
 	t.Helper()
-	cmd := exec.Command("sh", r.gate, r.base, "HEAD")
+	return r.runMode(t, "--fast-path")
+}
+
+func (r *changelogGateRepo) runMode(t *testing.T, mode string) (string, error) {
+	t.Helper()
+	return r.runRefs(t, mode, r.base, "HEAD")
+}
+
+func (r *changelogGateRepo) runRefs(t *testing.T, mode, base, head string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("sh", r.gate, mode, base, head)
 	cmd.Dir = r.root
 	output, err := cmd.CombinedOutput()
 	return string(output), err
@@ -176,6 +203,158 @@ func TestChangelogPRGateAcceptsTargetedChanges(t *testing.T) {
 	}
 }
 
+func TestChangelogPRContentOnlyAllowsOtherFiles(t *testing.T) {
+	repo := newChangelogGateRepo(t)
+	changelogGateWrite(t, repo.root, "CHANGELOG.md", changelogGateValidRelease, 0o644)
+	changelogGateWrite(t, repo.root, "internal/change.go", "package internal\n", 0o644)
+	repo.commit(t, "change code with release notes")
+
+	output, err := repo.runMode(t, "--content-only")
+	if err != nil {
+		t.Fatalf("content-only gate error = %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(output, "CHANGELOG PR check: ok (mode=content-only") {
+		t.Fatalf("content-only gate output missing success marker:\n%s", output)
+	}
+}
+
+func TestChangelogPRContentOnlyStillValidatesContentWithOtherFiles(t *testing.T) {
+	tests := []struct {
+		name       string
+		changelog  string
+		wantOutput string
+	}{
+		{
+			name: "invalid calendar date",
+			changelog: strings.Replace(
+				changelogGateValidRelease,
+				"2026-07-17",
+				"2026-02-30",
+				1,
+			),
+			wantOutput: "invalid calendar date",
+		},
+		{
+			name: "placeholder",
+			changelog: strings.Replace(
+				changelogGateValidRelease,
+				"- Valid release note.",
+				"- TODO: write release notes.",
+				1,
+			),
+			wantOutput: "must not contain TODO/TBD",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo := newChangelogGateRepo(t)
+			changelogGateWrite(t, repo.root, "CHANGELOG.md", test.changelog, 0o644)
+			changelogGateWrite(t, repo.root, "internal/change.go", "package internal\n", 0o644)
+			repo.commit(t, test.name)
+
+			output, err := repo.runMode(t, "--content-only")
+			if err == nil {
+				t.Fatalf("unsafe content-only change unexpectedly passed:\n%s", output)
+			}
+			if !strings.Contains(output, test.wantOutput) {
+				t.Fatalf("content-only gate output missing %q:\n%s", test.wantOutput, output)
+			}
+		})
+	}
+}
+
+func TestChangelogPRGateValidatesSyntheticMergeTree(t *testing.T) {
+	repo := newChangelogGateRepo(t)
+	commonChangelog := `# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2026-07-01
+
+### Added
+
+- Initial release.
+
+## [0.9.0] - 2026-06-01
+
+### Added
+
+- Earlier release.
+`
+	changelogGateWrite(t, repo.root, "CHANGELOG.md", commonChangelog, 0o644)
+	repo.commit(t, "expand changelog history")
+	common := strings.TrimSpace(changelogGateGit(t, repo.root, "rev-parse", "HEAD"))
+	repo.base = common
+
+	changelogGateGit(t, repo.root, "switch", "-c", "feature")
+	featureChangelog := strings.Replace(
+		commonChangelog,
+		"## [1.0.0] - 2026-07-01",
+		`## [1.0.1-beta.1] - 2026-07-17
+
+### Changed
+
+- Feature branch release note.
+
+## [1.0.0] - 2026-07-01`,
+		1,
+	)
+	changelogGateWrite(t, repo.root, "CHANGELOG.md", featureChangelog, 0o644)
+	repo.commit(t, "add feature release note")
+	featureHead := strings.TrimSpace(changelogGateGit(t, repo.root, "rev-parse", "HEAD"))
+	if output, err := repo.runRefs(t, "--fast-path", common, featureHead); err != nil {
+		t.Fatalf("feature head should be valid before merging: %v\n%s", err, output)
+	}
+
+	changelogGateGit(t, repo.root, "switch", "main")
+	mainChangelog := strings.Replace(
+		commonChangelog,
+		"## [0.9.0] - 2026-06-01",
+		`## [1.0.1-beta.1] - 2026-07-17
+
+### Changed
+
+- Main branch release note.
+
+## [0.9.0] - 2026-06-01`,
+		1,
+	)
+	changelogGateWrite(t, repo.root, "CHANGELOG.md", mainChangelog, 0o644)
+	repo.commit(t, "add main release note")
+	mergeBase := strings.TrimSpace(changelogGateGit(t, repo.root, "rev-parse", "HEAD"))
+	changelogGateGit(t, repo.root, "merge", "--no-ff", "feature", "-m", "merge feature")
+	mergeHead := strings.TrimSpace(changelogGateGit(t, repo.root, "rev-parse", "HEAD"))
+
+	output, err := repo.runRefs(t, "--fast-path", mergeBase, mergeHead)
+	if err == nil {
+		t.Fatalf("synthetic merge with duplicate release heading unexpectedly passed:\n%s", output)
+	}
+	if !strings.Contains(output, "exactly one well-formed section") {
+		t.Fatalf("synthetic merge rejection missing duplicate-section evidence:\n%s", output)
+	}
+}
+
+func TestChangelogPRGateRejectsExecutableModeInBothModes(t *testing.T) {
+	for _, mode := range []string{"--fast-path", "--content-only"} {
+		t.Run(strings.TrimPrefix(mode, "--"), func(t *testing.T) {
+			repo := newChangelogGateRepo(t)
+			changelogGateWrite(t, repo.root, "CHANGELOG.md", changelogGateValidRelease, 0o644)
+			changelogGateGit(t, repo.root, "add", "CHANGELOG.md")
+			changelogGateGit(t, repo.root, "update-index", "--chmod=+x", "CHANGELOG.md")
+			changelogGateGit(t, repo.root, "commit", "-m", "make changelog executable")
+
+			output, err := repo.runMode(t, mode)
+			if err == nil {
+				t.Fatalf("executable CHANGELOG unexpectedly passed:\n%s", output)
+			}
+			if !strings.Contains(output, "regular 100644 blob at head") {
+				t.Fatalf("gate output missing regular-file rejection:\n%s", output)
+			}
+		})
+	}
+}
+
 func TestReleaseChangelogExtractionAllowsLowercaseTodoProductName(t *testing.T) {
 	sourceRoot, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {
@@ -210,42 +389,96 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Abs(repo root) error = %v", err)
 	}
-	workflows := map[string][]string{
-		".github/workflows/ci.yml": {
-			"name: Classify PR changes",
-			"name: Changelog Check",
-			`run: ./scripts/policy/check-changelog-pr.sh "$PR_BASE_SHA" "$PR_HEAD_SHA"`,
-			"expected_heavy_result=skipped",
-			"name: CI Gate",
-		},
-		".github/workflows/multi-profile-e2e.yml": {
-			"branches:",
-			"- main",
-			"Record changelog-only fast path",
-			"Full E2E: runs after merge",
-		},
+
+	readWorkflow := func(path string) string {
+		t.Helper()
+		data, readErr := os.ReadFile(filepath.Join(root, path))
+		if readErr != nil {
+			t.Fatalf("ReadFile(%s) error = %v", path, readErr)
+		}
+		return string(data)
 	}
-	classifierContract := []string{
+
+	admission := readWorkflow(".github/workflows/ci.yml")
+	for _, want := range []string{
+		"name: Code Admission — PR 合入门禁",
 		"files.length === 1",
 		"files[0].filename === 'CHANGELOG.md'",
 		"files[0].status === 'modified'",
 		"!files[0].previous_filename",
+		"pre-classification",
+		"post-classification",
+		"before.changed_files !== files.length",
+		"after.changed_files !== files.length",
+		`test "$(git rev-parse HEAD^1)" = "$PR_BASE_SHA"`,
+		`test "$(git rev-parse HEAD^2)" = "$PR_HEAD_SHA"`,
+		"Files API and synthetic merge tree disagree on CHANGELOG scope",
+		"mode=--content-only",
+		"mode=--fast-path",
+		`"$mode" "$PR_BASE_SHA" HEAD`,
+		"needs.lint.outputs.platform_sensitive == 'true'",
+	} {
+		if !strings.Contains(admission, want) {
+			t.Errorf("Code Admission workflow missing contract %q", want)
+		}
+	}
+	for _, context := range []string{
+		"Lint",
+		"Test",
+		"Coverage",
+		"Policy",
+		"Edition",
+		"Interface Integrity",
+		"CLI Smoke",
+		"Mock MCP",
+	} {
+		if !strings.Contains(admission, "\n    name: "+context+"\n") {
+			t.Errorf("Code Admission workflow missing exact context %q", context)
+		}
+	}
+	for _, forbidden := range []string{
+		"name: CI Gate",
+		"name: Changelog Check",
+		"name: Policy Check",
+		"name: Edition Contract Tests",
+		"name: Mock MCP Smoke",
+	} {
+		if strings.Contains(admission, forbidden) {
+			t.Errorf("Code Admission workflow retains legacy context %q", forbidden)
+		}
+	}
+	if strings.Contains(admission, "paths-ignore:") {
+		t.Error("Code Admission must not suppress required contexts with paths-ignore")
 	}
 
-	for path, required := range workflows {
-		data, err := os.ReadFile(filepath.Join(root, path))
-		if err != nil {
-			t.Fatalf("ReadFile(%s) error = %v", path, err)
+	aiBehavior := readWorkflow(".github/workflows/ai-behavior-check.yml")
+	for _, want := range []string{
+		"name: Code Admission — AI Behavior",
+		"\n    name: AI Behavior\n",
+		"context: 'AI Behavior'",
+		"pull_request_target:",
+		"pull.head.sha !== expectedHead",
+		"pull.base.sha !== expectedBase",
+	} {
+		if !strings.Contains(aiBehavior, want) {
+			t.Errorf("AI Behavior workflow missing contract %q", want)
 		}
-		workflow := string(data)
-		for _, want := range append(classifierContract, required...) {
-			if !strings.Contains(workflow, want) {
-				t.Errorf("%s missing fast-path contract %q", path, want)
-			}
+	}
+
+	integration := readWorkflow(".github/workflows/multi-profile-e2e.yml")
+	for _, want := range []string{
+		"name: Main Integration — 主干集成",
+		"\n    name: Multi-profile E2E\n",
+		"branches:",
+		"- main",
+		"workflow_dispatch:",
+	} {
+		if !strings.Contains(integration, want) {
+			t.Errorf("main integration workflow missing contract %q", want)
 		}
-		if strings.Contains(workflow, "paths-ignore:") {
-			t.Errorf("%s must not skip the required workflow with paths-ignore", path)
-		}
+	}
+	if strings.Contains(integration, "pull_request:") {
+		t.Error("complete Multi-profile E2E must not run as a pull-request admission context")
 	}
 }
 
@@ -351,7 +584,7 @@ func TestChangelogPRGateRejectsUnsafeChanges(t *testing.T) {
 					t.Fatalf("Rename CHANGELOG.md error = %v", err)
 				}
 			},
-			wantOutput: "exactly one in-place modification",
+			wantOutput: "regular 100644 blob at head",
 		},
 	}
 

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -33,6 +33,18 @@ var expectedPackagedSkillTargets = []string{
 	".hermes/skills/dws",
 }
 
+var expectedReleaseAdmissionContexts = []string{
+	"Lint",
+	"Test",
+	"Coverage",
+	"Policy",
+	"Edition",
+	"Interface Integrity",
+	"AI Behavior",
+	"CLI Smoke",
+	"Mock MCP",
+}
+
 func seedDistArchive(t *testing.T, path string) {
 	t.Helper()
 	file, err := os.Create(path)
@@ -630,11 +642,15 @@ func TestReleaseWorkflowUsesDedicatedGovernanceIdentity(t *testing.T) {
 
 	const (
 		checksCall    = "github.rest.checks.listForRef"
+		paginatedCall = "github.paginate(github.rest.checks.listForRef"
 		immutableCall = `"GET /repos/{owner}/{repo}/immutable-releases"`
 		governanceID  = `github-token: ${{ secrets.RELEASE_GOVERNANCE_TOKEN }}`
 	)
 	if got := strings.Count(workflow, checksCall); got != 2 {
 		t.Fatalf("release workflow Checks API call count = %d, want one tag check and one preflight check", got)
+	}
+	if got := strings.Count(workflow, paginatedCall); got != 2 {
+		t.Fatalf("release workflow paginated Checks API call count = %d, want one tag check and one preflight check", got)
 	}
 	if got := strings.Count(workflow, immutableCall); got != 2 {
 		t.Fatalf("release workflow immutable governance call count = %d, want one tag check and one preflight check", got)
@@ -651,6 +667,12 @@ func TestReleaseWorkflowUsesDedicatedGovernanceIdentity(t *testing.T) {
 		for _, required := range []string{
 			"checks: read",
 			checksCall,
+			paginatedCall,
+			"run.head_sha !== sha",
+			"const missing = requiredContexts.filter",
+			"const nonSuccess = requiredContexts.flatMap",
+			"missing:",
+			"non-success:",
 			immutableCall,
 			governanceID,
 			"RELEASE_GOVERNANCE_TOKEN with repository Administration read permission is required",
@@ -659,12 +681,65 @@ func TestReleaseWorkflowUsesDedicatedGovernanceIdentity(t *testing.T) {
 				t.Errorf("%s governance path is missing %q", name, required)
 			}
 		}
+		for _, context := range expectedReleaseAdmissionContexts {
+			if !strings.Contains(section, fmt.Sprintf("%q", context)) {
+				t.Errorf("%s governance path is missing exact Code Admission context %q", name, context)
+			}
+		}
+		if strings.Contains(section, "check_name:") {
+			t.Errorf("%s governance path must fetch all check runs in one exact-SHA query", name)
+		}
 		if strings.Contains(section, "contents: write") {
 			t.Errorf("%s governance path must not grant contents write permission", name)
 		}
 		if strings.Contains(section, `github-token: ${{ secrets.GITHUB_TOKEN }}`) {
 			t.Errorf("%s immutable governance path must not fall back to GITHUB_TOKEN", name)
 		}
+	}
+	if strings.Contains(workflow, "CI"+" Gate") {
+		t.Error("release workflow must not retain the retired aggregate gate name")
+	}
+}
+
+func TestReleaseScriptRequiresExactCodeAdmissionContexts(t *testing.T) {
+	t.Parallel()
+
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "release", "release.sh"))
+	if err != nil {
+		t.Fatalf("Abs(release.sh) error = %v", err)
+	}
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", scriptPath, err)
+	}
+	script := string(data)
+
+	const checksQuery = `commits/$sealed_commit/check-runs?filter=latest&per_page=100`
+	if got := strings.Count(script, checksQuery); got != 1 {
+		t.Fatalf("release script exact-SHA Checks API query count = %d, want 1", got)
+	}
+	for _, required := range []string{
+		`group_by(.name) | map(max_by(.id))`,
+		`missing_contexts=""`,
+		`non_success_contexts=""`,
+		`"$context_state" != "success"`,
+		"Code Admission contexts are not all successful for sealed commit",
+		"missing: %s; non-success: %s",
+	} {
+		if !strings.Contains(script, required) {
+			t.Errorf("release script Code Admission gate is missing %q", required)
+		}
+	}
+	for _, context := range expectedReleaseAdmissionContexts {
+		if !strings.Contains(script, "\n"+context+"\n") {
+			t.Errorf("release script is missing exact Code Admission context %q", context)
+		}
+	}
+	if strings.Contains(script, "check_name=") {
+		t.Error("release script must fetch all check runs in one exact-SHA query")
+	}
+	if strings.Contains(script, "CI"+" Gate") {
+		t.Error("release script must not retain the retired aggregate gate name")
 	}
 }
 
@@ -703,10 +778,10 @@ func TestReleaseWorkflowGovernancePreflightCannotPublish(t *testing.T) {
 			t.Errorf("governance preflight must not contain publishing behavior %q", forbidden)
 		}
 	}
-	ciGate := strings.Index(preflight, "Require successful CI Gate on the preflight commit")
+	admission := strings.Index(preflight, "Require successful Code Admission contexts on the preflight commit")
 	homebrewCanary := strings.Index(preflight, "Verify Homebrew PR automation permission")
-	if ciGate == -1 || homebrewCanary == -1 || ciGate > homebrewCanary {
-		t.Error("governance preflight must validate the exact CI Gate before exposing Homebrew credentials")
+	if admission == -1 || homebrewCanary == -1 || admission > homebrewCanary {
+		t.Error("governance preflight must validate all exact Code Admission contexts before exposing Homebrew credentials")
 	}
 
 	mirror := releaseWorkflowSection(t, workflow, "  mirror-gitee-release:\n", "\n  repair-npm:\n")
@@ -839,7 +914,8 @@ func TestReleaseWorkflowRecoveryReusesGuardedJobs(t *testing.T) {
 		"dws-release-recovery run=%s tag-object=%s commit=%s",
 		"Public release is not bound to this exact recovery run.",
 		"Public recovery asset differs from this run's sealed artifact",
-		`ref: process.env.RELEASE_COMMIT`,
+		`const sha = process.env.RELEASE_COMMIT`,
+		`ref: sha`,
 		`path: tmp/trusted-release-tooling`,
 		`ref: ${{ github.sha }}`,
 		`step.name === "Require immutable published GitHub Release"`,
@@ -1335,10 +1411,10 @@ func TestReleaseWorkflowOpensHomebrewPROnlyForOfficialStableTags(t *testing.T) {
 		t.Errorf("Homebrew PR permission preflight count = %d, want one default-branch preflight and one tag contract", got)
 	}
 	tagContract := releaseWorkflowSection(t, workflow, "  release-contract:\n", "\n  release:\n")
-	tagCI := strings.Index(tagContract, "Require successful CI Gate on the sealed commit")
+	tagAdmission := strings.Index(tagContract, "Require successful Code Admission contexts on the sealed commit")
 	tagHomebrew := strings.Index(tagContract, "Verify Homebrew PR automation permission")
-	if tagCI == -1 || tagHomebrew == -1 || tagCI > tagHomebrew {
-		t.Error("tag contract must validate the sealed CI Gate before exposing Homebrew credentials")
+	if tagAdmission == -1 || tagHomebrew == -1 || tagAdmission > tagHomebrew {
+		t.Error("tag contract must validate all exact Code Admission contexts before exposing Homebrew credentials")
 	}
 
 	start := strings.Index(workflow, "- name: Open stable Homebrew formula PR")


### PR DESCRIPTION
## Summary

- Align the PR admission stage with the published `Code Admission — PR 合入门禁` contract and expose exactly nine stable checks: `Lint`, `Test`, `Coverage`, `Policy`, `Edition`, `Interface Integrity`, `AI Behavior`, `CLI Smoke`, and `Mock MCP`.
- Keep an exact, fail-closed `CHANGELOG.md` fast path without turning skipped helpers into synthetic quality results. The named admission jobs still run and validate the classification contract.
- Move full Multi-profile E2E and native multi-platform coverage to downstream main integration. PRs retain primary-environment gates plus fast cross-platform compile checks; OS/auth/release-sensitive changes trigger targeted native validation.
- Make release governance require the same nine checks on the exact release SHA, and move Wukong notification to a least-privilege downstream `workflow_run`.
- Harden CHANGELOG validation against Files API truncation, stale-base/synthetic-merge drift, file-mode changes, renames, duplicates, invalid dates/versions, and unresolved placeholders.

## Verification

- [x] Exact `CHANGELOG.md`-only check: N/A (this PR changes CI, release, policy, tests, and docs)
- [x] `DWS_PACKAGE_VERSION=0.0.0-test make build`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test make policy`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test -count=1 -timeout=10m ./test/scripts`
- [x] Focused CHANGELOG synthetic-merge and file-mode regression tests
- [x] Focused release exact-check-context tests
- [x] `go test ./pkg/editiontest/...`
- [x] actionlint for all workflows
- [x] Darwin amd64/arm64 and Windows amd64/arm64 compile checks
- [x] `sh -n`, `gofmt`, generated-drift/policy gates, and `git diff --check`

## Notes

- This is a human-owned, high-risk CI/release-governance change and requires explicit maintainer review.
- The repository ruleset migration is deliberately two-phase with no protection gap. For this PR only, required checks are the eight new Actions contexts plus the base-owned legacy `AI Behavior Check`; after merge and successful main validation, the ruleset is atomically finalized to the nine names above using `AI Behavior`.
- Multi-profile E2E remains a real downstream main integration check; it is not represented as a synthetic PR success.
- No CHANGELOG entry: this changes engineering admission/release infrastructure, not user-visible CLI behavior.
- A later narrow follow-up may add pagination to the local release helper; Actions-side check queries are already paginated and this PR is not blocked by that follow-up.
