### PR TITLE
fix(release): accept guarded local tag metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -541,8 +541,7 @@ jobs:
               }
               tagFields.set(key, line.slice(separator + 2));
             }
-            const cloudKeys = [
-              "Channel",
+            const cloudOnlyKeys = [
               "Release-Run",
               "Release-Run-Attempt",
               "Requested-By",
@@ -551,7 +550,8 @@ jobs:
               "Workflow-Commit",
               "Allocation-Fingerprint",
             ];
-            const hasAnyCloudMetadata = cloudKeys.some((key) => tagFields.has(key));
+            const cloudKeys = ["Channel", ...cloudOnlyKeys];
+            const hasAnyCloudMetadata = cloudOnlyKeys.some((key) => tagFields.has(key));
             const isCloudSeal = cloudKeys.every((key) => tagFields.has(key));
             if (hasAnyCloudMetadata && !isCloudSeal) {
               core.setFailed(`${version} contains incomplete cloud seal metadata`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+### Fixed
+
+- **Guarded local release compatibility** — The tag-push Release workflow now accepts the `Channel`-only annotated tags created by the guarded local release entry while continuing to reject any partial cloud-only seal metadata.
+
 ## [1.0.53-beta.5] - 2026-07-21
 
 This beta validates long-running access-token recovery and the faster, recoverable guarded release path introduced after v1.0.53-beta.4.

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -884,6 +884,25 @@ func TestReleaseWorkflowPlansAndSealsCurrentMainInTheCloud(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowAcceptsGuardedLocalTagMetadata(t *testing.T) {
+	t.Parallel()
+	workflow := readReleaseWorkflow(t)
+
+	for _, required := range []string{
+		`const cloudOnlyKeys = [`,
+		`const cloudKeys = ["Channel", ...cloudOnlyKeys];`,
+		`const hasAnyCloudMetadata = cloudOnlyKeys.some((key) => tagFields.has(key));`,
+		`const isCloudSeal = cloudKeys.every((key) => tagFields.has(key));`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Errorf("local tag metadata compatibility is missing %q", required)
+		}
+	}
+	if strings.Contains(workflow, `const hasAnyCloudMetadata = cloudKeys.some((key) => tagFields.has(key));`) {
+		t.Error("Channel-only guarded local tags must not be classified as partial cloud seals")
+	}
+}
+
 func TestReleaseWorkflowChannelRepairUsesSealedReleaseAuthority(t *testing.T) {
 	t.Parallel()
 	workflow := readReleaseWorkflow(t)


### PR DESCRIPTION
## Summary

- Treat Channel as shared local/cloud metadata and use only cloud-exclusive fields to detect whether a tag claims a cloud seal.
- Keep the complete eight-field cloud seal requirement unchanged once any cloud-exclusive field is present.
- Add a regression test and document the compatibility fix under Unreleased.

This is needed because the immutable v1.0.53-beta.5 tag created by the guarded local release entry contains Channel: prerelease, and the tag-push Release run incorrectly rejected that valid local seal as incomplete cloud metadata before any build or publication job started.

## Verification

- [x] Exact CHANGELOG.md-only check: N/A — this is not a CHANGELOG-only PR.
- [x] make build
- [ ] make lint — baseline-blocked by the same 19 pre-existing staticcheck findings on main at f9b9b83f486d8eeb4519d5de37da9d9b8e1ee540; no reported file is changed here.
- [x] make test
- [x] make policy
- [x] ./scripts/policy/check-generated-drift.sh
- [x] ./scripts/policy/check-command-surface.sh --strict (run by make policy; command surface unchanged)
- [x] go test ./test/scripts -run TestReleaseWorkflowAcceptsGuardedLocalTagMetadata -count=1

## Notes

- The existing v1.0.53-beta.5 tag object 4b81dc9a3b8fe6b47bec164b4f0c491204a39990 and peeled commit f9b9b83f486d8eeb4519d5de37da9d9b8e1ee540 remain untouched.
- Failed tag-push run: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/29800758938
- After this lands and default-branch checks pass, the existing tag must be resumed through the protected dws-release recover flow; it must not be deleted, moved, or reused.