### PR TITLE
fix(chat): resolve media upload credentials from secure config

### DIFF
--- a/internal/app/legacy.go
+++ b/internal/app/legacy.go
@@ -17,11 +17,13 @@ import (
 	"log/slog"
 	"sort"
 
+	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cobracmd"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/executor"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/builtin"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/userdef"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/mcptypes"
 	"github.com/spf13/cobra"
@@ -30,6 +32,10 @@ import (
 func newLegacyPublicCommands(runner executor.Runner, caller edition.ToolCaller, loadUserShortcuts bool) []*cobra.Command {
 	injectStaticServers()
 	helpers.InitDeps(caller)
+	helpers.SetMediaCredentialResolver(func() (string, string, error) {
+		clientID, clientSecret, _, _, err := authpkg.ResolveAppCredentialsStrict(config.DefaultConfigDir())
+		return clientID, clientSecret, err
+	})
 	commands := helpers.NewPublicCommands(runner)
 	// Load user-defined shortcuts (~/.dws/shortcuts/*.yaml) BEFORE compiling the
 	// command tree, so distilled high-frequency operations mount alongside the

--- a/internal/helpers/chat_media_upload.go
+++ b/internal/helpers/chat_media_upload.go
@@ -36,7 +36,27 @@ var (
 	mediaCreateFormFile      = func(w *multipart.Writer, field, name string) (io.Writer, error) { return w.CreateFormFile(field, name) }
 	mediaOpenFile            = os.Open
 	mediaCopyFile            = io.Copy
+	mediaResolveCredentials  = resolveMediaCredentialsFromEnv
 )
+
+func resolveMediaCredentialsFromEnv() (string, string, error) {
+	appKey := os.Getenv("DWS_CLIENT_ID")
+	appSecret := os.Getenv("DWS_CLIENT_SECRET")
+	if appKey == "" || appSecret == "" {
+		return "", "", fmt.Errorf("DWS_CLIENT_ID and DWS_CLIENT_SECRET must be set as a pair")
+	}
+	return appKey, appSecret, nil
+}
+
+// SetMediaCredentialResolver lets the host application provide credentials
+// from its secure config/keychain resolver without introducing an import cycle.
+func SetMediaCredentialResolver(resolve func() (string, string, error)) {
+	if resolve == nil {
+		mediaResolveCredentials = resolveMediaCredentialsFromEnv
+		return
+	}
+	mediaResolveCredentials = resolve
+}
 
 func newChatMediaGroup() *cobra.Command {
 	media := &cobra.Command{
@@ -109,12 +129,11 @@ func mediaResolveAppToken(ctx context.Context) (string, error) {
 type mediaRequestFactory func(context.Context, string, string, io.Reader) (*http.Request, error)
 
 func mediaResolveAppTokenWithRequest(ctx context.Context, newRequest mediaRequestFactory) (string, error) {
-	appKey := os.Getenv("DWS_CLIENT_ID")
-	appSecret := os.Getenv("DWS_CLIENT_SECRET")
-	if appKey == "" || appSecret == "" {
+	appKey, appSecret, err := mediaResolveCredentials()
+	if err != nil {
 		return "", apperrors.NewAuth(
-			"缺少应用凭证。chat media upload 需要 DWS_CLIENT_ID / DWS_CLIENT_SECRET 环境变量。\n" +
-				"请使用 dws auth login --client-id <APP_KEY> --client-secret <APP_SECRET> 登录。")
+			"缺少或无法解析应用凭证。请运行 dws auth login，并通过交互式密码输入将 AppSecret 存入系统 Keychain。\n" +
+				"自动化环境仅可在受控进程环境中成对注入 DWS_CLIENT_ID / DWS_CLIENT_SECRET；不要把 AppSecret 写入命令行。详情: " + err.Error())
 	}
 	endpoint := url.URL{Scheme: "https", Host: "oapi.dingtalk.com", Path: "/gettoken"}
 	endpoint.RawQuery = url.Values{

--- a/internal/helpers/chat_media_upload_coverage_more_test.go
+++ b/internal/helpers/chat_media_upload_coverage_more_test.go
@@ -13,6 +13,35 @@ import (
 	"testing"
 )
 
+func TestMediaResolveAppTokenUsesSecureCredentialResolver(t *testing.T) {
+	origResolve := mediaResolveCredentials
+	origTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		mediaResolveCredentials = origResolve
+		http.DefaultTransport = origTransport
+	})
+
+	mediaResolveCredentials = func() (string, string, error) {
+		return "keychain-id", "keychain-secret", nil
+	}
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		query := req.URL.Query()
+		if query.Get("appkey") != "keychain-id" || query.Get("appsecret") != "keychain-secret" {
+			t.Fatalf("resolved credentials not used: %v", query)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"access_token":"token","errcode":0}`)),
+			Request:    req,
+		}, nil
+	})
+
+	if token, err := mediaResolveAppToken(context.Background()); err != nil || token != "token" {
+		t.Fatalf("token = %q, err = %v", token, err)
+	}
+}
+
 func TestCrossPlatformCoverageChatMediaUploadCommandRemainingCoverage(t *testing.T) {
 	file := filepath.Join(t.TempDir(), "image.png")
 	if err := os.WriteFile(file, []byte("image"), 0o600); err != nil {


### PR DESCRIPTION
## Summary

- route chat media upload credential lookup through the existing strict app credential resolver
- preserve paired environment-variable fallback while allowing `app.json` + OS Keychain credentials
- remove remediation that encouraged passing AppSecret on the command line
- keep helpers decoupled from auth through host-level dependency injection

## Why

`chat media upload` currently reads only `DWS_CLIENT_ID` and `DWS_CLIENT_SECRET` from the process environment, even though DWS already persists AppSecret through a SecretRef in the OS Keychain. This forces users away from the existing secure credential channel.

## Tests

- `go test ./internal/helpers -run 'Test(MediaResolveAppTokenUsesSecureCredentialResolver|CrossPlatformCoverageChatMediaUploadCommandRemainingCoverage|CrossPlatformCoverageChatMediaHTTPAndDocVersionsCoverage)' -count=1`\n- `go test ./internal/app ./internal/helpers -count=1`