### PR TITLE
fix: disable Expect for Gitee uploads

### DIFF
--- a/scripts/release/reconcile-gitee-assets.sh
+++ b/scripts/release/reconcile-gitee-assets.sh
@@ -243,7 +243,9 @@ gitee_attach() {
     if response="$(curl -fsS --connect-timeout "$GITEE_CURL_CONNECT_TIMEOUT" \
       --max-time "$max_time" \
       -X POST "${base}/releases/${release_id}/attach_files" \
-      -H "Authorization: token ${GITEE_TOKEN}" -F "file=@${file}" 2>&1)"; then
+      -H "Authorization: token ${GITEE_TOKEN}" \
+      -H "Expect:" \
+      -F "file=@${file}" 2>&1)"; then
       status=0
     else
       status=$?

--- a/test/scripts/gitee_sync_test.go
+++ b/test/scripts/gitee_sync_test.go
@@ -416,6 +416,31 @@ func TestReconcileGiteeAssetsRecoversACommittedUploadWithLostResponse(t *testing
 	}
 }
 
+func TestReconcileGiteeAssetsDisablesExpectContinueForLargeUploads(t *testing.T) {
+	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "reconcile-gitee-assets.sh"))
+	distDir := seedGiteeDist(t)
+	mustWriteFile(
+		t,
+		filepath.Join(distDir, requiredGiteeAssets[0]),
+		[]byte(strings.Repeat("x", 2<<20)),
+		0o644,
+	)
+	fake := newFakeGiteeRelease(false, false)
+	fake.rejectExpectContinue = true
+	server := httptest.NewServer(fake)
+	defer server.Close()
+
+	cmd := exec.Command("bash", scriptPath)
+	cmd.Env = giteeAssetEnv(distDir, server.URL, "1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("large-asset reconciliation error = %v\noutput:\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "all 8 verified") {
+		t.Fatalf("large-asset reconciliation did not verify every asset:\n%s", output)
+	}
+}
+
 func TestReconcileGiteeAssetsFailsWhenAnyUploadIsMissing(t *testing.T) {
 	scriptPath := mustAbs(t, filepath.Join("..", "..", "scripts", "release", "reconcile-gitee-assets.sh"))
 	distDir := seedGiteeDist(t)
@@ -754,14 +779,15 @@ type fakeGiteeAsset struct {
 }
 
 type fakeGiteeRelease struct {
-	mu                sync.Mutex
-	nextID            int
-	assets            map[int]fakeGiteeAsset
-	uploadCalls       map[string]int
-	dropFirstResponse bool
-	droppedResponse   bool
-	failUploads       bool
-	uploadDelay       time.Duration
+	mu                   sync.Mutex
+	nextID               int
+	assets               map[int]fakeGiteeAsset
+	uploadCalls          map[string]int
+	dropFirstResponse    bool
+	droppedResponse      bool
+	failUploads          bool
+	uploadDelay          time.Duration
+	rejectExpectContinue bool
 }
 
 func newFakeGiteeRelease(dropFirstResponse, failUploads bool) *fakeGiteeRelease {
@@ -820,6 +846,10 @@ func (f *fakeGiteeRelease) list(w http.ResponseWriter, r *http.Request) {
 }
 
 func (f *fakeGiteeRelease) upload(w http.ResponseWriter, r *http.Request) {
+	if f.rejectExpectContinue && r.Header.Get("Expect") != "" {
+		http.Error(w, "Expect: 100-continue is not supported", http.StatusExpectationFailed)
+		return
+	}
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return


### PR DESCRIPTION
## Summary

- Disable curl's automatic `Expect: 100-continue` header for Gitee Release multipart attachment uploads.
- Add a large-upload regression test whose fake Gitee endpoint rejects any non-empty `Expect` header.

This is needed because the small `dws-skills.zip` and `checksums.txt` attachments upload successfully, while every ~9–10 MB platform archive stalls with zero response bytes. Curl adds `Expect: 100-continue` for large multipart POST bodies, and its official documentation recommends an empty `Expect:` header for servers or proxies that do not handle the handshake correctly.

## Verification

- [x] Exact `CHANGELOG.md`-only check (otherwise `N/A`): N/A
- [ ] `make build`
- [ ] `make lint`
- [ ] `make test`
- [ ] `make policy`
- [ ] `./scripts/policy/check-generated-drift.sh`
- [x] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed): N/A — command surface unchanged
- [x] `bash -n scripts/release/reconcile-gitee-assets.sh`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run 'TestReconcileGiteeAssetsDisablesExpectContinueForLargeUploads|TestReconcileGiteeAssetsRecoversACommittedUploadWithLostResponse|TestGiteeReleaseWorkflowUsesImmutableTagsAndBoundedRetryBudget' -count=1`

## Notes

- The 300-second response budget and fail-closed release lookup from PR #758 remain in place.
- Publication still runs only through the protected repair workflow and verifies every asset SHA after upload.
