### PR TITLE
fix(release): make publication retries seamless

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ on:
         required: false
         type: string
       recover_release_nonce:
-        description: "Unique identifier for this protected recovery request"
+        description: "Unique identifier for this machine-verified recovery request"
         required: false
         type: string
       recover_release_confirmation:
@@ -218,44 +218,6 @@ jobs:
             }
             echo "mode=recover_release" >> "$GITHUB_OUTPUT"
           fi
-
-  authorize-recovery:
-    name: Approve existing tag recovery
-    needs: dispatch-contract
-    if: ${{ needs.dispatch-contract.outputs.mode == 'recover_release' }}
-    environment: release-recovery
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    permissions:
-      actions: read
-    steps:
-      - name: Verify break-glass environment protection
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const response = await github.request(
-              "GET /repos/{owner}/{repo}/environments/{environment_name}",
-              { owner, repo, environment_name: "release-recovery" },
-            );
-            const reviewerRule = response.data.protection_rules.find(
-              (rule) => rule.type === "required_reviewers",
-            );
-            if (
-              !reviewerRule ||
-              reviewerRule.prevent_self_review !== true ||
-              !Array.isArray(reviewerRule.reviewers) ||
-              reviewerRule.reviewers.length === 0
-            ) {
-              core.setFailed("release-recovery must require a reviewer and prevent self-review");
-              return;
-            }
-            if (response.data.deployment_branch_policy?.protected_branches !== true) {
-              core.setFailed("release-recovery must allow only protected branches");
-            }
-            if (response.data.can_admins_bypass !== false) {
-              core.setFailed("release-recovery must not allow administrator bypass");
-            }
 
   governance-preflight:
     name: Release governance preflight
@@ -410,24 +372,9 @@ jobs:
               core.setFailed("Immutable releases must be enabled before publishing");
             }
 
-      - name: Verify Homebrew PR automation permission
-        env:
-          HOMEBREW_PR_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
-          RELEASE_GOVERNANCE_TOKEN: ${{ secrets.RELEASE_GOVERNANCE_TOKEN }}
-        run: |
-          test -n "$HOMEBREW_PR_TOKEN" || {
-            echo "HOMEBREW_PR_TOKEN is required to open Formula PRs from official releases" >&2
-            exit 1
-          }
-          test "$HOMEBREW_PR_TOKEN" != "$RELEASE_GOVERNANCE_TOKEN" || {
-            echo "HOMEBREW_PR_TOKEN and RELEASE_GOVERNANCE_TOKEN must use separate least-privilege identities" >&2
-            exit 1
-          }
-          ./scripts/release/verify-homebrew-pr-token.sh "$GITHUB_REPOSITORY" --canary
-
   release-contract:
