### PR TITLE
chore: update Homebrew beta formula for v1.0.53-beta.5

### DIFF
--- a/Formula/dingtalk-workspace-cli-beta.rb
+++ b/Formula/dingtalk-workspace-cli-beta.rb
@@ -1,33 +1,33 @@
 class DingtalkWorkspaceCliBeta < Formula
   desc "Automate DingTalk workspace tasks from the terminal (beta channel)"
   homepage "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli"
-  version "1.0.53-beta.4"
+  version "1.0.53-beta.5"
   license "Apache-2.0"
   keg_only "it is the beta channel and conflicts with dingtalk-workspace-cli"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.4/dws-darwin-arm64.tar.gz"
-      sha256 "32a442d5b42dfed8512a695a7cef513722db6912f3c3168954cfaefb68e0b075"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.5/dws-darwin-arm64.tar.gz"
+      sha256 "2d97f31bbb59f26eeddeb8f1869d639c26407e5b3f2ca5d742a40fb03326d4f0"
     else
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.4/dws-darwin-amd64.tar.gz"
-      sha256 "00c694677b9ce2e1a711535740681defe0a5f83d6b72140f305483501628faf8"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.5/dws-darwin-amd64.tar.gz"
+      sha256 "92a6a1ede223743f6262b3d3f7968f314f9bb26e104e7e8cb943f9d9e0297d06"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.4/dws-linux-arm64.tar.gz"
-      sha256 "98516620e861e516cf846cf418f1a0ad5c5eb9a8681bd066b1fd29f4847aca6a"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.5/dws-linux-arm64.tar.gz"
+      sha256 "8083a101469c81681f1aaf295aba6c30bf5a69ecd17939dcec33be4399cf57e9"
     else
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.4/dws-linux-amd64.tar.gz"
-      sha256 "266df80e8a989971789a157dd134685a7c9eda01dd1d082719ec9e09d5a07bf0"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.5/dws-linux-amd64.tar.gz"
+      sha256 "70559027b6e2f40973331cd7ef229329a9005271cb06db2ffa215c2714101361"
     end
   end
 
   resource "skills" do
-    url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.4/dws-skills.zip"
-    sha256 "6770511ab9b04b4d97da1858069ff694830ba91d47c1e8564fd85856f95b016e"
+    url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.53-beta.5/dws-skills.zip"
+    sha256 "87eefe2f2a89bc57c3e7fa93ef92cc494dcca673307b9135e734ab21d28f834f"
   end
 
   def install


### PR DESCRIPTION
Automated Homebrew Formula update. Merge after required checks pass.