### PR TITLE
chore(release): prepare v1.0.55-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.55-beta.2] - 2026-07-23
+
+This beta validates Wukong capability parity across Chat, Contacts, documents,
+Drive, Markdown, and Todos, together with faster guarded releases and legacy
+authentication migration.
+
 ### Added
 
 - **Chat editing and group management** — adds `chat message edit`, conversation-category lookups through `chat category list-by-conv` and `chat category batch-info`, and the confirmed, irreversible `chat group upgrade-to-external` flow.


### PR DESCRIPTION
## Summary

- Adds the exact `v1.0.55-beta.2` CHANGELOG section allocated by the official beta/patch release plan.
- Seals the current Unreleased notes for Wukong capability parity, guarded-release acceleration, and legacy authentication migration.
- Keeps a new empty `Unreleased` section for subsequent changes.

## Verification

- [x] Exact `CHANGELOG.md`-only check:
  `./scripts/policy/check-changelog-pr.sh --fast-path 7b77b4e61572596c59eae2465bb3f0a15be03dc1 HEAD`
- [x] `make build` — N/A: exact CHANGELOG-only fast path.
- [x] `make lint` — N/A: exact CHANGELOG-only fast path.
- [x] `make test` — N/A: exact CHANGELOG-only fast path.
- [x] `make policy` — N/A: exact CHANGELOG-only fast path.
- [x] `./scripts/policy/check-generated-drift.sh` — N/A: no generated inputs changed.
- [x] `./scripts/policy/check-command-surface.sh --strict` — N/A: command surface unchanged.

Observed result: `open-source audit: ok`; `CHANGELOG PR check: ok (mode=fast-path release_sections=1 unreleased_changed=1)`.

## Notes

- Official plan: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/29999471957
- Planned version: `v1.0.55-beta.2`; channel: beta; planned source: `7b77b4e61572596c59eae2465bb3f0a15be03dc1`; OSS mirror: deferred.
- The plan created no tag or package. Publishing remains gated on this PR merging, exact-main checks, and explicit release confirmation.