### PR TITLE
docs(changelog): seal v1.0.53-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.53-beta.4] - 2026-07-17
+
+This beta validates the expanded personal IM event subscriptions and the flattened `event consume` structured output introduced after v1.0.53-beta.3.
+
 ### Added
 
-- **Expanded personal IM event subscriptions** — adds one-to-one and group events for message read receipts, recalls, and reactions; publishes the specified-sender receive event; and lets one-to-one/sender subscriptions target either a staff `--user` or an `--open-dingtalk-id`. Event Schema now exposes these alternatives through machine-readable parameter constraints.
+- **Expanded personal IM event subscriptions** (#651) — adds one-to-one and group events for message read receipts, recalls, and reactions; publishes the specified-sender receive event; and lets one-to-one/sender subscriptions target either a staff `--user` or an `--open-dingtalk-id`. Event Schema now exposes these alternatives through machine-readable parameter constraints.
 
 ### Changed
 
-- **Personal event structured output is now flat** — `event consume` projects NDJSON/JSON/pretty/compact output into event-specific top-level DTOs, so consumers read fields such as `content`, `sender`, and `conversation_id` directly instead of parsing `.data | fromjson`. This is a breaking change for scripts using the former transport envelope; the original server payload remains available through `-f raw`, while `--debug-raw-events` preserves the full diagnostic envelope.
+- **Personal event structured output is now flat** (#651) — `event consume` projects NDJSON/JSON/pretty/compact output into event-specific top-level DTOs, so consumers read fields such as `content`, `sender`, and `conversation_id` directly instead of parsing `.data | fromjson`. This is a breaking change for scripts using the former transport envelope; the original server payload remains available through `-f raw`, while `--debug-raw-events` preserves the full diagnostic envelope.
 
 ## [1.0.53-beta.3] - 2026-07-17
 


### PR DESCRIPTION
## Summary
- Promote the accumulated `[Unreleased]` entries into a dated `## [1.0.53-beta.4] - 2026-07-17` section and keep an empty `[Unreleased]` for future PRs.
- Content sealed: expanded personal IM event subscriptions and the flattened `event consume` structured output (#651).

## Why
Release contract requires the exact CHANGELOG section to be merged to `main` before the annotated `v1.0.53-beta.4` tag can be published.

## Test plan
- [x] CHANGELOG diff is docs-only (`CHANGELOG.md`, +6/-2)
- [ ] CI Gate green on merge commit