### PR TITLE
chore: update Homebrew beta formula for v1.0.55-beta.1

### DIFF
--- a/Formula/dingtalk-workspace-cli-beta.rb
+++ b/Formula/dingtalk-workspace-cli-beta.rb
@@ -1,33 +1,33 @@
 class DingtalkWorkspaceCliBeta < Formula
   desc "Automate DingTalk workspace tasks from the terminal (beta channel)"
   homepage "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli"
-  version "1.0.54-beta.2"
+  version "1.0.55-beta.1"
   license "Apache-2.0"
   keg_only "it is the beta channel and conflicts with dingtalk-workspace-cli"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.54-beta.2/dws-darwin-arm64.tar.gz"
-      sha256 "46b57bed1f6e9f7ba007d8a86a6f5eb280fdeb557fc9bb5946f14f9b1f8f0c9f"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.55-beta.1/dws-darwin-arm64.tar.gz"
+      sha256 "7bb716eeb50c2fbc7f325af07e5749e77951d1459359e5362a47194a0931fb3f"
     else
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.54-beta.2/dws-darwin-amd64.tar.gz"
-      sha256 "1b7fd08e64b1c86bbcee217604ffe07e0e8f1b3b5c4de518534386972bcf0f9b"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.55-beta.1/dws-darwin-amd64.tar.gz"
+      sha256 "ec5590e2ebc172faf26a4f3c91db3c2dbe80b0926e0704dfc55a0ab5457d423f"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.54-beta.2/dws-linux-arm64.tar.gz"
-      sha256 "108d3861ef606519f9934530d29654eab55a73607d1ee6775461f98ef5a6acd4"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.55-beta.1/dws-linux-arm64.tar.gz"
+      sha256 "b71651b431241a871dbe39ae3ad9cebcf3b66a699f48304dcab9e5cdfab698ec"
     else
-      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.54-beta.2/dws-linux-amd64.tar.gz"
-      sha256 "6cb96ee09419bbbcc1eb336218ac2aa1d9ca0ed5cbd5a80c79bc20e1e1f03ff7"
+      url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.55-beta.1/dws-linux-amd64.tar.gz"
+      sha256 "fe95a3769cb793f28ce487fc1bb275678d50e6bc2fe1c1a712960489638a6570"
     end
   end
 
   resource "skills" do
-    url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.54-beta.2/dws-skills.zip"
-    sha256 "572b93f04a10268d185ad1f8e70e0d412949ae056be8494a9949387076fd14bc"
+    url "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/download/v1.0.55-beta.1/dws-skills.zip"
+    sha256 "c3b141d0608af8f221c9efbe43d44cabd470e0895bf974f89fd4614a020e8608"
   end
 
   def install


### PR DESCRIPTION
Automated Homebrew Formula update. Merge after required checks pass.