### PR TITLE
ci(schema): require base-owned migration approvals

### DIFF
--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -106,6 +106,44 @@ parameter mappings, positional execution fields, constraints, and safety
 semantics remain protected. Positional descriptions are documentation and may
 change without breaking compatibility.
 
+### Two-stage exact contract migrations
+
+An intentional interface-mode or interface-ref migration requires two pull
+requests and explicit human review. The same exact approval may optionally
+carry canonical `old_constraints` and `new_constraints` snapshots when that
+interface transition also requires a reviewed constraint migration:
+
+1. A governance pull request adds one exact old-to-new entry to
+   `scripts/policy/schema-compat/approved-interface-migrations-v1.json` without
+   changing the product Schema. The entry names one exact
+   `product/canonical_path`, both interface modes, both interface refs, and a
+   concrete review reason. Constraint snapshots, when present, must be supplied
+   as an old/new pair of exact JSON objects.
+2. After that governance pull request is merged, the product pull request
+   rebases onto it, applies exactly the approved interface and optional
+   constraint transition, and removes the consumed entry (or the manifest when
+   it becomes empty).
+
+The authoritative check builds the compatibility checker and reads approvals
+from the temporary worktree at the PR merge-base. The candidate manifest is
+read only to enforce lifecycle: a pending base entry must remain the same
+normalized exact entry after strict parsing, while an entry whose complete
+interface-and-constraint contract matches exact `new` must be removed. A
+candidate may add a separately reviewed future entry, but cannot authorize a
+Schema transition in the same pull request. Wildcards, duplicate or
+non-canonical JSON keys, unknown tools, malformed refs or constraint snapshots,
+and entries whose complete historical contract matches neither exact `old` nor
+exact `new` fail closed. If a previously merged product change accidentally
+left an already-applied entry behind, a cleanup pull request may recover only
+by removing that entry while preserving normal Schema compatibility.
+
+An active exact approval suppresses `interface_mode` and `interface_ref` drift,
+and suppresses the constraints failure only when both reviewed constraint
+snapshots are present and match exactly. It does not relax other constraint
+fields. Availability, parameters, positional fields, and
+safety semantics remain protected; newly added `require_one_of` members still
+must resolve to optional parameters or historical positionals.
+
 `make update-interface-baseline` still extends the local checked-in Interface
 fixture used by `make interface-integrity`. Updates are monotonic: they add new
 commands and flags without removing history.

--- a/scripts/policy/check-authoritative-schema-compatibility.sh
+++ b/scripts/policy/check-authoritative-schema-compatibility.sh
@@ -54,6 +54,9 @@ BASE_RAW="$TMP_ROOT/base-schema.json"
 BASELINE="$TMP_ROOT/base-contract.json"
 CANDIDATE_RAW="$TMP_ROOT/candidate-schema.json"
 CHECKER="$TMP_ROOT/schema-compat"
