### PR TITLE
chore(release): prepare v1.0.55-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.55-beta.1] - 2026-07-23
+
+This beta validates MCP Market URL resolution, the supported Wukong local-file
+send path after retiring the legacy credential-based media upload command from
+discovery, and reliable message-read rendering for rich content, forwarded
+records, encrypted messages, and media-download ID aliases.
+
 ### Added
 
 - **MCP URL resolution** — adds `dws mcp url get <mcpId>` for resolving a DingTalk MCP Market ID to the current user and organization scoped Streamable HTTP URL, while keeping the helper-only `mcp-meta` endpoint out of the public product command surface.


### PR DESCRIPTION
## Summary

- Adds the exact `v1.0.55-beta.1` CHANGELOG section allocated by the official beta/patch release plan.
- Seals the existing Unreleased notes for MCP URL resolution, Chat local-file sending/media-upload retirement, and message-read projection fixes.
- Keeps a new empty `Unreleased` section for subsequent changes.

This CHANGELOG-only PR is required before the cloud Release workflow can publish the beta from `main`.

## Verification

- [x] Exact `CHANGELOG.md`-only check:
  `./scripts/policy/check-changelog-pr.sh --fast-path "$(git merge-base HEAD origin/main)" HEAD`
- [x] `make build` — N/A: exact CHANGELOG-only fast path.
- [x] `make lint` — N/A: exact CHANGELOG-only fast path.
- [x] `make test` — N/A: exact CHANGELOG-only fast path.
- [x] `make policy` — N/A: exact CHANGELOG-only fast path.
- [x] `./scripts/policy/check-generated-drift.sh` — N/A: no generated inputs changed.
- [x] `./scripts/policy/check-command-surface.sh --strict` — N/A: command surface unchanged.

Observed result: `open-source audit: ok`; `CHANGELOG PR check: ok (mode=fast-path release_sections=1 unreleased_changed=1)`.

## Notes

- Official plan: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/29982391820
- Planned version: `v1.0.55-beta.1`; channel: beta; base: `v1.0.54`; OSS mirror: deferred.
- The plan created no tag or package. Publishing remains gated on this PR merging, exact-main governance checks, explicit release confirmation, and verified delivery of the resulting immutable assets.