### PR TITLE
feat: token injection for stdio subprocess + plugin command registration with merging

### DIFF
--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -824,11 +824,17 @@ func loadPlugins(engine *pipeline.Engine, _ executor.Runner) []*cobra.Command {
 	tokenData, _ := rootAuthLoadTokenData(defaultConfigDir())
 	var userCtx *plugin.UserContext
 	if tokenData != nil {
-		// Inject user context if either UserID or CorpID is present.
-		if tokenData.UserID != "" || tokenData.CorpID != "" {
+		accessToken := tokenData.AccessToken
+		if accessToken == "" {
+			if resolved, err := resolveAccessTokenFromDir(context.Background(), defaultConfigDir()); err == nil {
+				accessToken = resolved
+			}
+		}
+		if tokenData.UserID != "" || tokenData.CorpID != "" || accessToken != "" {
 			userCtx = &plugin.UserContext{
 				UserID: tokenData.UserID,
 				CorpID: tokenData.CorpID,
+				Token:  accessToken,
 			}
 		}
 	}

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -15,6 +15,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	stderrors "errors"
 	"fmt"
 	"io"
@@ -73,6 +74,7 @@ var (
 	rootPluginLoadHooks             = (*plugin.Plugin).LoadHooks
 	rootPluginSyncSkills            = plugin.SyncSkills
 	rootAuthLoadTokenData           = authpkg.LoadTokenData
+	rootBuildPluginProductCommand   = buildPluginProductCommand
 )
 
 // Execute runs the root command and returns the process exit code.
@@ -399,20 +401,22 @@ func NewRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine) 
 	root.AddCommand(newLegacyPublicCommands(runner, patCaller)...)
 	root.AddCommand(newLegacyHiddenCommands(runner)...)
 
-	// --- Plugin loading: runs AFTER legacy commands so plugin endpoints can
-	// be appended on top of the static endpoint registry.
-	pluginCmds := rootLoadPlugins(engine, runner)
-	if len(pluginCmds) > 0 {
-		addPluginCommandsSafe(root, pluginCmds)
-	}
-
 	// PAT authorization commands (open-source core)
 	pat.RegisterCommands(root, patCaller)
 
+	// Hardcoded products register first (RegisterProducts completes arbitration
+	// and establishes the final command tree).
 	if fn := edition.Get().RegisterExtraCommands; fn != nil {
 		caller := newToolCallerAdapter(runner, flags)
 		fn(root, caller)
 		deduplicateCommands(root)
+	}
+
+	// --- Plugin loading: runs AFTER hardcoded products so plugin subcommands
+	// are merged into the already-established command tree.
+	pluginCmds := rootLoadPlugins(engine, runner)
+	if len(pluginCmds) > 0 {
+		addPluginCommandsSafe(root, pluginCmds)
 	}
 	hideNonDirectRuntimeCommands(root)
 	configureRootHelp(root)
@@ -631,12 +635,14 @@ var reservedCommands = map[string]bool{
 	"schema": true, "mcp": true, "help": true,
 }
 
-// addPluginCommandsSafe registers plugin commands with conflict detection.
+// addPluginCommandsSafe registers plugin commands with conflict detection and
+// subcommand merging.
 //
 // Rules:
 //   - Plugin vs reserved (auth/plugin/cache/...) → reject, warn
 //   - Plugin vs plugin (same name)               → reject later one, warn
-//   - Plugin vs Market dynamic command            → allow, plugin wins
+//   - Plugin vs existing (hardcoded/Market)       → merge plugin's subcommands
+//     into the existing command (existing subcommands take precedence)
 func addPluginCommandsSafe(root *cobra.Command, pluginCmds []*cobra.Command) {
 	// Build index of existing commands before plugin registration.
 	existing := make(map[string]bool)
@@ -664,20 +670,42 @@ func addPluginCommandsSafe(root *cobra.Command, pluginCmds []*cobra.Command) {
 		}
 		pluginSeen[name] = true
 
-		// Rule 3: plugin vs Market — plugin wins, remove the old one.
+		// Rule 3: existing same-name command — merge plugin subcommands into it.
 		if existing[name] {
-			for _, old := range root.Commands() {
-				if old.Name() == name {
-					root.RemoveCommand(old)
-					slog.Debug("plugin: overriding Market command",
-						"command", name)
-					break
+			if target := findByName(root, name); target != nil {
+				for _, sub := range cmd.Commands() {
+					if !hasSubCommand(target, sub.Name()) {
+						target.AddCommand(sub)
+					}
 				}
+				slog.Debug("plugin: merged subcommands into existing command",
+					"command", name)
+				continue
 			}
 		}
 
 		root.AddCommand(cmd)
 	}
+}
+
+// hasSubCommand reports whether parent has a subcommand with the given name.
+func hasSubCommand(parent *cobra.Command, name string) bool {
+	for _, sub := range parent.Commands() {
+		if sub.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// findByName finds a direct child command of root by name.
+func findByName(root *cobra.Command, name string) *cobra.Command {
+	for _, cmd := range root.Commands() {
+		if cmd.Name() == name {
+			return cmd
+		}
+	}
+	return nil
 }
 
 // deduplicateCommands removes duplicate top-level commands, keeping the last
@@ -811,7 +839,7 @@ func CloseFileLogger() {
 // loadPlugins registers versioned plugin manifests, stdio clients, hooks, and
 // skills. It deliberately does not initialize MCP transports or call
 // tools/list while constructing the command tree.
-func loadPlugins(engine *pipeline.Engine, _ executor.Runner) []*cobra.Command {
+func loadPlugins(engine *pipeline.Engine, runner executor.Runner) []*cobra.Command {
 	pluginLoader := plugin.NewLoader(RawVersion())
 
 	// 0a. Inject plugin config values from settings.json as environment
@@ -847,10 +875,19 @@ func loadPlugins(engine *pipeline.Engine, _ executor.Runner) []*cobra.Command {
 
 	allPlugins := append(userPlugins, devPlugins...)
 
+	var pluginCmds []*cobra.Command
+	seen := make(map[string]bool)
+
 	// 3. Register HTTP descriptors and authentication from the manifest.
 	for _, p := range allPlugins {
 		for _, srv := range rootPluginDescriptors(p) {
 			rootRegisterPluginHTTPServer(srv)
+			if cmd := rootBuildPluginProductCommand(srv, runner); cmd != nil {
+				if !seen[cmd.Name()] {
+					seen[cmd.Name()] = true
+					pluginCmds = append(pluginCmds, cmd)
+				}
+			}
 		}
 	}
 
@@ -858,7 +895,13 @@ func loadPlugins(engine *pipeline.Engine, _ executor.Runner) []*cobra.Command {
 	// started and initialized only when a command is actually executed.
 	for _, p := range allPlugins {
 		for _, sc := range rootPluginStdioClients(p, userCtx) {
-			rootRegisterStdioManifest(p, sc)
+			desc := rootRegisterStdioManifest(p, sc)
+			if cmd := rootBuildPluginProductCommand(desc, runner); cmd != nil {
+				if !seen[cmd.Name()] {
+					seen[cmd.Name()] = true
+					pluginCmds = append(pluginCmds, cmd)
+				}
+			}
 		}
 	}
 
@@ -890,7 +933,166 @@ func loadPlugins(engine *pipeline.Engine, _ executor.Runner) []*cobra.Command {
 		)
 	}
 
-	return nil
+	return pluginCmds
+}
+
+// buildPluginProductCommand builds a Cobra command tree from a plugin's
+// ServerDescriptor CLI overlay. It uses static metadata only — no tools/list
+// or subprocess start happens here. Each declared tool becomes a subcommand
+// that dispatches via helper_invocation to the correct endpoint at runtime.
+func buildPluginProductCommand(desc mcptypes.ServerDescriptor, runner executor.Runner) *cobra.Command {
+	overlay := desc.CLI
+	cmdName := strings.TrimSpace(overlay.Command)
+	if cmdName == "" {
+		cmdName = strings.TrimSpace(overlay.ID)
+	}
+	if cmdName == "" || overlay.Skip {
+		return nil
+	}
+
+	productID := strings.TrimSpace(overlay.ID)
+	if productID == "" {
+		productID = cmdName
+	}
+
+	root := &cobra.Command{
+		Use:               cmdName,
+		Short:             desc.Description,
+		Aliases:           nonEmptyAliases(overlay.Aliases),
+		DisableAutoGenTag: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	// Build tool subcommands from static CLI overlay declarations.
+	addedTools := make(map[string]bool)
+	groupCmds := make(map[string]*cobra.Command)
+
+	for _, tool := range overlay.Tools {
+		toolName := strings.TrimSpace(tool.Name)
+		if toolName == "" || addedTools[toolName] {
+			continue
+		}
+		addedTools[toolName] = true
+		root.AddCommand(newPluginToolLeaf(productID, toolName, toolName, "", runner))
+	}
+
+	// ToolOverrides: use cliName for display, group for hierarchy, skip hidden.
+	for mcpToolName, override := range overlay.ToolOverrides {
+		mcpToolName = strings.TrimSpace(mcpToolName)
+		if mcpToolName == "" || addedTools[mcpToolName] {
+			continue
+		}
+		if strings.TrimSpace(override.ServerOverride) != "" {
+			continue // belongs to another server
+		}
+		if override.Hidden {
+			continue
+		}
+		addedTools[mcpToolName] = true
+
+		cliName := strings.TrimSpace(override.CLIName)
+		if cliName == "" {
+			cliName = mcpToolName
+		}
+
+		leaf := newPluginToolLeaf(productID, mcpToolName, cliName, override.Description, runner)
+
+		groupName := strings.TrimSpace(override.Group)
+		if groupName == "" {
+			root.AddCommand(leaf)
+			continue
+		}
+
+		grp, ok := groupCmds[groupName]
+		if !ok {
+			groupDesc := ""
+			if overlay.Groups != nil {
+				if meta, exists := overlay.Groups[groupName]; exists {
+					groupDesc = meta.Description
+				}
+			}
+			grp = &cobra.Command{
+				Use:               groupName,
+				Short:             groupDesc,
+				DisableAutoGenTag: true,
+				RunE: func(cmd *cobra.Command, _ []string) error {
+					return cmd.Help()
+				},
+			}
+			root.AddCommand(grp)
+			groupCmds[groupName] = grp
+		}
+		grp.AddCommand(leaf)
+	}
+
+	return root
+}
+
+// newPluginToolLeaf builds a single tool leaf command that dispatches to the
+// given product + tool via the runtime runner.
+func newPluginToolLeaf(productID, mcpToolName, cliName, description string, runner executor.Runner) *cobra.Command {
+	short := description
+	if short == "" {
+		short = fmt.Sprintf("调用 %s.%s", productID, mcpToolName)
+	}
+	return &cobra.Command{
+		Use:                cliName,
+		Short:              short,
+		DisableAutoGenTag:  true,
+		DisableFlagParsing: true,
+		Args:               cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			params := parsePluginToolArgs(args)
+			inv := executor.NewHelperInvocation(
+				productID+"."+mcpToolName,
+				productID,
+				mcpToolName,
+				params,
+			)
+			result, err := runner.Run(cmd.Context(), inv)
+			if err != nil {
+				return err
+			}
+			return writePluginResult(cmd, result)
+		},
+	}
+}
+
+// parsePluginToolArgs converts positional args into a params map.
+// Supports: key=value pairs or bare positional args.
+func parsePluginToolArgs(args []string) map[string]any {
+	params := make(map[string]any, len(args))
+	for i, arg := range args {
+		if k, v, ok := strings.Cut(arg, "="); ok {
+			params[k] = v
+		} else {
+			params[fmt.Sprintf("arg%d", i)] = arg
+		}
+	}
+	return params
+}
+
+// writePluginResult outputs the execution result to stdout.
+func writePluginResult(cmd *cobra.Command, result executor.Result) error {
+	if result.Response == nil {
+		return nil
+	}
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result.Response)
+}
+
+// nonEmptyAliases filters out empty strings from an alias slice.
+func nonEmptyAliases(aliases []string) []string {
+	var out []string
+	for _, a := range aliases {
+		if strings.TrimSpace(a) != "" {
+			out = append(out, strings.TrimSpace(a))
+		}
+	}
+	return out
 }
 
 func registerPluginHTTPServer(srv mcptypes.ServerDescriptor) {

--- a/internal/app/root_full_coverage_test.go
+++ b/internal/app/root_full_coverage_test.go
@@ -240,6 +240,7 @@ func TestCrossPlatformCoverageRootLoadPluginsRemainingCoverage(t *testing.T) {
 	oldHooks := rootPluginLoadHooks
 	oldSync := rootPluginSyncSkills
 	oldToken := rootAuthLoadTokenData
+	oldBuildCmd := rootBuildPluginProductCommand
 	t.Cleanup(func() {
 		rootPluginInjectConfigEnv = oldInject
 		rootPluginLoadUser = oldUser
@@ -251,6 +252,7 @@ func TestCrossPlatformCoverageRootLoadPluginsRemainingCoverage(t *testing.T) {
 		rootPluginLoadHooks = oldHooks
 		rootPluginSyncSkills = oldSync
 		rootAuthLoadTokenData = oldToken
+		rootBuildPluginProductCommand = oldBuildCmd
 	})
 
 	p1 := &plugin.Plugin{Manifest: plugin.Manifest{Name: "one"}}
@@ -294,10 +296,176 @@ func TestCrossPlatformCoverageRootLoadPluginsRemainingCoverage(t *testing.T) {
 	}
 	synced := false
 	rootPluginSyncSkills = func([]*plugin.Plugin) { synced = true }
+
+	// Case 1: no CLI overlay in descriptors → buildPluginProductCommand returns nil → no commands
 	if got := loadPlugins(pipeline.NewEngine(), runnerCoverageFallback{}); got != nil {
-		t.Fatalf("loaded plugin commands = %#v", got)
+		t.Fatalf("empty overlay: expected nil commands, got %d", len(got))
 	}
 	if httpCount != 3 || stdioCount != 1 || !synced {
 		t.Fatalf("registered http=%d stdio=%d synced=%v", httpCount, stdioCount, synced)
+	}
+
+	// Case 2: descriptors with CLIOverlay + ToolOverrides → buildPluginProductCommand returns commands
+	httpCount, stdioCount, synced = 0, 0, false
+	rootPluginDescriptors = func(p *plugin.Plugin) []mcptypes.ServerDescriptor {
+		if p == p1 {
+			return []mcptypes.ServerDescriptor{{
+				Key:      "http-with-cli",
+				Endpoint: "https://example.test",
+				CLI: mcptypes.CLIOverlay{
+					ID:      "myproduct",
+					Command: "myproduct",
+					Tools:   []mcptypes.CLITool{{Name: "list"}},
+					ToolOverrides: map[string]mcptypes.CLIToolOverride{
+						"raw_tool": {CLIName: "friendly", Description: "A friendly tool"},
+					},
+				},
+			}}
+		}
+		return nil
+	}
+	rootPluginStdioClients = func(*plugin.Plugin, *plugin.UserContext) []plugin.StdioServerClient { return nil }
+	got := loadPlugins(pipeline.NewEngine(), runnerCoverageFallback{})
+	if len(got) != 1 {
+		t.Fatalf("CLI overlay: expected 1 command, got %d", len(got))
+	}
+	if got[0].Name() != "myproduct" {
+		t.Fatalf("CLI overlay: expected command name 'myproduct', got %q", got[0].Name())
+	}
+	// Verify both 'list' (from Tools) and 'friendly' (cliName of raw_tool) are subcommands
+	if !hasSubCommand(got[0], "list") {
+		t.Fatal("expected 'list' subcommand from Tools")
+	}
+	if !hasSubCommand(got[0], "friendly") {
+		t.Fatal("expected 'friendly' subcommand from ToolOverrides cliName")
+	}
+	if hasSubCommand(got[0], "raw_tool") {
+		t.Fatal("raw_tool should not appear as subcommand; it should use cliName 'friendly'")
+	}
+}
+
+// TestAddPluginCommandsSafeMerge verifies that addPluginCommandsSafe merges
+// plugin subcommands into an existing same-name command.
+func TestAddPluginCommandsSafeMerge(t *testing.T) {
+	// Setup: root has a "conference" command with subcommand "meeting"
+	root := &cobra.Command{Use: "root"}
+	existingConf := &cobra.Command{Use: "conference", Run: func(*cobra.Command, []string) {}}
+	existingConf.AddCommand(&cobra.Command{Use: "meeting", Run: func(*cobra.Command, []string) {}})
+	root.AddCommand(existingConf)
+
+	// Plugin provides a "conference" command with subcommand "plugin_tool"
+	pluginConf := &cobra.Command{Use: "conference"}
+	pluginConf.AddCommand(&cobra.Command{Use: "plugin_tool", Run: func(*cobra.Command, []string) {}})
+
+	addPluginCommandsSafe(root, []*cobra.Command{pluginConf})
+
+	// Verify: root's "conference" should have both "meeting" and "plugin_tool"
+	conf := findByName(root, "conference")
+	if conf == nil {
+		t.Fatal("conference command not found on root")
+	}
+	if !hasSubCommand(conf, "meeting") {
+		t.Fatal("expected subcommand 'meeting' to remain")
+	}
+	if !hasSubCommand(conf, "plugin_tool") {
+		t.Fatal("expected subcommand 'plugin_tool' to be merged")
+	}
+	// Verify duplicate subcommands are not merged again
+	pluginConf2 := &cobra.Command{Use: "conference"}
+	pluginConf2.AddCommand(&cobra.Command{Use: "meeting", Run: func(*cobra.Command, []string) {}})
+	addPluginCommandsSafe(root, []*cobra.Command{pluginConf2})
+	// "meeting" should still appear only once (hasSubCommand checks existence, count stays 2)
+	subs := conf.Commands()
+	count := 0
+	for _, s := range subs {
+		if s.Name() == "meeting" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 'meeting' subcommand, got %d", count)
+	}
+
+	// Verify group commands participate in merge: plugin provides a "conference"
+	// with a group subcommand "camera" containing "open". It should merge into
+	// the existing conference command.
+	pluginConf3 := &cobra.Command{Use: "conference"}
+	grpCmd := &cobra.Command{Use: "camera", Run: func(*cobra.Command, []string) {}}
+	grpCmd.AddCommand(&cobra.Command{Use: "open", Run: func(*cobra.Command, []string) {}})
+	pluginConf3.AddCommand(grpCmd)
+	addPluginCommandsSafe(root, []*cobra.Command{pluginConf3})
+
+	// conference should now have meeting, plugin_tool, camera
+	if !hasSubCommand(conf, "camera") {
+		t.Fatal("expected 'camera' group command to be merged into conference")
+	}
+	cameraCmd := findByName(conf, "camera")
+	if cameraCmd == nil || !hasSubCommand(cameraCmd, "open") {
+		t.Fatal("expected 'open' subcommand under merged 'camera'")
+	}
+}
+
+// TestBuildPluginProductCommandGrouping tests that buildPluginProductCommand
+// correctly handles groups, hidden tools, cliName overrides, and fallback names.
+func TestBuildPluginProductCommandGrouping(t *testing.T) {
+	desc := mcptypes.ServerDescriptor{
+		Description: "test product",
+		CLI: mcptypes.CLIOverlay{
+			ID:      "testprod",
+			Command: "testprod",
+			Groups: map[string]mcptypes.GroupMeta{
+				"grp1": {Description: "Group One"},
+			},
+			ToolOverrides: map[string]mcptypes.CLIToolOverride{
+				"mcp_tool_a":            {CLIName: "alpha", Description: "Alpha tool"},
+				"mcp_tool_b":            {CLIName: "beta", Group: "grp1", Description: "Beta tool"},
+				"mcp_tool_c":            {CLIName: "gamma", Group: "grp1", Description: "Gamma tool"},
+				"mcp_tool_hidden":       {CLIName: "secret", Hidden: true},
+				"mcp_tool_other_server": {ServerOverride: "other-server"},
+				"no_cli_name":           {Description: "fallback name"},
+			},
+		},
+	}
+
+	cmd := buildPluginProductCommand(desc, runnerCoverageFallback{})
+	if cmd == nil {
+		t.Fatal("expected non-nil command")
+	}
+
+	// Verify top-level subcommands: alpha, grp1, no_cli_name (uses raw tool name as fallback)
+	if !hasSubCommand(cmd, "alpha") {
+		t.Error("expected 'alpha' as direct subcommand (cliName of mcp_tool_a)")
+	}
+	if !hasSubCommand(cmd, "grp1") {
+		t.Error("expected 'grp1' group command")
+	}
+	if !hasSubCommand(cmd, "no_cli_name") {
+		t.Error("expected 'no_cli_name' as fallback (no cliName set)")
+	}
+
+	// Verify hidden and other_server tools are not exposed
+	if hasSubCommand(cmd, "secret") {
+		t.Error("hidden tool 'secret' should not be exposed")
+	}
+	if hasSubCommand(cmd, "mcp_tool_hidden") {
+		t.Error("hidden tool raw name should not be exposed")
+	}
+	if hasSubCommand(cmd, "mcp_tool_other_server") {
+		t.Error("other server tool should not be exposed")
+	}
+
+	// Verify grp1 subcommands
+	grp := findByName(cmd, "grp1")
+	if grp == nil {
+		t.Fatal("grp1 not found")
+	}
+	if grp.Short != "Group One" {
+		t.Errorf("grp1 Short = %q, want %q", grp.Short, "Group One")
+	}
+	if !hasSubCommand(grp, "beta") {
+		t.Error("expected 'beta' under grp1")
+	}
+	if !hasSubCommand(grp, "gamma") {
+		t.Error("expected 'gamma' under grp1")
 	}
 }

--- a/internal/app/runner.go
+++ b/internal/app/runner.go
@@ -732,6 +732,31 @@ func (r *runtimeRunner) executeInvocation(ctx context.Context, endpoint string, 
 	return executor.Result{Invocation: invocation, Response: response}, nil
 }
 
+// ensureStdioClientStarted resolves the latest token, injects env vars,
+// and ensures the subprocess is initialized (restarting if env changed).
+func ensureStdioClientStarted(ctx context.Context, client *transport.StdioClient) error {
+	if td, _ := rootAuthLoadTokenData(defaultConfigDir()); td != nil {
+		accessToken := td.AccessToken
+		if accessToken == "" {
+			if resolved, err := resolveAccessTokenFromDir(ctx, defaultConfigDir()); err == nil {
+				accessToken = resolved
+			}
+		}
+		if accessToken != "" {
+			client.UpdateEnvIfDifferent("DWS_TOKEN", accessToken)
+		}
+		client.UpdateEnvIfDifferent("DWS_USER_ID", td.UserID)
+		client.UpdateEnvIfDifferent("DWS_CORP_ID", td.CorpID)
+	}
+
+	if client.NeedsRestart() {
+		if err := client.Stop(); err != nil {
+			return err
+		}
+	}
+	return client.EnsureInitialized(ctx)
+}
+
 // executeStdioInvocation dispatches a tool call through a local StdioClient
 // subprocess instead of the HTTP transport. This is used for plugin stdio
 // servers whose endpoints use the stdio:// scheme.
@@ -760,7 +785,7 @@ func (r *runtimeRunner) executeStdioInvocation(ctx context.Context, invocation e
 		callCtx, cancel = context.WithTimeout(ctx, time.Duration(r.globalFlags.Timeout)*time.Second)
 		defer cancel()
 	}
-	if err := runnerStdioEnsureInitialized(client, callCtx); err != nil {
+	if err := ensureStdioClientStarted(callCtx, client); err != nil {
 		return executor.Result{}, apperrors.NewAPI(
 			fmt.Sprintf("stdio initialize failed: %v", err),
 			apperrors.WithOperation("initialize"),

--- a/internal/plugin/converter.go
+++ b/internal/plugin/converter.go
@@ -29,6 +29,7 @@ import (
 type UserContext struct {
 	UserID string
 	CorpID string
+	Token  string
 }
 
 // StdioServerClient pairs a transport.StdioClient with its server key.
@@ -57,15 +58,15 @@ func (p *Plugin) StdioClients(uc *UserContext) []StdioServerClient {
 		}
 
 		// Expand ${DWS_PLUGIN_ROOT} in command and args.
-		command = expandPluginVars(command, p.Root)
+		command = expandWithContext(command, p.Root, uc)
 		args := make([]string, len(srv.Args))
 		for i, a := range srv.Args {
-			args[i] = expandPluginVars(a, p.Root)
+			args[i] = expandWithContext(a, p.Root, uc)
 		}
 
 		env := make(map[string]string)
 		for k, v := range srv.Env {
-			env[k] = expandPluginVars(v, p.Root)
+			env[k] = expandWithContext(v, p.Root, uc)
 		}
 		env["DWS_PLUGIN_ROOT"] = p.Root
 		env["DWS_PLUGIN_DATA"] = filepath.Join(filepath.Dir(filepath.Dir(p.Root)), "data", p.Manifest.Name)
@@ -77,6 +78,9 @@ func (p *Plugin) StdioClients(uc *UserContext) []StdioServerClient {
 			}
 			if uc.CorpID != "" {
 				env["DWS_CORP_ID"] = uc.CorpID
+			}
+			if uc.Token != "" {
+				env["DWS_TOKEN"] = uc.Token
 			}
 		}
 
@@ -93,6 +97,32 @@ func expandPluginVars(s, root string) string {
 	dataDir := filepath.Join(filepath.Dir(filepath.Dir(root)), "data")
 	s = strings.ReplaceAll(s, "${DWS_PLUGIN_DATA}", dataDir)
 	return os.Expand(s, os.Getenv)
+}
+
+// expandWithContext resolves plugin variables with UserContext fallback for DWS_TOKEN.
+func expandWithContext(s, root string, uc *UserContext) string {
+	s = strings.ReplaceAll(s, "${DWS_PLUGIN_ROOT}", root)
+	dataDir := filepath.Join(filepath.Dir(filepath.Dir(root)), "data")
+	s = strings.ReplaceAll(s, "${DWS_PLUGIN_DATA}", dataDir)
+	return os.Expand(s, func(key string) string {
+		if uc != nil {
+			switch key {
+			case "DWS_TOKEN":
+				if uc.Token != "" {
+					return uc.Token
+				}
+			case "DWS_USER_ID":
+				if uc.UserID != "" {
+					return uc.UserID
+				}
+			case "DWS_CORP_ID":
+				if uc.CorpID != "" {
+					return uc.CorpID
+				}
+			}
+		}
+		return os.Getenv(key)
+	})
 }
 
 // ToServerDescriptors converts a loaded plugin's MCP servers into

--- a/internal/transport/stdio.go
+++ b/internal/transport/stdio.go
@@ -43,6 +43,8 @@ type StdioClient struct {
 	nextID  int64
 	started bool
 
+	envUpdatedAfterStart bool // Start() 后是否有 env 变化
+
 	lifecycleMu sync.Mutex
 	initialized bool
 	initResult  InitializeResult
@@ -72,10 +74,7 @@ func (s *StdioClient) Start(ctx context.Context) error {
 	cmd := stdioCommandContext(ctx, s.command, s.args...)
 
 	// Build environment: inherit current env + merge plugin-specific vars.
-	cmd.Env = os.Environ()
-	for k, v := range s.env {
-		cmd.Env = append(cmd.Env, k+"="+v)
-	}
+	cmd.Env = mergeEnv(os.Environ(), s.env)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -104,6 +103,7 @@ func (s *StdioClient) Start(ctx context.Context) error {
 	s.stdout = bufio.NewReaderSize(stdout, 64*1024)
 	s.stderr = stderr
 	s.started = true
+	s.envUpdatedAfterStart = false
 
 	// Drain stderr in background for debug logging.
 	go s.drainStderr()
@@ -277,6 +277,30 @@ func (s *StdioClient) call(ctx context.Context, method string, params any, resul
 	}
 }
 
+// UpdateEnvIfDifferent updates an env var for the subprocess. Returns true if the value changed.
+func (s *StdioClient) UpdateEnvIfDifferent(key, value string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.env == nil {
+		s.env = make(map[string]string)
+	}
+	if s.env[key] == value {
+		return false
+	}
+	s.env[key] = value
+	if s.started {
+		s.envUpdatedAfterStart = true
+	}
+	return true
+}
+
+// NeedsRestart reports whether env has diverged since the last Start.
+func (s *StdioClient) NeedsRestart() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.envUpdatedAfterStart
+}
+
 // drainStderr reads stderr in the background and logs lines at debug level.
 func (s *StdioClient) drainStderr() {
 	scanner := bufio.NewScanner(s.stderr)
@@ -286,4 +310,35 @@ func (s *StdioClient) drainStderr() {
 			slog.Debug("stdio: subprocess stderr", "command", s.command, "line", line)
 		}
 	}
+}
+
+// mergeEnv replaces existing keys in base with overrides, appends new ones.
+func mergeEnv(base []string, overrides map[string]string) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+	merged := make(map[string]bool, len(overrides))
+	result := make([]string, 0, len(base)+len(overrides))
+	for _, entry := range base {
+		key := envKey(entry)
+		if val, ok := overrides[key]; ok {
+			result = append(result, key+"="+val)
+			merged[key] = true
+		} else {
+			result = append(result, entry)
+		}
+	}
+	for k, v := range overrides {
+		if !merged[k] {
+			result = append(result, k+"="+v)
+		}
+	}
+	return result
+}
+
+func envKey(entry string) string {
+	if i := strings.IndexByte(entry, '='); i >= 0 {
+		return entry[:i]
+	}
+	return entry
 }

--- a/pkg/cmdutil/provenance.go
+++ b/pkg/cmdutil/provenance.go
@@ -61,3 +61,4 @@ func MarkGroup(cmd *cobra.Command) {
 func IsGroup(cmd *cobra.Command) bool {
 	return cmd != nil && cmd.Annotations[KindAnnotation] == KindGroup
 }
+

--- a/pkg/mcptypes/types.go
+++ b/pkg/mcptypes/types.go
@@ -21,6 +21,7 @@ type CLIOverlay struct {
 	Skip          bool                       `json:"skip"`
 	Tools         []CLITool                  `json:"tools"`
 	ToolOverrides map[string]CLIToolOverride `json:"toolOverrides,omitempty"`
+	Groups        map[string]GroupMeta       `json:"groups,omitempty"`
 }
 
 type CLITool struct {
@@ -28,7 +29,17 @@ type CLITool struct {
 }
 
 type CLIToolOverride struct {
-	ServerOverride string `json:"serverOverride,omitempty"`
+	ServerOverride string         `json:"serverOverride,omitempty"`
+	CLIName        string         `json:"cliName,omitempty"`
+	Group          string         `json:"group,omitempty"`
+	Description    string         `json:"description,omitempty"`
+	Hidden         bool           `json:"hidden,omitempty"`
+	IsSensitive    bool           `json:"isSensitive,omitempty"`
+	Flags          map[string]any `json:"flags,omitempty"`
+}
+
+type GroupMeta struct {
+	Description string `json:"description,omitempty"`
 }
 
 func OverlayFromJSON(data json.RawMessage) CLIOverlay {


### PR DESCRIPTION
## Summary

Two independent features for MCP server security and plugin usability:

### 1. Token Injection for Stdio Subprocess

Injects `DWS_TOKEN`, `DWS_USER_ID`, `DWS_CORP_ID` into stdio subprocess environment variables, enabling MCP servers to authenticate requests from the desktop client.

**Key changes:**
- `StdioClient.UpdateEnvIfDifferent` / `NeedsRestart`: track env changes and trigger restart when token rotates
- `mergeEnv`: replace-or-append semantics to avoid duplicate env keys on Windows
- `ensureStdioClientStarted`: resolve latest token → inject env → restart if diverged → EnsureInitialized
- `converter.go`: `expandWithContext` for `${DWS_TOKEN}` / `${DWS_USER_ID}` / `${DWS_CORP_ID}` in plugin manifests

### 2. Plugin Command Registration with Subcommand Merging

Fixes two bugs:
1. `loadPlugins()` previously returned `nil` → no Cobra commands for plugins
2. Plugin commands registered before hardcoded products → evicted by RegisterProducts

**Solution:**
- Reorder registration: hardcoded products first, plugins merge after
- `addPluginCommandsSafe`: merge plugin subcommands into existing same-name commands (existing wins on conflict)
- `buildPluginProductCommand`: build static command tree from CLIOverlay metadata (no tools/list call)
- Support `cliName` override, group hierarchy (`dws conference camera close`), and hidden tool filtering
- Extend `CLIToolOverride` with `cliName`/`group`/`description`/`hidden` fields

## Test Plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/app/... -race` passes
- [x] `go test ./internal/plugin/... -race` passes
- [x] `go test ./internal/transport/... -race` passes

## Breaking Changes

None. All changes are additive. Existing behavior is preserved when new CLIOverlay fields are absent.
