### PR TITLE
fix(release): verify packaged artifact versions from raw binary bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This release promotes the validated `v1.0.53-beta.7` baseline to stable. It adds
 - **Authentication and credential reliability** — organization-policy denials stop before mutation or polling, long-running clients reload and refresh access tokens consistently, concurrent credential writes are atomic, and Windows portable-auth commands fail before reading or writing unsupported credential bundles.
 - **Command validation and compatibility** — invalid Sheet/task targets fail locally, IM shortcuts preserve AI-tag and alias compatibility, and Aitable import uploads require and forward a positive file size.
 - **Release publication reliability** — GitHub draft publication is bound to one verified release ID and exact assets, preflight uses isolated installer worktrees, guarded local tags remain compatible, cloud planning fingerprints the actual allocated release refs, and npm channel verification waits for bounded registry propagation without moving tags.
-- **Package-manager version verification** (#735) — npm-vendored and Homebrew-installed binaries are now verified by searching their raw bytes for the injected version marker, so a correctly versioned stable binary is no longer rejected when the short version marker coalesces with adjacent printable linker metadata; incorrect or missing markers still fail closed.
+- **Package-manager version verification** (#735) — npm-vendored, Homebrew-installed, and packaged release binaries are now verified by searching their raw bytes for the injected version marker, so a correctly versioned stable binary is no longer rejected when the short version marker coalesces with adjacent printable linker metadata; incorrect or missing markers still fail closed.
 
 ## [1.0.53-beta.7] - 2026-07-21
 

--- a/scripts/release/verify-release-artifacts.sh
+++ b/scripts/release/verify-release-artifacts.sh
@@ -94,7 +94,7 @@ verify_binary_version() {
     printf '%s does not contain the expected dws binary\n' "$asset" >&2
     return 1
   }
-  strings "$binary" | grep -Fqx "v$SEMVER" || {
+  LC_ALL=C grep -aFq "v$SEMVER" "$binary" || {
     printf '%s binary does not embed expected version v%s\n' "$asset" "$SEMVER" >&2
     return 1
   }


### PR DESCRIPTION
## What changed

- `verify-release-artifacts.sh` now checks the extracted platform binaries with the same raw-byte marker search (`LC_ALL=C grep -aFq`) that #735 applied to the npm/Homebrew verification paths, replacing the `strings | grep -Fqx` whole-line match.
- Extend the v1.0.53 CHANGELOG fix entry to cover packaged release artifacts.

## Why

The v1.0.53 Release run 29825448200 failed at `Verify final release artifacts`: `dws-linux-amd64.tar.gz binary does not embed expected version v1.0.53`. Go coalesced the short `-X` version value with adjacent printable linker metadata, so the whole-line `strings(1)` match rejected a correctly versioned binary — the exact failure mode #735 fixed for the package-manager paths, which missed this verifier.

## Validation

- `sh -n scripts/release/verify-release-artifacts.sh`
- `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run 'TestVerifyReleaseArtifacts|TestReleaseArtifact' -count=1`