### PR TITLE
fix(release): restore tag-push publication after recovery refactor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -622,7 +622,7 @@ jobs:
 
   release:
     name: Build signed release artifacts
-    if: ${{ needs.release-contract.result == 'success' }}
+    if: ${{ !cancelled() && needs.release-contract.result == 'success' }}
     needs: [release-contract]
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -788,7 +788,7 @@ jobs:
 
   verify-darwin-signatures:
     name: Verify Apple Developer ID signatures
-    if: ${{ needs.release.result == 'success' }}
+    if: ${{ !cancelled() && needs.release.result == 'success' }}
     needs: [release-contract, release]
     runs-on: macos-latest
     timeout-minutes: 10
@@ -816,7 +816,7 @@ jobs:
 
   publish-release:
     name: Publish immutable GitHub Release
-    if: ${{ needs.release-contract.result == 'success' && needs.release.result == 'success' && needs.verify-darwin-signatures.result == 'success' }}
+    if: ${{ !cancelled() && needs.release-contract.result == 'success' && needs.release.result == 'success' && needs.verify-darwin-signatures.result == 'success' }}
     needs: [release-contract, release, verify-darwin-signatures]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1055,7 +1055,7 @@ jobs:
 
   publish-channels:
     name: Publish npm and mirrors
-    if: ${{ needs.release-contract.result == 'success' && needs.publish-release.result == 'success' }}
+    if: ${{ !cancelled() && needs.release-contract.result == 'success' && needs.publish-release.result == 'success' }}
     needs: [release-contract, publish-release]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1286,7 +1286,7 @@ jobs:
 
   mirror-gitee-release:
     name: Mirror immutable release to Gitee
-    if: ${{ vars.ENABLE_GITEE_UPLOAD_FALLBACK == 'true' && needs.release-contract.result == 'success' && needs.release.result == 'success' && needs.publish-channels.result == 'success' }}
+    if: ${{ vars.ENABLE_GITEE_UPLOAD_FALLBACK == 'true' && !cancelled() && needs.release-contract.result == 'success' && needs.release.result == 'success' && needs.publish-channels.result == 'success' }}
     needs: [release-contract, release, publish-channels]
     runs-on: ubuntu-latest
     timeout-minutes: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 ### Fixed
 
 - **Release preflight reliability** — source-mode installer tests now use isolated temporary checkouts and HOME directories instead of overwriting and deleting the real repository `dws` binary, release preflight explicitly rebuilds before policy checks, and the full-suite runner gives the growing script package a non-flaky five-minute per-suite budget.
+- **Tag-push publication after the recovery refactor** — the guarded-recovery jobs are skipped on ordinary tag pushes, and the downstream build/sign/publish jobs relied on an implicit `success()` that treats those skipped ancestors as a chain failure, so pushing an annotated release tag validated the contract but silently skipped every publish job. The `release`, `verify-darwin-signatures`, `publish-release`, `publish-channels`, and `mirror-gitee-release` gates now use an explicit `!cancelled()` status check alongside their existing `result == 'success'` conditions, restoring direct tag-push delivery while keeping protected recovery as the failure break-glass.
 
 ## [1.0.53-beta.4] - 2026-07-17
 


### PR DESCRIPTION
## 根因

自 `1.0.53-beta.1` 的守护恢复重构引入了 `dispatch-contract` / `authorize-recovery` 两个**仅 `workflow_dispatch`** 用到的前置 job，并给 `release-contract` 加了 `if: always() && (...)`。

- **push tag 时**：`dispatch-contract` / `authorize-recovery` 被 `skipped`，`release-contract` 靠 `always()` 跑过并 `success`。
- 下游 `release` / `verify-darwin-signatures` / `publish-release` / `publish-channels` / `mirror-gitee-release` 的 `if` 只写了 `needs.X.result == 'success'`（不含状态函数），GitHub 会叠加隐式 `success()`，而隐式 `success()` 因 needs 链上存在 `skipped` 祖先而返回 false → **整条发布链被跳过**。
- 结果：push 一个 annotated release tag 后 run 显示 `success`，但 `release`/`publish-*` 全部 `skipped`，**什么都没发布**。

### 证据
- `1.0.52-beta.5` push run（旧 workflow，无 dispatch-contract）：`release`→`verify`→`publish-release` 全部执行成功。
- `1.0.53-beta.1/2/3`：push run 均无法发布，逐个改走 `workflow_dispatch` recovery 交付。
- `v1.0.53-beta.4` 两个 push run（`29571214596` / `29627422375`）：`release-contract` 全绿，但发布链仍全 `skipped`。

## 修复

给 push→publish 链的 5 个 job 的 `if` 加显式 `!cancelled() &&` 前缀。`!cancelled()` 是状态检查函数，会**关闭 GitHub 的隐式 `success()`**，改由表达式自身决定；保留原有 `result == 'success'` 门禁做实际把关。run 被取消时 `!cancelled()` 为 false，不会误发。

| Job | 行 |
|---|---|
| `release` | 625 |
| `verify-darwin-signatures` | 791 |
| `publish-release` | 819 |
| `publish-channels` | 1058 |
| `mirror-gitee-release` | 1289 |

## 为什么安全
- `release` job 的 `if` **没有** `is_recovery`/`event_name` 门禁——原始设计意图就是「contract 过就发布」，push 直接发布是重构前既有能力。当前 skip 是重构副作用（bug），本修复恢复原意。
- **不改** `release-contract` 及其治理段（governance token / immutable releases / CI Gate 校验）。
- **recovery 路径不受影响**：其祖先本就 `success`，`!cancelled() && result=='success'` 仍成立，行为不变。protected `release-recovery` 环境审批作为失败补救的 break-glass 保留。

## 验证
- 本地：`DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts/ -run 'TestReleaseWorkflow' -count=1` → `ok`（1.9s）。workflow 结构/治理/恢复复用等断言全过。
- 期望 CI：CI Gate 全绿。
- 合入后重打 `v1.0.53-beta.4` tag 到含本修复的 commit，push run 应真正执行 `release`→`verify-darwin-signatures`→`publish-release`→`publish-channels` 全链并完成交付（六平台归档 + `dws-skills.zip` + `checksums.txt`、npm `beta`、Homebrew beta Formula）。