-    needs: [dispatch-contract, authorize-recovery, governance-preflight, release-plan, seal-release]
-    if: ${{ !cancelled() && (github.event_name == 'push' || (needs.dispatch-contract.result == 'success' && needs.dispatch-contract.outputs.mode == 'recover_release' && needs.authorize-recovery.result == 'success') || (needs.dispatch-contract.result == 'success' && needs.dispatch-contract.outputs.mode == 'create_release' && needs.governance-preflight.result == 'success' && needs.release-plan.result == 'success' && needs.seal-release.result == 'success')) }}
+    needs: [dispatch-contract, governance-preflight, release-plan, seal-release]
+    if: ${{ !cancelled() && (github.event_name == 'push' || (needs.dispatch-contract.result == 'success' && needs.dispatch-contract.outputs.mode == 'recover_release') || (needs.dispatch-contract.result == 'success' && needs.dispatch-contract.outputs.mode == 'create_release' && needs.governance-preflight.result == 'success' && needs.release-plan.result == 'success' && needs.seal-release.result == 'success')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -568,6 +515,8 @@ jobs:
             if (isCloudSeal) {
               const expectedChannel = version.includes("-beta.") ? "prerelease" : "stable";
               const actorId = String(context.payload.sender?.id || "");
+              const sealedRunAttempt = Number(tagFields.get("Release-Run-Attempt"));
+              const currentRunAttempt = Number(process.env.GITHUB_RUN_ATTEMPT);
               if (
                 tagFields.get("Channel") !== expectedChannel ||
                 tagFields.get("Sealed-Commit") !== commit ||
@@ -582,7 +531,10 @@ jobs:
               }
               if (isCreate && (
                 tagFields.get("Release-Run") !== String(context.runId) ||
-                tagFields.get("Release-Run-Attempt") !== process.env.GITHUB_RUN_ATTEMPT ||
+                !Number.isSafeInteger(sealedRunAttempt) ||
+                !Number.isSafeInteger(currentRunAttempt) ||
+                sealedRunAttempt < 1 ||
+                sealedRunAttempt > currentRunAttempt ||
                 tagFields.get("Requested-By") !== context.actor ||
                 tagFields.get("Requested-By-ID") !== actorId
               )) {
@@ -642,6 +594,7 @@ jobs:
               if (failedByCloud && (
                 tagFields.get("Release-Run") !== failedRunId ||
                 tagFields.get("Release-Run-Attempt") !== failedRunAttempt ||
+                tagFields.get("Requested-By") !== String(run.actor?.login || "") ||
                 tagFields.get("Requested-By-ID") !== String(run.actor?.id || "")
               )) {
                 core.setFailed(
@@ -817,23 +770,6 @@ jobs:
             if (response.data.enabled !== true) {
               core.setFailed("Immutable releases must be enabled before publishing");
             }
-
-      - name: Verify Homebrew PR automation permission
-        if: ${{ github.repository_owner == 'DingTalk-Real-AI' && (github.event_name == 'push' || needs.dispatch-contract.outputs.mode == 'recover_release') }}
-        env:
-          HOMEBREW_PR_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
-          RELEASE_GOVERNANCE_TOKEN: ${{ secrets.RELEASE_GOVERNANCE_TOKEN }}
-        run: |
-          if [ -z "$HOMEBREW_PR_TOKEN" ]; then
-            echo "HOMEBREW_PR_TOKEN is required to open Formula PRs from official releases" >&2
-            exit 1
-          fi
-          if [ "$HOMEBREW_PR_TOKEN" = "$RELEASE_GOVERNANCE_TOKEN" ]; then
-            echo "HOMEBREW_PR_TOKEN and RELEASE_GOVERNANCE_TOKEN must use separate least-privilege identities" >&2
-            exit 1
-          fi
-          "$GITHUB_WORKSPACE/tmp/trusted-release-tooling/scripts/release/verify-homebrew-pr-token.sh" \
-            "$GITHUB_REPOSITORY" --canary
 
       - name: Require successful beta delivery before stable promotion
         if: ${{ steps.contract.outputs.channel == 'stable' && (github.event_name == 'push' || needs.dispatch-contract.outputs.mode == 'recover_release') }}
@@ -1146,6 +1082,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      checks: write
       contents: write
     env:
       RELEASE_VERSION: ${{ needs.release-contract.outputs.release_version }}
@@ -1499,29 +1436,189 @@ jobs:
           "$GITHUB_WORKSPACE/tmp/trusted-release-tooling/scripts/release/verify-github-tag-authority.sh" \
             "$RELEASE_VERSION" "$RELEASE_COMMIT" "$RELEASE_TAG_OBJECT"
 
-      - name: Open stable Homebrew formula PR
+      - name: Publish stable Homebrew formula
+        id: homebrew-stable
         if: ${{ github.repository_owner == 'DingTalk-Real-AI' && needs.release-contract.outputs.channel == 'stable' }}
-        run: ./scripts/release/publish-homebrew-formula.sh
+        run: DWS_PUBLISH_OUTPUT="$GITHUB_OUTPUT" "$GITHUB_WORKSPACE/tmp/trusted-release-tooling/scripts/release/publish-homebrew-formula.sh"
         env:
+          DWS_FORMULA_SOURCE: ${{ github.workspace }}/dist/homebrew/dingtalk-workspace-cli.rb
           DWS_TAP_REPO_URL: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli.git
-          DWS_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
-          DWS_TAP_PR_REPOSITORY: ${{ github.repository }}
-          DWS_TAP_PR_BRANCH: "automation/homebrew-${{ needs.release-contract.outputs.release_version }}"
-          DWS_TAP_PR_TITLE: "chore: update Homebrew formula for ${{ needs.release-contract.outputs.release_version }}"
-          DWS_TAP_COMMIT_MESSAGE: "chore: update formula for ${{ needs.release-contract.outputs.release_version }}"
+          DWS_TAP_BRANCH: main
+          DWS_TAP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DWS_TAP_COMMIT_MESSAGE: "chore: update formula for ${{ needs.release-contract.outputs.release_version }} [skip ci]"
+          DWS_GIT_NAME: github-actions[bot]
+          DWS_GIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
-      - name: Open beta Homebrew formula PR
+      - name: Publish beta Homebrew formula
+        id: homebrew-beta
         if: ${{ github.repository_owner == 'DingTalk-Real-AI' && needs.release-contract.outputs.channel == 'prerelease' }}
-        run: ./scripts/release/publish-homebrew-formula.sh
+        run: DWS_PUBLISH_OUTPUT="$GITHUB_OUTPUT" "$GITHUB_WORKSPACE/tmp/trusted-release-tooling/scripts/release/publish-homebrew-formula.sh"
         env:
-          DWS_FORMULA_SOURCE: dist/homebrew/dingtalk-workspace-cli-beta.rb
+          DWS_FORMULA_SOURCE: ${{ github.workspace }}/dist/homebrew/dingtalk-workspace-cli-beta.rb
           DWS_TAP_FORMULA_PATH: Formula/dingtalk-workspace-cli-beta.rb
           DWS_TAP_REPO_URL: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli.git
-          DWS_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_PR_TOKEN }}
-          DWS_TAP_PR_REPOSITORY: ${{ github.repository }}
-          DWS_TAP_PR_BRANCH: "automation/homebrew-beta-${{ needs.release-contract.outputs.release_version }}"
-          DWS_TAP_PR_TITLE: "chore: update Homebrew beta formula for ${{ needs.release-contract.outputs.release_version }}"
-          DWS_TAP_COMMIT_MESSAGE: "chore: update beta formula for ${{ needs.release-contract.outputs.release_version }}"
+          DWS_TAP_BRANCH: main
+          DWS_TAP_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DWS_TAP_COMMIT_MESSAGE: "chore: update beta formula for ${{ needs.release-contract.outputs.release_version }} [skip ci]"
+          DWS_GIT_NAME: github-actions[bot]
+          DWS_GIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+
+      - name: Seal Formula-only Code Admission contexts
+        if: ${{ github.repository_owner == 'DingTalk-Real-AI' }}
+        uses: actions/github-script@v7
+        env:
+          FORMULA_CHANGED: ${{ steps.homebrew-stable.outputs.formula_changed || steps.homebrew-beta.outputs.formula_changed }}
+          FORMULA_COMMIT: ${{ steps.homebrew-stable.outputs.published_commit || steps.homebrew-beta.outputs.published_commit }}
+          RELEASE_CHANNEL: ${{ needs.release-contract.outputs.channel }}
+        with:
+          script: |
+            const fs = require("fs");
+            const { owner, repo } = context.repo;
+            const commit = process.env.FORMULA_COMMIT;
+            const formulaChanged = process.env.FORMULA_CHANGED === "true";
+            const channel = process.env.RELEASE_CHANNEL;
+            const version = process.env.RELEASE_VERSION;
+            const formulaPath = channel === "stable"
+              ? "Formula/dingtalk-workspace-cli.rb"
+              : "Formula/dingtalk-workspace-cli-beta.rb";
+            const sourcePath = channel === "stable"
+              ? "dist/homebrew/dingtalk-workspace-cli.rb"
+              : "dist/homebrew/dingtalk-workspace-cli-beta.rb";
+            const expectedMessage = channel === "stable"
+              ? `chore: update formula for ${version} [skip ci]`
+              : `chore: update beta formula for ${version} [skip ci]`;
+
+            if (!/^[0-9a-f]{40}$/.test(commit)) {
+              core.setFailed("Homebrew publisher did not return one full commit SHA");
+              return;
+            }
+            const commitResponse = await github.rest.repos.getCommit({
+              owner,
+              repo,
+              ref: commit,
+              per_page: 100,
+            });
+            const files = commitResponse.data.files || [];
+            const requiredContexts = [
+              "Lint",
+              "Test",
+              "Coverage",
+              "Policy",
+              "Edition",
+              "Interface Integrity",
+              "AI Behavior",
+              "CLI Smoke",
+              "Mock MCP",
+            ];
+            const exactFormulaCommit =
+              commitResponse.data.sha === commit &&
+              commitResponse.data.parents.length === 1 &&
+              commitResponse.data.commit.message === expectedMessage &&
+              commitResponse.data.author?.login === "github-actions[bot]" &&
+              commitResponse.data.committer?.login === "github-actions[bot]" &&
+              files.length === 1 &&
+              files[0].filename === formulaPath &&
+              ["added", "modified"].includes(files[0].status);
+            if (!exactFormulaCommit) {
+              if (formulaChanged) {
+                core.setFailed(
+                  `${commit} is not the exact github-actions Formula-only commit for ${version}`,
+                );
+              } else {
+                core.info("Formula was already current; no Formula-only check sealing is needed.");
+              }
+              return;
+            }
+
+            const parent = commitResponse.data.parents[0].sha;
+            const parentRuns = await github.paginate(github.rest.checks.listForRef, {
+              owner,
+              repo,
+              ref: parent,
+              filter: "latest",
+              per_page: 100,
+            });
+            const latestParentRunByName = new Map();
+            for (const run of parentRuns) {
+              if (
+                run.head_sha !== parent ||
+                run.app?.slug !== "github-actions" ||
+                !requiredContexts.includes(run.name)
+              ) {
+                continue;
+              }
+              const current = latestParentRunByName.get(run.name);
+              if (!current || run.id > current.id) {
+                latestParentRunByName.set(run.name, run);
+              }
+            }
+            const invalidParentContexts = requiredContexts.filter((name) => {
+              const run = latestParentRunByName.get(name);
+              return !run || run.conclusion !== "success";
+            });
+            if (invalidParentContexts.length > 0) {
+              core.setFailed(
+                `Formula commit parent ${parent} lacks successful Code Admission contexts: ` +
+                invalidParentContexts.join(", "),
+              );
+              return;
+            }
+
+            const remoteFormula = await github.rest.repos.getContent({
+              owner,
+              repo,
+              path: formulaPath,
+              ref: commit,
+            });
+            if (
+              Array.isArray(remoteFormula.data) ||
+              remoteFormula.data.type !== "file" ||
+              remoteFormula.data.encoding !== "base64"
+            ) {
+              core.setFailed(`${formulaPath} is not a regular base64 GitHub blob at ${commit}`);
+              return;
+            }
+            const expectedFormula = fs.readFileSync(sourcePath);
+            const actualFormula = Buffer.from(
+              remoteFormula.data.content.replace(/\s/g, ""),
+              "base64",
+            );
+            if (!actualFormula.equals(expectedFormula)) {
+              core.setFailed(`${formulaPath} at ${commit} differs from the verified release Formula`);
+              return;
+            }
+
+            const branch = await github.rest.repos.getBranch({
+              owner,
+              repo,
+              branch: context.payload.repository.default_branch,
+            });
+            const comparison = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${commit}...${branch.data.commit.sha}`,
+            });
+            if (!["ahead", "identical"].includes(comparison.data.status)) {
+              core.setFailed(`${commit} is no longer contained in the default branch`);
+              return;
+            }
+
+            for (const name of requiredContexts) {
+              await github.rest.checks.create({
+                owner,
+                repo,
+                name,
+                head_sha: commit,
+                status: "completed",
+                conclusion: "success",
+                output: {
+                  title: "Verified Formula-only release commit",
+                  summary:
+                    `${formulaPath} was generated from immutable ${version} assets, ` +
+                    "validated byte-for-byte, and was the commit's only changed file.",
+                },
+              });
+            }
 
       - name: Reverify exact immutable npm package
         run: ./scripts/release/verify-package-managers.sh --npm-only --expected-version "$RELEASE_VERSION"
@@ -2049,7 +2146,6 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - dispatch-contract
-      - authorize-recovery
       - governance-preflight
       - release-contract
       - release-validation
@@ -2072,7 +2168,6 @@ jobs:
           DISPATCH_MODE: ${{ needs.dispatch-contract.outputs.mode }}
           GITEE_FALLBACK_ENABLED: ${{ vars.ENABLE_GITEE_UPLOAD_FALLBACK }}
           DISPATCH_RESULT: ${{ needs.dispatch-contract.result }}
-          AUTHORIZE_RECOVERY_RESULT: ${{ needs.authorize-recovery.result }}
           GOVERNANCE_PREFLIGHT_RESULT: ${{ needs.governance-preflight.result }}
           RELEASE_CONTRACT_RESULT: ${{ needs.release-contract.result }}
           RELEASE_VALIDATION_RESULT: ${{ needs.release-validation.result }}
@@ -2116,7 +2211,6 @@ jobs:
           case "$EVENT_NAME:$DISPATCH_MODE" in
             push:)
               require_result dispatch-contract "$DISPATCH_RESULT" skipped
-              require_result authorize-recovery "$AUTHORIZE_RECOVERY_RESULT" skipped
               require_result governance-preflight "$GOVERNANCE_PREFLIGHT_RESULT" skipped
               require_result repair-npm "$REPAIR_NPM_RESULT" skipped
               require_result repair-channel "$REPAIR_CHANNEL_RESULT" skipped
@@ -2128,7 +2222,6 @@ jobs:
               require_result governance-preflight "$GOVERNANCE_PREFLIGHT_RESULT" success
               require_result release-plan "$RELEASE_PLAN_RESULT" success
               require_result seal-release "$SEAL_RELEASE_RESULT" success
-              require_result authorize-recovery "$AUTHORIZE_RECOVERY_RESULT" skipped
               require_result repair-npm "$REPAIR_NPM_RESULT" skipped
               require_result repair-channel "$REPAIR_CHANNEL_RESULT" skipped
               require_publication
@@ -2137,7 +2230,6 @@ jobs:
               require_result dispatch-contract "$DISPATCH_RESULT" success
               require_result release-plan "$RELEASE_PLAN_RESULT" success
               require_result seal-release "$SEAL_RELEASE_RESULT" skipped
-              require_result authorize-recovery "$AUTHORIZE_RECOVERY_RESULT" skipped
               require_result governance-preflight "$GOVERNANCE_PREFLIGHT_RESULT" skipped
               require_result release-contract "$RELEASE_CONTRACT_RESULT" skipped
               require_result release-validation "$RELEASE_VALIDATION_RESULT" skipped
@@ -2151,7 +2243,6 @@ jobs:
               ;;
             workflow_dispatch:recover_release)
               require_result dispatch-contract "$DISPATCH_RESULT" success
-              require_result authorize-recovery "$AUTHORIZE_RECOVERY_RESULT" success
               require_result governance-preflight "$GOVERNANCE_PREFLIGHT_RESULT" skipped
               require_result repair-npm "$REPAIR_NPM_RESULT" skipped
               require_result repair-channel "$REPAIR_CHANNEL_RESULT" skipped
@@ -2161,7 +2252,6 @@ jobs:
             workflow_dispatch:governance_preflight)
               require_result dispatch-contract "$DISPATCH_RESULT" success
               require_result governance-preflight "$GOVERNANCE_PREFLIGHT_RESULT" success
-              require_result authorize-recovery "$AUTHORIZE_RECOVERY_RESULT" skipped
               require_result release-contract "$RELEASE_CONTRACT_RESULT" skipped
               require_result release-validation "$RELEASE_VALIDATION_RESULT" skipped
               require_result release "$RELEASE_RESULT" skipped
@@ -2176,7 +2266,6 @@ jobs:
             workflow_dispatch:repair_npm)
               require_result dispatch-contract "$DISPATCH_RESULT" success
               require_result repair-npm "$REPAIR_NPM_RESULT" success
-              require_result authorize-recovery "$AUTHORIZE_RECOVERY_RESULT" skipped
               require_result governance-preflight "$GOVERNANCE_PREFLIGHT_RESULT" skipped
               require_result release-contract "$RELEASE_CONTRACT_RESULT" skipped
               require_result release-validation "$RELEASE_VALIDATION_RESULT" skipped
@@ -2191,7 +2280,6 @@ jobs:
             workflow_dispatch:repair_gitee)
               require_result dispatch-contract "$DISPATCH_RESULT" success
               require_result repair-channel "$REPAIR_CHANNEL_RESULT" success
-              require_result authorize-recovery "$AUTHORIZE_RECOVERY_RESULT" skipped
               require_result governance-preflight "$GOVERNANCE_PREFLIGHT_RESULT" skipped
               require_result release-contract "$RELEASE_CONTRACT_RESULT" skipped
               require_result release-validation "$RELEASE_VALIDATION_RESULT" skipped
@@ -2206,7 +2294,6 @@ jobs:
             workflow_dispatch:repair_oss)
               require_result dispatch-contract "$DISPATCH_RESULT" success
               require_result repair-channel "$REPAIR_CHANNEL_RESULT" success
-              require_result authorize-recovery "$AUTHORIZE_RECOVERY_RESULT" skipped
               require_result governance-preflight "$GOVERNANCE_PREFLIGHT_RESULT" skipped
               require_result release-contract "$RELEASE_CONTRACT_RESULT" skipped
               require_result release-validation "$RELEASE_VALIDATION_RESULT" skipped
@@ -2816,10 +2903,94 @@ jobs:
               repo,
               branch: defaultBranch,
             });
-            if (branch.data.commit.sha !== commit) {
-              core.setFailed(`${defaultBranch} moved to ${branch.data.commit.sha}; run the release again`);
+            const currentBranchCommit = branch.data.commit.sha;
+            const branchMoved = branch.data.commit.sha !== commit;
+
+            const currentAttempt = Number(process.env.GITHUB_RUN_ATTEMPT);
+            const requestedById = String(context.payload.sender?.id || "");
+            if (!Number.isSafeInteger(currentAttempt) || currentAttempt < 1 || !/^[1-9]\d*$/.test(requestedById)) {
+              core.setFailed("cloud release request contains an invalid run attempt or requester identity");
               return;
             }
+            const messageForAttempt = (attempt) => [
+              `Release ${version}`,
+              "",
+              `Channel: ${channel}`,
+              ...(fromBeta ? [`From-Beta: ${fromBeta}`] : []),
+              `OSS-Mirror: ${ossMirror}`,
+              `Release-Run: ${context.runId}`,
+              `Release-Run-Attempt: ${attempt}`,
+              `Requested-By: ${context.actor}`,
+              `Requested-By-ID: ${context.payload.sender?.id || ""}`,
+              `Sealed-Commit: ${commit}`,
+              `Workflow-Commit: ${context.sha}`,
+              `Allocation-Fingerprint: ${expectedFingerprint}`,
+            ].join("\n");
+            const retryablePostWriteError = (error) =>
+              error.status === 404 ||
+              error.status === 429 ||
+              (
+                Number.isInteger(error.status) &&
+                error.status >= 500 &&
+                error.status < 600
+              );
+            const postWriteRetryDelaysMs = [0, 1000, 2000, 4000, 8000, 16000];
+            const sleep = (delayMs) =>
+              new Promise((resolve) => setTimeout(resolve, delayMs));
+            const readAfterWrite = async (description, operation) => {
+              let lastError;
+              for (const delayMs of postWriteRetryDelaysMs) {
+                if (delayMs > 0) {
+                  core.info(`${description} is not visible yet; retrying in ${delayMs}ms`);
+                  await sleep(delayMs);
+                }
+                try {
+                  return await operation();
+                } catch (error) {
+                  lastError = error;
+                  if (!retryablePostWriteError(error)) {
+                    throw error;
+                  }
+                }
+              }
+              throw lastError;
+            };
+            const verifyExactTag = async (refResponse, expectedTagObject = "") => {
+              if (refResponse.data.object.type !== "tag") {
+                throw new Error(`${version} does not point to an annotated tag object`);
+              }
+              const tagObject = refResponse.data.object.sha;
+              if (expectedTagObject && tagObject !== expectedTagObject) {
+                throw new Error(
+                  `${version} points to ${tagObject}, expected new tag object ${expectedTagObject}`,
+                );
+              }
+              const tagResponse = await readAfterWrite(
+                `${version} annotated tag object`,
+                () => github.rest.git.getTag({ owner, repo, tag_sha: tagObject }),
+              );
+              const attemptMatches = [
+                ...tagResponse.data.message.matchAll(/^Release-Run-Attempt: ([1-9]\d*)$/gm),
+              ];
+              if (attemptMatches.length !== 1) {
+                throw new Error(`${version} has invalid Release-Run-Attempt metadata`);
+              }
+              const sealedAttempt = Number(attemptMatches[0][1]);
+              if (
+                !Number.isSafeInteger(sealedAttempt) ||
+                sealedAttempt < 1 ||
+                sealedAttempt > currentAttempt ||
+                tagResponse.data.tag !== version ||
+                tagResponse.data.object.type !== "commit" ||
+                tagResponse.data.object.sha !== commit ||
+                tagResponse.data.message !== messageForAttempt(sealedAttempt)
+              ) {
+                throw new Error(
+                  `${version} existing annotated tag is not the exact seal from this workflow run`,
+                );
+              }
+              return tagObject;
+            };
 
             const refs = [];
             for (const prefix of ["tags/v", "tags/withdrawn/v"]) {
@@ -2830,6 +3001,12 @@ jobs:
                 per_page: 100,
               });
               for (const ref of matching) {
+                // A failed-jobs rerun keeps the successful release-plan output.
+                // Ignore only this run's candidate ref while recomputing that
+                // pre-write fingerprint; verify its complete authority below.
+                if (ref.ref === `refs/tags/${version}`) {
+                  continue;
+                }
                 refs.push(`${ref.ref}=${ref.object.sha}`);
               }
             }
@@ -2843,10 +3020,13 @@ jobs:
               return;
             }
 
+            let existingRef = null;
             try {
-              await github.rest.git.getRef({ owner, repo, ref: `tags/${version}` });
-              core.setFailed(`release tag already exists: ${version}`);
-              return;
+              existingRef = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: `tags/${version}`,
+              });
             } catch (error) {
               if (error.status !== 404) throw error;
             }
@@ -2862,66 +3042,121 @@ jobs:
               if (error.status !== 404) throw error;
             }
 
-            const message = [
-              `Release ${version}`,
-              "",
-              `Channel: ${channel}`,
-              ...(fromBeta ? [`From-Beta: ${fromBeta}`] : []),
-              `OSS-Mirror: ${ossMirror}`,
-              `Release-Run: ${context.runId}`,
-              `Release-Run-Attempt: ${process.env.GITHUB_RUN_ATTEMPT}`,
-              `Requested-By: ${context.actor}`,
-              `Requested-By-ID: ${context.payload.sender?.id || ""}`,
-              `Sealed-Commit: ${commit}`,
-              `Workflow-Commit: ${context.sha}`,
-              `Allocation-Fingerprint: ${expectedFingerprint}`,
-            ].join("\n");
-            const tag = await github.rest.git.createTag({
-              owner,
-              repo,
-              tag: version,
-              message,
-              object: commit,
-              type: "commit",
-            });
-            await github.rest.git.createRef({
-              owner,
-              repo,
-              ref: `refs/tags/${version}`,
-              sha: tag.data.sha,
-            });
-
-            const sealedRef = await github.rest.git.getRef({
-              owner,
-              repo,
-              ref: `tags/${version}`,
-            });
-            if (
-              sealedRef.data.object.type !== "tag" ||
-              sealedRef.data.object.sha !== tag.data.sha
-            ) {
-              core.setFailed(`${version} did not seal to the new annotated tag object`);
-              return;
+            if (branchMoved) {
+              if (!existingRef) {
+                core.setFailed(
+                  `${defaultBranch} moved to ${currentBranchCommit} before the tag was created; run the release again`,
+                );
+                return;
+              }
+              const comparison = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${commit}...${currentBranchCommit}`,
+              });
+              if (!["ahead", "identical"].includes(comparison.data.status)) {
+                core.setFailed(
+                  `${version} sealed commit is no longer contained in ${defaultBranch}`,
+                );
+                return;
+              }
             }
-            const sealedTag = await github.rest.git.getTag({
-              owner,
-              repo,
-              tag_sha: tag.data.sha,
-            });
-            if (
-              sealedTag.data.tag !== version ||
-              sealedTag.data.object.type !== "commit" ||
-              sealedTag.data.object.sha !== commit ||
-              sealedTag.data.message !== message
-            ) {
-              core.setFailed(`${version} annotated tag authority differs after creation`);
-              return;
+
+            let sealedTagObject = "";
+            let reusedExistingSeal = false;
+            if (existingRef) {
+              sealedTagObject = await verifyExactTag(existingRef);
+              reusedExistingSeal = true;
+              core.info(
+                `Reusing exact ${version} seal from run ${context.runId}; continuing failed jobs without recovery approval`,
+              );
+            } else {
+              const message = messageForAttempt(currentAttempt);
+              const tag = await github.rest.git.createTag({
+                owner,
+                repo,
+                tag: version,
+                message,
+                object: commit,
+                type: "commit",
+              });
+              if (
+                tag.data.tag !== version ||
+                tag.data.object.type !== "commit" ||
+                tag.data.object.sha !== commit ||
+                tag.data.message !== message
+              ) {
+                core.setFailed(`${version} annotated tag creation response differs from the seal`);
+                return;
+              }
+
+              let createRefResponse = null;
+              let createRefError = null;
+              for (const delayMs of postWriteRetryDelaysMs) {
+                if (delayMs > 0) {
+                  core.info(
+                    `${version} ref creation is not confirmed; retrying in ${delayMs}ms`,
+                  );
+                  await sleep(delayMs);
+                }
+                try {
+                  createRefResponse = await github.rest.git.createRef({
+                    owner,
+                    repo,
+                    ref: `refs/tags/${version}`,
+                    sha: tag.data.sha,
+                  });
+                  break;
+                } catch (error) {
+                  createRefError = error;
+                  if (
+                    error.status !== 422 &&
+                    error.status !== 429 &&
+                    !(Number.isInteger(error.status) && error.status >= 500 && error.status < 600)
+                  ) {
+                    throw error;
+                  }
+                  try {
+                    const observedRef = await github.rest.git.getRef({
+                      owner,
+                      repo,
+                      ref: `tags/${version}`,
+                    });
+                    await verifyExactTag(observedRef, tag.data.sha);
+                    createRefResponse = observedRef;
+                    break;
+                  } catch (observeError) {
+                    if (!retryablePostWriteError(observeError)) {
+                      throw observeError;
+                    }
+                  }
+                }
+              }
+              if (!createRefResponse) {
+                throw createRefError;
+              }
+              if (
+                createRefResponse.data.object.type !== "tag" ||
+                createRefResponse.data.object.sha !== tag.data.sha
+              ) {
+                core.setFailed(`${version} ref creation response differs from the new tag object`);
+                return;
+              }
+
+              const sealedRef = await readAfterWrite(
+                `${version} tag ref`,
+                () => github.rest.git.getRef({ owner, repo, ref: `tags/${version}` }),
+              );
+              sealedTagObject = await verifyExactTag(sealedRef, tag.data.sha);
             }
 
             core.setOutput("release_version", version);
             core.setOutput("release_commit", commit);
-            core.setOutput("release_tag_object", tag.data.sha);
+            core.setOutput("release_tag_object", sealedTagObject);
             await core.summary
               .addHeading("Cloud release sealed")
-              .addRaw(`\`${version}\` → \`${commit}\` (run ${context.runId})`)
+              .addRaw(
+                `\`${version}\` → \`${commit}\` (run ${context.runId}` +
+                `${reusedExistingSeal ? ", exact seal reused" : ""})`,
+              )
               .write();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+### Changed
+
+- **Smoother guarded releases** — publishes verified stable and beta Homebrew Formula updates directly from the release workflow, retries transient tag-ref visibility failures, lets an exact same-run retry reuse its sealed tag, and allows machine-verified rebuild recovery without a separate approval wait.
+
+### Fixed
+
+- **Deterministic Markdown coverage** — replaces timing-dependent temporary-file deletion tests with synchronized file-stat failures so release admission no longer flakes on scheduler timing.
+
 ## [1.0.55-beta.2] - 2026-07-23
 
 This beta validates Wukong capability parity across Chat, Contacts, documents,

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -62,32 +62,32 @@ make lint
 git diff --check
 ```
 
-## Homebrew Formula PR Automation
+## Homebrew Formula Delivery
 
-Official tag releases require the repository Actions secret
-`HOMEBREW_PR_TOKEN`. Prefer a fine-grained personal access token owned by a
-maintainer or release-bot account, limited to this repository with
-`Contents: write` and `Pull requests: write`. If organization policy prevents
-that account from targeting the repository, use a dedicated classic token with
-only the `public_repo` scope. Do not reuse a broad developer token.
+Official releases use the Release workflow's built-in `GITHUB_TOKEN` to update
+exactly one tracked Formula after the immutable GitHub assets and their
+checksums have passed verification. The publisher validates the rendered Ruby,
+commits only the configured Formula path, never force-pushes `main`, and retries
+from a fresh clone up to three times when `main` advances concurrently. Normal
+stable and beta releases do not create a Formula PR and do not require a
+personal PAT or permission canary. Because a built-in-token push does not start
+another CI run, the workflow creates the nine Code Admission checks for the
+Formula-only commit only after proving its sole parent already has all nine
+successful checks and the committed Formula exactly matches this release's
+verified bytes.
 
-Store the dedicated token as the `HOMEBREW_PR_TOKEN` repository Actions secret
-and rotate it before its configured expiration. Replace it immediately if it is
-exposed, its owner loses repository access, or the release-bot ownership
-changes. The Release workflow uses this
-dedicated token only to push an `automation/homebrew-*` branch and open the
-stable or beta Formula PR. It does not push Formula changes directly to `main`.
-The default-branch governance preflight and every tag contract authenticate the
-token before publication, reject over-scoped classic tokens, confirm its
-identity, and run a controlled write canary. The canary pushes a unique
-`automation/homebrew-token-canary-*` branch with a `[skip ci]` commit, creates a
-draft PR, closes it, and deletes the branch with the same token. This proves both
-Contents and Pull requests write access before publication without merging
-anything. The gate also rejects reuse of `RELEASE_GOVERNANCE_TOKEN`.
-No maintainer environment variable is required when creating a tag. Using the
-built-in `GITHUB_TOKEN` is insufficient because organization policy prevents
-Actions from creating pull requests, and its generated PR events may require
-separate workflow approval.
+Repository rules must allow the GitHub Actions integration used by the trusted
+Release workflow to push that Formula-only commit to `main`. This bypass is a
+platform setting and cannot be installed by repository code; keep it scoped to
+the GitHub Actions integration, audit changes to the Release workflow, and do
+not grant an equivalent bypass to a personal PAT. The workflow and publisher
+provide the path restriction; GitHub rulesets do not infer that restriction
+from the token.
+
+`HOMEBREW_PR_TOKEN` remains only for the withdrawal workflow while Homebrew
+rollback still uses an independently reviewed PR. Keep that credential
+repository-scoped with only `Contents: write` and `Pull requests: write`, and
+do not reuse `RELEASE_GOVERNANCE_TOKEN`.
 
 ## Release Governance and Recovery
 
@@ -98,15 +98,14 @@ administration setting and cannot be read by the workflow's built-in
 contract use this same credential so a missing or expired identity is detected
 before an irreversible tag is created.
 
-Create a protected `release-recovery` environment limited to protected
-branches, with a required reviewer, self-review disabled, and administrator
-bypass disabled. The workflow reads the environment through the GitHub API and
-fails closed unless the required-reviewer, prevent-self-review, and protected-
-branch rules are present.
 Recovery is restricted to an existing annotated tag whose exact tag object,
-commit, and failed tag-push run all match; it then reuses the normal release
-jobs. Do not put publication secrets in temporary branches or create ad-hoc
-recovery workflows.
+commit, sealed metadata, original failed run/attempt, requester identity and
+Release state all match; it then reuses the normal release jobs without a
+second-person environment approval. A same-run “Re-run failed jobs” is even
+lighter: the seal job may adopt an existing tag only when its complete
+authority matches that run and its original attempt is not newer than the
+current attempt. Do not put publication secrets in temporary branches or
+create ad-hoc recovery workflows.
 
 Cloud-sealed releases mirror to OSS only when the repository variable
 `ENABLE_OSS_MIRROR` is exactly `true`. Leave the variable unset while no Bucket

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # 发布手册（预发 / 正式）
 
-发布只走一条受控链路：GitHub Actions 的 `Release` workflow 负责版本分配、封板、构建、签名和下游发布；Homebrew 以 workflow 自动创建的 Formula PR 经独立审核合入为交付边界。本地 `dws-release` 仍是兼容入口，但不再要求某一台固定电脑承担打包；不要直接运行 `goreleaser release`，也不要手工补打、移动或复用 tag。
+发布只走一条受控链路：GitHub Actions 的 `Release` workflow 负责版本分配、封板、构建、签名和下游发布；Homebrew Formula 在不可变 Release 资产及 checksum 通过校验后，由同一 workflow 直接写入 `main`，不再创建二次 PR。本地 `dws-release` 仍是兼容入口，但不再要求某一台固定电脑承担打包；不要直接运行 `goreleaser release`，也不要手工补打、移动或复用 tag。
 
 发布前必须完成平台治理：目标 GitHub 仓库已启用 immutable releases，`main` 精确要求 `CI` workflow 的九个 context：`Lint`、`Test`、`Coverage`、`Policy`、`Edition`、`Interface Integrity`、`AI Behavior`、`CLI Smoke`、`Mock MCP`。云端和本地入口都会在封 tag 前检查 immutable releases、当前 SHA 的全部九个 context 和在途 Release；`v*` tag ruleset 仍需仓库管理员预先配置。
 
@@ -13,7 +13,7 @@
 3. workflow summary 会给出唯一的下一版本。把对应的精确 `CHANGELOG.md` 章节通过 PR 合入 `main`。
 4. 再次运行，改为 `release_operation=publish`，并输入 `PUBLISH beta` 或 `PUBLISH stable`。
 
-`plan` 是纯只读操作，不创建 tag、预留版本号或生成包。CHANGELOG 合入期间若另一个发布先占用了该版本，`publish` 会重新分配并因 CHANGELOG 章节不匹配而拒绝，需要重新 plan。`publish` 会先再次确认 dispatch SHA 仍是当前 `main`、Code Admission 和平台治理均通过，再由唯一的 write job 使用 GitHub API 原子创建 annotated tag；同一次 run 随即进入既有的跨平台构建、GitHub/npm、可选 OSS/Gitee 发布和 Homebrew PR DAG。内置 `GITHUB_TOKEN` 创建的 tag 不依赖第二条 workflow 被再次触发。
+`plan` 是纯只读操作，不创建 tag、预留版本号或生成包。CHANGELOG 合入期间若另一个发布先占用了该版本，`publish` 会重新分配并因 CHANGELOG 章节不匹配而拒绝，需要重新 plan。`publish` 会先再次确认 dispatch SHA 仍是当前 `main`、Code Admission 和平台治理均通过，再由唯一的 write job 使用 GitHub API 原子创建 annotated tag；同一次 run 随即进入既有的跨平台构建、GitHub/npm、可选 OSS/Gitee 发布和 Homebrew 直交付 DAG。内置 `GITHUB_TOKEN` 创建的 tag 不依赖第二条 workflow 被再次触发。
 
 为缩短封板前后的关键路径，`publish` 的只读版本规划会与平台治理检查并行，seal 仍严格等待二者成功；plan 在 candidate annotated tag 上验证过的 contract 和 stable/beta baseline 会绑定进 seal，并由 seal 后的 tag authority 检查复用。Code Admission 状态与 immutable-releases 治理仍会在 seal 后再次读取，避免 preflight 与发布之间的状态变化被忽略。随后三类只读门禁（release automation、命令兼容性、multi-profile E2E）与 GoReleaser 构建并行；Node/archive 等仅供后处理使用的工具也延后到构建完成后安装。并行和已验证结果复用只改变调度，不降低发布门禁：任何一条验证失败都会阻止 GitHub Release、npm、镜像和 Homebrew 发布，delivery proof 也要求三条验证 job 全部成功。
 
@@ -132,14 +132,14 @@ dws-release v1.2.3 --from-beta v1.2.3-beta.1 --publish
 
 ## CI/CD 保证
 
-- 只接受 `vX.Y.Z-beta.N` 和 `vX.Y.Z`，且新版本必须高于上一正式版。这里的“上一正式版”必须同时具备公开非草稿 GitHub Release 和同 tag/commit 的成功 Release workflow；只有 tag、没有交付成功的孤儿版本会阻断后续发布，要求走受保护恢复补齐。云端 tag 会固定 `Release-Run`、requester、commit 和版本分配指纹，交付验证按该精确 run/attempt 及完整 job graph 取证，不接受任意 `workflow_dispatch`。历史版本若曾通过专用 recovery workflow 完成交付，只能使用仓库内 `delivered-stable-recoveries.json` 中精确到 tag、commit、run、workflow SHA 与 attempt 的 reviewed 证据。
+- 只接受 `vX.Y.Z-beta.N` 和 `vX.Y.Z`，且新版本必须高于上一正式版。这里的“上一正式版”必须同时具备公开非草稿 GitHub Release 和同 tag/commit 的成功 Release workflow；只有 tag、没有交付成功的孤儿版本会阻断后续发布，要求走机器核验恢复补齐。云端 tag 会固定 `Release-Run`、requester、commit 和版本分配指纹，交付验证按该精确 run/attempt 及完整 job graph 取证，不接受任意 `workflow_dispatch`。历史版本若曾通过专用 recovery workflow 完成交付，只能使用仓库内 `delivered-stable-recoveries.json` 中精确到 tag、commit、run、workflow SHA 与 attempt 的 reviewed 证据。
 - tag 必须是 annotated tag；本地脚本要求封板提交已通过 PR 合入并包含在远端 `main` 历史中，发布只推送 tag。CI 允许其后 `main` 继续前进，但始终要求封板提交位于 `main` 历史中。
 - 日常 CI 和发布前都会对比“最新已交付正式版”的完整命令树；若长时间预检期间该 baseline 发生变化，会针对新的 baseline 重新比较。
 - GoReleaser 只构建；Darwin 重签、checksums 重算和 npm 安装验证通过后，才统一上传 GitHub Release 的最终产物。
 - 六个平台归档会逐个解包并核验二进制内嵌版本；公开资产集合、checksums 集合和 npm tarball integrity 都必须精确一致。npm tarball 固定由 npm `10.9.2` 打包，避免重跑时因 runner 自带 npm 漂移产生不同字节。
 - stable 发布到 npm `latest`；prerelease 发布到 npm `beta`。启用 `ENABLE_OSS_MIRROR=true` 后，stable 同步 OSS `latest.txt` 和共享安装脚本，prerelease 只同步 OSS `beta.txt`，不会覆盖稳定入口。
 - Release workflow 使用一个最多容纳 100 个 pending run 的串行 publication queue；版本规划、云端封板、发布、恢复、修复和撤回共享同一发布锁。
-- 本地 tag push 失败时会删除本次新建的本地 tag。远端 tag 一旦创建，后续发布归 CI 所有；发布中途失败时走受保护恢复，禁止改 tag 指向或复用版本号。只有已经公开版本经过受保护的全渠道撤回并留下永久 `withdrawn/...` 墓碑后，撤回 workflow 才会在最后一步删除原 tag。
+- 本地 tag push 失败时会删除本次新建的本地 tag。远端 tag 一旦创建，后续发布归 CI 所有；发布中途失败时先重跑同一 run 的失败 jobs，必须跨 run 时走机器核验恢复，禁止改 tag 指向或复用版本号。只有已经公开版本经过受保护的全渠道撤回并留下永久 `withdrawn/...` 墓碑后，撤回 workflow 才会在最后一步删除原 tag。
 
 npm 补发只允许从默认分支触发 Release workflow 的 `repair_npm_version`。它只支持启用 immutable releases 后、由本流水线成功产出的公开 immutable release：目标必须是 `main` 历史中的 annotated tag，并且同 commit 的 `Build immutable GitHub Release` job 已成功。即使后续 npm 分发失败，这个独立的产物封存边界仍可作为补发依据。补发会用目标 commit 的 npm 模板重组包，逐平台核验资产和二进制版本，再发布到隔离的 `backfill` dist-tag，不会回滚 `latest` / `beta`。历史 mutable release 不进入自动补发路径，避免把可被替换的资产带入 npm。
 
@@ -166,17 +166,17 @@ dws-release recover v1.2.3-beta.1
 
 - 输入精确绑定原 annotated tag object、commit 和失败的 sealed `Release` run；云端 run 还必须与 tag 内的 run ID、attempt、requester 完全一致，commit 必须仍在 `main` 历史中。
 - 目标只允许不存在 GitHub Release 或仍为 Draft；已经公开的版本不能全量重建：单个下游故障走对应的 channel repair，版本本身有问题则走受保护的全平台 withdrawal。
-- `release-recovery` environment 必须限制为受保护分支、配置至少一名 required reviewer，并禁止自审；workflow 会通过 API 复核这些设置，未配置时 fail closed。
+- 恢复不再进入人工审批 environment。workflow 会机器核验 tag object、commit、原失败 run/attempt、请求人、完整 seal metadata、`main` 祖先关系以及 Release 状态；任一事实不一致都会在构建前 fail closed。
 - 恢复复用正常的 contract、构建、Developer ID 签名、资产校验、immutable 发布、Homebrew、npm，以及已启用的 OSS jobs，不存在 recovery 专用 publisher 或门禁跳过。
 - 如果 GitHub Release 已在 recovery 中封存、后续 Homebrew/npm 校验发生瞬时失败，只重跑该 run 的 failed jobs；流水线仅在隐藏 run marker、tag object、commit 和 finalized artifact 字节全部精确一致时复用公开 Release。
 
 成功的默认分支恢复 run 会成为后续 beta → stable 和 stable baseline 验证的可审计交付证据；历史临时分支恢复仍只接受 reviewed manifest 中的固定证据。
 
-云端 seal 后不要使用 GitHub 的 “Re-run failed jobs” 作为交付修复：annotated tag 永久绑定最初的 run attempt，普通 rerun 不会成为可接受的交付证据。GitHub Release 尚未公开时走上述 protected recovery；已经公开且仅 npm/OSS/Gitee 某一渠道失败时走对应 repair；版本内容本身有问题时走 withdrawal。
+seal job 写入 tag 后如果只因 GitHub API 瞬时 404/429/5xx 或后续 job 失败，可直接使用 GitHub 的 “Re-run failed jobs”。同一 run 会精确复用原 release-plan；seal 只在 version、tag object、commit、channel、beta 来源、OSS policy、请求人、run ID 和完整 message 全部匹配且原 attempt 不大于当前 attempt 时认领已有 tag。不同 run 或任一字段不匹配时不会认领。GitHub Release 尚未公开且必须跨 run 重建时走上述机器核验 recovery；已经公开且仅 npm/OSS/Gitee 某一渠道失败时走对应 repair；版本内容本身有问题时走 withdrawal。
 
 OSS 的 `latest.txt` / `beta.txt` 是镜像频道元数据；当前仓库安装器仍主要从 GitHub/Gitee 解析版本。启用 OSS 后，发布和撤回把它作为受控分发渠道处理，保证一旦外部消费者接入该 pointer，也不会继续解析到已撤回版本；未启用时两条流程都明确跳过不存在的 OSS 渠道。
 
-Release workflow 会生成 Darwin/Linux 双架构 Formula，并分别为 stable/beta 打开 Homebrew PR；tap 的默认分支仍以独立审核合入为交付边界。撤回 workflow 使用相同模板和回退版本 checksums 打开反向 PR；问题 GitHub Release 会先被移除以阻止新安装，永久墓碑和 workflow 日志承担审计/续跑依据。
+Release workflow 会生成 Darwin/Linux 双架构 Formula，并在不可变资产逐个校验后，只提交对应 stable 或 beta Formula 文件到 `main`；并发 `main` 更新会以全新 clone 最多重试三次，绝不 force push。由于 `GITHUB_TOKEN` 的 push 不会启动另一轮 CI，workflow 只在确认该 commit 单父、唯一改动为目标 Formula、内容与本次已验证产物逐字节一致，且父 commit 九项 Code Admission 全绿后，直接为 Formula-only commit 封存同名九项成功 checks，避免下一次发布因缺失 contexts 被卡住。撤回 workflow 暂时仍使用相同模板和回退版本 checksums 打开反向 PR；问题 GitHub Release 会先被移除以阻止新安装，永久墓碑和 workflow 日志承担审计/续跑依据。
 
 ## 平台治理前置
 
@@ -189,9 +189,9 @@ Release workflow 会生成 Darwin/Linux 双架构 Formula，并分别为 stable/
 - 配置 `APPLE_CERTIFICATE_P12_BASE64`、`APPLE_CERTIFICATE_PASSWORD` 和具备发布权限的 `NPM_TOKEN`；撤回还要求该 npm 身份能够执行 `deprecate` 和修改 dist-tag。
 - 启用 OSS 镜像时，先创建有效 Bucket，再设置仓库变量 `ENABLE_OSS_MIRROR=true`，并配置 `OSS_ACCESS_KEY_ID`、`OSS_ACCESS_KEY_SECRET`、`OSS_ENDPOINT`、`OSS_BUCKET`，按需配置 `OSS_PREFIX`。启用后发布保持 fail-closed；撤回身份必须能够补齐安全版本资产、写 `latest.txt` / `beta.txt` 并删除问题版本前缀。尚未 provision Bucket 时保持该变量未设置或不等于 `true`，新 tag 会封存 `OSS-Mirror: deferred` 并跳过 OSS；该版本不能通过现有 repair 流程事后改成启用。
 - 若启用 Gitee fallback，设置 `ENABLE_GITEE_UPLOAD_FALLBACK=true`，并配置 `GITEE_TOKEN`、`GITEE_USER`、`GITEE_REPO`；该身份必须能够创建和删除目标仓库的 Release 与 tag。
-- 单独配置 `HOMEBREW_PR_TOKEN`，优先使用仅授权本仓库且具备 `Contents: write`、`Pull requests: write` 的 fine-grained PAT；若组织策略不允许该账号使用 fine-grained PAT，则回退到仅带 `public_repo` scope 的专用 classic PAT。治理预检和 tag contract 会验证 token 身份、classic scope，并用 `[skip ci]` 临时分支和 draft PR 完成真实写权限 canary，随后立即关闭 PR、删除分支；任何清理失败都会 fail closed。门禁也会拒绝与治理 token 复用。
-- 创建 `release-recovery` environment，只允许受保护分支，设置 required reviewer、禁止自审并关闭管理员绕过。workflow 会读取 environment 的 required-reviewer、prevent-self-review 和 protected-branch 规则；规则缺失时紧急恢复会失败，正常 beta/stable tag 发布不受影响。
+- 正常 Homebrew 发布使用 Release workflow 自带的 `GITHUB_TOKEN`，不需要 `HOMEBREW_PR_TOKEN`。为 GitHub Actions integration 配置默认分支规则的受控 bypass，使受信任的 Release workflow 能直接提交 Formula-only commit；仓库脚本会限制提交路径、校验 Ruby、禁止 force push，并在并发更新时重新基于最新 `main`。平台 bypass 无法由仓库代码自动创建或收窄，必须由管理员完成并定期审计。
+- `HOMEBREW_PR_TOKEN` 仅在撤回流程仍需创建回退 PR 时使用；应保持最小 `Contents: write` 与 `Pull requests: write` 权限，不得与治理 token 复用。
 - 创建 `release-withdrawal` environment，只允许受保护分支，设置至少一名 required reviewer、禁止申请人自审并关闭管理员绕过。撤回 workflow 会通过 API 复核这些规则；任何一项缺失都会在触碰 npm、OSS、Gitee、Homebrew 或 GitHub Release 前失败。
-- 仓库或组织的 Actions 策略必须允许 `Release` 与 `Withdraw release` workflow 的 `GITHUB_TOKEN` 获得各 job 声明的 `contents: write`。若上述发布凭证采用 environment secret，确认 `release-withdrawal` 审批完成后能够读取撤回所需的 npm、OSS、Gitee 和 Homebrew 凭证。
+- 仓库或组织的 Actions 策略必须允许 `Release` 与 `Withdraw release` workflow 的 `GITHUB_TOKEN` 获得各 job 声明的 `contents: write`；Release 的 GitHub Actions identity 还必须能够直接更新两个受控 Formula 路径。若撤回凭证采用 environment secret，确认 `release-withdrawal` 审批完成后能够读取撤回所需的 npm、OSS、Gitee 和 Homebrew 凭证。
 
 immutable releases，或任一 Code Admission context 缺失、未成功时，发布脚本会自动拒绝封 tag。tag ruleset 可能来自组织层，脚本不自动推断其最终作用范围；管理员确认不能省略，脚本约定也不能替代平台强制。

--- a/internal/helpers/markdown.go
+++ b/internal/helpers/markdown.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var markdownUploadStat = os.Stat
+
 func newMarkdownCommand() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "markdown",
@@ -257,7 +259,7 @@ func runMarkdownCreate(cmd *cobra.Command, _ []string) error {
 	if !hasMarkdownExtension(nameFlag) {
 		return fmt.Errorf("--name 必须以 .md 结尾，当前: %s", nameFlag)
 	}
-	info, err := os.Stat(uploadPath)
+	info, err := markdownUploadStat(uploadPath)
 	if err != nil {
 		return fmt.Errorf("读取上传文件失败: %w", err)
 	}
@@ -421,7 +423,7 @@ func runMarkdownOverwrite(cmd *cobra.Command, _ []string) error {
 	if !hasMarkdownExtension(nameFlag) {
 		return fmt.Errorf("--name 必须以 .md 结尾，当前: %s", nameFlag)
 	}
-	info, err := os.Stat(uploadPath)
+	info, err := markdownUploadStat(uploadPath)
 	if err != nil {
 		return fmt.Errorf("读取上传文件失败: %w", err)
 	}
@@ -563,7 +565,7 @@ func runMarkdownPatch(cmd *cobra.Command, _ []string) error {
 	if err := os.WriteFile(uploadPath, []byte(newContent), 0o600); err != nil {
 		return fmt.Errorf("写入临时文件失败: %w", err)
 	}
-	info, err := os.Stat(uploadPath)
+	info, err := markdownUploadStat(uploadPath)
 	if err != nil {
 		return fmt.Errorf("读取临时文件失败: %w", err)
 	}

--- a/internal/helpers/markdown_ci_coverage_test.go
+++ b/internal/helpers/markdown_ci_coverage_test.go
@@ -12,10 +12,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -26,47 +24,58 @@ func (markdownCIFailingReader) Read([]byte) (int, error) {
 	return 0, errors.New("forced read failure")
 }
 
-func startMarkdownCITempFileRemover(t *testing.T, root, dirPrefix, fileName string) <-chan error {
+func installMarkdownCITempFileDisappearance(t *testing.T) {
 	t.Helper()
-	result := make(chan error, 1)
-	go func() {
-		deadline := time.Now().Add(10 * time.Second)
-		for time.Now().Before(deadline) {
-			entries, err := os.ReadDir(root)
-			if err != nil {
-				result <- err
-				return
-			}
-			for _, entry := range entries {
-				if !entry.IsDir() || !strings.HasPrefix(entry.Name(), dirPrefix) {
-					continue
-				}
-				target := filepath.Join(root, entry.Name(), fileName)
-				if err := os.Remove(target); err == nil {
-					result <- nil
-					return
-				} else if !os.IsNotExist(err) {
-					result <- err
-					return
-				}
-			}
-			runtime.Gosched()
+	original := markdownUploadStat
+	markdownUploadStat = func(path string) (os.FileInfo, error) {
+		if err := os.Remove(path); err != nil {
+			return nil, err
 		}
-		result <- fmt.Errorf("timed out waiting for %s/%s", dirPrefix, fileName)
-	}()
-	return result
+		return os.Stat(path)
+	}
+	t.Cleanup(func() { markdownUploadStat = original })
 }
 
-func waitMarkdownCIRemover(t *testing.T, result <-chan error) {
-	t.Helper()
-	select {
-	case err := <-result:
-		if err != nil {
-			t.Fatal(err)
+func TestCrossPlatformCoverageMarkdownUploadStatFailures(t *testing.T) {
+	t.Run("create", func(t *testing.T) {
+		installMarkdownDriveDeps(t, &markdownDriveCaller{format: "json"})
+		installMarkdownCITempFileDisappearance(t)
+		err := executeMarkdownDriveCommand(t, newMarkdownCommand(), nil,
+			"markdown", "create", "--name", "a.md", "--content", "body")
+		if err == nil || !strings.Contains(err.Error(), "读取上传文件失败") {
+			t.Fatalf("error = %v", err)
 		}
-	case <-time.After(12 * time.Second):
-		t.Fatal("timed out waiting for temporary-file remover")
-	}
+	})
+
+	t.Run("overwrite", func(t *testing.T) {
+		installMarkdownDriveDeps(t, &markdownDriveCaller{format: "json"})
+		installMarkdownCITempFileDisappearance(t)
+		err := executeMarkdownDriveCommand(t, newMarkdownCommand(), nil,
+			"markdown", "overwrite", "--node", "node-1", "--space-id", "space-1",
+			"--name", "a.md", "--content", "body")
+		if err == nil || !strings.Contains(err.Error(), "读取上传文件失败") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("patch", func(t *testing.T) {
+		caller := &markdownDriveCaller{
+			format: "json",
+			steps: []markdownDriveStep{
+				{text: `{"downloadUrl":"https://download.test/current.md","fileName":"current.md"}`},
+				{text: `{"fileName":"current.md"}`},
+			},
+		}
+		installMarkdownDriveDeps(t, caller)
+		installMarkdownHTTPGet(t, "old")
+		installMarkdownCITempFileDisappearance(t)
+		err := executeMarkdownDriveCommand(t, newMarkdownCommand(), nil,
+			"markdown", "patch", "--node", "node-1", "--space-id", "space-1",
+			"--pattern", "old", "--content", "new", "--yes")
+		if err == nil || !strings.Contains(err.Error(), "读取临时文件失败") {
+			t.Fatalf("error = %v", err)
+		}
+	})
 }
 
 func TestMarkdownCICoverageFetchAndOutputPaths(t *testing.T) {
@@ -189,13 +198,9 @@ func TestMarkdownCICoverageCreateEdges(t *testing.T) {
 
 	t.Run("temporary file disappears before stat", func(t *testing.T) {
 		installMarkdownDriveDeps(t, &markdownDriveCaller{format: "json"})
-		tempRoot := t.TempDir()
-		t.Setenv("TMPDIR", tempRoot)
-		removed := startMarkdownCITempFileRemover(t, tempRoot, "dws-markdown-create-", "a.md")
-		content := strings.Repeat("x", 16<<20)
+		installMarkdownCITempFileDisappearance(t)
 		err := executeMarkdownDriveCommand(t, newMarkdownCommand(), nil,
-			"markdown", "create", "--name", "a.md", "--content", content)
-		waitMarkdownCIRemover(t, removed)
+			"markdown", "create", "--name", "a.md", "--content", "body")
 		if err == nil || !strings.Contains(err.Error(), "读取上传文件失败") {
 			t.Fatalf("error = %v", err)
 		}
@@ -270,14 +275,10 @@ func TestMarkdownCICoverageOverwriteEdges(t *testing.T) {
 
 	t.Run("temporary file disappears before stat", func(t *testing.T) {
 		installMarkdownDriveDeps(t, &markdownDriveCaller{format: "json"})
-		tempRoot := t.TempDir()
-		t.Setenv("TMPDIR", tempRoot)
-		removed := startMarkdownCITempFileRemover(t, tempRoot, "dws-markdown-overwrite-", "a.md")
-		content := strings.Repeat("x", 16<<20)
+		installMarkdownCITempFileDisappearance(t)
 		err := executeMarkdownDriveCommand(t, newMarkdownCommand(), nil,
 			"markdown", "overwrite", "--node", "node-1", "--space-id", "space-1",
-			"--name", "a.md", "--content", content)
-		waitMarkdownCIRemover(t, removed)
+			"--name", "a.md", "--content", "body")
 		if err == nil || !strings.Contains(err.Error(), "读取上传文件失败") {
 			t.Fatalf("error = %v", err)
 		}
@@ -451,14 +452,10 @@ func TestMarkdownCICoveragePatchEdges(t *testing.T) {
 		}
 		installMarkdownDriveDeps(t, caller)
 		installMarkdownHTTPGet(t, "old")
-		tempRoot := t.TempDir()
-		t.Setenv("TMPDIR", tempRoot)
-		removed := startMarkdownCITempFileRemover(t, tempRoot, "dws-markdown-patch-", "current.md")
-		replacement := strings.Repeat("x", 16<<20)
+		installMarkdownCITempFileDisappearance(t)
 		err := executeMarkdownDriveCommand(t, newMarkdownCommand(), nil,
 			"markdown", "patch", "--node", "node-1", "--space-id", "space-1",
-			"--pattern", "old", "--content", replacement, "--yes")
-		waitMarkdownCIRemover(t, removed)
+			"--pattern", "old", "--content", "new", "--yes")
 		if err == nil || !strings.Contains(err.Error(), "读取临时文件失败") {
 			t.Fatalf("error = %v", err)
 		}

--- a/scripts/release/publish-homebrew-formula.sh
+++ b/scripts/release/publish-homebrew-formula.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/../.." && pwd)"
 FORMULA_SOURCE="${DWS_FORMULA_SOURCE:-$ROOT/dist/homebrew/dingtalk-workspace-cli.rb}"
 TAP_REPO_URL="${DWS_TAP_REPO_URL:-}"
 TAP_BRANCH="${DWS_TAP_BRANCH:-main}"
@@ -14,6 +14,7 @@ PR_TITLE="${DWS_TAP_PR_TITLE:-chore: update Homebrew formula}"
 COMMIT_MESSAGE="${DWS_TAP_COMMIT_MESSAGE:-chore: update dingtalk-workspace-cli formula}"
 GIT_NAME="${DWS_GIT_NAME:-DWS Release Bot}"
 GIT_EMAIL="${DWS_GIT_EMAIL:-dws-release-bot@example.com}"
+PUBLISH_OUTPUT="${DWS_PUBLISH_OUTPUT:-${GITHUB_OUTPUT:-}}"
 
 say() {
   printf '%s\n' "$*"
@@ -36,6 +37,15 @@ need_env() {
   name="$1"
   value="$2"
   [ -n "$value" ] || err "missing required environment variable: $name"
+}
+
+record_direct_result() {
+  changed="$1"
+  commit="$2"
+  [ -z "$PUBLISH_OUTPUT" ] || {
+    printf 'formula_changed=%s\npublished_commit=%s\n' "$changed" "$commit" \
+      >> "$PUBLISH_OUTPUT"
+  }
 }
 
 checkout_tap_branch() {
@@ -87,6 +97,7 @@ if [ -n "$TAP_SSH_KEY" ]; then
 fi
 if [ -n "$TAP_GITHUB_TOKEN" ]; then
   ASKPASS="$TMP_ROOT/git-askpass.sh"
+  # shellcheck disable=SC2016 # Preserve variables for the generated helper.
   printf '%s\n' \
     '#!/bin/sh' \
     'case "$1" in' \
@@ -105,7 +116,70 @@ if [ -n "$PR_REPOSITORY" ] || [ -n "$PR_BRANCH" ]; then
   need_cmd gh
 fi
 
-TAP_DIR="$TMP_ROOT/tap"
+if [ -z "$PR_REPOSITORY" ]; then
+  case "$TAP_FORMULA_PATH" in
+    Formula/dingtalk-workspace-cli.rb|Formula/dingtalk-workspace-cli-beta.rb) ;;
+    *) err "direct Homebrew publication is restricted to the stable or beta DWS Formula" ;;
+  esac
+  attempt=1
+  max_attempts=3
+  while [ "$attempt" -le "$max_attempts" ]; do
+    TAP_DIR="$TMP_ROOT/tap-direct-$attempt"
+    checkout_tap_branch "$TAP_REPO_URL" "$TAP_BRANCH" "$TAP_DIR"
+
+    DEST_PATH="$TAP_DIR/$TAP_FORMULA_PATH"
+    mkdir -p "$(dirname "$DEST_PATH")"
+    cp "$FORMULA_SOURCE" "$DEST_PATH"
+
+    if (
+      cd "$TAP_DIR" || exit $?
+      formula_status="$(git status --porcelain --untracked-files=all)" || exit $?
+      if [ -z "$formula_status" ]; then
+        formula_commit="$(git log -1 --format=%H -- "$TAP_FORMULA_PATH")" || exit $?
+        [ -n "$formula_commit" ] ||
+          err "could not resolve the existing commit for $TAP_FORMULA_PATH"
+        record_direct_result false "$formula_commit" || exit $?
+        exit 20
+      fi
+      case "$formula_status" in
+        " M $TAP_FORMULA_PATH"|"?? $TAP_FORMULA_PATH") ;;
+        *) err "direct Homebrew publication may change only $TAP_FORMULA_PATH" ;;
+      esac
+      git config user.name "$GIT_NAME" || exit $?
+      git config user.email "$GIT_EMAIL" || exit $?
+      git add "$TAP_FORMULA_PATH" || exit $?
+      staged_paths="$(git diff --cached --name-only)" || exit $?
+      [ "$staged_paths" = "$TAP_FORMULA_PATH" ] ||
+        err "staged Homebrew publication contains files other than $TAP_FORMULA_PATH"
+      git commit -m "$COMMIT_MESSAGE" >/dev/null || exit $?
+      committed_paths="$(git diff-tree --no-commit-id --name-only -r HEAD)" || exit $?
+      [ "$committed_paths" = "$TAP_FORMULA_PATH" ] ||
+        err "Homebrew publication commit contains files other than $TAP_FORMULA_PATH"
+      # Never force the tap's default branch. A concurrent main update gets a
+      # fresh clone and a newly based Formula-only commit on the next attempt.
+      git push origin "HEAD:$TAP_BRANCH" >/dev/null || exit $?
+      published_commit="$(git rev-parse HEAD)" || exit $?
+      record_direct_result true "$published_commit" || exit $?
+    ); then
+      say "Published Homebrew formula to $TAP_REPO_URL ($TAP_BRANCH)"
+      exit 0
+    else
+      status=$?
+    fi
+
+    if [ "$status" -eq 20 ]; then
+      say "No formula changes to publish."
+      exit 0
+    fi
+    if [ "$attempt" -eq "$max_attempts" ]; then
+      err "could not publish Homebrew formula after $max_attempts non-forced attempts"
+    fi
+    say "Homebrew target branch moved or rejected the update; retrying from a fresh clone."
+    attempt=$((attempt + 1))
+  done
+fi
+
+TAP_DIR="$TMP_ROOT/tap-pr"
 checkout_tap_branch "$TAP_REPO_URL" "$TAP_BRANCH" "$TAP_DIR"
 
 DEST_PATH="$TAP_DIR/$TAP_FORMULA_PATH"
@@ -123,34 +197,24 @@ cp "$FORMULA_SOURCE" "$DEST_PATH"
   git config user.email "$GIT_EMAIL"
   git add "$TAP_FORMULA_PATH"
   git commit -m "$COMMIT_MESSAGE" >/dev/null
-
-  if [ -n "$PR_REPOSITORY" ]; then
-    git push --force-with-lease origin "HEAD:$PR_BRANCH" >/dev/null
+  git push --force-with-lease origin "HEAD:$PR_BRANCH" >/dev/null
+  pr_url="$(
+    GH_TOKEN="$TAP_GITHUB_TOKEN" gh pr list \
+      --repo "$PR_REPOSITORY" \
+      --head "$PR_BRANCH" \
+      --state open \
+      --json url \
+      --jq '.[0].url'
+  )"
+  if [ -z "$pr_url" ]; then
     pr_url="$(
-      GH_TOKEN="$TAP_GITHUB_TOKEN" gh pr list \
+      GH_TOKEN="$TAP_GITHUB_TOKEN" gh pr create \
         --repo "$PR_REPOSITORY" \
+        --base "$TAP_BRANCH" \
         --head "$PR_BRANCH" \
-        --state open \
-        --json url \
-        --jq '.[0].url'
+        --title "$PR_TITLE" \
+        --body "Automated Homebrew Formula update. Merge after required checks pass."
     )"
-    if [ -z "$pr_url" ]; then
-      pr_url="$(
-        GH_TOKEN="$TAP_GITHUB_TOKEN" gh pr create \
-          --repo "$PR_REPOSITORY" \
-          --base "$TAP_BRANCH" \
-          --head "$PR_BRANCH" \
-          --title "$PR_TITLE" \
-          --body "Automated Homebrew Formula update. Merge after required checks pass."
-      )"
-    fi
-    say "Opened Homebrew formula PR: $pr_url"
-    exit 0
   fi
-
-  git push origin "HEAD:$TAP_BRANCH" >/dev/null
+  say "Opened Homebrew formula PR: $pr_url"
 )
-
-if [ -z "$PR_REPOSITORY" ]; then
-  say "Published Homebrew formula to $TAP_REPO_URL ($TAP_BRANCH)"
-fi

--- a/scripts/release/recover-release.sh
+++ b/scripts/release/recover-release.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 set -eu
 
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
 . "$SCRIPT_DIR/release-lib.sh"
-ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
+ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../.." && pwd)"
 
 VERSION="${1:-}"
 REMOTE=""
@@ -247,7 +248,7 @@ printf '  commit:     %s\n' "$commit"
 printf '  failed run: https://github.com/%s/actions/runs/%s/attempts/%s\n' \
   "$EXPECTED_REPOSITORY" "$FAILED_RUN_ID" "$FAILED_RUN_ATTEMPT"
 [ -t 0 ] || { printf '%s\n' 'interactive recovery confirmation is required' >&2; exit 1; }
-printf 'Type %s to request protected recovery: ' "$VERSION"
+printf 'Type %s to request machine-verified recovery: ' "$VERSION"
 IFS= read -r confirmation
 [ "$confirmation" = "$VERSION" ] || { printf '%s\n' 'release recovery cancelled' >&2; exit 1; }
 
@@ -284,8 +285,8 @@ while :; do
   sleep 2
 done
 
-printf 'Protected recovery run: https://github.com/%s/actions/runs/%s\n' "$EXPECTED_REPOSITORY" "$run_id"
-printf '%s\n' 'Approve the release-recovery environment when prompted; this command will follow the run.'
+printf 'Machine-verified recovery run: https://github.com/%s/actions/runs/%s\n' "$EXPECTED_REPOSITORY" "$run_id"
+printf '%s\n' 'The workflow will verify the exact tag, failed run, requester, and sealed metadata before rebuilding.'
 if ! gh run watch "$run_id" --repo "$EXPECTED_REPOSITORY" --exit-status; then
   gh run view "$run_id" --repo "$EXPECTED_REPOSITORY" --log-failed >&2 || true
   exit 1

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -697,11 +698,11 @@ func TestReleaseWorkflowUsesDedicatedGovernanceIdentity(t *testing.T) {
 		immutableCall = `"GET /repos/{owner}/{repo}/immutable-releases"`
 		governanceID  = `github-token: ${{ secrets.RELEASE_GOVERNANCE_TOKEN }}`
 	)
-	if got := strings.Count(workflow, checksCall); got != 2 {
-		t.Fatalf("release workflow Checks API call count = %d, want one tag check and one preflight check", got)
+	if got := strings.Count(workflow, checksCall); got != 3 {
+		t.Fatalf("release workflow Checks API call count = %d, want one tag check, one preflight check, and one Formula-parent check", got)
 	}
-	if got := strings.Count(workflow, paginatedCall); got != 2 {
-		t.Fatalf("release workflow paginated Checks API call count = %d, want one tag check and one preflight check", got)
+	if got := strings.Count(workflow, paginatedCall); got != 3 {
+		t.Fatalf("release workflow paginated Checks API call count = %d, want one tag check, one preflight check, and one Formula-parent check", got)
 	}
 	if got := strings.Count(workflow, immutableCall); got != 2 {
 		t.Fatalf("release workflow immutable governance call count = %d, want one tag check and one preflight check", got)
@@ -764,7 +765,7 @@ func TestReleaseWorkflowUsesDedicatedGovernanceIdentity(t *testing.T) {
 		t,
 		sections["tag"],
 		"      - name: Require immutable releases governance\n",
-		"\n      - name: Verify Homebrew PR automation permission\n",
+		"\n      - name: Require successful beta delivery before stable promotion\n",
 	)
 	for name, section := range map[string]string{
 		"sealed Code Admission recheck":       tagChecks,
@@ -858,9 +859,18 @@ func TestReleaseWorkflowGovernancePreflightCannotPublish(t *testing.T) {
 		}
 	}
 	admission := strings.Index(preflight, "Require successful Code Admission contexts on the preflight commit")
-	homebrewCanary := strings.Index(preflight, "Verify Homebrew PR automation permission")
-	if admission == -1 || homebrewCanary == -1 || admission > homebrewCanary {
-		t.Error("governance preflight must validate all exact Code Admission contexts before exposing Homebrew credentials")
+	immutableGovernance := strings.Index(preflight, "Require immutable releases governance")
+	if admission == -1 || immutableGovernance == -1 || admission > immutableGovernance {
+		t.Error("governance preflight must validate all exact Code Admission contexts before immutable-release governance")
+	}
+	for _, forbidden := range []string{
+		"HOMEBREW_PR_TOKEN",
+		"verify-homebrew-pr-token.sh",
+		"DWS_TAP_PR_",
+	} {
+		if strings.Contains(preflight, forbidden) {
+			t.Errorf("governance preflight must not retain obsolete Homebrew PR machinery %q", forbidden)
+		}
 	}
 
 	mirror := releaseWorkflowSection(t, workflow, "  mirror-gitee-release:\n", "\n  repair-npm:\n")
@@ -960,6 +970,46 @@ func TestReleaseWorkflowPlansAndSealsCurrentMainInTheCloud(t *testing.T) {
 		if !strings.Contains(seal, required) {
 			t.Errorf("cloud release seal is missing %q", required)
 		}
+	}
+	createRef := strings.Index(seal, "github.rest.git.createRef")
+	visibilityRead := strings.LastIndex(seal, "github.rest.git.getRef")
+	if createRef == -1 || visibilityRead == -1 || visibilityRead < createRef {
+		t.Fatal("cloud release seal must confirm tag-ref visibility after creating the ref")
+	}
+	postCreate := seal[createRef:]
+	for _, required := range []string{
+		"error.status === 404",
+		"error.status === 429",
+		"error.status >= 500",
+		"setTimeout",
+		`.data.object.type !== "tag"`,
+		"!== expectedTagObject",
+		".data.tag !== version",
+		".data.object.sha !== commit",
+		".data.message !==",
+	} {
+		if !strings.Contains(seal, required) {
+			t.Errorf("post-create tag verification is missing %q", required)
+		}
+	}
+	if strings.Count(postCreate, "github.rest.git.getRef") < 2 {
+		t.Error("post-create tag handling must both adopt an exact uncertain write and confirm final ref visibility")
+	}
+	if !regexp.MustCompile(`(?m)const \w*[Rr]etry\w*[Dd]elays\w* = \[(?:0,?\s*){1}[\d,\s]+\];`).MatchString(seal) {
+		t.Error("post-create tag verification must use a bounded retry policy")
+	}
+	for _, required := range []string{
+		"`${version} tag ref`",
+		"() => github.rest.git.getRef",
+	} {
+		if !strings.Contains(postCreate, required) {
+			t.Errorf("the bounded visibility retry must be used after createRef: missing %q", required)
+		}
+	}
+	retryLoop := strings.LastIndex(seal[:createRef], "for (const delayMs of")
+	retrySleep := strings.LastIndex(seal[:createRef], "await sleep(delayMs)")
+	if retryLoop == -1 || retrySleep == -1 || retryLoop > retrySleep {
+		t.Error("the bounded visibility retry must be used after createRef, not only declared")
 	}
 	for _, forbidden := range []string{
 		"actions/checkout",
@@ -1181,7 +1231,7 @@ func TestReleaseWorkflowRequiresOSSOnlyWhenMirrorIsEnabled(t *testing.T) {
 func TestReleaseWorkflowChannelRepairUsesSealedReleaseAuthority(t *testing.T) {
 	t.Parallel()
 	workflow := readReleaseWorkflow(t)
-	dispatch := releaseWorkflowSection(t, workflow, "  dispatch-contract:\n", "\n  authorize-recovery:\n")
+	dispatch := releaseWorkflowSection(t, workflow, "  dispatch-contract:\n", "\n  governance-preflight:\n")
 	start := strings.Index(workflow, "  repair-channel:\n")
 	if start == -1 {
 		t.Fatal("release workflow is missing the channel repair job")
@@ -1349,10 +1399,6 @@ func TestReleaseWorkflowRecoveryReusesGuardedJobs(t *testing.T) {
 		"workflow_dispatch must select exactly one release mode",
 		"release recovery confirmation must equal the exact version",
 		"recover_release_nonce must be bound to the release commit",
-		"environment: release-recovery",
-		"prevent_self_review !== true",
-		"protected_branches !== true",
-		"can_admins_bypass !== false",
 		`run.path !== ".github/workflows/release.yml"`,
 		`const expectedEvent = failedByCloud ? "workflow_dispatch" : "push"`,
 		`run.event !== expectedEvent`,
@@ -1382,6 +1428,16 @@ func TestReleaseWorkflowRecoveryReusesGuardedJobs(t *testing.T) {
 			t.Errorf("release recovery contract is missing %q", required)
 		}
 	}
+	for _, forbidden := range []string{
+		"authorize-recovery:",
+		"environment: release-recovery",
+		"needs.authorize-recovery",
+		"AUTHORIZE_RECOVERY_RESULT",
+	} {
+		if strings.Contains(workflow, forbidden) {
+			t.Errorf("machine-verified release recovery must not wait on manual approval %q", forbidden)
+		}
+	}
 
 	sections := map[string]string{
 		"release":          releaseWorkflowSection(t, workflow, "  release:\n", "\n  verify-darwin-signatures:\n"),
@@ -1408,6 +1464,49 @@ func TestReleaseWorkflowRecoveryReusesGuardedJobs(t *testing.T) {
 		strings.Count(workflow, "name: Publish immutable GitHub Release") != 1 ||
 		strings.Count(workflow, "name: Publish npm and mirrors") != 1 {
 		t.Fatal("normal and recovery publication must share one build/sign/publish job graph")
+	}
+}
+
+func TestReleaseWorkflowRerunAdoptsOnlyItsExactSeal(t *testing.T) {
+	t.Parallel()
+	workflow := readReleaseWorkflow(t)
+	sealStart := strings.Index(workflow, "  seal-release:\n")
+	if sealStart == -1 {
+		t.Fatal("release workflow is missing the cloud seal job")
+	}
+	seal := workflow[sealStart:]
+
+	for _, required := range []string{
+		`const currentAttempt = Number(process.env.GITHUB_RUN_ATTEMPT)`,
+		`Release-Run: ${context.runId}`,
+		`Release-Run-Attempt: ${attempt}`,
+		`Requested-By-ID: ${context.payload.sender?.id || ""}`,
+		`Workflow-Commit: ${context.sha}`,
+		`Allocation-Fingerprint: ${expectedFingerprint}`,
+		`ref.ref === ` + "`refs/tags/${version}`",
+		`existingRef = await github.rest.git.getRef`,
+		`sealedAttempt > currentAttempt`,
+		`.data.message !== messageForAttempt(sealedAttempt)`,
+		`if (branchMoved)`,
+		`if (!existingRef)`,
+		`basehead: ` + "`${commit}...${currentBranchCommit}`",
+		`["ahead", "identical"].includes(comparison.data.status)`,
+		`if (existingRef)`,
+		`continuing failed jobs without recovery approval`,
+	} {
+		if !strings.Contains(seal, required) {
+			t.Errorf("same-run release rerun exact-seal contract is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"github.rest.git.updateRef",
+		"github.rest.git.deleteRef",
+		"environment: release-recovery",
+		"needs.authorize-recovery",
+	} {
+		if strings.Contains(seal, forbidden) {
+			t.Errorf("same-run exact seal reuse must not mutate the tag or require approval: found %q", forbidden)
+		}
 	}
 }
 
@@ -1547,7 +1646,7 @@ func TestReleaseWorkflowPublicationBypassesSkippedDispatchButStopsOnCancellation
 			name:      "release contract",
 			start:     "  release-contract:\n",
 			end:       "\n  release:\n",
-			condition: `if: ${{ !cancelled() && (github.event_name == 'push' || (needs.dispatch-contract.result == 'success' && needs.dispatch-contract.outputs.mode == 'recover_release' && needs.authorize-recovery.result == 'success') || (needs.dispatch-contract.result == 'success' && needs.dispatch-contract.outputs.mode == 'create_release' && needs.governance-preflight.result == 'success' && needs.release-plan.result == 'success' && needs.seal-release.result == 'success')) }}`,
+			condition: `if: ${{ !cancelled() && (github.event_name == 'push' || (needs.dispatch-contract.result == 'success' && needs.dispatch-contract.outputs.mode == 'recover_release') || (needs.dispatch-contract.result == 'success' && needs.dispatch-contract.outputs.mode == 'create_release' && needs.governance-preflight.result == 'success' && needs.release-plan.result == 'success' && needs.seal-release.result == 'success')) }}`,
 		},
 		{
 			name:      "build",
@@ -1600,7 +1699,6 @@ func TestReleaseWorkflowDeliveryGateFailsClosed(t *testing.T) {
 		"name: Release delivery gate",
 		`if: ${{ !cancelled() }}`,
 		"- dispatch-contract",
-		"- authorize-recovery",
 		"- governance-preflight",
 		"- release-contract",
 		"- release-validation",
@@ -1637,6 +1735,16 @@ func TestReleaseWorkflowDeliveryGateFailsClosed(t *testing.T) {
 	} {
 		if !strings.Contains(gate, required) {
 			t.Errorf("release delivery gate is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"- authorize-recovery",
+		"AUTHORIZE_RECOVERY_RESULT",
+		"needs.authorize-recovery",
+		"require_result authorize-recovery",
+	} {
+		if strings.Contains(gate, forbidden) {
+			t.Errorf("release delivery gate must not retain recovery approval dependency %q", forbidden)
 		}
 	}
 }
@@ -1840,10 +1948,10 @@ func TestReleaseWorkflowUsesAppleCodesignBeforePublication(t *testing.T) {
 		"Publish or reuse immutable GitHub Release",
 		"gh release upload",
 		"Publish missing version to npm channel",
-		"Open stable Homebrew formula PR",
-		"Open beta Homebrew formula PR",
+		"Publish stable Homebrew formula",
+		"Publish beta Homebrew formula",
 		"DingTalk-Real-AI/dingtalk-workspace-cli.git",
-		"secrets.HOMEBREW_PR_TOKEN",
+		"secrets.GITHUB_TOKEN",
 	} {
 		if !strings.Contains(publishSection, required) {
 			t.Errorf("post-verification publication stage is missing %q", required)
@@ -1851,7 +1959,7 @@ func TestReleaseWorkflowUsesAppleCodesignBeforePublication(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowOpensHomebrewPROnlyForOfficialStableTags(t *testing.T) {
+func TestReleaseWorkflowPublishesStableHomebrewFormulaDirectly(t *testing.T) {
 	t.Parallel()
 
 	workflowPath, err := filepath.Abs(filepath.Join("..", "..", ".github", "workflows", "release.yml"))
@@ -1863,61 +1971,46 @@ func TestReleaseWorkflowOpensHomebrewPROnlyForOfficialStableTags(t *testing.T) {
 		t.Fatalf("ReadFile(%s) error = %v", workflowPath, err)
 	}
 	workflow := string(data)
-	if strings.Contains(workflow, "pull-requests: write") {
-		t.Fatal("the built-in GITHUB_TOKEN must not receive pull-request write permission")
-	}
-	for _, required := range []string{
+	for _, forbidden := range []string{
 		"Verify Homebrew PR automation permission",
 		"secrets.HOMEBREW_PR_TOKEN",
 		"verify-homebrew-pr-token.sh",
-		"--canary",
-		"HOMEBREW_PR_TOKEN and RELEASE_GOVERNANCE_TOKEN must use separate least-privilege identities",
+		"DWS_TAP_PR_REPOSITORY",
+		"DWS_TAP_PR_BRANCH",
+		"Open stable Homebrew formula PR",
+		"Open beta Homebrew formula PR",
 	} {
-		if !strings.Contains(workflow, required) {
-			t.Errorf("release workflow is missing Homebrew PR token preflight %q", required)
+		if strings.Contains(workflow, forbidden) {
+			t.Errorf("release workflow must not retain Homebrew PR machinery %q", forbidden)
 		}
 	}
-	if got := strings.Count(workflow, "Verify Homebrew PR automation permission"); got != 2 {
-		t.Errorf("Homebrew PR permission preflight count = %d, want one default-branch preflight and one tag contract", got)
-	}
-	tagContract := releaseWorkflowSection(t, workflow, "  release-contract:\n", "\n  release:\n")
-	tagAdmission := strings.Index(tagContract, "Require successful Code Admission contexts on the sealed commit")
-	tagHomebrew := strings.Index(tagContract, "Verify Homebrew PR automation permission")
-	if tagAdmission == -1 || tagHomebrew == -1 || tagAdmission > tagHomebrew {
-		t.Error("tag contract must validate all exact Code Admission contexts before exposing Homebrew credentials")
-	}
 
-	start := strings.Index(workflow, "- name: Open stable Homebrew formula PR")
+	start := strings.Index(workflow, "- name: Publish stable Homebrew formula")
 	if start == -1 {
-		t.Fatal("release workflow is missing the stable Homebrew PR step")
+		t.Fatal("release workflow is missing direct stable Homebrew publication")
 	}
-	end := strings.Index(workflow[start:], "- name: Open beta Homebrew formula PR")
+	end := strings.Index(workflow[start:], "- name: Publish beta Homebrew formula")
 	if end == -1 {
-		t.Fatal("release workflow is missing the beta Homebrew PR step after the stable step")
+		t.Fatal("release workflow is missing direct beta Homebrew publication after the stable step")
 	}
 	section := workflow[start : start+end]
 	for _, required := range []string{
 		"github.repository_owner == 'DingTalk-Real-AI'",
 		"needs.release-contract.outputs.channel == 'stable'",
-		"./scripts/release/publish-homebrew-formula.sh",
-		"secrets.HOMEBREW_PR_TOKEN",
-		"DWS_TAP_PR_REPOSITORY",
-		"automation/homebrew-${{ needs.release-contract.outputs.release_version }}",
+		"scripts/release/publish-homebrew-formula.sh",
+		"secrets.GITHUB_TOKEN",
 	} {
 		if !strings.Contains(section, required) {
-			t.Errorf("Homebrew publication step is missing %q", required)
+			t.Errorf("direct stable Homebrew publication is missing %q", required)
 		}
-	}
-	if strings.Contains(section, "secrets.GITHUB_TOKEN") {
-		t.Error("Homebrew Formula PRs must use the dedicated token so their CI is triggered")
 	}
 	stableNPM := strings.Index(workflow, "- name: Publish missing version to npm channel")
 	if stableNPM == -1 || start > stableNPM {
-		t.Fatal("Homebrew PR creation must run before npm so a failure is safely rerunnable")
+		t.Fatal("Homebrew publication must run before npm so a failure is safely rerunnable")
 	}
 }
 
-func TestReleaseWorkflowOpensVersionedHomebrewPRForBetaTags(t *testing.T) {
+func TestReleaseWorkflowPublishesBetaHomebrewFormulaDirectly(t *testing.T) {
 	t.Parallel()
 
 	workflowPath, err := filepath.Abs(filepath.Join("..", "..", ".github", "workflows", "release.yml"))
@@ -1930,9 +2023,9 @@ func TestReleaseWorkflowOpensVersionedHomebrewPRForBetaTags(t *testing.T) {
 	}
 	workflow := string(data)
 
-	start := strings.Index(workflow, "- name: Open beta Homebrew formula PR")
+	start := strings.Index(workflow, "- name: Publish beta Homebrew formula")
 	if start == -1 {
-		t.Fatal("release workflow is missing the beta Homebrew PR step")
+		t.Fatal("release workflow is missing direct beta Homebrew publication")
 	}
 	end := strings.Index(workflow[start:], "- name: Reverify exact immutable npm package")
 	if end == -1 {
@@ -1944,15 +2037,109 @@ func TestReleaseWorkflowOpensVersionedHomebrewPRForBetaTags(t *testing.T) {
 		"needs.release-contract.outputs.channel == 'prerelease'",
 		"dist/homebrew/dingtalk-workspace-cli-beta.rb",
 		"Formula/dingtalk-workspace-cli-beta.rb",
-		"secrets.HOMEBREW_PR_TOKEN",
-		"automation/homebrew-beta-${{ needs.release-contract.outputs.release_version }}",
+		"secrets.GITHUB_TOKEN",
 	} {
 		if !strings.Contains(section, required) {
-			t.Errorf("beta Homebrew PR step is missing %q", required)
+			t.Errorf("direct beta Homebrew publication is missing %q", required)
 		}
 	}
-	if strings.Contains(section, "secrets.GITHUB_TOKEN") {
-		t.Error("Homebrew beta Formula PRs must use the dedicated token so their CI is triggered")
+	for _, forbidden := range []string{
+		"DWS_TAP_PR_REPOSITORY",
+		"DWS_TAP_PR_BRANCH",
+		"automation/homebrew-beta-",
+	} {
+		if strings.Contains(section, forbidden) {
+			t.Errorf("direct beta Homebrew publication must not open a PR: found %q", forbidden)
+		}
+	}
+}
+
+func TestReleaseWorkflowSealsOnlyVerifiedFormulaCommitContexts(t *testing.T) {
+	t.Parallel()
+	workflow := readReleaseWorkflow(t)
+	publishJob := releaseWorkflowSection(t, workflow, "  publish-release:\n", "\n  publish-channels:\n")
+	if !strings.Contains(publishJob, "checks: write") {
+		t.Fatal("Formula-only delivery must receive checks: write in the already write-capable publication job")
+	}
+
+	for _, required := range []string{
+		"id: homebrew-stable",
+		"id: homebrew-beta",
+		`FORMULA_CHANGED: ${{ steps.homebrew-stable.outputs.formula_changed || steps.homebrew-beta.outputs.formula_changed }}`,
+		`FORMULA_COMMIT: ${{ steps.homebrew-stable.outputs.published_commit || steps.homebrew-beta.outputs.published_commit }}`,
+	} {
+		if !strings.Contains(publishJob, required) {
+			t.Errorf("Homebrew publisher output wiring is missing %q", required)
+		}
+	}
+
+	seal := releaseWorkflowSection(
+		t,
+		publishJob,
+		"      - name: Seal Formula-only Code Admission contexts\n",
+		"\n      - name: Reverify exact immutable npm package\n",
+	)
+	for _, required := range []string{
+		`const commit = process.env.FORMULA_COMMIT`,
+		`commitResponse.data.sha === commit`,
+		`commitResponse.data.parents.length === 1`,
+		`commitResponse.data.commit.message === expectedMessage`,
+		`commitResponse.data.author?.login === "github-actions[bot]"`,
+		`commitResponse.data.committer?.login === "github-actions[bot]"`,
+		`files.length === 1`,
+		`files[0].filename === formulaPath`,
+		`["added", "modified"].includes(files[0].status)`,
+		`const parent = commitResponse.data.parents[0].sha`,
+		`github.rest.checks.listForRef`,
+		`ref: parent`,
+		`run.head_sha !== parent`,
+		`run.app?.slug !== "github-actions"`,
+		`run.conclusion !== "success"`,
+		`github.rest.repos.getContent`,
+		`path: formulaPath`,
+		`ref: commit`,
+		`actualFormula.equals(expectedFormula)`,
+		`github.rest.repos.compareCommitsWithBasehead`,
+		`basehead: ` + "`${commit}...${branch.data.commit.sha}`",
+		`["ahead", "identical"].includes(comparison.data.status)`,
+		`github.rest.checks.create`,
+		`head_sha: commit`,
+		`status: "completed"`,
+		`conclusion: "success"`,
+	} {
+		if !strings.Contains(seal, required) {
+			t.Errorf("Formula-only Code Admission sealing is missing %q", required)
+		}
+	}
+	for _, context := range expectedReleaseAdmissionContexts {
+		if strings.Count(seal, fmt.Sprintf("%q", context)) != 1 {
+			t.Errorf("Formula-only Code Admission must derive exactly one %q context from the reviewed list", context)
+		}
+	}
+	if strings.Count(seal, "github.rest.checks.create") != 1 {
+		t.Error("Formula-only checks must be created only by the single verified context loop")
+	}
+	for _, forbidden := range []string{
+		"head_sha: context.sha",
+		"head_sha: parent",
+		"head_sha: branch.data.commit.sha",
+	} {
+		if strings.Contains(seal, forbidden) {
+			t.Errorf("Formula-only Code Admission must not mark an unverified head green: found %q", forbidden)
+		}
+	}
+
+	createCheck := strings.Index(seal, "github.rest.checks.create")
+	for name, marker := range map[string]string{
+		"single-parent Formula-only identity": "const exactFormulaCommit",
+		"successful parent contexts":          "invalidParentContexts.length > 0",
+		"byte-for-byte Formula content":       "actualFormula.equals(expectedFormula)",
+		"default-branch containment":          `["ahead", "identical"].includes(comparison.data.status)`,
+	} {
+		index := strings.Index(seal, marker)
+		if index == -1 || createCheck == -1 || index > createCheck {
+			t.Errorf("%s must be verified before any success check is created", name)
+		}
 	}
 }
 

--- a/test/scripts/publish_homebrew_formula_test.go
+++ b/test/scripts/publish_homebrew_formula_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestPublishHomebrewFormulaPushesUpdatedFormula(t *testing.T) {
+func TestPublishHomebrewFormulaPublishesDirectlyWithoutPR(t *testing.T) {
 	t.Parallel()
 
 	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "release", "publish-homebrew-formula.sh"))
@@ -23,12 +23,22 @@ func TestPublishHomebrewFormulaPushesUpdatedFormula(t *testing.T) {
 
 	sourceFormula := filepath.Join(root, "dingtalk-workspace-cli.rb")
 	mustWriteFile(t, sourceFormula, []byte("class DingtalkWorkspaceCli < Formula\n  desc \"DingTalk Workspace CLI\"\nend\n"), 0o644)
+	publishOutput := filepath.Join(root, "publish-output")
+
+	fakeBin := filepath.Join(root, "bin")
+	ghLog := filepath.Join(root, "gh.log")
+	mustWriteFile(t, filepath.Join(fakeBin, "gh"), []byte(`#!/bin/sh
+printf '%s\n' "$*" >> "$GH_LOG"
+exit 97
+`), 0o755)
 
 	cmd := exec.Command("sh", scriptPath)
 	cmd.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GH_LOG="+ghLog,
 		"DWS_TAP_REPO_URL="+remoteDir,
-		"DWS_TAP_BRANCH=main",
 		"DWS_FORMULA_SOURCE="+sourceFormula,
+		"GITHUB_OUTPUT="+publishOutput,
 		"DWS_GIT_NAME=DWS Bot",
 		"DWS_GIT_EMAIL=dws@example.com",
 	)
@@ -50,6 +60,28 @@ func TestPublishHomebrewFormulaPushesUpdatedFormula(t *testing.T) {
 	if string(got) != "class DingtalkWorkspaceCli < Formula\n  desc \"DingTalk Workspace CLI\"\nend\n" {
 		t.Fatalf("published formula = %q", string(got))
 	}
+	publishedCommit := strings.TrimSpace(mustOutput(t, cloneDir, "git", "rev-parse", "HEAD"))
+	result, err := os.ReadFile(publishOutput)
+	if err != nil {
+		t.Fatalf("ReadFile(publish output) error = %v", err)
+	}
+	wantResult := "formula_changed=true\npublished_commit=" + publishedCommit + "\n"
+	if string(result) != wantResult {
+		t.Fatalf("publish result = %q, want %q", result, wantResult)
+	}
+	parentLine := strings.Fields(mustOutput(t, cloneDir, "git", "rev-list", "--parents", "-n", "1", "HEAD"))
+	if len(parentLine) != 2 {
+		t.Fatalf("published Formula commit parent fields = %v, want exactly one parent", parentLine)
+	}
+	changedPaths := strings.TrimSpace(mustOutput(t, cloneDir, "git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"))
+	if changedPaths != "Formula/dingtalk-workspace-cli.rb" {
+		t.Fatalf("published Formula commit changed %q", changedPaths)
+	}
+	if calls, err := os.ReadFile(ghLog); err == nil {
+		t.Fatalf("direct Homebrew publication unexpectedly invoked gh:\n%s", calls)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("ReadFile(gh log) error = %v", err)
+	}
 }
 
 func TestPublishHomebrewFormulaSkipsWhenFormulaUnchanged(t *testing.T) {
@@ -63,11 +95,27 @@ func TestPublishHomebrewFormulaSkipsWhenFormulaUnchanged(t *testing.T) {
 	root := t.TempDir()
 	remoteDir := filepath.Join(root, "tap.git")
 	mustRun(t, root, "git", "init", "--bare", remoteDir)
+	seedTapRepo(t, remoteDir, "main", "class OldFormula < Formula\nend\n")
 	initialFormula := "class DingtalkWorkspaceCli < Formula\n  desc \"DingTalk Workspace CLI\"\nend\n"
-	seedTapRepo(t, remoteDir, "main", initialFormula)
+
+	historyDir := filepath.Join(root, "history")
+	mustRun(t, root, "git", "clone", "--branch", "main", remoteDir, historyDir)
+	mustRun(t, historyDir, "git", "config", "user.name", "DWS Bot")
+	mustRun(t, historyDir, "git", "config", "user.email", "dws@example.com")
+	mustWriteFile(t, filepath.Join(historyDir, "Formula", "dingtalk-workspace-cli.rb"), []byte(initialFormula), 0o644)
+	mustRun(t, historyDir, "git", "add", "Formula/dingtalk-workspace-cli.rb")
+	mustRun(t, historyDir, "git", "commit", "-m", "chore: update formula for v1.2.3 [skip ci]")
+	formulaCommit := strings.TrimSpace(mustOutput(t, historyDir, "git", "rev-parse", "HEAD"))
+	mustRun(t, historyDir, "git", "config", "user.name", "Another Maintainer")
+	mustRun(t, historyDir, "git", "config", "user.email", "maintainer@example.com")
+	mustWriteFile(t, filepath.Join(historyDir, "README.md"), []byte("unrelated main update\n"), 0o644)
+	mustRun(t, historyDir, "git", "add", "README.md")
+	mustRun(t, historyDir, "git", "commit", "-m", "docs: unrelated main update")
+	mustRun(t, historyDir, "git", "push", "origin", "main")
 
 	sourceFormula := filepath.Join(root, "dingtalk-workspace-cli.rb")
 	mustWriteFile(t, sourceFormula, []byte(initialFormula), 0o644)
+	publishOutput := filepath.Join(root, "publish-output")
 
 	beforeHead := strings.TrimSpace(mustOutput(t, root, "git", "ls-remote", remoteDir, "refs/heads/main"))
 
@@ -76,6 +124,7 @@ func TestPublishHomebrewFormulaSkipsWhenFormulaUnchanged(t *testing.T) {
 		"DWS_TAP_REPO_URL="+remoteDir,
 		"DWS_TAP_BRANCH=main",
 		"DWS_FORMULA_SOURCE="+sourceFormula,
+		"DWS_PUBLISH_OUTPUT="+publishOutput,
 		"DWS_GIT_NAME=DWS Bot",
 		"DWS_GIT_EMAIL=dws@example.com",
 	)
@@ -90,6 +139,125 @@ func TestPublishHomebrewFormulaSkipsWhenFormulaUnchanged(t *testing.T) {
 	afterHead := strings.TrimSpace(mustOutput(t, root, "git", "ls-remote", remoteDir, "refs/heads/main"))
 	if beforeHead != afterHead {
 		t.Fatalf("remote head changed unexpectedly:\nbefore: %s\nafter:  %s", beforeHead, afterHead)
+	}
+	result, err := os.ReadFile(publishOutput)
+	if err != nil {
+		t.Fatalf("ReadFile(publish output) error = %v", err)
+	}
+	wantResult := "formula_changed=false\npublished_commit=" + formulaCommit + "\n"
+	if string(result) != wantResult {
+		t.Fatalf("no-op publish result = %q, want last matching Formula-only bot commit %q", result, wantResult)
+	}
+}
+
+func TestPublishHomebrewFormulaRetriesNonFastForwardFromFreshMain(t *testing.T) {
+	t.Parallel()
+
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "release", "publish-homebrew-formula.sh"))
+	if err != nil {
+		t.Fatalf("Abs(publish-homebrew-formula.sh) error = %v", err)
+	}
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("LookPath(git) error = %v", err)
+	}
+
+	root := t.TempDir()
+	remoteDir := filepath.Join(root, "tap.git")
+	mustRun(t, root, "git", "init", "--bare", remoteDir)
+	seedTapRepo(t, remoteDir, "main", "class OldFormula < Formula\nend\n")
+
+	raceDir := filepath.Join(root, "racer")
+	mustRun(t, root, "git", "clone", "--branch", "main", remoteDir, raceDir)
+	mustRun(t, raceDir, "git", "config", "user.name", "Concurrent Maintainer")
+	mustRun(t, raceDir, "git", "config", "user.email", "concurrent@example.com")
+	mustWriteFile(t, filepath.Join(raceDir, "README.md"), []byte("concurrent main update\n"), 0o644)
+	mustRun(t, raceDir, "git", "add", "README.md")
+	mustRun(t, raceDir, "git", "commit", "-m", "docs: concurrent main update")
+	raceCommit := strings.TrimSpace(mustOutput(t, raceDir, "git", "rev-parse", "HEAD"))
+
+	sourceFormula := filepath.Join(root, "dingtalk-workspace-cli.rb")
+	newFormula := "class DingtalkWorkspaceCli < Formula\n  desc \"DingTalk Workspace CLI\"\nend\n"
+	mustWriteFile(t, sourceFormula, []byte(newFormula), 0o644)
+	publishOutput := filepath.Join(root, "publish-output")
+
+	fakeBin := filepath.Join(root, "bin")
+	gitLog := filepath.Join(root, "git.log")
+	raceOnce := filepath.Join(root, "race-once")
+	mustWriteFile(t, filepath.Join(fakeBin, "git"), []byte(`#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "$GIT_LOG"
+if [ "${1:-}" = push ] && [ "${2:-}" = origin ] &&
+   [ "${3:-}" = "HEAD:main" ] && [ ! -e "$GIT_RACE_ONCE" ]; then
+  : > "$GIT_RACE_ONCE"
+  "$REAL_GIT" -C "$RACE_REPO" push origin main >/dev/null
+  exit 1
+fi
+exec "$REAL_GIT" "$@"
+`), 0o755)
+
+	cmd := exec.Command("sh", scriptPath)
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"REAL_GIT="+realGit,
+		"RACE_REPO="+raceDir,
+		"GIT_LOG="+gitLog,
+		"GIT_RACE_ONCE="+raceOnce,
+		"DWS_TAP_REPO_URL="+remoteDir,
+		"DWS_TAP_BRANCH=main",
+		"DWS_FORMULA_SOURCE="+sourceFormula,
+		"DWS_PUBLISH_OUTPUT="+publishOutput,
+		"DWS_GIT_NAME=DWS Bot",
+		"DWS_GIT_EMAIL=dws@example.com",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("publish-homebrew-formula.sh race recovery error = %v\noutput:\n%s", err, string(output))
+	}
+	if !strings.Contains(string(output), "retrying from a fresh clone") ||
+		!strings.Contains(string(output), "Published Homebrew formula") {
+		t.Fatalf("publisher did not report bounded fresh-clone recovery:\n%s", output)
+	}
+
+	checkDir := filepath.Join(root, "check")
+	mustRun(t, root, "git", "clone", "--branch", "main", remoteDir, checkDir)
+	publishedCommit := strings.TrimSpace(mustOutput(t, checkDir, "git", "rev-parse", "HEAD"))
+	parent := strings.TrimSpace(mustOutput(t, checkDir, "git", "rev-parse", "HEAD^"))
+	if parent != raceCommit {
+		t.Fatalf("retried Formula commit parent = %s, want concurrent main %s", parent, raceCommit)
+	}
+	parentLine := strings.Fields(mustOutput(t, checkDir, "git", "rev-list", "--parents", "-n", "1", "HEAD"))
+	if len(parentLine) != 2 {
+		t.Fatalf("retried Formula commit parent fields = %v, want exactly one parent", parentLine)
+	}
+	changedPaths := strings.TrimSpace(mustOutput(t, checkDir, "git", "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"))
+	if changedPaths != "Formula/dingtalk-workspace-cli.rb" {
+		t.Fatalf("retried Formula commit changed %q", changedPaths)
+	}
+	formula, err := os.ReadFile(filepath.Join(checkDir, "Formula", "dingtalk-workspace-cli.rb"))
+	if err != nil {
+		t.Fatalf("ReadFile(published formula) error = %v", err)
+	}
+	if string(formula) != newFormula {
+		t.Fatalf("published formula = %q, want %q", formula, newFormula)
+	}
+	result, err := os.ReadFile(publishOutput)
+	if err != nil {
+		t.Fatalf("ReadFile(publish output) error = %v", err)
+	}
+	wantResult := "formula_changed=true\npublished_commit=" + publishedCommit + "\n"
+	if string(result) != wantResult {
+		t.Fatalf("race-recovered publish result = %q, want %q", result, wantResult)
+	}
+	gitCalls, err := os.ReadFile(gitLog)
+	if err != nil {
+		t.Fatalf("ReadFile(git log) error = %v", err)
+	}
+	if strings.Contains(string(gitCalls), "--force") {
+		t.Fatalf("direct Formula publication must never force push:\n%s", gitCalls)
+	}
+	if got := strings.Count(string(gitCalls), "push origin HEAD:main"); got != 2 {
+		t.Fatalf("direct Formula push attempts = %d, want one rejected attempt and one retry\n%s", got, gitCalls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Publish stable/beta Homebrew Formula updates directly from the trusted Release workflow after immutable assets and checksums are verified; remove the follow-up Formula PR and PAT canary from normal releases.
- Make tag sealing idempotent: retry post-write 404/429/5xx responses, adopt only an exact same-run seal on “Re-run failed jobs”, and allow cross-run rebuild recovery after machine verification without a reviewer wait.
- Keep direct Formula writes Formula-only, non-forced, and concurrency-safe; validate the bot commit, its admitted parent, and byte-for-byte generated Formula before sealing the nine required check contexts.
- Replace timing-dependent Markdown temporary-file coverage tests with deterministic stat failures.

## Verification

- [x] Exact `CHANGELOG.md`-only check: N/A (implementation PR)
- [x] Build: `go build -o <temporary-directory>/dws ./cmd`
- [x] Full release script suite: `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -count=1`
- [x] Release/Formula focused tests and Markdown edge tests (50 repetitions)
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml`
- [x] `shellcheck --severity=error` and `sh -n` for modified release scripts
- [x] `./scripts/policy/check-generated-drift.sh`
- [x] `./scripts/policy/check-schema-catalog.sh`
- [ ] `make lint` (required CI)
- [ ] `make test` (required CI; modified scopes passed locally)
- [ ] `make policy` (required CI; generated/schema policies passed locally)
- [x] `./scripts/policy/check-command-surface.sh --strict`: N/A (command surface unchanged)

## Notes

- After merge, the repository's two `main` rulesets must grant bypass to the GitHub Actions integration (app id `15368`) so the trusted workflow can write the verified Formula-only commit. No personal PAT bypass is needed.
- Withdrawal remains deliberately separate: its destructive channel rollback still uses the existing reviewed Homebrew rollback PR and protected withdrawal environment.
- A full local `go test ./...` run passed all packages except one existing stdio initialization timeout in `internal/transport`; that exact test then passed three consecutive focused runs.
