### PR TITLE
fix(event): pass bus ready pipe via handle inheritance on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows event bus spawn** (#760) — `dws event consume` no longer fails on Windows with `fork/exec ...: not supported by windows` when it needs to auto-start the bus daemon. The ready pipe now reaches the `event _bus` child via Windows handle inheritance (`SysProcAttr.AdditionalInheritedHandles`) instead of the Unix-only `cmd.ExtraFiles`; Unix behavior is unchanged.
+
 ## [1.0.54] - 2026-07-21
 
 This release promotes the validated `v1.0.54-beta.2` baseline to stable. It restores the default transport envelope for personal event output with opt-in flattening, plus Schema CLI path and plugin overlay compatibility fixes.

--- a/internal/event/busctl/spawn.go
+++ b/internal/event/busctl/spawn.go
@@ -27,9 +27,12 @@ import (
 var busctlReadFull = io.ReadFull
 
 // ReadyFDEnv is the env var the spawned `event _bus` child inspects to find
-// the ready-pipe write end. The parent passes the FD number; child opens it
-// via os.NewFile(fd, "ready") and writes 'R' on success or 'E' on failure.
-// 3 is the first FD slot beyond stdio in cmd.ExtraFiles.
+// the ready-pipe write end. The child opens the value via os.NewFile and
+// writes 'R' on success or 'E' on failure. On Unix the value is always 3 —
+// the first FD slot beyond stdio in cmd.ExtraFiles. On Windows ExtraFiles
+// is not supported (os.StartProcess rejects >3 files with EWINDOWS), so the
+// value is the pipe's handle value, which handle inheritance preserves in
+// the child — see attachReadyPipe in spawn_windows.go.
 const ReadyFDEnv = "DWS_EVENT_BUS_READY_FD"
 
 // ReadyTimeout caps how long Spawn waits for the child to signal readiness.
@@ -115,12 +118,18 @@ func Spawn(cfg SpawnConfig) (pid int, err error) {
 
 	args := append([]string{"event", "_bus", "--client-id", cfg.ClientID}, cfg.ExtraArgs...)
 	cmd := exec.Command(cfg.ExecPath, args...)
-	cmd.Env = append(cfg.Env, ReadyFDEnv+"=3")
-	cmd.ExtraFiles = []*os.File{pw} // child sees fd 3 = pw
 	cmd.Stdin = nil
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	applyDetach(cmd) // platform-specific Setsid / new process group
+	// Must come after applyDetach: the Windows variant appends to the
+	// SysProcAttr that applyDetach installs.
+	readyRef, err := attachReadyPipe(cmd, pw)
+	if err != nil {
+		_ = pw.Close()
+		return 0, fmt.Errorf("busctl: attach ready pipe: %w", err)
+	}
+	cmd.Env = append(cfg.Env, ReadyFDEnv+"="+readyRef)
 
 	if err := cmd.Start(); err != nil {
 		_ = pw.Close()
@@ -203,7 +212,10 @@ func waitReady(pr *os.File) error {
 // ReadyFDFromEnv returns the inherited ready pipe (or nil if not set). The
 // `event _bus` command handler calls this at startup, passes the returned
 // *os.File to bus.Run as Config.ReadyPipe, and the bus signals readiness
-// through it.
+// through it. The env value is an FD number on Unix and a handle value on
+// Windows; os.NewFile accepts either on its platform. The < 3 guard rejects
+// stdio FDs on Unix and is harmless on Windows, where real handle values
+// are nonzero multiples of 4.
 func ReadyFDFromEnv() *os.File {
 	v := os.Getenv(ReadyFDEnv)
 	if v == "" {

--- a/internal/event/busctl/spawn_test.go
+++ b/internal/event/busctl/spawn_test.go
@@ -17,8 +17,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -101,9 +99,6 @@ func spawnWithMarker(t *testing.T, marker string, opts ...func(*SpawnConfig)) (i
 }
 
 func TestSpawn_ReadySuccess(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Spawn uses Unix Setsid; Windows path covered separately")
-	}
 	pid, err := spawnWithMarker(t, "ready")
 	if err != nil {
 		t.Fatalf("Spawn ready: %v", err)
@@ -119,9 +114,6 @@ func TestSpawn_ReadySuccess(t *testing.T) {
 }
 
 func TestSpawn_ReadyFailReportsErrSpawnFailed(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Spawn uses Unix Setsid")
-	}
 	pid, err := spawnWithMarker(t, "fail")
 	if !errors.Is(err, ErrSpawnFailed) {
 		t.Fatalf("err = %v, want ErrSpawnFailed", err)
@@ -132,9 +124,6 @@ func TestSpawn_ReadyFailReportsErrSpawnFailed(t *testing.T) {
 }
 
 func TestSpawn_ChildSilentExitReportsErrSpawnFailed(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Spawn uses Unix Setsid")
-	}
 	_, err := spawnWithMarker(t, "silent")
 	if !errors.Is(err, ErrSpawnFailed) {
 		t.Fatalf("err = %v, want ErrSpawnFailed (EOF on pipe)", err)
@@ -142,52 +131,28 @@ func TestSpawn_ChildSilentExitReportsErrSpawnFailed(t *testing.T) {
 }
 
 func TestSpawn_StallReportsTimeout(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Spawn uses Unix Setsid")
-	}
-	// Temporarily shorten ReadyTimeout via a local Spawn variant. The
-	// production timeout is 10s — too long for a unit test. We exec
-	// manually with a tiny io-wait wrapper to verify the behaviour.
-	//
-	// We can't change the package-level const, so we re-implement the
-	// timeout part directly using the same primitives the production
-	// code uses.
-	cmd := exec.Command(os.Args[0])
-	cmd.Env = append(os.Environ(), childEnvMarker+"=stall", ReadyFDEnv+"=3")
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cmd.ExtraFiles = []*os.File{pw}
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start: %v", err)
-	}
-	defer func() {
-		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
-	}()
-	_ = pw.Close()
+	// Production ReadyTimeout is 10s — too long for a unit test. It is a
+	// package var precisely so tests can shrink it; safe to mutate because
+	// these tests never call t.Parallel.
+	old := ReadyTimeout
+	ReadyTimeout = 300 * time.Millisecond
+	defer func() { ReadyTimeout = old }()
 
-	// Replicate waitReady with a tiny timeout.
-	done := make(chan error, 1)
-	go func() {
-		b := make([]byte, 1)
-		_, err := pr.Read(b)
-		done <- err
-	}()
-	select {
-	case <-done:
-		t.Fatal("child should have stalled; got data on ready pipe")
-	case <-time.After(200 * time.Millisecond):
-		// expected — child is stalling, no ready byte arrived
+	pid, err := spawnWithMarker(t, "stall")
+	if pid > 0 {
+		defer func() {
+			if proc, ferr := os.FindProcess(pid); ferr == nil {
+				_ = proc.Kill()
+				_, _ = proc.Wait()
+			}
+		}()
 	}
-	_ = pr.Close()
+	if !errors.Is(err, ErrSpawnTimeout) {
+		t.Fatalf("err = %v, want ErrSpawnTimeout", err)
+	}
 }
 
 func TestSpawn_StdioDetached(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Spawn uses Unix Setsid; Windows stdio handling differs")
-	}
 	// Capture this process's stdout for the duration of the child run.
 	// If applyDetach is broken and cmd.Stdout would otherwise inherit,
 	// the child's "POLLUTION-FROM-CHILD" line would land in our pipe.
@@ -252,9 +217,6 @@ func TestReadyFDFromEnv_LowFDRejected(t *testing.T) {
 // waitReady must surface the child's real startup error (written after the
 // 'E' byte) so consume shows WHY the bus failed, not an opaque message.
 func TestWaitReady_FailureSurfacesChildError(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("uses Unix pipe")
-	}
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
@@ -277,9 +239,6 @@ func TestWaitReady_FailureSurfacesChildError(t *testing.T) {
 
 // A bare 'E' (no trailing text) still reports ErrSpawnFailed.
 func TestWaitReady_BareFailureByte(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("uses Unix pipe")
-	}
 	pr, pw, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/event/busctl/spawn_unix.go
+++ b/internal/event/busctl/spawn_unix.go
@@ -16,6 +16,7 @@
 package busctl
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -28,4 +29,11 @@ func applyDetach(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setsid: true,
 	}
+}
+
+// attachReadyPipe hands pw to the child as fd 3 via ExtraFiles and returns
+// the ReadyFDEnv value the child passes to os.NewFile.
+func attachReadyPipe(cmd *exec.Cmd, pw *os.File) (string, error) {
+	cmd.ExtraFiles = []*os.File{pw} // child sees fd 3 = pw
+	return "3", nil
 }

--- a/internal/event/busctl/spawn_windows.go
+++ b/internal/event/busctl/spawn_windows.go
@@ -16,7 +16,10 @@
 package busctl
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
+	"strconv"
 	"syscall"
 )
 
@@ -29,4 +32,24 @@ func applyDetach(cmd *exec.Cmd) {
 		CreationFlags: createNewProcessGroup,
 		HideWindow:    true,
 	}
+}
+
+// attachReadyPipe hands pw to the child on Windows, where cmd.ExtraFiles is
+// not supported — os.StartProcess fails with EWINDOWS ("fork/exec ...: not
+// supported by windows") on more than the 3 stdio files. Instead the pipe
+// handle is marked inheritable and listed in AdditionalInheritedHandles.
+// Inherited handles keep their value in the child, so ReadyFDEnv carries
+// the handle value itself and the child's os.NewFile reconstructs the
+// write end from it. Must run after applyDetach, which installs
+// SysProcAttr (the nil check below is a safety net, not the normal path).
+func attachReadyPipe(cmd *exec.Cmd, pw *os.File) (string, error) {
+	h := syscall.Handle(pw.Fd())
+	if err := syscall.SetHandleInformation(h, syscall.HANDLE_FLAG_INHERIT, syscall.HANDLE_FLAG_INHERIT); err != nil {
+		return "", fmt.Errorf("mark ready pipe inheritable: %w", err)
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.AdditionalInheritedHandles = append(cmd.SysProcAttr.AdditionalInheritedHandles, h)
+	return strconv.FormatUint(uint64(h), 10), nil
 }


### PR DESCRIPTION
# Summary

Fixes #688. Fixes #693.

On Windows, every `dws event consume` invocation that needs to auto-start the bus daemon fails with:

```json
{
  "error": {
    "category": "internal",
    "code": 5,
    "message": "consume: discover bus: busctl: spawn bus: busctl: start C:\\Users\\...\\dws.exe: fork/exec C:\\Users\\...\\dws.exe: not supported by windows"
  }
}
```

## Root cause

`busctl.Spawn` hands the ready pipe to the forked `event _bus` child via `cmd.ExtraFiles` (`internal/event/busctl/spawn.go`). Go's `os/exec` documents that **ExtraFiles is not supported on Windows**: `syscall.StartProcess` (`GOROOT/src/syscall/exec_windows.go`) rejects more than the 3 stdio files with `EWINDOWS`, whose message is exactly `not supported by windows`. So the spawn fails 100% of the time on Windows; the bug was invisible because all five Spawn tests were `t.Skip`ped on Windows with a "covered separately" note that never materialized.

## Fix

Split the pipe hand-off into the existing platform files as `attachReadyPipe`:

- **Unix** (`spawn_unix.go`): keeps `cmd.ExtraFiles` / fd 3 — behavior byte-for-byte unchanged.
- **Windows** (`spawn_windows.go`): marks the pipe handle inheritable (`SetHandleInformation(HANDLE_FLAG_INHERIT)`) and lists it in `SysProcAttr.AdditionalInheritedHandles` — the mechanism Go provides for handle inheritance. `DWS_EVENT_BUS_READY_FD` carries the handle value, which inheritance preserves in the child.
- **Child side**: `ReadyFDFromEnv` → `os.NewFile` is shared by both platforms and needs no changes (`os.NewFile` takes an fd on Unix and a handle on Windows; the `< 3` guard stays safe because NT handle values are nonzero multiples of 4).

Test changes: the five Windows skips are removed so the real fork path now runs on Windows, and `TestSpawn_StallReportsTimeout` is rewritten to drive `Spawn` through the `ReadyTimeout` knob instead of hand-rolling `ExtraFiles` (which itself could never run on Windows).

## Verification

On Windows 11 (amd64, go1.25.9), where the bug reproduces:

- `go build ./...`, `go vet ./...`: clean.
- `go test ./internal/event/... -count=1`: all packages ok; the five previously-skipped Spawn tests now execute a real fork + handle-inheritance round-trip on Windows and pass (ready / fail-with-reason / silent-exit-EOF / stall-timeout / stdio-detach).
- Full `go test -count=1 -timeout=10m ./...`: 69 of 70 packages ok. The single failing package is `internal/app` (17–18 failures in PAT device-flow / auth-import-DPAPI / upgrade-coverage tests). These are pre-existing and environment-dependent on this Windows dev box, unrelated to this change: the identical `-run` subset produces the same 17 failures (byte-identical test-name list) on a clean `origin/main` worktree on the same machine; the 18th (DPAPI import) appears only under full-suite interference on both trees. The event-related `internal/app` tests (`go test ./internal/app/ -run 'Event'`) pass.
- Coverage: full-repo `scripts/dev/coverage.sh` cannot complete on this box due to those same pre-existing `internal/app` failures (CI runs it authoritatively). Scoped to the changed package on Windows: `internal/event/busctl` coverage rises from 94.7% (main) to **97.1%** on this branch, because the previously-skipped spawn tests now execute for real.
- `GOOS=linux go build ./...` and `GOOS=darwin go build ./...`: OK (Unix spawn path unchanged; also verified `go test ./internal/event/...` green before/after on the same base).
- gofmt: changed files clean. staticcheck v0.7.0 repo-wide: no findings in changed files (pre-existing findings in unrelated test files untouched).
- `git diff --check`: clean.
- Manual: rebuilt `dws.exe` from this branch with release ldflags and replaced the installed binary; the spawn path that previously errored is exercised end-to-end by the un-skipped real-exec tests on the same machine.

Not applicable per checklist: no command paths/flags changed (`check-command-surface.sh` n/a), no generated artifacts affected (`check-generated-drift.sh` n/a), no packaging surfaces touched.

`CHANGELOG.md`: entry added under `[Unreleased]` → `Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