+APPROVED_MIGRATIONS_REL="scripts/policy/schema-compat/approved-interface-migrations-v1.json"
+BASE_APPROVED_MIGRATIONS="$BASE_WORKTREE/$APPROVED_MIGRATIONS_REL"
+CANDIDATE_APPROVED_MIGRATIONS="$ROOT/$APPROVED_MIGRATIONS_REL"
 
 cleanup() {
 	git -C "$ROOT" worktree remove --force "$BASE_WORKTREE" >/dev/null 2>&1 || true
@@ -68,8 +71,8 @@ git -C "$ROOT" worktree add --detach "$BASE_WORKTREE" "$BASE_REF" >/dev/null
 (
 	cd "$BASE_WORKTREE"
 	go build -o "$BASE_BIN" ./cmd
+	go build -o "$CHECKER" ./scripts/policy/schema-compat
 )
-go build -o "$CHECKER" ./scripts/policy/schema-compat
 
 mkdir -p "$TMP_ROOT/base-home" "$TMP_ROOT/candidate-home"
 HOME="$TMP_ROOT/base-home" DWS_LANG=zh \
@@ -79,4 +82,29 @@ HOME="$TMP_ROOT/candidate-home" DWS_LANG=zh \
 
 "$CHECKER" --normalize "$BASE_RAW" >"$BASELINE"
 printf 'checking complete Schema contract against PR merge-base %s\n' "$BASE_REF"
-"$CHECKER" --check "$BASELINE" --current "$CANDIDATE_RAW"
+if git -C "$BASE_WORKTREE" ls-files --error-unmatch "$APPROVED_MIGRATIONS_REL" >/dev/null 2>&1; then
+	if [ ! -f "$BASE_APPROVED_MIGRATIONS" ] || [ -L "$BASE_APPROVED_MIGRATIONS" ]; then
+		printf 'error: base-approved interface migrations must be a tracked regular file: %s\n' "$APPROVED_MIGRATIONS_REL" >&2
+		exit 2
+	fi
+	printf 'using base-approved interface migrations from %s:%s\n' "$BASE_REF" "$APPROVED_MIGRATIONS_REL"
+	if git -C "$ROOT" ls-files --error-unmatch "$APPROVED_MIGRATIONS_REL" >/dev/null 2>&1; then
+		if [ ! -f "$CANDIDATE_APPROVED_MIGRATIONS" ] || [ -L "$CANDIDATE_APPROVED_MIGRATIONS" ]; then
+			printf 'error: candidate interface migrations must be a tracked regular file: %s\n' "$APPROVED_MIGRATIONS_REL" >&2
+			exit 2
+		fi
+		"$CHECKER" \
+			--check "$BASELINE" \
+			--current "$CANDIDATE_RAW" \
+			--approved-interface-migrations "$BASE_APPROVED_MIGRATIONS" \
+			--candidate-interface-migrations "$CANDIDATE_APPROVED_MIGRATIONS"
+	else
+		"$CHECKER" \
+			--check "$BASELINE" \
+			--current "$CANDIDATE_RAW" \
+			--approved-interface-migrations "$BASE_APPROVED_MIGRATIONS"
+	fi
+else
+	printf 'no base-approved interface migrations at %s:%s\n' "$BASE_REF" "$APPROVED_MIGRATIONS_REL"
+	"$CHECKER" --check "$BASELINE" --current "$CANDIDATE_RAW"
+fi

--- a/scripts/policy/schema-compat/approved-interface-migrations-v1.json
+++ b/scripts/policy/schema-compat/approved-interface-migrations-v1.json
@@ -1,0 +1,87 @@
+{
+  "version": 1,
+  "migrations": [
+    {
+      "tool": "pat/pat.batch_grant",
+      "old": {
+        "interface_mode": "mcp",
+        "interface_ref": {
+          "product_id": "pat",
+          "rpc_name": "pat.batch_grant"
+        }
+      },
+      "new": {
+        "interface_mode": "composite",
+        "interface_ref": null
+      },
+      "old_constraints": {
+        "require_one_of": [
+          [
+            "scope",
+            "product",
+            "products",
+            "domain",
+            "domains",
+            "recommend"
+          ]
+        ]
+      },
+      "new_constraints": {
+        "mutually_exclusive": [
+          [
+            "all",
+            "scope"
+          ],
+          [
+            "all",
+            "recommend"
+          ],
+          [
+            "all",
+            "revoke"
+          ],
+          [
+            "revoke",
+            "product"
+          ],
+          [
+            "revoke",
+            "products"
+          ],
+          [
+            "revoke",
+            "domain"
+          ],
+          [
+            "revoke",
+            "domains"
+          ],
+          [
+            "revoke",
+            "recommend"
+          ],
+          [
+            "revoke",
+            "grant-type"
+          ],
+          [
+            "revoke",
+            "session-id"
+          ]
+        ],
+        "require_one_of": [
+          [
+            "scope",
+            "product",
+            "products",
+            "domain",
+            "domains",
+            "recommend",
+            "all"
+          ]
+        ]
+      },
+      "reason": "Reviewed exact PAT chmod contract migration: composite grant/revoke routing plus the ten mode-exclusion pairs and optional --all selector."
+    }
+  ]
+}

--- a/scripts/policy/schema-compat/main.go
+++ b/scripts/policy/schema-compat/main.go
@@ -16,7 +16,10 @@ import (
 	"strings"
 )
 
-const schemaContractVersion = 3
+const (
+	schemaContractVersion              = 3
+	approvedInterfaceMigrationsVersion = 1
+)
 
 type schemaContract struct {
 	Version  int                      `json:"version"`
@@ -63,18 +66,65 @@ type parameterSchema struct {
 	Enum             []string `json:"enum,omitempty"`
 }
 
+type approvedInterfaceMigrationManifest struct {
+	Version    int                          `json:"version"`
+	Migrations []approvedInterfaceMigration `json:"migrations"`
+}
+
+type approvedInterfaceMigration struct {
+	Tool           string                     `json:"tool"`
+	Old            interfaceMigrationEndpoint `json:"old"`
+	New            interfaceMigrationEndpoint `json:"new"`
+	OldConstraints json.RawMessage            `json:"old_constraints,omitempty"`
+	NewConstraints json.RawMessage            `json:"new_constraints,omitempty"`
+	Reason         string                     `json:"reason"`
+}
+
+type interfaceMigrationEndpoint struct {
+	InterfaceMode string          `json:"interface_mode"`
+	InterfaceRef  json.RawMessage `json:"interface_ref"`
+}
+
+type normalizedInterfaceMigration struct {
+	Tool           string
+	Old            interfaceState
+	New            interfaceState
+	HasConstraints bool
+	OldConstraints string
+	NewConstraints string
+	Reason         string
+}
+
+type interfaceState struct {
+	Mode string
+	Ref  string
+}
+
+type approvedInterfaceRef struct {
+	ProductID string `json:"product_id"`
+	RPCName   string `json:"rpc_name"`
+}
+
+type constraintContract struct {
+	RequireOneOf    [][]string
+	HasRequireOneOf bool
+}
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
 
 func run(args []string, stdout, stderr io.Writer) int {
 	var normalizePath, checkPath, mergePath, currentPath string
+	var approvedMigrationsPath, candidateMigrationsPath string
 	flags := flag.NewFlagSet("schema-compat", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	flags.StringVar(&normalizePath, "normalize", "", "normalize a raw complete Schema response")
 	flags.StringVar(&checkPath, "check", "", "check against a normalized historical baseline")
 	flags.StringVar(&mergePath, "merge", "", "merge additions into a normalized historical baseline")
 	flags.StringVar(&currentPath, "current", "", "raw current complete Schema response")
+	flags.StringVar(&approvedMigrationsPath, "approved-interface-migrations", "", "base-owned exact interface migration manifest")
+	flags.StringVar(&candidateMigrationsPath, "candidate-interface-migrations", "", "candidate manifest used only to verify approval retention and consumption")
 	if err := flags.Parse(args); err != nil {
 		return 2
 	}
@@ -87,6 +137,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 	if modes != 1 {
 		fmt.Fprintln(stderr, "exactly one of --normalize, --check, or --merge is required")
+		return 2
+	}
+	if approvedMigrationsPath != "" && checkPath == "" {
+		fmt.Fprintln(stderr, "--approved-interface-migrations is only valid with --check")
+		return 2
+	}
+	if candidateMigrationsPath != "" && approvedMigrationsPath == "" {
+		fmt.Fprintln(stderr, "--candidate-interface-migrations requires --approved-interface-migrations")
 		return 2
 	}
 
@@ -115,7 +173,32 @@ func run(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "read schema baseline: %v\n", err)
 			return 2
 		}
-		failures := checkCompatibility(baseline, current)
+		migrations := map[string]normalizedInterfaceMigration{}
+		candidateMigrations := map[string]normalizedInterfaceMigration{}
+		if approvedMigrationsPath != "" {
+			migrations, err = readApprovedInterfaceMigrations(approvedMigrationsPath)
+			if err != nil {
+				fmt.Fprintf(stderr, "read approved interface migrations: %v\n", err)
+				return 2
+			}
+			if candidateMigrationsPath != "" {
+				candidateMigrations, err = readApprovedInterfaceMigrations(candidateMigrationsPath)
+				if err != nil {
+					fmt.Fprintf(stderr, "read candidate interface migrations: %v\n", err)
+					return 2
+				}
+			}
+		}
+		failures, err := checkCompatibilityWithMigrationManifests(
+			baseline,
+			current,
+			migrations,
+			candidateMigrations,
+		)
+		if err != nil {
+			fmt.Fprintf(stderr, "validate approved interface migrations: %v\n", err)
+			return 2
+		}
 		if len(failures) > 0 {
 			fmt.Fprintln(stderr, "Schema backwards-compatibility check failed:")
 			for _, failure := range failures {
@@ -430,6 +513,365 @@ func schemaType(schema map[string]any) string {
 	return "unspecified"
 }
 
+// readApprovedInterfaceMigrations accepts only explicit, versioned endpoints;
+// the authoritative shell decides which merge-base-owned file is passed here.
+func readApprovedInterfaceMigrations(path string) (map[string]normalizedInterfaceMigration, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var manifest approvedInterfaceMigrationManifest
+	if err := decodeStrictJSON(data, &manifest); err != nil {
+		return nil, err
+	}
+	if manifest.Version != approvedInterfaceMigrationsVersion {
+		return nil, fmt.Errorf("unsupported approved interface migrations version %d", manifest.Version)
+	}
+	if len(manifest.Migrations) == 0 {
+		return nil, fmt.Errorf("approved interface migrations manifest contains no migrations")
+	}
+
+	migrations := make(map[string]normalizedInterfaceMigration, len(manifest.Migrations))
+	for index, migration := range manifest.Migrations {
+		tool := strings.TrimSpace(migration.Tool)
+		if err := validateApprovedToolPath(tool); err != nil {
+			return nil, fmt.Errorf("migration %d: %w", index, err)
+		}
+		if tool != migration.Tool {
+			return nil, fmt.Errorf("migration %d tool path must not contain surrounding whitespace", index)
+		}
+		if _, exists := migrations[tool]; exists {
+			return nil, fmt.Errorf("migration %d duplicates tool %q", index, tool)
+		}
+		reason := strings.TrimSpace(migration.Reason)
+		if reason == "" {
+			return nil, fmt.Errorf("migration %d for %q has no review reason", index, tool)
+		}
+		oldState, err := normalizeMigrationEndpoint("old", migration.Old)
+		if err != nil {
+			return nil, fmt.Errorf("migration %d for %q: %w", index, tool, err)
+		}
+		newState, err := normalizeMigrationEndpoint("new", migration.New)
+		if err != nil {
+			return nil, fmt.Errorf("migration %d for %q: %w", index, tool, err)
+		}
+		oldConstraints, hasOldConstraints, err := normalizeMigrationConstraints("old_constraints", migration.OldConstraints)
+		if err != nil {
+			return nil, fmt.Errorf("migration %d for %q: %w", index, tool, err)
+		}
+		newConstraints, hasNewConstraints, err := normalizeMigrationConstraints("new_constraints", migration.NewConstraints)
+		if err != nil {
+			return nil, fmt.Errorf("migration %d for %q: %w", index, tool, err)
+		}
+		if hasOldConstraints != hasNewConstraints {
+			return nil, fmt.Errorf(
+				"migration %d for %q must provide old_constraints and new_constraints together",
+				index,
+				tool,
+			)
+		}
+		if hasOldConstraints {
+			if _, err := parseConstraintContract(oldConstraints); err != nil {
+				return nil, fmt.Errorf("migration %d for %q: old_constraints is invalid: %w", index, tool, err)
+			}
+			if _, err := parseConstraintContract(newConstraints); err != nil {
+				return nil, fmt.Errorf("migration %d for %q: new_constraints is invalid: %w", index, tool, err)
+			}
+		}
+		if oldState == newState {
+			return nil, fmt.Errorf("migration %d for %q does not change the interface contract", index, tool)
+		}
+		migrations[tool] = normalizedInterfaceMigration{
+			Tool:           tool,
+			Old:            oldState,
+			New:            newState,
+			HasConstraints: hasOldConstraints,
+			OldConstraints: oldConstraints,
+			NewConstraints: newConstraints,
+			Reason:         reason,
+		}
+	}
+	return migrations, nil
+}
+
+func decodeStrictJSON(data []byte, target any) error {
+	// encoding/json otherwise accepts duplicate object keys with last-value-wins.
+	if err := rejectDuplicateJSONKeys(data); err != nil {
+		return err
+	}
+	if err := rejectNonCanonicalApprovedJSONKeys(data, target); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	return nil
+}
+
+func rejectNonCanonicalApprovedJSONKeys(data []byte, target any) error {
+	switch target.(type) {
+	case *approvedInterfaceMigrationManifest:
+		return validateApprovedMigrationManifestKeys(data)
+	case *approvedInterfaceRef:
+		if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+			return nil
+		}
+		fields, err := decodeStrictJSONObject(data, "interface_ref")
+		if err != nil {
+			return err
+		}
+		return requireCanonicalJSONFields("interface_ref", fields, "product_id", "rpc_name")
+	default:
+		return nil
+	}
+}
+
+func validateApprovedMigrationManifestKeys(data []byte) error {
+	fields, err := decodeStrictJSONObject(data, "manifest")
+	if err != nil {
+		return err
+	}
+	if err := requireCanonicalJSONFields("manifest", fields, "version", "migrations"); err != nil {
+		return err
+	}
+	migrationsRaw, ok := fields["migrations"]
+	if !ok {
+		return nil
+	}
+	var migrations []json.RawMessage
+	if err := json.Unmarshal(migrationsRaw, &migrations); err != nil {
+		return err
+	}
+	for index, migrationRaw := range migrations {
+		path := fmt.Sprintf("manifest.migrations[%d]", index)
+		migration, err := decodeStrictJSONObject(migrationRaw, path)
+		if err != nil {
+			return err
+		}
+		if err := requireCanonicalJSONFields(
+			path,
+			migration,
+			"tool",
+			"old",
+			"new",
+			"old_constraints",
+			"new_constraints",
+			"reason",
+		); err != nil {
+			return err
+		}
+		for _, endpointName := range []string{"old", "new"} {
+			endpointRaw, ok := migration[endpointName]
+			if !ok {
+				continue
+			}
+			endpointPath := path + "." + endpointName
+			endpoint, err := decodeStrictJSONObject(endpointRaw, endpointPath)
+			if err != nil {
+				return err
+			}
+			if err := requireCanonicalJSONFields(endpointPath, endpoint, "interface_mode", "interface_ref"); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func decodeStrictJSONObject(data []byte, path string) (map[string]json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, fmt.Errorf("%s must be a JSON object: %w", path, err)
+	}
+	if fields == nil {
+		return nil, fmt.Errorf("%s must be a JSON object", path)
+	}
+	return fields, nil
+}
+
+func requireCanonicalJSONFields(path string, fields map[string]json.RawMessage, allowed ...string) error {
+	canonical := stringSet(allowed)
+	for field := range fields {
+		if !canonical[field] {
+			return fmt.Errorf("unknown field %q at %s (field names must use canonical case)", field, path)
+		}
+	}
+	return nil
+}
+
+func rejectDuplicateJSONKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := consumeJSONValue(decoder, "$"); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return fmt.Errorf("decode trailing JSON: %w", err)
+	}
+	return nil
+}
+
+func consumeJSONValue(decoder *json.Decoder, path string) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	return consumeJSONDelimitedValue(decoder, path, delimiter)
+}
+
+func consumeJSONDelimitedValue(decoder *json.Decoder, path string, delimiter json.Delim) error {
+	switch delimiter {
+	case '{':
+		seen := map[string]bool{}
+		seenFolded := map[string]string{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			// encoding/json guarantees object-key tokens are strings.
+			key := keyToken.(string)
+			if seen[key] {
+				return fmt.Errorf("duplicate JSON key %q at %s", key, path)
+			}
+			seen[key] = true
+			folded := strings.ToLower(key)
+			if previous, exists := seenFolded[folded]; exists {
+				return fmt.Errorf("duplicate JSON keys %q and %q at %s differ only by case", previous, key, path)
+			}
+			seenFolded[folded] = key
+			if err := consumeJSONValue(decoder, path+"."+key); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		return requireClosingJSONDelimiter(closing, json.Delim('}'), "object", path)
+	case '[':
+		index := 0
+		for decoder.More() {
+			if err := consumeJSONValue(decoder, fmt.Sprintf("%s[%d]", path, index)); err != nil {
+				return err
+			}
+			index++
+		}
+		closing, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		return requireClosingJSONDelimiter(closing, json.Delim(']'), "array", path)
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q at %s", delimiter, path)
+	}
+}
+
+func requireClosingJSONDelimiter(token json.Token, expected json.Delim, kind, path string) error {
+	if token != expected {
+		return fmt.Errorf("JSON %s at %s is not closed", kind, path)
+	}
+	return nil
+}
+
+func validateApprovedToolPath(tool string) error {
+	if strings.Count(tool, "/") != 1 {
+		return fmt.Errorf("approved tool %q must be an exact product/canonical path", tool)
+	}
+	productID, canonical, _ := strings.Cut(tool, "/")
+	if !exactMigrationToken(productID) || !exactMigrationToken(canonical) {
+		return fmt.Errorf("approved tool %q contains an empty, wildcard, or unsupported token", tool)
+	}
+	return nil
+}
+
+func exactMigrationToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, character := range value {
+		switch {
+		case character >= 'a' && character <= 'z':
+		case character >= 'A' && character <= 'Z':
+		case character >= '0' && character <= '9':
+		case character == '.', character == '_', character == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeMigrationEndpoint(label string, endpoint interfaceMigrationEndpoint) (interfaceState, error) {
+	mode := strings.TrimSpace(endpoint.InterfaceMode)
+	if mode != endpoint.InterfaceMode {
+		return interfaceState{}, fmt.Errorf("%s interface_mode must not contain surrounding whitespace", label)
+	}
+	refRaw := bytes.TrimSpace(endpoint.InterfaceRef)
+	if len(refRaw) == 0 {
+		return interfaceState{}, fmt.Errorf("%s interface_ref is missing", label)
+	}
+
+	switch mode {
+	case "mcp":
+		var ref approvedInterfaceRef
+		if err := decodeStrictJSON(refRaw, &ref); err != nil {
+			return interfaceState{}, fmt.Errorf("%s mcp interface_ref: %w", label, err)
+		}
+		if ref.ProductID != strings.TrimSpace(ref.ProductID) || ref.RPCName != strings.TrimSpace(ref.RPCName) {
+			return interfaceState{}, fmt.Errorf("%s mcp interface_ref values must not contain surrounding whitespace", label)
+		}
+		if !exactMigrationToken(ref.ProductID) || !exactMigrationToken(ref.RPCName) {
+			return interfaceState{}, fmt.Errorf("%s mcp interface_ref must contain exact product_id and rpc_name", label)
+		}
+		// approvedInterfaceRef contains only strings, so Marshal cannot fail.
+		encoded, _ := json.Marshal(ref)
+		return interfaceState{Mode: mode, Ref: string(encoded)}, nil
+	case "local", "composite":
+		if !bytes.Equal(refRaw, []byte("null")) {
+			return interfaceState{}, fmt.Errorf("%s %s interface_ref must be explicit null", label, mode)
+		}
+		return interfaceState{Mode: mode, Ref: "null"}, nil
+	case "":
+		return interfaceState{}, fmt.Errorf("%s interface_mode is missing", label)
+	default:
+		return interfaceState{}, fmt.Errorf("%s interface_mode %q is not supported", label, mode)
+	}
+}
+
+func normalizeMigrationConstraints(label string, raw json.RawMessage) (string, bool, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return "", false, nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", false, fmt.Errorf("%s must be a JSON object: %w", label, err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return "", false, fmt.Errorf("%s contains multiple JSON values", label)
+		}
+		return "", false, fmt.Errorf("%s trailing JSON: %w", label, err)
+	}
+	object, ok := value.(map[string]any)
+	if !ok || object == nil {
+		return "", false, fmt.Errorf("%s must be a JSON object", label)
+	}
+	// Values decoded from JSON are always JSON-marshalable.
+	encoded, _ := json.Marshal(object)
+	return string(encoded), true, nil
+}
+
 func readContract(path string) (schemaContract, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -449,6 +891,48 @@ func readContract(path string) (schemaContract, error) {
 }
 
 func checkCompatibility(baseline, current schemaContract) []string {
+	failures, _ := checkCompatibilityWithMigrations(
+		baseline,
+		current,
+		map[string]normalizedInterfaceMigration{},
+	)
+	return failures
+}
+
+func checkCompatibilityWithMigrations(
+	baseline, current schemaContract,
+	migrations map[string]normalizedInterfaceMigration,
+) ([]string, error) {
+	active, _, err := classifyApprovedInterfaceMigrations(baseline, migrations)
+	if err != nil {
+		return nil, err
+	}
+	return checkCompatibilityWithActiveMigrations(baseline, current, active), nil
+}
+
+func checkCompatibilityWithMigrationManifests(
+	baseline, current schemaContract,
+	baseMigrations, candidateMigrations map[string]normalizedInterfaceMigration,
+) ([]string, error) {
+	active, alreadyApplied, err := classifyApprovedInterfaceMigrations(baseline, baseMigrations)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateCandidateInterfaceMigrationLifecycle(
+		current,
+		baseMigrations,
+		candidateMigrations,
+		alreadyApplied,
+	); err != nil {
+		return nil, err
+	}
+	return checkCompatibilityWithActiveMigrations(baseline, current, active), nil
+}
+
+func checkCompatibilityWithActiveMigrations(
+	baseline, current schemaContract,
+	migrations map[string]normalizedInterfaceMigration,
+) []string {
 	var failures []string
 	for productID, oldProduct := range baseline.Products {
 		newProduct, ok := current.Products[productID]
@@ -463,7 +947,12 @@ func checkCompatibility(baseline, current schemaContract) []string {
 				continue
 			}
 			toolPath := productID + "/" + toolID
-			failures = append(failures, checkToolCompatibility(toolPath, oldTool, newTool)...)
+			migration, hasMigration := migrations[toolPath]
+			if hasMigration {
+				failures = append(failures, checkToolCompatibilityWithMigration(toolPath, oldTool, newTool, &migration)...)
+				continue
+			}
+			failures = append(failures, checkToolCompatibilityWithMigration(toolPath, oldTool, newTool, nil)...)
 		}
 	}
 	sort.Strings(failures)
@@ -471,17 +960,25 @@ func checkCompatibility(baseline, current schemaContract) []string {
 }
 
 func checkToolCompatibility(toolPath string, oldTool, newTool toolSchema) []string {
+	return checkToolCompatibilityWithMigration(toolPath, oldTool, newTool, nil)
+}
+
+func checkToolCompatibilityWithMigration(
+	toolPath string,
+	oldTool, newTool toolSchema,
+	migration *normalizedInterfaceMigration,
+) []string {
 	var failures []string
+	exactContractMigrationApproved := migration != nil &&
+		toolMatchesMigrationOld(oldTool, *migration) &&
+		toolMatchesMigrationNew(newTool, *migration)
 	for _, field := range []struct {
 		name string
 		old  string
 		new  string
 	}{
 		{name: "primary_cli_path", old: oldTool.PrimaryCLIPath, new: newTool.PrimaryCLIPath},
-		{name: "interface_mode", old: oldTool.InterfaceMode, new: newTool.InterfaceMode},
-		{name: "interface_ref", old: oldTool.InterfaceRef, new: newTool.InterfaceRef},
 		{name: "availability", old: oldTool.Availability, new: newTool.Availability},
-		{name: "constraints", old: oldTool.Constraints, new: newTool.Constraints},
 		{name: "effect", old: oldTool.Effect, new: newTool.Effect},
 		{name: "risk", old: oldTool.Risk, new: newTool.Risk},
 		{name: "confirmation", old: oldTool.Confirmation, new: newTool.Confirmation},
@@ -490,6 +987,24 @@ func checkToolCompatibility(toolPath string, oldTool, newTool toolSchema) []stri
 		if field.old != field.new {
 			failures = append(failures, fmt.Sprintf("schema tool %q changed %s", toolPath, field.name))
 		}
+	}
+	if !exactContractMigrationApproved {
+		if oldTool.InterfaceMode != newTool.InterfaceMode {
+			failures = append(failures, fmt.Sprintf("schema tool %q changed interface_mode", toolPath))
+		}
+		if oldTool.InterfaceRef != newTool.InterfaceRef {
+			failures = append(failures, fmt.Sprintf("schema tool %q changed interface_ref", toolPath))
+		}
+	}
+	constraintsMigrationApproved := exactContractMigrationApproved && migration.HasConstraints
+	if constraintsMigrationApproved {
+		if addedMembers, valid := addedRequireOneOfMembers(oldTool.Constraints, newTool.Constraints); valid {
+			failures = append(failures, checkAddedRequireOneOfMembers(toolPath, oldTool, newTool, addedMembers)...)
+		} else {
+			failures = append(failures, fmt.Sprintf("schema tool %q has invalid approved constraints", toolPath))
+		}
+	} else if oldTool.Constraints != newTool.Constraints {
+		failures = append(failures, fmt.Sprintf("schema tool %q changed constraints", toolPath))
 	}
 	if !compatiblePositionals(oldTool.Positionals, newTool.Positionals) {
 		failures = append(failures, fmt.Sprintf("schema tool %q changed positionals", toolPath))
@@ -508,6 +1023,291 @@ func checkToolCompatibility(toolPath string, oldTool, newTool toolSchema) []stri
 	}
 	sort.Strings(failures)
 	return failures
+}
+
+func classifyApprovedInterfaceMigrations(
+	baseline schemaContract,
+	migrations map[string]normalizedInterfaceMigration,
+) (map[string]normalizedInterfaceMigration, map[string]bool, error) {
+	// Only old-matching entries are active authority. Exact new-matching entries
+	// are retained solely so a cleanup PR can remove a previously missed entry.
+	active := make(map[string]normalizedInterfaceMigration, len(migrations))
+	alreadyApplied := map[string]bool{}
+	tools := make([]string, 0, len(migrations))
+	for tool := range migrations {
+		tools = append(tools, tool)
+	}
+	sort.Strings(tools)
+	for _, toolPath := range tools {
+		migration := migrations[toolPath]
+		productID, toolID, _ := strings.Cut(toolPath, "/")
+		product, productExists := baseline.Products[productID]
+		if !productExists {
+			return nil, nil, fmt.Errorf("approved interface migration %q references unknown historical product", toolPath)
+		}
+		tool, toolExists := product.Tools[toolID]
+		if !toolExists {
+			return nil, nil, fmt.Errorf("approved interface migration %q references unknown historical tool", toolPath)
+		}
+		switch {
+		case toolMatchesMigrationOld(tool, migration):
+			active[toolPath] = migration
+		case toolMatchesMigrationNew(tool, migration):
+			alreadyApplied[toolPath] = true
+		default:
+			return nil, nil, fmt.Errorf(
+				"approved interface migration %q is stale: historical contract matches neither old nor new",
+				toolPath,
+			)
+		}
+	}
+	return active, alreadyApplied, nil
+}
+
+func validateCandidateInterfaceMigrationLifecycle(
+	current schemaContract,
+	baseMigrations, candidateMigrations map[string]normalizedInterfaceMigration,
+	alreadyApplied map[string]bool,
+) error {
+	// A candidate cannot mutate base authority in place: pending entries stay
+	// exact, while consumed or already-applied entries disappear.
+	tools := sortedMigrationTools(baseMigrations)
+	for _, toolPath := range tools {
+		baseMigration := baseMigrations[toolPath]
+		candidateMigration, retained := candidateMigrations[toolPath]
+		if alreadyApplied[toolPath] {
+			if retained {
+				return fmt.Errorf(
+					"candidate must remove already-applied interface migration %q to recover the stale manifest",
+					toolPath,
+				)
+			}
+			continue
+		}
+
+		currentTool, exists := contractToolSchema(current, toolPath)
+		if exists && toolMatchesMigrationNew(currentTool, baseMigration) {
+			if retained {
+				return fmt.Errorf("candidate must remove consumed interface migration %q", toolPath)
+			}
+			continue
+		}
+		if !exists || !toolMatchesMigrationOld(currentTool, baseMigration) {
+			return fmt.Errorf(
+				"candidate contract for approved interface migration %q matches neither exact old nor exact new",
+				toolPath,
+			)
+		}
+		if !retained {
+			return fmt.Errorf("candidate must retain pending interface migration %q", toolPath)
+		}
+		if candidateMigration != baseMigration {
+			return fmt.Errorf("candidate must retain pending interface migration %q exactly", toolPath)
+		}
+	}
+
+	for _, toolPath := range sortedMigrationTools(candidateMigrations) {
+		if _, baseOwned := baseMigrations[toolPath]; baseOwned {
+			continue
+		}
+		migration := candidateMigrations[toolPath]
+		currentTool, exists := contractToolSchema(current, toolPath)
+		if !exists {
+			return fmt.Errorf("candidate interface migration %q references an unknown current tool", toolPath)
+		}
+		if !toolMatchesMigrationOld(currentTool, migration) {
+			return fmt.Errorf(
+				"candidate interface migration %q is stale: current contract does not match old",
+				toolPath,
+			)
+		}
+	}
+	return nil
+}
+
+func sortedMigrationTools(migrations map[string]normalizedInterfaceMigration) []string {
+	tools := make([]string, 0, len(migrations))
+	for tool := range migrations {
+		tools = append(tools, tool)
+	}
+	sort.Strings(tools)
+	return tools
+}
+
+func contractToolSchema(contract schemaContract, toolPath string) (toolSchema, bool) {
+	productID, toolID, ok := strings.Cut(toolPath, "/")
+	if !ok {
+		return toolSchema{}, false
+	}
+	product, ok := contract.Products[productID]
+	if !ok {
+		return toolSchema{}, false
+	}
+	tool, ok := product.Tools[toolID]
+	if !ok {
+		return toolSchema{}, false
+	}
+	return tool, true
+}
+
+func toolMatchesMigrationOld(tool toolSchema, migration normalizedInterfaceMigration) bool {
+	return toolMatchesMigrationSnapshot(tool, migration.Old, migration.HasConstraints, migration.OldConstraints)
+}
+
+func toolMatchesMigrationNew(tool toolSchema, migration normalizedInterfaceMigration) bool {
+	return toolMatchesMigrationSnapshot(tool, migration.New, migration.HasConstraints, migration.NewConstraints)
+}
+
+func toolMatchesMigrationSnapshot(
+	tool toolSchema,
+	endpoint interfaceState,
+	hasConstraints bool,
+	constraints string,
+) bool {
+	if normalizedToolInterfaceState(tool) != endpoint {
+		return false
+	}
+	return !hasConstraints || tool.Constraints == constraints
+}
+
+func normalizedToolInterfaceState(tool toolSchema) interfaceState {
+	ref := tool.InterfaceRef
+	if ref == "" && (tool.InterfaceMode == "local" || tool.InterfaceMode == "composite") {
+		ref = "null"
+	}
+	return interfaceState{Mode: tool.InterfaceMode, Ref: ref}
+}
+
+func addedRequireOneOfMembers(oldConstraints, newConstraints string) ([]string, bool) {
+	oldContract, err := parseConstraintContract(oldConstraints)
+	if err != nil {
+		return nil, false
+	}
+	newContract, err := parseConstraintContract(newConstraints)
+	if err != nil {
+		return nil, false
+	}
+
+	oldMembers := map[string]bool{}
+	if oldContract.HasRequireOneOf {
+		for _, group := range oldContract.RequireOneOf {
+			for _, member := range group {
+				oldMembers[member] = true
+			}
+		}
+	}
+	added := map[string]bool{}
+	if newContract.HasRequireOneOf {
+		for _, group := range newContract.RequireOneOf {
+			for _, member := range group {
+				if !oldMembers[member] {
+					added[member] = true
+				}
+			}
+		}
+	}
+	result := make([]string, 0, len(added))
+	for member := range added {
+		result = append(result, member)
+	}
+	sort.Strings(result)
+	return result, true
+}
+
+func checkAddedRequireOneOfMembers(toolPath string, oldTool, newTool toolSchema, members []string) []string {
+	historicalPositionals := map[string]bool{}
+	for _, positional := range oldTool.Positionals {
+		historicalPositionals[positional.Name] = true
+	}
+
+	var failures []string
+	for _, member := range members {
+		parameter, exists := newTool.Parameters[member]
+		if !exists {
+			if !historicalPositionals[member] {
+				failures = append(failures, fmt.Sprintf(
+					"schema tool %q added require_one_of member %q without a parameter or historical positional",
+					toolPath, member,
+				))
+			}
+			continue
+		}
+		if _, historical := oldTool.Parameters[member]; historical {
+			continue
+		}
+		if parameter.Required {
+			failures = append(failures, fmt.Sprintf(
+				"schema tool %q added required require_one_of parameter %q", toolPath, member,
+			))
+		}
+		if parameter.CLIRequired {
+			failures = append(failures, fmt.Sprintf(
+				"schema tool %q added cli_required require_one_of parameter %q", toolPath, member,
+			))
+		}
+		if parameter.RequiredWhen != "" {
+			failures = append(failures, fmt.Sprintf(
+				"schema tool %q added conditional require_one_of parameter %q", toolPath, member,
+			))
+		}
+	}
+	return failures
+}
+
+func parseConstraintContract(raw string) (constraintContract, error) {
+	if raw == "" {
+		return constraintContract{}, nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+		return constraintContract{}, err
+	}
+	if fields == nil {
+		return constraintContract{}, fmt.Errorf("constraints must be an object")
+	}
+	requireOneOfRaw, hasRequireOneOf := fields["require_one_of"]
+	contract := constraintContract{
+		HasRequireOneOf: hasRequireOneOf,
+	}
+	if !hasRequireOneOf {
+		return contract, nil
+	}
+	if bytes.Equal(bytes.TrimSpace(requireOneOfRaw), []byte("null")) {
+		return constraintContract{}, fmt.Errorf("require_one_of must be an array")
+	}
+	if err := json.Unmarshal(requireOneOfRaw, &contract.RequireOneOf); err != nil {
+		return constraintContract{}, err
+	}
+	if len(contract.RequireOneOf) == 0 {
+		return constraintContract{}, fmt.Errorf("require_one_of must contain at least one group")
+	}
+	seenGroups := map[string]bool{}
+	for groupIndex, group := range contract.RequireOneOf {
+		if len(group) == 0 {
+			return constraintContract{}, fmt.Errorf("require_one_of group %d is empty", groupIndex)
+		}
+		seenMembers := map[string]bool{}
+		for memberIndex, member := range group {
+			if member != strings.TrimSpace(member) {
+				return constraintContract{}, fmt.Errorf("require_one_of group %d member %d contains surrounding whitespace", groupIndex, memberIndex)
+			}
+			if member == "" {
+				return constraintContract{}, fmt.Errorf("require_one_of group %d member %d is empty", groupIndex, memberIndex)
+			}
+			if seenMembers[member] {
+				return constraintContract{}, fmt.Errorf("require_one_of group %d duplicates member %q", groupIndex, member)
+			}
+			seenMembers[member] = true
+			contract.RequireOneOf[groupIndex][memberIndex] = member
+		}
+		sort.Strings(contract.RequireOneOf[groupIndex])
+		groupKey := strings.Join(contract.RequireOneOf[groupIndex], "\x00")
+		if seenGroups[groupKey] {
+			return constraintContract{}, fmt.Errorf("require_one_of duplicates group %d", groupIndex)
+		}
+		seenGroups[groupKey] = true
+	}
+	return contract, nil
 }
 
 func compatiblePositionals(oldPositionals, newPositionals []positionalSchema) bool {

--- a/scripts/policy/schema-compat/main_test.go
+++ b/scripts/policy/schema-compat/main_test.go
@@ -5,9 +5,12 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -60,11 +63,63 @@ const completeSchemaJSON = `{
   }]
 }`
 
+const exactDocInterfaceMigrationEntryJSON = `{
+    "tool": "doc/doc.create",
+    "old": {
+      "interface_mode": "mcp",
+      "interface_ref": {"product_id": "doc", "rpc_name": "create"}
+    },
+    "new": {
+      "interface_mode": "composite",
+      "interface_ref": null
+    },
+    "reason": "reviewed exact migration"
+  }`
+
+const exactDocInterfaceMigrationJSON = `{
+  "version": 1,
+  "migrations": [` + exactDocInterfaceMigrationEntryJSON + `]
+}`
+
+const exactDocOldConstraints = `{"require_one_of":[["title","format"]]}`
+
+const exactDocNewConstraints = `{"mutually_exclusive":[["all","format"]],"require_one_of":[["title","format","all"]]}`
+
+const exactDocContractMigrationEntryJSON = `{
+    "tool":"doc/doc.create",
+    "old":{"interface_mode":"mcp","interface_ref":{"product_id":"doc","rpc_name":"create"}},
+    "new":{"interface_mode":"composite","interface_ref":null},
+    "old_constraints":` + exactDocOldConstraints + `,
+    "new_constraints":` + exactDocNewConstraints + `,
+    "reason":"reviewed exact contract migration"
+  }`
+
+const exactDocContractMigrationJSON = `{
+  "version":1,
+  "migrations":[` + exactDocContractMigrationEntryJSON + `]
+}`
+
+const exactDocConstraintsOnlyMigrationJSON = `{
+  "version":1,
+  "migrations":[{
+    "tool":"doc/doc.create",
+    "old":{"interface_mode":"mcp","interface_ref":{"product_id":"doc","rpc_name":"create"}},
+    "new":{"interface_mode":"mcp","interface_ref":{"product_id":"doc","rpc_name":"create"}},
+    "old_constraints":` + exactDocOldConstraints + `,
+    "new_constraints":` + exactDocNewConstraints + `,
+    "reason":"constraints-only migration is unsupported"
+  }]
+}`
+
+const exactPATOldConstraints = `{"require_one_of":[["scope","product","products","domain","domains","recommend"]]}`
+
+const exactPATNewConstraints = `{"mutually_exclusive":[["all","scope"],["all","recommend"],["all","revoke"],["revoke","product"],["revoke","products"],["revoke","domain"],["revoke","domains"],["revoke","recommend"],["revoke","grant-type"],["revoke","session-id"]],"require_one_of":[["scope","product","products","domain","domains","recommend","all"]]}`
+
 type failingWriter struct{}
 
 func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("write failed") }
 
-func TestRunSchemaModes(t *testing.T) {
+func TestCrossPlatformCoverageRunSchemaModes(t *testing.T) {
 	directory := t.TempDir()
 	raw := filepath.Join(directory, "raw.json")
 	writeTestFile(t, raw, completeSchemaJSON)
@@ -105,6 +160,9 @@ func TestRunSchemaModes(t *testing.T) {
 		nil,
 		{"--normalize", raw, "--check", baseline},
 		{"--check", baseline},
+		{"--normalize", raw, "--approved-interface-migrations", raw},
+		{"--check", baseline, "--current", raw, "--candidate-interface-migrations", raw},
+		{"--merge", baseline, "--current", raw, "--approved-interface-migrations", raw},
 		{"--normalize", filepath.Join(directory, "missing")},
 		{"--unknown"},
 	} {
@@ -120,7 +178,164 @@ func TestRunSchemaModes(t *testing.T) {
 	}
 }
 
-func TestNormalizeRawFileValidation(t *testing.T) {
+func TestCrossPlatformCoverageRunUsesExactApprovedInterfaceMigration(t *testing.T) {
+	directory := t.TempDir()
+	oldRaw := filepath.Join(directory, "old.json")
+	currentRaw := filepath.Join(directory, "current.json")
+	baselinePath := filepath.Join(directory, "baseline.json")
+	migrationPath := filepath.Join(directory, "migrations.json")
+	writeTestFile(t, oldRaw, completeSchemaWithInterface("mcp", `{"product_id":"doc","rpc_name":"create"}`))
+	writeTestFile(t, currentRaw, completeSchemaWithInterface("composite", `null`))
+	writeTestFile(t, migrationPath, exactDocInterfaceMigrationJSON)
+
+	baseline, err := normalizeRawFile(oldRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var encoded bytes.Buffer
+	if err := writeContract(&encoded, baseline); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, baselinePath, encoded.String())
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"--check", baselinePath, "--current", currentRaw}, &stdout, &stderr); code != 1 {
+		t.Fatalf("unapproved transition code=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := run([]string{
+		"--check", baselinePath,
+		"--current", currentRaw,
+		"--approved-interface-migrations", migrationPath,
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("approved transition code=%d stderr=%s", code, stderr.String())
+	}
+}
+
+func TestCrossPlatformCoverageRunEnforcesApprovedInterfaceMigrationLifecycle(t *testing.T) {
+	directory := t.TempDir()
+	oldRaw := filepath.Join(directory, "old.json")
+	newRaw := filepath.Join(directory, "new.json")
+	oldBaseline := filepath.Join(directory, "old-baseline.json")
+	newBaseline := filepath.Join(directory, "new-baseline.json")
+	baseManifest := filepath.Join(directory, "base-migrations.json")
+	candidateManifest := filepath.Join(directory, "candidate-migrations.json")
+	modifiedCandidateManifest := filepath.Join(directory, "modified-candidate-migrations.json")
+	writeTestFile(t, oldRaw, completeSchemaWithInterface("mcp", `{"product_id":"doc","rpc_name":"create"}`))
+	writeTestFile(t, newRaw, completeSchemaWithInterface("composite", `null`))
+	writeNormalizedBaseline(t, oldRaw, oldBaseline)
+	writeNormalizedBaseline(t, newRaw, newBaseline)
+	writeTestFile(t, baseManifest, exactDocInterfaceMigrationJSON)
+	writeTestFile(t, candidateManifest, exactDocInterfaceMigrationJSON)
+	writeTestFile(
+		t,
+		modifiedCandidateManifest,
+		strings.Replace(exactDocInterfaceMigrationJSON, "reviewed exact migration", "different review", 1),
+	)
+
+	assertRunCode := func(name string, wantCode int, wantError string, args ...string) {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		if code := run(args, &stdout, &stderr); code != wantCode {
+			t.Fatalf("%s code=%d, want=%d stdout=%s stderr=%s", name, code, wantCode, stdout.String(), stderr.String())
+		}
+		if wantError != "" && !strings.Contains(stderr.String(), wantError) {
+			t.Fatalf("%s stderr=%q, want %q", name, stderr.String(), wantError)
+		}
+	}
+
+	assertRunCode(
+		"pending approval retained",
+		0,
+		"",
+		"--check", oldBaseline,
+		"--current", oldRaw,
+		"--approved-interface-migrations", baseManifest,
+		"--candidate-interface-migrations", candidateManifest,
+	)
+	assertRunCode(
+		"pending approval removed",
+		2,
+		"must retain pending",
+		"--check", oldBaseline,
+		"--current", oldRaw,
+		"--approved-interface-migrations", baseManifest,
+	)
+	assertRunCode(
+		"pending approval modified",
+		2,
+		"must retain pending interface migration \"doc/doc.create\" exactly",
+		"--check", oldBaseline,
+		"--current", oldRaw,
+		"--approved-interface-migrations", baseManifest,
+		"--candidate-interface-migrations", modifiedCandidateManifest,
+	)
+	assertRunCode(
+		"migration consumes and removes approval",
+		0,
+		"",
+		"--check", oldBaseline,
+		"--current", newRaw,
+		"--approved-interface-migrations", baseManifest,
+	)
+	assertRunCode(
+		"migration retains consumed approval",
+		2,
+		"must remove consumed",
+		"--check", oldBaseline,
+		"--current", newRaw,
+		"--approved-interface-migrations", baseManifest,
+		"--candidate-interface-migrations", candidateManifest,
+	)
+	assertRunCode(
+		"ordinary PR after clean migration",
+		0,
+		"",
+		"--check", newBaseline,
+		"--current", newRaw,
+	)
+	assertRunCode(
+		"stale manifest recovery by removal",
+		0,
+		"",
+		"--check", newBaseline,
+		"--current", newRaw,
+		"--approved-interface-migrations", baseManifest,
+	)
+	assertRunCode(
+		"stale manifest retained",
+		2,
+		"must remove already-applied",
+		"--check", newBaseline,
+		"--current", newRaw,
+		"--approved-interface-migrations", baseManifest,
+		"--candidate-interface-migrations", candidateManifest,
+	)
+}
+
+func TestCrossPlatformCoverageRunWithoutApprovedManifestSupportsBootstrap(t *testing.T) {
+	directory := t.TempDir()
+	raw := filepath.Join(directory, "raw.json")
+	baselinePath := filepath.Join(directory, "baseline.json")
+	writeTestFile(t, raw, completeSchemaJSON)
+	baseline, err := normalizeRawFile(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var encoded bytes.Buffer
+	if err := writeContract(&encoded, baseline); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, baselinePath, encoded.String())
+
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"--check", baselinePath, "--current", raw}, &stdout, &stderr); code != 0 {
+		t.Fatalf("bootstrap without base manifest code=%d stderr=%s", code, stderr.String())
+	}
+}
+
+func TestCrossPlatformCoverageNormalizeRawFileValidation(t *testing.T) {
 	tests := []struct {
 		name string
 		body string
@@ -149,7 +364,7 @@ func TestNormalizeRawFileValidation(t *testing.T) {
 	}
 }
 
-func TestNormalizeCompleteSchemaPayload(t *testing.T) {
+func TestCrossPlatformCoverageNormalizeCompleteSchemaPayload(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "schema.json")
 	writeTestFile(t, path, completeSchemaJSON)
 
@@ -172,7 +387,7 @@ func TestNormalizeCompleteSchemaPayload(t *testing.T) {
 	}
 }
 
-func TestSchemaCompatibilityIgnoresPositionalDescription(t *testing.T) {
+func TestCrossPlatformCoverageSchemaCompatibilityIgnoresPositionalDescription(t *testing.T) {
 	directory := t.TempDir()
 	baselinePath := filepath.Join(directory, "baseline.json")
 	currentPath := filepath.Join(directory, "current.json")
@@ -192,7 +407,7 @@ func TestSchemaCompatibilityIgnoresPositionalDescription(t *testing.T) {
 	}
 }
 
-func TestSchemaTypeAndHelpers(t *testing.T) {
+func TestCrossPlatformCoverageSchemaTypeAndHelpers(t *testing.T) {
 	if got := schemaType(map[string]any{"type": []any{"string", "null"}}); got != `["string","null"]` {
 		t.Fatalf("schemaType(type)=%q", got)
 	}
@@ -207,7 +422,513 @@ func TestSchemaTypeAndHelpers(t *testing.T) {
 	}
 }
 
-func TestSchemaCompatibilityAllowsAdditionsAndLooserInputs(t *testing.T) {
+func TestCrossPlatformCoverageCommittedApprovedInterfaceMigrationManifestIsValidWhenPresent(t *testing.T) {
+	path := "approved-interface-migrations-v1.json"
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	migrations, err := readApprovedInterfaceMigrations(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for tool, migration := range migrations {
+		if migration.Tool != tool || migration.Old == migration.New || strings.TrimSpace(migration.Reason) == "" {
+			t.Fatalf("invalid committed migration %q: %#v", tool, migration)
+		}
+	}
+	patMigration, ok := migrations["pat/pat.batch_grant"]
+	if !ok {
+		t.Fatal("committed PAT contract migration is missing")
+	}
+	if !patMigration.HasConstraints ||
+		patMigration.OldConstraints != exactPATOldConstraints ||
+		patMigration.NewConstraints != exactPATNewConstraints {
+		t.Fatalf("committed PAT constraint snapshots are not exact: %#v", patMigration)
+	}
+}
+
+func TestCrossPlatformCoverageApprovedInterfaceMigrationManifestFailsClosed(t *testing.T) {
+	duplicate := `{"version":1,"migrations":[` + exactDocInterfaceMigrationEntryJSON + `,` + exactDocInterfaceMigrationEntryJSON + `]}`
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "unknown version", body: strings.Replace(exactDocInterfaceMigrationJSON, `"version": 1`, `"version": 2`, 1), want: "unsupported"},
+		{name: "empty list", body: `{"version":1,"migrations":[]}`, want: "contains no migrations"},
+		{name: "duplicate tool", body: duplicate, want: "duplicates tool"},
+		{name: "wildcard tool", body: strings.Replace(exactDocInterfaceMigrationJSON, "doc/doc.create", "doc/*", 1), want: "unsupported token"},
+		{name: "tool whitespace", body: strings.Replace(exactDocInterfaceMigrationJSON, "doc/doc.create", " doc/doc.create", 1), want: "surrounding whitespace"},
+		{name: "empty reason", body: strings.Replace(exactDocInterfaceMigrationJSON, "reviewed exact migration", " ", 1), want: "no review reason"},
+		{name: "unknown mode", body: strings.Replace(exactDocInterfaceMigrationJSON, `"interface_mode": "mcp"`, `"interface_mode": "remote"`, 1), want: "is not supported"},
+		{name: "mcp null ref", body: strings.Replace(exactDocInterfaceMigrationJSON, `{"product_id": "doc", "rpc_name": "create"}`, `null`, 1), want: "exact product_id"},
+		{name: "mcp ref whitespace", body: strings.Replace(exactDocInterfaceMigrationJSON, `"product_id": "doc"`, `"product_id": " doc"`, 1), want: "surrounding whitespace"},
+		{name: "mcp ref extra field", body: strings.Replace(exactDocInterfaceMigrationJSON, `"rpc_name": "create"`, `"rpc_name": "create", "wildcard": true`, 1), want: "unknown field"},
+		{name: "composite non-null ref", body: strings.Replace(exactDocInterfaceMigrationJSON, `"interface_ref": null`, `"interface_ref": {}`, 1), want: "explicit null"},
+		{name: "no-op migration", body: strings.Replace(strings.Replace(exactDocInterfaceMigrationJSON, `"interface_mode": "composite"`, `"interface_mode": "mcp"`, 1), `"interface_ref": null`, `"interface_ref": {"product_id":"doc","rpc_name":"create"}`, 1), want: "does not change"},
+		{name: "unknown top-level field", body: strings.Replace(exactDocInterfaceMigrationJSON, `"version": 1,`, `"version": 1, "allow_all": true,`, 1), want: "unknown field"},
+		{name: "duplicate top-level key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"version": 1,`, `"version": 1, "version": 1,`, 1), want: "duplicate JSON key"},
+		{name: "case-folded duplicate top-level key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"version": 1,`, `"version": 1, "Version": 1,`, 1), want: "differ only by case"},
+		{name: "duplicate migration key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"tool": "doc/doc.create",`, `"tool": "doc/doc.create", "tool": "doc/doc.create",`, 1), want: "duplicate JSON key"},
+		{name: "case-folded duplicate migration key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"tool": "doc/doc.create",`, `"tool": "doc/doc.create", "Tool": "doc/doc.create",`, 1), want: "differ only by case"},
+		{name: "duplicate old endpoint key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"interface_mode": "mcp",`, `"interface_mode": "mcp", "interface_mode": "mcp",`, 1), want: "duplicate JSON key"},
+		{name: "duplicate new endpoint key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"interface_mode": "composite",`, `"interface_mode": "composite", "interface_mode": "composite",`, 1), want: "duplicate JSON key"},
+		{name: "duplicate mcp ref key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"product_id": "doc",`, `"product_id": "doc", "product_id": "doc",`, 1), want: "duplicate JSON key"},
+		{name: "non-canonical top-level key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"version"`, `"Version"`, 1), want: "canonical case"},
+		{name: "non-canonical migration key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"tool"`, `"Tool"`, 1), want: "canonical case"},
+		{name: "non-canonical endpoint key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"interface_mode"`, `"Interface_Mode"`, 1), want: "canonical case"},
+		{name: "non-canonical mcp ref key", body: strings.Replace(exactDocInterfaceMigrationJSON, `"product_id"`, `"Product_ID"`, 1), want: "canonical case"},
+		{name: "constraints snapshot pair required", body: strings.Replace(exactDocContractMigrationJSON, `"new_constraints":`+exactDocNewConstraints+`,`, ``, 1), want: "provide old_constraints and new_constraints together"},
+		{name: "constraints snapshot must be object", body: strings.Replace(exactDocContractMigrationJSON, `"old_constraints":`+exactDocOldConstraints, `"old_constraints":[]`, 1), want: "old_constraints must be a JSON object"},
+		{name: "duplicate constraints snapshot key", body: strings.Replace(exactDocContractMigrationJSON, `"old_constraints":`, `"old_constraints":{},"old_constraints":`, 1), want: "duplicate JSON key"},
+		{name: "case-folded duplicate constraints snapshot key", body: strings.Replace(exactDocContractMigrationJSON, `"old_constraints":`, `"old_constraints":{},"Old_Constraints":`, 1), want: "differ only by case"},
+		{name: "non-canonical constraints snapshot key", body: strings.Replace(exactDocContractMigrationJSON, `"old_constraints"`, `"Old_Constraints"`, 1), want: "canonical case"},
+		{name: "duplicate nested constraint key", body: strings.Replace(exactDocContractMigrationJSON, `"old_constraints":{"require_one_of":`, `"old_constraints":{"require_one_of":[["x"]],"require_one_of":`, 1), want: "duplicate JSON key"},
+		{name: "case-folded duplicate nested constraint key", body: strings.Replace(exactDocContractMigrationJSON, `"old_constraints":{"require_one_of":`, `"old_constraints":{"require_one_of":[["x"]],"Require_One_Of":`, 1), want: "differ only by case"},
+		{name: "invalid old constraints semantics", body: strings.Replace(exactDocContractMigrationJSON, `"old_constraints":`+exactDocOldConstraints, `"old_constraints":{"require_one_of":null}`, 1), want: "old_constraints is invalid"},
+		{name: "invalid new constraints semantics", body: strings.Replace(exactDocContractMigrationJSON, `"new_constraints":`+exactDocNewConstraints, `"new_constraints":{"require_one_of":[[]]}`, 1), want: "new_constraints is invalid"},
+		{name: "constraints-only migration", body: exactDocConstraintsOnlyMigrationJSON, want: "does not change the interface contract"},
+		{name: "trailing json", body: exactDocInterfaceMigrationJSON + `{}`, want: "multiple JSON values"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "migrations.json")
+			writeTestFile(t, path, test.body)
+			_, err := readApprovedInterfaceMigrations(path)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageRunReportsMigrationAndMergeBoundaryFailures(t *testing.T) {
+	directory := t.TempDir()
+	raw := filepath.Join(directory, "raw.json")
+	baselinePath := filepath.Join(directory, "baseline.json")
+	invalidManifest := filepath.Join(directory, "invalid-migrations.json")
+	incompatibleRaw := filepath.Join(directory, "incompatible.json")
+	missing := filepath.Join(directory, "missing.json")
+	writeTestFile(t, raw, completeSchemaJSON)
+	writeNormalizedBaseline(t, raw, baselinePath)
+	writeTestFile(t, invalidManifest, `{`)
+	writeTestFile(t, incompatibleRaw, strings.Replace(completeSchemaJSON, `"primary_cli_path":"doc create"`, `"primary_cli_path":"doc make"`, 1))
+
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "missing check baseline", args: []string{"--check", missing, "--current", raw}, want: 2},
+		{name: "missing approved manifest", args: []string{"--check", baselinePath, "--current", raw, "--approved-interface-migrations", missing}, want: 2},
+		{name: "missing merge baseline", args: []string{"--merge", missing, "--current", raw}, want: 2},
+		{name: "incompatible merge", args: []string{"--merge", baselinePath, "--current", incompatibleRaw}, want: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code := run(test.args, &stdout, &stderr); code != test.want {
+				t.Fatalf("run() code=%d, want=%d, stdout=%s stderr=%s", code, test.want, stdout.String(), stderr.String())
+			}
+		})
+	}
+
+	var stderr bytes.Buffer
+	if code := run([]string{"--merge", baselinePath, "--current", raw}, failingWriter{}, &stderr); code != 2 {
+		t.Fatalf("merge write failure code=%d, want=2 stderr=%s", code, stderr.String())
+	}
+
+	validManifest := filepath.Join(directory, "valid-migrations.json")
+	writeTestFile(t, validManifest, exactDocInterfaceMigrationJSON)
+	var stdout bytes.Buffer
+	stderr.Reset()
+	if code := run([]string{
+		"--check", baselinePath,
+		"--current", raw,
+		"--approved-interface-migrations", validManifest,
+		"--candidate-interface-migrations", invalidManifest,
+	}, &stdout, &stderr); code != 2 {
+		t.Fatalf("invalid candidate manifest code=%d, want=2 stderr=%s", code, stderr.String())
+	}
+}
+
+func TestCrossPlatformCoverageStrictJSONAndEndpointBoundaryFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "missing file", body: "", want: ""},
+		{name: "wrong version type", body: `{"version":"one","migrations":[]}`, want: "cannot unmarshal"},
+		{name: "missing migrations field", body: `{"version":1}`, want: "contains no migrations"},
+		{name: "migrations wrong type", body: `{"version":1,"migrations":"bad"}`, want: "cannot unmarshal"},
+		{name: "migration is null", body: `{"version":1,"migrations":[null]}`, want: "must be a JSON object"},
+		{name: "missing old endpoint", body: `{"version":1,"migrations":[{"tool":"doc/doc.create","new":{"interface_mode":"composite","interface_ref":null},"reason":"reviewed"}]}`, want: "old interface_ref is missing"},
+		{name: "missing new endpoint", body: `{"version":1,"migrations":[{"tool":"doc/doc.create","old":{"interface_mode":"mcp","interface_ref":{"product_id":"doc","rpc_name":"create"}},"reason":"reviewed"}]}`, want: "new interface_ref is missing"},
+		{name: "old endpoint is array", body: `{"version":1,"migrations":[{"tool":"doc/doc.create","old":[],"new":{"interface_mode":"composite","interface_ref":null},"reason":"reviewed"}]}`, want: "must be a JSON object"},
+		{name: "manifest is array", body: `[]`, want: "manifest must be a JSON object"},
+		{name: "manifest is null", body: `null`, want: "manifest must be a JSON object"},
+		{name: "mode whitespace", body: strings.Replace(exactDocInterfaceMigrationJSON, `"interface_mode": "mcp"`, `"interface_mode": " mcp"`, 1), want: "interface_mode must not contain"},
+		{name: "missing ref", body: strings.Replace(exactDocInterfaceMigrationJSON, `"interface_ref": {"product_id": "doc", "rpc_name": "create"}`, `"interface_ref": null`, 1), want: "exact product_id"},
+		{name: "missing mode", body: strings.Replace(exactDocInterfaceMigrationJSON, `"interface_mode": "composite"`, `"interface_mode": ""`, 1), want: "interface_mode is missing"},
+		{name: "tool has no slash", body: strings.Replace(exactDocInterfaceMigrationJSON, "doc/doc.create", "doc.create", 1), want: "exact product/canonical path"},
+		{name: "invalid constraints json", body: strings.Replace(exactDocContractMigrationJSON, `"old_constraints":`+exactDocOldConstraints, `"old_constraints":{`, 1), want: "invalid character"},
+		{name: "invalid new constraints type", body: strings.Replace(exactDocContractMigrationJSON, `"new_constraints":`+exactDocNewConstraints, `"new_constraints":[]`, 1), want: "new_constraints must be a JSON object"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "migrations.json")
+			if test.name == "missing file" {
+				path = filepath.Join(t.TempDir(), "missing.json")
+			} else {
+				writeTestFile(t, path, test.body)
+			}
+			_, err := readApprovedInterfaceMigrations(path)
+			if err == nil || (test.want != "" && !strings.Contains(err.Error(), test.want)) {
+				t.Fatalf("error=%v, want %q", err, test.want)
+			}
+		})
+	}
+
+	if err := rejectNonCanonicalApprovedJSONKeys([]byte(`null`), &approvedInterfaceRef{}); err != nil {
+		t.Fatalf("explicit null interface ref should pass key validation: %v", err)
+	}
+	if err := rejectNonCanonicalApprovedJSONKeys([]byte(`{}`), &struct{}{}); err != nil {
+		t.Fatalf("unrecognized strict target should not add key rules: %v", err)
+	}
+	if err := rejectNonCanonicalApprovedJSONKeys([]byte(`[]`), &approvedInterfaceRef{}); err == nil {
+		t.Fatal("non-object interface ref unexpectedly passed key validation")
+	}
+	for _, body := range []string{"", `{"key"`, `{"key":1`, `[1`, `}`, `{}x`} {
+		if err := rejectDuplicateJSONKeys([]byte(body)); err == nil {
+			t.Errorf("rejectDuplicateJSONKeys(%q) unexpectedly passed", body)
+		}
+	}
+	if err := requireClosingJSONDelimiter(json.Delim(']'), json.Delim('}'), "object", "$"); err == nil {
+		t.Fatal("wrong closing delimiter unexpectedly passed")
+	}
+	if err := consumeJSONDelimitedValue(json.NewDecoder(strings.NewReader("")), "$", json.Delim(']')); err == nil {
+		t.Fatal("unexpected opening delimiter was not rejected")
+	}
+	for _, body := range []string{`{`, `{}{} `, `{}x`, `[]`} {
+		if _, _, err := normalizeMigrationConstraints("constraints", []byte(body)); err == nil {
+			t.Errorf("normalizeMigrationConstraints(%q) unexpectedly passed", body)
+		}
+	}
+}
+
+func TestCrossPlatformCoverageMigrationLifecycleAndConstraintHelperEdges(t *testing.T) {
+	baseline := baselineContract()
+	migration := normalizedInterfaceMigration{
+		Tool: "doc/doc.create",
+		Old:  interfaceState{Mode: "local", Ref: `{"transport":"local"}`},
+		New:  interfaceState{Mode: "composite", Ref: "null"},
+	}
+
+	unknownTool := migration
+	unknownTool.Tool = "doc/doc.missing"
+	if _, err := checkCompatibilityWithMigrations(baseline, baseline, map[string]normalizedInterfaceMigration{unknownTool.Tool: unknownTool}); err == nil || !strings.Contains(err.Error(), "unknown historical tool") {
+		t.Fatalf("unknown historical tool error=%v", err)
+	}
+	if _, err := checkCompatibilityWithMigrationManifests(baseline, baseline, map[string]normalizedInterfaceMigration{"missing/tool": migration}, nil); err == nil {
+		t.Fatal("manifest classification failure unexpectedly passed")
+	}
+	if err := validateCandidateInterfaceMigrationLifecycle(baseline, nil, map[string]normalizedInterfaceMigration{"missing/tool": migration}, nil); err == nil || !strings.Contains(err.Error(), "unknown current tool") {
+		t.Fatalf("unknown current tool error=%v", err)
+	}
+
+	if _, ok := contractToolSchema(baseline, "invalid"); ok {
+		t.Fatal("malformed tool path resolved")
+	}
+	if _, ok := contractToolSchema(baseline, "missing/tool"); ok {
+		t.Fatal("missing product resolved")
+	}
+	if _, ok := contractToolSchema(baseline, "doc/missing"); ok {
+		t.Fatal("missing tool resolved")
+	}
+
+	oldTool := baseline.Products["doc"].Tools["doc.create"]
+	newTool := oldTool
+	if failures := checkToolCompatibility("doc/doc.create", oldTool, newTool); len(failures) != 0 {
+		t.Fatalf("wrapper rejected identical tools: %v", failures)
+	}
+	invalidConstraints := `{"require_one_of":null}`
+	oldTool.InterfaceMode = "mcp"
+	oldTool.InterfaceRef = `{"product_id":"doc","rpc_name":"create"}`
+	oldTool.Constraints = invalidConstraints
+	newTool = oldTool
+	newTool.InterfaceMode = "composite"
+	newTool.InterfaceRef = "null"
+	migration = normalizedInterfaceMigration{
+		Old:            interfaceState{Mode: "mcp", Ref: `{"product_id":"doc","rpc_name":"create"}`},
+		New:            interfaceState{Mode: "composite", Ref: "null"},
+		HasConstraints: true,
+		OldConstraints: invalidConstraints,
+		NewConstraints: invalidConstraints,
+	}
+	if failures := checkToolCompatibilityWithMigration("doc/doc.create", oldTool, newTool, &migration); !strings.Contains(strings.Join(failures, "\n"), "invalid approved constraints") {
+		t.Fatalf("invalid approved constraints failures=%v", failures)
+	}
+
+	if _, ok := addedRequireOneOfMembers(`{`, `{}`); ok {
+		t.Fatal("invalid old constraints produced members")
+	}
+	if _, ok := addedRequireOneOfMembers(`{}`, `{`); ok {
+		t.Fatal("invalid new constraints produced members")
+	}
+	if failures := checkAddedRequireOneOfMembers("doc/doc.create", oldTool, newTool, []string{"title"}); len(failures) != 0 {
+		t.Fatalf("historical parameter should remain valid: %v", failures)
+	}
+	safetyOld := toolSchema{
+		Parameters:  map[string]parameterSchema{"title": {Type: `"string"`}},
+		Positionals: []positionalSchema{{Name: "content"}},
+	}
+	safetyCases := []struct {
+		name      string
+		member    string
+		parameter *parameterSchema
+		want      string
+	}{
+		{name: "historical positional", member: "content"},
+		{name: "unknown member", member: "all", want: "without a parameter or historical positional"},
+		{name: "optional parameter", member: "all", parameter: &parameterSchema{Type: `"boolean"`}},
+		{name: "required parameter", member: "all", parameter: &parameterSchema{Type: `"boolean"`, Required: true}, want: "added required require_one_of"},
+		{name: "cli required parameter", member: "all", parameter: &parameterSchema{Type: `"boolean"`, CLIRequired: true}, want: "added cli_required require_one_of"},
+		{name: "conditional parameter", member: "all", parameter: &parameterSchema{Type: `"boolean"`, RequiredWhen: "product=pat"}, want: "added conditional require_one_of"},
+	}
+	for _, test := range safetyCases {
+		t.Run("approved constraint safety/"+test.name, func(t *testing.T) {
+			safetyNew := toolSchema{Parameters: map[string]parameterSchema{"title": {Type: `"string"`}}}
+			if test.parameter != nil {
+				safetyNew.Parameters[test.member] = *test.parameter
+			}
+			failures := strings.Join(checkAddedRequireOneOfMembers("doc/doc.create", safetyOld, safetyNew, []string{test.member}), "\n")
+			if test.want == "" && failures != "" {
+				t.Fatalf("unexpected failures: %s", failures)
+			}
+			if test.want != "" && !strings.Contains(failures, test.want) {
+				t.Fatalf("failures=%q, want %q", failures, test.want)
+			}
+		})
+	}
+
+	for _, body := range []string{
+		"",
+		`{`,
+		`null`,
+		`{}`,
+		`{"require_one_of":[]}`,
+		`{"require_one_of":[[""]]}`,
+		`{"require_one_of":["scope"]}`,
+		`{"require_one_of":[[" scope"]]}`,
+		`{"require_one_of":[["scope","scope"]]}`,
+		`{"require_one_of":[["scope"],["scope"]]}`,
+	} {
+		if _, err := parseConstraintContract(body); body == "" || body == `{}` {
+			if err != nil {
+				t.Errorf("parseConstraintContract(%q) error=%v", body, err)
+			}
+		} else if err == nil {
+			t.Errorf("parseConstraintContract(%q) unexpectedly passed", body)
+		}
+	}
+}
+
+func TestCrossPlatformCoverageApprovedInterfaceMigrationCompatibilityIsExact(t *testing.T) {
+	baseline := baselineContract()
+	mutateTool(&baseline, func(tool *toolSchema) {
+		tool.InterfaceMode = "mcp"
+		tool.InterfaceRef = `{"product_id":"doc","rpc_name":"create"}`
+	})
+	migration := normalizedInterfaceMigration{
+		Tool: "doc/doc.create",
+		Old:  interfaceState{Mode: "mcp", Ref: `{"product_id":"doc","rpc_name":"create"}`},
+		New:  interfaceState{Mode: "composite", Ref: "null"},
+	}
+	migrations := map[string]normalizedInterfaceMigration{migration.Tool: migration}
+
+	pending := cloneContract(baseline)
+	if failures, err := checkCompatibilityWithMigrations(baseline, pending, migrations); err != nil || len(failures) != 0 {
+		t.Fatalf("pending approval should not block unrelated PRs: failures=%v err=%v", failures, err)
+	}
+
+	current := cloneContract(baseline)
+	mutateTool(&current, func(tool *toolSchema) {
+		tool.InterfaceMode = "composite"
+		tool.InterfaceRef = "null"
+	})
+	if failures, err := checkCompatibilityWithMigrations(baseline, current, migrations); err != nil || len(failures) != 0 {
+		t.Fatalf("exact migration failures=%v err=%v", failures, err)
+	}
+	omittedNull := cloneContract(current)
+	mutateTool(&omittedNull, func(tool *toolSchema) { tool.InterfaceRef = "" })
+	if failures, err := checkCompatibilityWithMigrations(baseline, omittedNull, migrations); err != nil || len(failures) != 0 {
+		t.Fatalf("omitted composite ref must normalize to null: failures=%v err=%v", failures, err)
+	}
+
+	changedAvailability := cloneContract(current)
+	mutateTool(&changedAvailability, func(tool *toolSchema) { tool.Availability = "unavailable" })
+	failures, err := checkCompatibilityWithMigrations(baseline, changedAvailability, migrations)
+	if err != nil || !strings.Contains(strings.Join(failures, "\n"), "changed availability") {
+		t.Fatalf("availability drift escaped approval: failures=%v err=%v", failures, err)
+	}
+
+	wrongTarget := cloneContract(current)
+	mutateTool(&wrongTarget, func(tool *toolSchema) { tool.InterfaceRef = `{"product_id":"doc","rpc_name":"other"}` })
+	failures, err = checkCompatibilityWithMigrations(baseline, wrongTarget, migrations)
+	if err != nil || !strings.Contains(strings.Join(failures, "\n"), "changed interface_ref") {
+		t.Fatalf("non-exact target escaped approval: failures=%v err=%v", failures, err)
+	}
+
+	unknown := map[string]normalizedInterfaceMigration{
+		"missing/missing.tool": {
+			Tool: "missing/missing.tool",
+			Old:  interfaceState{Mode: "mcp", Ref: `{"product_id":"doc","rpc_name":"create"}`},
+			New:  interfaceState{Mode: "composite", Ref: "null"},
+		},
+	}
+	if _, err := checkCompatibilityWithMigrations(baseline, current, unknown); err == nil || !strings.Contains(err.Error(), "unknown historical product") {
+		t.Fatalf("unknown approval error=%v", err)
+	}
+
+	stale := migration
+	stale.Old.Ref = `{"product_id":"doc","rpc_name":"stale"}`
+	if _, err := checkCompatibilityWithMigrations(baseline, current, map[string]normalizedInterfaceMigration{stale.Tool: stale}); err == nil || !strings.Contains(err.Error(), "is stale") {
+		t.Fatalf("stale approval error=%v", err)
+	}
+}
+
+func TestCrossPlatformCoverageApprovedConstraintMigrationIsExactAndPreservesNewMemberSafety(t *testing.T) {
+	baseline := baselineContract()
+	mutateTool(&baseline, func(tool *toolSchema) {
+		tool.InterfaceMode = "mcp"
+		tool.InterfaceRef = `{"product_id":"doc","rpc_name":"create"}`
+	})
+	migration := normalizedInterfaceMigration{
+		Tool:           "doc/doc.create",
+		Old:            interfaceState{Mode: "mcp", Ref: `{"product_id":"doc","rpc_name":"create"}`},
+		New:            interfaceState{Mode: "composite", Ref: "null"},
+		HasConstraints: true,
+		OldConstraints: exactDocOldConstraints,
+		NewConstraints: exactDocNewConstraints,
+	}
+	migrations := map[string]normalizedInterfaceMigration{migration.Tool: migration}
+
+	current := cloneContract(baseline)
+	mutateTool(&current, func(tool *toolSchema) {
+		tool.InterfaceMode = "composite"
+		tool.InterfaceRef = "null"
+		tool.Constraints = exactDocNewConstraints
+		tool.Parameters["all"] = parameterSchema{Type: `"boolean"`}
+	})
+	if failures, err := checkCompatibilityWithMigrations(baseline, current, migrations); err != nil || len(failures) != 0 {
+		t.Fatalf("exact contract migration failures=%v err=%v", failures, err)
+	}
+
+	arbitrary := cloneContract(current)
+	mutateTool(&arbitrary, func(tool *toolSchema) {
+		tool.Constraints = `{"mutually_exclusive":[["all","title"]],"require_one_of":[["title","format","all"]]}`
+	})
+	if failures, err := checkCompatibilityWithMigrations(baseline, arbitrary, migrations); err != nil || !strings.Contains(strings.Join(failures, "\n"), "changed constraints") {
+		t.Fatalf("unapproved constraints escaped exact approval: failures=%v err=%v", failures, err)
+	}
+
+	regrouped := cloneContract(current)
+	regroupedConstraints := `{"require_one_of":[["all"],["title","format"]]}`
+	mutateTool(&regrouped, func(tool *toolSchema) {
+		tool.Constraints = regroupedConstraints
+		parameter := tool.Parameters["all"]
+		parameter.Required = true
+		tool.Parameters["all"] = parameter
+	})
+	regroupedMigration := migration
+	regroupedMigration.NewConstraints = regroupedConstraints
+	if failures, err := checkCompatibilityWithMigrations(
+		baseline,
+		regrouped,
+		map[string]normalizedInterfaceMigration{regroupedMigration.Tool: regroupedMigration},
+	); err != nil || !strings.Contains(strings.Join(failures, "\n"), `added required require_one_of parameter "all"`) {
+		t.Fatalf("regrouped require_one_of escaped new-member safety: failures=%v err=%v", failures, err)
+	}
+}
+
+func TestCrossPlatformCoverageApprovedConstraintMigrationLifecycleRejectsPartialState(t *testing.T) {
+	current := baselineContract()
+	mutateTool(&current, func(tool *toolSchema) {
+		tool.InterfaceMode = "mcp"
+		tool.InterfaceRef = `{"product_id":"doc","rpc_name":"create"}`
+	})
+	migration := normalizedInterfaceMigration{
+		Tool:           "doc/doc.create",
+		Old:            interfaceState{Mode: "mcp", Ref: `{"product_id":"doc","rpc_name":"create"}`},
+		New:            interfaceState{Mode: "composite", Ref: "null"},
+		HasConstraints: true,
+		OldConstraints: exactDocOldConstraints,
+		NewConstraints: exactDocNewConstraints,
+	}
+	migrations := map[string]normalizedInterfaceMigration{migration.Tool: migration}
+
+	mutateTool(&current, func(tool *toolSchema) {
+		tool.Constraints = `{"require_one_of":[["title","format","all"]]}`
+		tool.Parameters["all"] = parameterSchema{Type: `"boolean"`}
+	})
+	if err := validateCandidateInterfaceMigrationLifecycle(current, migrations, migrations, map[string]bool{}); err == nil || !strings.Contains(err.Error(), "matches neither exact old nor exact new") {
+		t.Fatalf("partial approved contract state error=%v", err)
+	}
+}
+
+func TestCrossPlatformCoverageCandidateManifestMayAddFutureExactMigration(t *testing.T) {
+	current := baselineContract()
+	mutateTool(&current, func(tool *toolSchema) {
+		tool.InterfaceMode = "mcp"
+		tool.InterfaceRef = `{"product_id":"doc","rpc_name":"create"}`
+	})
+	product := current.Products["doc"]
+	product.Tools["doc.read"] = toolSchema{
+		PrimaryCLIPath: "doc read",
+		InterfaceMode:  "mcp",
+		InterfaceRef:   `{"product_id":"doc","rpc_name":"read"}`,
+		Availability:   "available",
+		Parameters:     map[string]parameterSchema{},
+		Effect:         "read",
+		Risk:           "low",
+		Confirmation:   "not_required",
+		Idempotency:    "idempotent",
+	}
+	current.Products["doc"] = product
+
+	baseMigration := normalizedInterfaceMigration{
+		Tool:   "doc/doc.create",
+		Old:    interfaceState{Mode: "mcp", Ref: `{"product_id":"doc","rpc_name":"create"}`},
+		New:    interfaceState{Mode: "composite", Ref: "null"},
+		Reason: "existing approval",
+	}
+	futureMigration := normalizedInterfaceMigration{
+		Tool:   "doc/doc.read",
+		Old:    interfaceState{Mode: "mcp", Ref: `{"product_id":"doc","rpc_name":"read"}`},
+		New:    interfaceState{Mode: "composite", Ref: "null"},
+		Reason: "future approval",
+	}
+	base := map[string]normalizedInterfaceMigration{baseMigration.Tool: baseMigration}
+	candidate := map[string]normalizedInterfaceMigration{
+		baseMigration.Tool:   baseMigration,
+		futureMigration.Tool: futureMigration,
+	}
+	if err := validateCandidateInterfaceMigrationLifecycle(current, base, candidate, map[string]bool{}); err != nil {
+		t.Fatalf("future governance entry rejected: %v", err)
+	}
+
+	staleFuture := futureMigration
+	staleFuture.Old.Ref = `{"product_id":"doc","rpc_name":"other"}`
+	candidate[futureMigration.Tool] = staleFuture
+	if err := validateCandidateInterfaceMigrationLifecycle(current, base, candidate, map[string]bool{}); err == nil || !strings.Contains(err.Error(), "current contract does not match old") {
+		t.Fatalf("stale future governance entry error=%v", err)
+	}
+}
+
+func TestCrossPlatformCoverageSchemaCompatibilityAllowsAdditionsAndLooserInputs(t *testing.T) {
 	baseline := baselineContract()
 	mutateTool(&baseline, func(tool *toolSchema) {
 		tool.DryRun = ""
@@ -229,7 +950,7 @@ func TestSchemaCompatibilityAllowsAdditionsAndLooserInputs(t *testing.T) {
 	}
 }
 
-func TestSchemaCompatibilityAllowsLooserAndAppendedOptionalPositionals(t *testing.T) {
+func TestCrossPlatformCoverageSchemaCompatibilityAllowsLooserAndAppendedOptionalPositionals(t *testing.T) {
 	baseline := baselineContract()
 	mutateTool(&baseline, func(tool *toolSchema) {
 		tool.Positionals[0].Required = true
@@ -249,7 +970,7 @@ func TestSchemaCompatibilityAllowsLooserAndAppendedOptionalPositionals(t *testin
 	}
 }
 
-func TestCompatiblePositionals(t *testing.T) {
+func TestCrossPlatformCoverageCompatiblePositionals(t *testing.T) {
 	baseline := []positionalSchema{
 		{Name: "content", Index: 0, Type: "string", Required: true},
 		{Name: "format", Index: 1, Type: "string"},
@@ -314,7 +1035,7 @@ func TestCompatiblePositionals(t *testing.T) {
 	}
 }
 
-func TestSchemaCompatibilityRejectsContractDrift(t *testing.T) {
+func TestCrossPlatformCoverageSchemaCompatibilityRejectsContractDrift(t *testing.T) {
 	tests := []struct {
 		name   string
 		want   string
@@ -361,8 +1082,11 @@ func TestSchemaCompatibilityRejectsContractDrift(t *testing.T) {
 		{name: "changed interface mode", want: "changed interface_mode", mutate: func(contract *schemaContract) {
 			mutateTool(contract, func(tool *toolSchema) { tool.InterfaceMode = "mcp" })
 		}},
-		{name: "changed constraints", want: "changed constraints", mutate: func(contract *schemaContract) {
-			mutateTool(contract, func(tool *toolSchema) { tool.Constraints = `{}` })
+		{name: "unapproved require_one_of widening", want: "changed constraints", mutate: func(contract *schemaContract) {
+			mutateTool(contract, func(tool *toolSchema) {
+				tool.Constraints = `{"require_one_of":[["title","format","all"]]}`
+				tool.Parameters["all"] = parameterSchema{Type: `"boolean"`}
+			})
 		}},
 		{name: "changed positionals", want: "changed positionals", mutate: func(contract *schemaContract) {
 			mutateTool(contract, func(tool *toolSchema) { tool.Positionals[0].Name = "id" })
@@ -398,7 +1122,7 @@ func TestSchemaCompatibilityRejectsContractDrift(t *testing.T) {
 	}
 }
 
-func TestMergeContracts(t *testing.T) {
+func TestCrossPlatformCoverageMergeContracts(t *testing.T) {
 	historical := baselineContract()
 	current := cloneContract(historical)
 	mutateTool(&current, func(tool *toolSchema) {
@@ -471,8 +1195,143 @@ func mutateParameter(contract *schemaContract, mutate func(*parameterSchema)) {
 	})
 }
 
+func completeSchemaWithInterface(mode, ref string) string {
+	result := strings.Replace(
+		completeSchemaJSON,
+		`"interface_mode":"local"`,
+		`"interface_mode":"`+mode+`"`,
+		1,
+	)
+	return strings.Replace(
+		result,
+		`"interface_ref":{"transport":"local"}`,
+		`"interface_ref":`+ref,
+		1,
+	)
+}
+
 func clonePositionals(source []positionalSchema) []positionalSchema {
 	return append([]positionalSchema(nil), source...)
+}
+
+func TestAuthoritativeSchemaShellUsesBaseOwnedCheckerAndManifest(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the authoritative policy entrypoint is a POSIX shell script")
+	}
+	for _, command := range []string{"git", "go", "sh"} {
+		if _, err := exec.LookPath(command); err != nil {
+			t.Skipf("%s is unavailable: %v", command, err)
+		}
+	}
+
+	sandbox := t.TempDir()
+	repository := filepath.Join(sandbox, "repository")
+	temporary := filepath.Join(sandbox, "tmp")
+	for _, directory := range []string{repository, temporary} {
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	repositoryRoot, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	policyScript, err := os.ReadFile(filepath.Join(repositoryRoot, "scripts", "policy", "check-authoritative-schema-compatibility.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkerSource, err := os.ReadFile(filepath.Join(repositoryRoot, "scripts", "policy", "schema-compat", "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseSchema := completeSchemaWithInterface("mcp", `{"product_id":"doc","rpc_name":"create"}`)
+	candidateSchema := completeSchemaWithInterface("composite", `null`)
+	candidateSchema = strings.Replace(
+		candidateSchema,
+		`"parameters":{`,
+		`"parameters":{"all":{"type":"boolean","property":"all","required":false,"interface_type":"boolean","default":null,"field_provenance":{}},`,
+		1,
+	)
+	candidateSchema = strings.Replace(
+		candidateSchema,
+		`"constraints":{"require_one_of":[["title","format"]]}`,
+		`"constraints":`+exactDocNewConstraints,
+		1,
+	)
+
+	writeFixtureFile(t, repository, ".gitignore", "/dws\n", 0o600)
+	writeFixtureFile(t, repository, "go.mod", "module example.com/schema-authority-fixture\n\ngo 1.23\n", 0o600)
+	writeFixtureFile(t, repository, "cmd/main.go", fixtureSchemaCommandSource(baseSchema), 0o600)
+	writeFixtureFile(t, repository, "scripts/policy/check-authoritative-schema-compatibility.sh", string(policyScript), 0o700)
+	writeFixtureFile(t, repository, "scripts/policy/policy-runtime.sh", `policy_prepare_runtime() { :; }
+policy_runtime_mktemp_dir() { mktemp -d "${TMPDIR:-/tmp}/$1.XXXXXX"; }
+`, 0o600)
+	writeFixtureFile(t, repository, "scripts/policy/schema-compat/approved-interface-migrations-v1.json", exactDocContractMigrationJSON, 0o600)
+	writeFixtureFile(t, repository, "scripts/policy/schema-compat/main.go", string(checkerSource), 0o600)
+
+	mustRunFixtureCommand(t, repository, nil, "git", "init", "-q")
+	mustRunFixtureCommand(t, repository, nil, "git", "add", "-A")
+	mustRunFixtureCommand(t, repository, nil, "git", "-c", "user.name=Schema Test", "-c", "user.email=schema-test@example.com", "commit", "-q", "-m", "base authority")
+	baseRef := strings.TrimSpace(mustRunFixtureCommand(t, repository, nil, "git", "rev-parse", "HEAD"))
+
+	writeFixtureFile(t, repository, "cmd/main.go", fixtureSchemaCommandSource(candidateSchema), 0o600)
+	writeFixtureFile(t, repository, "scripts/policy/schema-compat/main.go", "package main\n\nfunc main() {}\n", 0o600)
+	mustRunFixtureCommand(t, repository, nil, "git", "add", "-A")
+	mustRunFixtureCommand(t, repository, nil, "git", "-c", "user.name=Schema Test", "-c", "user.email=schema-test@example.com", "commit", "-q", "-m", "candidate attempts override")
+
+	commandEnv := []string{
+		"TMPDIR=" + temporary,
+	}
+	mustRunFixtureCommand(t, repository, commandEnv, "go", "build", "-o", "dws", "./cmd")
+	command := exec.Command("sh", "scripts/policy/check-authoritative-schema-compatibility.sh", "--base-ref", baseRef)
+	command.Dir = repository
+	command.Env = append(os.Environ(), commandEnv...)
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("candidate checker bypassed base-owned approval lifecycle: %s", output)
+	}
+	if !strings.Contains(string(output), "candidate must remove consumed interface migration") {
+		t.Fatalf("base checker did not enforce the base-owned manifest: %s", output)
+	}
+
+	if err := os.Remove(filepath.Join(repository, "scripts", "policy", "schema-compat", "approved-interface-migrations-v1.json")); err != nil {
+		t.Fatal(err)
+	}
+	mustRunFixtureCommand(t, repository, nil, "git", "add", "-A")
+	mustRunFixtureCommand(t, repository, nil, "git", "-c", "user.name=Schema Test", "-c", "user.email=schema-test@example.com", "commit", "-q", "-m", "consume approval")
+	output = []byte(mustRunFixtureCommand(t, repository, commandEnv, "sh", "scripts/policy/check-authoritative-schema-compatibility.sh", "--base-ref", baseRef))
+	if !strings.Contains(string(output), "Schema compatibility check: ok") {
+		t.Fatalf("consumed base approval did not pass: %s", output)
+	}
+}
+
+func fixtureSchemaCommandSource(schema string) string {
+	encoded, _ := json.Marshal(schema)
+	return "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Print(" + string(encoded) + ") }\n"
+}
+
+func mustRunFixtureCommand(t *testing.T, directory string, extraEnv []string, name string, args ...string) string {
+	t.Helper()
+	command := exec.Command(name, args...)
+	command.Dir = directory
+	command.Env = append(os.Environ(), extraEnv...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", name, strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+func writeFixtureFile(t *testing.T, root, relative, body string, mode os.FileMode) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(relative))
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), mode); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func writeTestFile(t *testing.T, path, body string) {
@@ -480,4 +1339,17 @@ func writeTestFile(t *testing.T, path, body string) {
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func writeNormalizedBaseline(t *testing.T, rawPath, baselinePath string) {
+	t.Helper()
+	baseline, err := normalizeRawFile(rawPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var encoded bytes.Buffer
+	if err := writeContract(&encoded, baseline); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, baselinePath, encoded.String())
 }


### PR DESCRIPTION
## Summary

- build the authoritative Schema compatibility checker from the PR merge-base worktree, so candidate code cannot weaken its own checker
- add an exact, one-shot PAT interface migration approval covering the reviewed `pat.batch_grant` transition
- bind approval to canonical old/new interface and constraints snapshots
- fail closed on malformed, duplicate, unknown, partial, stale, retained, or symlinked approval state
- document the base-owned approval and consumption lifecycle

## Why

The PAT CLI now has a composite flow:

- `pat.batch_plan` for authenticated read-only planning, including `--all`
- `pat.batch_grant` for confirmed writes
- `pat.scope_revoke` for safe single-scope revoke

That is an intentional contract migration from a direct MCP binding to a composite command. The migration must be approved by the merge-base rather than self-authorized by the product PR.

## Scope

Exactly 5 governance files, one commit on current `main`. No runtime product code, release script, workflow, dependency, or unrelated constraint widening is included.

## Verification

- final commit: `371862f0b3330f5d4fc0ee7c94ec4442784216b5`
- final tree is byte-identical to the independently reviewed `f9865654` candidate
- focused schema-compat tests: pass
- race: pass
- vet: pass
- shell syntax and diff check: pass
- `make build`: pass
- `make policy`: pass
- authoritative schema compatibility against `upstream/main@e69a1084`: pass
- changed executable coverage: **100.0% (421/421)**
- independent qinze-style review: no P0/P1 in the technical change

## Trust boundary / merge order

This PR intentionally changes `scripts/policy/**` and therefore requires real human ownership/adoption, CODEOWNER review, and explicit approval. It must not be self-approved or self-merged.

Merge order:

1. human-review and merge this governance PR
2. rebase the PAT product PR onto the new `main`
3. consume/delete the one-shot approval manifest in the product PR
4. run the full product CI and release validation

Supersedes #633, whose public head contains historical merge noise and an older technical revision.
