### PR TITLE
fix(release): verify package versions from raw binaries

### DIFF
--- a/scripts/release/verify-package-managers.sh
+++ b/scripts/release/verify-package-managers.sh
@@ -53,8 +53,6 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-[ -z "$EXPECTED_VERSION" ] || need_cmd strings
-
 TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/dws-package-verify-XXXXXX")"
 HOME_AGENT_PARENTS="
 .claude
@@ -145,8 +143,8 @@ verify_npm() {
   if [ -n "$EXPECTED_VERSION" ]; then
     vendor_bin="$npm_prefix/lib/node_modules/dingtalk-workspace-cli/vendor/dws"
     need_file "$vendor_bin"
-    strings "$vendor_bin" | grep -Fqx "v$EXPECTED_VERSION" || \
-      err "npm-installed binary does not embed expected version v$EXPECTED_VERSION"
+    LC_ALL=C grep -aFq "v$EXPECTED_VERSION" "$vendor_bin" || \
+      err "npm-installed binary does not contain expected version marker v$EXPECTED_VERSION"
     EXPECTED_VERSION="$EXPECTED_VERSION" node -e '
       const pkg = require(process.argv[1]);
       if (pkg.version !== process.env.EXPECTED_VERSION) process.exit(1);
@@ -193,8 +191,8 @@ verify_brew() {
   [ -x "$prefix/bin/dws" ] || err "brew install did not create $prefix/bin/dws"
   "$prefix/bin/dws" --help >/dev/null
   if [ -n "$EXPECTED_VERSION" ]; then
-    strings "$prefix/bin/dws" | grep -Fqx "v$EXPECTED_VERSION" || \
-      err "Homebrew-installed binary does not embed expected version v$EXPECTED_VERSION"
+    LC_ALL=C grep -aFq "v$EXPECTED_VERSION" "$prefix/bin/dws" || \
+      err "Homebrew-installed binary does not contain expected version marker v$EXPECTED_VERSION"
   fi
   need_file "$prefix/share/dingtalk-workspace-cli-local/skills/dws/SKILL.md"
 }

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -46,6 +46,29 @@ var expectedReleaseAdmissionContexts = []string{
 	"Mock MCP",
 }
 
+func TestPackageManagerVersionVerificationReadsRawBinary(t *testing.T) {
+	t.Parallel()
+
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "release", "verify-package-managers.sh"))
+	if err != nil {
+		t.Fatalf("Abs(verify-package-managers.sh) error = %v", err)
+	}
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", scriptPath, err)
+	}
+	script := string(data)
+	for _, binary := range []string{`"$vendor_bin"`, `"$prefix/bin/dws"`} {
+		want := `LC_ALL=C grep -aFq "v$EXPECTED_VERSION" ` + binary
+		if !strings.Contains(script, want) {
+			t.Errorf("package-manager verifier is missing raw binary marker check %q", want)
+		}
+	}
+	if strings.Contains(script, `strings "$vendor_bin"`) || strings.Contains(script, `strings "$prefix/bin/dws"`) {
+		t.Fatal("package-manager verifier still requires the version marker to occupy a strings(1) line")
+	}
+}
+
 func seedDistArchive(t *testing.T, path string) {
 	t.Helper()
 	file, err := os.Create(path)


### PR DESCRIPTION
## What changed

- verify the npm-vendored and Homebrew-installed binaries by searching their raw bytes for the injected version marker
- remove the unnecessary `strings` dependency from package-manager verification
- add a regression test covering both package-manager paths

## Why

Go can place a short `-X` value such as `v1.0.53` next to printable linker metadata. The previous `strings | grep -Fqx` check required the version to occupy a complete `strings(1)` line, so a correctly versioned stable binary could be rejected even though the CLI reported the expected version.

The release artifact verifier on `main` already uses raw binary marker checks. This change applies the same behavior to the downstream npm and Homebrew installation verification paths.

## Impact

Stable package-manager verification no longer fails solely because a short version marker is coalesced with adjacent printable bytes. Incorrect or missing markers still fail closed.

## Validation

- `sh -n scripts/release/verify-package-managers.sh`
- `go test ./test/scripts -run '^TestPackageManagerVersionVerificationReadsRawBinary$' -count=1`
- `git diff --check`

The full CI suite was not run locally.
