### PR TITLE
fix(release): check commit statuses in Code Admission gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,6 +358,25 @@ jobs:
                 latestByName.set(run.name, run);
               }
             }
+            // Also check commit statuses — some contexts (e.g. "AI Behavior")
+            // are reported as commit statuses rather than check runs.
+            const statuses = await github.paginate(
+              github.rest.repos.listCommitStatusesForRef,
+              { owner, repo, ref: sha, per_page: 100 },
+            );
+            const seenStatusContexts = new Set();
+            for (const status of statuses) {
+              if (!requiredContexts.includes(status.context) || seenStatusContexts.has(status.context)) {
+                continue;
+              }
+              seenStatusContexts.add(status.context);
+              if (!latestByName.has(status.context)) {
+                latestByName.set(status.context, {
+                  conclusion: status.state,
+                  status: "completed",
+                });
+              }
+            }
             const missing = requiredContexts.filter((name) => !latestByName.has(name));
             const nonSuccess = requiredContexts.flatMap((name) => {
               const run = latestByName.get(name);
@@ -751,6 +770,25 @@ jobs:
               const current = latestByName.get(run.name);
               if (!current || run.id > current.id) {
                 latestByName.set(run.name, run);
+              }
+            }
+            // Also check commit statuses — some contexts (e.g. "AI Behavior")
+            // are reported as commit statuses rather than check runs.
+            const statuses = await github.paginate(
+              github.rest.repos.listCommitStatusesForRef,
+              { owner, repo, ref: sha, per_page: 100 },
+            );
+            const seenStatusContexts = new Set();
+            for (const status of statuses) {
+              if (!requiredContexts.includes(status.context) || seenStatusContexts.has(status.context)) {
+                continue;
+              }
+              seenStatusContexts.add(status.context);
+              if (!latestByName.has(status.context)) {
+                latestByName.set(status.context, {
+                  conclusion: status.state,
+                  status: "completed",
+                });
               }
             }
             const missing = requiredContexts.filter((name) => !latestByName.has(name));


### PR DESCRIPTION
## Summary

- The "AI Behavior" CI context is reported as a **commit status** (via `github.rest.repos.createCommitStatus`), not a check run
- The Code Admission gates in `release.yml` only queried check runs via `github.rest.checks.listForRef`, so "AI Behavior" was always reported as **missing**
- This caused the v1.0.53 stable release to fail at the "Require successful Code Admission contexts on the sealed commit" step

## Fix

Add a `github.rest.repos.listCommitStatusesForRef` query after the check-run loop in both Code Admission gates (preflight commit and sealed commit). Commit statuses are merged only for required contexts not already covered by a check run, preserving existing check-run precedence.

## Test plan

- [ ] CI passes on this PR (Lint, Test, Coverage, Policy, Edition, Interface Integrity, AI Behavior, CLI Smoke, Mock MCP)
- [ ] After merge, re-tag v1.0.53 at the new main HEAD
- [ ] Release workflow passes the Code Admission gate (AI Behavior found via commit status)
- [ ] Build and verify-release-artifacts pass (fixed in PR #730)
- [ ] GitHub Release for v1.0.53 is created with all assets