### PR TITLE
docs(changelog): seal v1.0.53-beta.5 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.53-beta.5] - 2026-07-21
+
+This beta validates long-running access-token recovery and the faster, recoverable guarded release path introduced after v1.0.53-beta.4.
+
 ### Changed
 
 - **Fast guarded beta and stable releases** — successful local release checks now leave a six-hour proof bound to the exact version, commit, repository identity, remote `main`, and stable baseline, so the subsequent guarded `--publish` invocation revalidates authority without repeating tests and packaging. A default-branch governance smoke uses the same dedicated immutable-release credential as the tag workflow before any tag is allocated.


### PR DESCRIPTION
## Summary

- seal the current Unreleased notes as v1.0.53-beta.5 dated 2026-07-21
- keep a fresh empty Unreleased section for subsequent changes
- preserve the existing user-visible entries and add only the beta validation summary

## Validation

- cloud Release plan succeeded: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/29799085602
- ./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD

## Release context

- channel: prerelease
- planned version: v1.0.53-beta.5
- production remote: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli.git