### PR TITLE
docs(pat): document safe authorization modes

### DIFF
--- a/internal/cli/schema_agent_metadata/index.json
+++ b/internal/cli/schema_agent_metadata/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "source_hash": "sha256:de587cba5051dd4c2715353012d8d9f2a7c5208a0c6dee4ea703cfc97b7351f0",
+  "source_hash": "sha256:d9a121df63c4d5022fbbd1734c13fa3d8aea2145256814727ccb361a67911bd5",
   "surface_hash": "sha256:7ef588f38052f0104e027c8daff5fefd68698781f2c87715461183d4058288ed",
   "coverage": {
     "surface_products": 22,

--- a/internal/cli/schema_agent_metadata_audit.json
+++ b/internal/cli/schema_agent_metadata_audit.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "source_hash": "sha256:de587cba5051dd4c2715353012d8d9f2a7c5208a0c6dee4ea703cfc97b7351f0",
+  "source_hash": "sha256:d9a121df63c4d5022fbbd1734c13fa3d8aea2145256814727ccb361a67911bd5",
   "surface_hash": "sha256:7ef588f38052f0104e027c8daff5fefd68698781f2c87715461183d4058288ed",
   "source_files": 150,
   "hint_files": 46,

--- a/skills/mono/SKILL.md
+++ b/skills/mono/SKILL.md
@@ -86,7 +86,7 @@ cli_version: ">=1.0.15"
 | `drive`           | 钉钉云盘：文件列表/元数据/文件夹/上传(两步)/下载                        | [drive.md](./references/products/drive.md)                     |
 | `minutes`         | AI听记：听记列表/摘要/关键词/转写/待办/思维导图/发言人/发言人段落总结/热词/录音控制/成员权限/上传 | [minutes.md](./references/products/minutes.md)                 |
 | `oa`              | OA审批：待处理/详情/同意/拒绝/撤销/记录/已发起/任务/转交/评论/抄送              | [oa.md](./references/products/oa.md)                           |
-| `pat`             | PAT 行为授权：浏览器策略/scope 预览/一次性、会话或永久授权                    | [pat.md](./references/products/pat.md)                         |
+| `pat`             | PAT 行为授权：浏览器策略/远程 scope 预览/显式、筛选或 `--all` 授权/单 scope 撤回 | [pat.md](./references/products/pat.md)                         |
 | `report`          | 日志：按模版创建/收件箱/已发送/模版查看/详情/已读统计                         | [report.md](./references/products/report.md)                   |
 | `mail`            | 邮箱：邮箱地址查询/邮件搜索(KQL)/邮件详情/发送邮件                        | [mail.md](./references/products/mail.md)                       |
 | `sheet`           | 在线电子表格(axls)：工作表 CRUD/区域读写/CSV 批量写入/行列增删/合并/查找替换/筛选视图/全局筛选/排序/下拉列表/条件格式/浮动图片/浮动图表/模板/导出 xlsx(单命令一站式) | [sheet.md](./references/products/sheet.md)                     |
@@ -111,7 +111,7 @@ cli_version: ">=1.0.15"
 用户提到"听记/AI听记/会议纪要/转写/摘要/思维导图/发言人/热词" → `minutes`
 用户提到"邮箱/邮件/发邮件/收邮件/搜邮件/查邮件/邮件草稿/转发邮件/回复邮件/邮件附件/抄送" → `mail`
 用户提到"审批/请假/报销/出差/加班/同意/拒绝/撤销审批" → `oa`
-用户提到"PAT 授权/行为权限/scope 授权/批量授权/一次性授权/会话授权/永久授权/授权浏览器策略" → `pat`
+用户提到"PAT 授权/行为权限/scope 授权/批量授权/全部授权/`--all`/单 scope 授权撤回/一次性授权/会话授权/永久授权/授权浏览器策略" → `pat`
 用户提到"日志/日报/周报/日志统计/写日报/提交周报/发日志/填日志" → `report`
 用户提到"在线电子表格/钉钉表格/axls/工作表/单元格读写/合并单元格/筛选视图/导出 xlsx" → `sheet`
 用户提到"待办/TODO/任务提醒/循环待办" → `todo`
@@ -284,7 +284,7 @@ Schema 与 Help 冲突是**契约漂移**，不得静默猜测或把两边字段
 - [scripts/](./scripts/) — 各产品批量/复合操作脚本（AI表格批量导入导出、AI应用创建轮询、日历、机器人消息、通讯录、考勤、日志、待办、文档创建并写入、钉盘目录树等）
 - [references/products/aitable/](./references/products/aitable/) — AI表格细分章节（单元格值/字段属性/公式/筛选排序/导入导出/仪表盘/记录增删改查/错误恢复/最佳实践）
 - [references/products/aitable-record-ops.md](./references/products/aitable-record-ops.md) — AI表格记录操作专项说明
-- [references/products/pat.md](./references/products/pat.md) — PAT 浏览器策略、行为 scope 预览与授权安全要求
+- [references/products/pat.md](./references/products/pat.md) — PAT 浏览器策略、`--all`、`--yes`、单 scope 撤回与严格远程 `--dry-run`
 - [references/capability-limits.md](./references/capability-limits.md) — 已知能力限制（doc/aitable/chat/minutes，遇到时直接告知用户不支持）
 - [references/best_practices/](./references/best_practices/) — 全场景 recipe 行动指南（11 个编号场景 + lite 速查）
   - [01-messaging.md](./references/best_practices/01-messaging.md) — 消息沟通

--- a/skills/mono/references/products/pat.md
+++ b/skills/mono/references/products/pat.md
@@ -16,25 +16,53 @@ dws pat browser-policy --enabled=false --agentCode <AGENT_CODE> --format json
 
 `--agentCode` 省略时写入全局默认策略；该命令只修改本地策略，不授予业务操作权限。
 
-### 授予行为权限
+### 预览或授予行为权限
 
 ```bash
-# 预览按产品展开的批量授权计划，不写入授权
+# 远程预览按产品展开的授权计划，不写入授权
 dws pat chmod --products calendar,aitable --grant-type session --session-id <SESSION_ID> --dry-run --format json
 
-# 执行批量行为授权（高影响，必须先让用户确认）
+# 执行授权（高影响，必须先让用户确认；任何真实 grant 都显式加 --yes）
 dws pat chmod --products calendar,aitable --grant-type session --session-id <SESSION_ID> --yes --format json
+
+# 预览服务端可操作的全部 scope；也可增加 --product / --domain 过滤
+dws pat chmod --all --dry-run --format json
+
+# 用户确认后，授予 calendar 下服务端计划选中的全部 scope
+dws pat chmod --product calendar --all --yes --format json
 ```
 
-scope 格式为 `<product>.<entity>:<permission>`。`grant-type` 支持 `once`、`session`、`permanent`；`session` 模式必须提供 `--session-id`。使用 `--products`、`--product`、`--domains`、`--domain` 或 `--recommend` 批量展开 scope 时，先用 `--dry-run` 检查计划，用户明确确认后才可加 `--yes`。
+scope 格式为 `<product>.<entity>:<permission>`。`grant-type` 支持 `once`、`session`、`permanent`；`session` 模式必须提供 `--session-id`。显式 scope、产品/域选择器、`--recommend` 和 `--all` 的任何真实授权都必须显式加 `--yes`；未加时 CLI 会在任何服务调用前阻断。`--all` 使用服务端可操作的全部 scope，可与产品/域过滤器组合，但不能与位置 scope 或 `--recommend` 组合。
+
+### 撤回一个显式授权
+
+```bash
+# 远程预览单 scope 撤回计划，不写入授权
+dws pat chmod --revoke --dry-run --format json calendar.event:read
+
+# 用户确认后执行单 scope 撤回
+dws pat chmod --revoke --yes --format json calendar.event:read
+```
+
+`--revoke` 只接受一个位置 scope，不能与 `--all`、`--product`、`--products`、`--domain`、`--domains`、`--recommend`、`--grant-type` 或 `--session-id` 组合。它只撤回 ACTIVE 的显式 PAT grant，不会退出 OAuth 登录或撤销 token；服务端必须拒绝 DENIED 记录。当前命令面没有 `batch_revoke`，CLI 也不会退化为多 scope 或选择器批量撤回。
+
+### `--dry-run` 与 `--yes` 安全语义
+
+- PAT `chmod --dry-run` 是一次需要认证的服务端只读计划，不是本地回显；它会原样返回服务端 challenge/error。
+- dry-run 不执行授权或撤回，不打开浏览器、不轮询、不登录、不刷新或重试认证，也不写入 profile、token、keychain、凭证或其他本地认证状态。
+- `--dry-run --yes` 仍以 dry-run 为准，不写入任何授权；不要把 `--yes` 当成浏览器、轮询或重试开关。
+- `--yes` 只表示用户已明确确认真实写操作；每个真实 grant 和单 scope revoke 都需要它。
 
 ## 意图判断
 
 用户说"PAT 授权时允许或禁止打开浏览器/配置浏览器授权策略" → `browser-policy`
-用户说"授予 Agent 行为权限/授权 scope/批量授权产品/一次性授权/会话授权/永久授权" → `chmod`
+用户说"授予 Agent 行为权限/授权 scope/按产品、域、推荐集合或 --all 授权/一次性授权/会话授权/永久授权" → `chmod`
+用户说"撤回一个 scope 的显式 PAT 授权" → `chmod <scope> --revoke`
 
 ## 注意事项
 
 - `browser-policy` 只写本地配置，不会发起授权。
-- `chmod` 会改变 Agent 可执行范围；批量或永久授权属于高影响写操作，必须先展示 scope、授权类型和有效期并获得用户确认。
+- `chmod` 会改变 Agent 可执行范围；所有真实授权和单 scope 撤回都是受保护写操作，必须先展示 scope、授权类型/当前状态和影响范围并获得用户确认，再加 `--yes`。
+- 预览优先使用 `--dry-run --format json`；它会访问服务端生成只读计划，但不得产生授权或本地凭证写入。
+- 不存在批量撤回能力；不要编造 `batch_revoke` 或把 `--revoke` 与多个 scope/集合选择器组合。
 - 不要把 PAT 行为授权与 `dws dev app permission` 的开放平台应用权限混用。

--- a/skills/multi/dingtalk-pat/SKILL.md
+++ b/skills/multi/dingtalk-pat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dingtalk-pat
-description: 钉钉 PAT 行为授权与本地浏览器策略管理。Use when 用户说 PAT 授权/行为权限/scope 授权/一次性授权/会话授权/永久授权/批量授权，或允许、禁止 PAT 授权流程打开浏览器。Distinct from dingtalk-dev（开放平台应用权限）。命令前缀：dws pat。
+description: 钉钉 PAT 行为授权与本地浏览器策略管理。Use when 用户说 PAT 授权/行为权限/scope 授权/一次性授权/会话授权/永久授权/批量或 --all 授权/单 scope 授权撤回，或允许、禁止 PAT 授权流程打开浏览器。Distinct from dingtalk-dev（开放平台应用权限）。命令前缀：dws pat。
 cli_version: ">=1.0.15"
 metadata:
   category: product
@@ -27,9 +27,14 @@ metadata:
 | "允许 / 禁止 PAT 授权时打开浏览器" | `dws pat browser-policy --enabled` / `dws pat browser-policy --enabled=false` |
 | "预览某产品或 scope 的行为授权" | `dws pat chmod ... --dry-run --format json` |
 | "授予一次性 / 会话 / 永久行为权限" | `dws pat chmod ...`；先预览并确认，再加 `--yes` 执行 |
+| "授予服务端可操作的全部行为权限" | `dws pat chmod --all ...`；先 `--dry-run`，确认后加 `--yes` |
+| "撤回一个 scope 的显式 PAT 授权" | `dws pat chmod <scope> --revoke`；先 `--dry-run`，确认后加 `--yes` |
 
 ## 安全边界
 
 - `browser-policy` 只修改本地策略，不授予业务权限。
-- `chmod` 会改变 Agent 可执行范围。先用 `--dry-run` 展示 scope、授权类型和有效期，得到用户明确确认后才可加 `--yes`。
+- PAT `chmod --dry-run` 是一次需要认证的服务端只读计划，不是本地回显；不得授权/撤回、打开浏览器、轮询、登录、认证刷新/重试，或写入 profile、token、keychain、凭证等本地认证状态。`--dry-run --yes` 仍不写入。
+- 每个真实 grant（包括显式 scope、产品/域、推荐集合和 `--all`）与单 scope revoke 都必须在用户明确确认后加 `--yes`。
+- `--all` 可与产品/域过滤器组合，但不能与位置 scope 或 `--recommend` 组合。
+- `--revoke` 只接受一个位置 scope，不能与 `--all`、产品/域选择器、`--recommend`、`--grant-type` 或 `--session-id` 组合；当前没有 `batch_revoke`，不得编造或退化成批量撤回。
 - PAT 行为授权不是开放平台应用权限；后者使用 `dws dev app permission`，并切到 `dingtalk-dev`。

--- a/skills/multi/dingtalk-pat/references/pat.md
+++ b/skills/multi/dingtalk-pat/references/pat.md
@@ -16,25 +16,53 @@ dws pat browser-policy --enabled=false --agentCode <AGENT_CODE> --format json
 
 `--agentCode` 省略时写入全局默认策略；该命令只修改本地策略，不授予业务操作权限。
 
-### 授予行为权限
+### 预览或授予行为权限
 
 ```bash
-# 预览按产品展开的批量授权计划，不写入授权
+# 远程预览按产品展开的授权计划，不写入授权
 dws pat chmod --products calendar,aitable --grant-type session --session-id <SESSION_ID> --dry-run --format json
 
-# 执行批量行为授权（高影响，必须先让用户确认）
+# 执行授权（高影响，必须先让用户确认；任何真实 grant 都显式加 --yes）
 dws pat chmod --products calendar,aitable --grant-type session --session-id <SESSION_ID> --yes --format json
+
+# 预览服务端可操作的全部 scope；也可增加 --product / --domain 过滤
+dws pat chmod --all --dry-run --format json
+
+# 用户确认后，授予 calendar 下服务端计划选中的全部 scope
+dws pat chmod --product calendar --all --yes --format json
 ```
 
-scope 格式为 `<product>.<entity>:<permission>`。`grant-type` 支持 `once`、`session`、`permanent`；`session` 模式必须提供 `--session-id`。使用 `--products`、`--product`、`--domains`、`--domain` 或 `--recommend` 批量展开 scope 时，先用 `--dry-run` 检查计划，用户明确确认后才可加 `--yes`。
+scope 格式为 `<product>.<entity>:<permission>`。`grant-type` 支持 `once`、`session`、`permanent`；`session` 模式必须提供 `--session-id`。显式 scope、产品/域选择器、`--recommend` 和 `--all` 的任何真实授权都必须显式加 `--yes`；未加时 CLI 会在任何服务调用前阻断。`--all` 使用服务端可操作的全部 scope，可与产品/域过滤器组合，但不能与位置 scope 或 `--recommend` 组合。
+
+### 撤回一个显式授权
+
+```bash
+# 远程预览单 scope 撤回计划，不写入授权
+dws pat chmod --revoke --dry-run --format json calendar.event:read
+
+# 用户确认后执行单 scope 撤回
+dws pat chmod --revoke --yes --format json calendar.event:read
+```
+
+`--revoke` 只接受一个位置 scope，不能与 `--all`、`--product`、`--products`、`--domain`、`--domains`、`--recommend`、`--grant-type` 或 `--session-id` 组合。它只撤回 ACTIVE 的显式 PAT grant，不会退出 OAuth 登录或撤销 token；服务端必须拒绝 DENIED 记录。当前命令面没有 `batch_revoke`，CLI 也不会退化为多 scope 或选择器批量撤回。
+
+### `--dry-run` 与 `--yes` 安全语义
+
+- PAT `chmod --dry-run` 是一次需要认证的服务端只读计划，不是本地回显；它会原样返回服务端 challenge/error。
+- dry-run 不执行授权或撤回，不打开浏览器、不轮询、不登录、不刷新或重试认证，也不写入 profile、token、keychain、凭证或其他本地认证状态。
+- `--dry-run --yes` 仍以 dry-run 为准，不写入任何授权；不要把 `--yes` 当成浏览器、轮询或重试开关。
+- `--yes` 只表示用户已明确确认真实写操作；每个真实 grant 和单 scope revoke 都需要它。
 
 ## 意图判断
 
 用户说"PAT 授权时允许或禁止打开浏览器/配置浏览器授权策略" → `browser-policy`
-用户说"授予 Agent 行为权限/授权 scope/批量授权产品/一次性授权/会话授权/永久授权" → `chmod`
+用户说"授予 Agent 行为权限/授权 scope/按产品、域、推荐集合或 --all 授权/一次性授权/会话授权/永久授权" → `chmod`
+用户说"撤回一个 scope 的显式 PAT 授权" → `chmod <scope> --revoke`
 
 ## 注意事项
 
 - `browser-policy` 只写本地配置，不会发起授权。
-- `chmod` 会改变 Agent 可执行范围；批量或永久授权属于高影响写操作，必须先展示 scope、授权类型和有效期并获得用户确认。
+- `chmod` 会改变 Agent 可执行范围；所有真实授权和单 scope 撤回都是受保护写操作，必须先展示 scope、授权类型/当前状态和影响范围并获得用户确认，再加 `--yes`。
+- 预览优先使用 `--dry-run --format json`；它会访问服务端生成只读计划，但不得产生授权或本地凭证写入。
+- 不存在批量撤回能力；不要编造 `batch_revoke` 或把 `--revoke` 与多个 scope/集合选择器组合。
 - 不要把 PAT 行为授权与 `dws dev app permission` 的开放平台应用权限混用。


### PR DESCRIPTION
## Summary

- document `pat chmod --all` planning and filtered-all behavior
- require explicit `--yes` for every real grant and single-scope revoke
- document server-backed `--dry-run`, including `--dry-run --yes` remaining read-only
- document single-scope revoke and explicitly reject invented `batch_revoke` behavior

## Boundary

This PR changes four Skill documents and three deterministic generated source-hash projections. It contains no runtime or server implementation.

## Verification

- `make build`
- `make policy`
- `make skill-command-integrity`

The policy gate regenerated and compared all Agent metadata/catalog outputs successfully.
