### PR TITLE
fix(chat): 去重翻页边界消息，避免 message list 无限循环 (#430)

### DIFF
--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -49,6 +49,64 @@ func resolveMessageForward(cmd *cobra.Command, defaultForward bool) (bool, error
 	}
 }
 
+// dedupChatMessageBoundary drops conversation messages whose createTime equals
+// the pagination anchor time from a successful chat message-list response.
+//
+// 上游 IM 接口使用含等号的时间边界（newer/forward 为 >=，older/backward 为 <=）。
+// 当调用方按文档建议把上一页的边界 createTime 作为下一页的 --time 传入时，这条
+// 精确命中边界的消息会在之后每一页被重复返回，导致无限翻页循环（见 issue #430）。
+//
+// 响应结构：{"result":{"messages":[{...,"createTime":"2006-01-02 15:04:05"},...]}}。
+// 只检查顶层 result.messages，不递归进嵌套的 forwardMessages。比较方式是去空格后的
+// 精确字符串匹配，因此只有当某条消息的 createTime 与调用方传入的锚点逐字节相同（即
+// 正是循环场景）时才会被丢弃。任何解析或结构不匹配都原样返回原文，可无条件安全套用。
+func dedupChatMessageBoundary(raw, anchorTime string) string {
+	anchorTime = strings.TrimSpace(anchorTime)
+	if anchorTime == "" {
+		return raw
+	}
+	var doc map[string]any
+	if json.Unmarshal([]byte(raw), &doc) != nil {
+		return raw
+	}
+	result, ok := doc["result"].(map[string]any)
+	if !ok {
+		return raw
+	}
+	msgs, ok := result["messages"].([]any)
+	if !ok || len(msgs) == 0 {
+		return raw
+	}
+	filtered := make([]any, 0, len(msgs))
+	changed := false
+	for _, m := range msgs {
+		obj, ok := m.(map[string]any)
+		if !ok {
+			filtered = append(filtered, m)
+			continue
+		}
+		if ct, _ := obj["createTime"].(string); strings.TrimSpace(ct) == anchorTime {
+			changed = true
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	if !changed {
+		return raw
+	}
+	result["messages"] = filtered
+	out, _ := json.Marshal(doc) // doc 来自 json.Unmarshal，只含可编码类型，Marshal 不会失败
+	return string(out)
+}
+
+// callMCPToolDedupBoundary 与 callMCPTool 行为一致，但在输出前丢弃 result.messages
+// 中 createTime 等于 anchorTime 的翻页边界消息（见 issue #430）。
+func callMCPToolDedupBoundary(toolName string, args map[string]any, anchorTime string) error {
+	return callMCPToolInternalOptsPost("", toolName, args, false, func(raw string) string {
+		return dedupChatMessageBoundary(raw, anchorTime)
+	})
+}
+
 func chatIntFlagOrFallback(cmd *cobra.Command, primary string, aliases ...string) int {
 	for _, alias := range aliases {
 		if f := cmd.Flags().Lookup(alias); f != nil && f.Changed {
@@ -1353,7 +1411,7 @@ func newChatCommand() *cobra.Command {
 				if v := chatIntFlagOrFallback(cmd, "limit", "size"); v > 0 {
 					toolArgs["limit"] = v
 				}
-				return callMCPTool("list_conversation_message_v2", toolArgs)
+				return callMCPToolDedupBoundary("list_conversation_message_v2", toolArgs, timeVal)
 			}
 			toolArgs := map[string]any{
 				"time":    timeVal,
@@ -1367,7 +1425,7 @@ func newChatCommand() *cobra.Command {
 			if v := chatIntFlagOrFallback(cmd, "limit", "size"); v > 0 {
 				toolArgs["limit"] = v
 			}
-			return callMCPTool("list_individual_chat_message", toolArgs)
+			return callMCPToolDedupBoundary("list_individual_chat_message", toolArgs, timeVal)
 		},
 	}
 
@@ -1414,7 +1472,7 @@ func newChatCommand() *cobra.Command {
 			if v, err := cmd.Flags().GetInt("limit"); err == nil && v > 0 {
 				toolArgs["limit"] = v
 			}
-			return callMCPTool("list_individual_chat_message", toolArgs)
+			return callMCPToolDedupBoundary("list_individual_chat_message", toolArgs, timeVal)
 		},
 	}
 
@@ -1873,7 +1931,7 @@ func newChatCommand() *cobra.Command {
 				return err
 			}
 			toolArgs["forward"] = forward
-			return callMCPTool("list_topic_replies", toolArgs)
+			return callMCPToolDedupBoundary("list_topic_replies", toolArgs, mustGetFlag(cmd, "time"))
 		},
 	}
 

--- a/internal/helpers/chat_dedup_test.go
+++ b/internal/helpers/chat_dedup_test.go
@@ -1,0 +1,240 @@
+package helpers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// messageIDsFrom extracts the openMessageId list from result.messages of a
+// chat message-list response, for assertion convenience.
+func messageIDsFrom(t *testing.T, raw string) []string {
+	t.Helper()
+	var doc struct {
+		Result struct {
+			Messages []struct {
+				OpenMessageID string `json:"openMessageId"`
+			} `json:"messages"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("invalid json %q: %v", raw, err)
+	}
+	ids := make([]string, 0, len(doc.Result.Messages))
+	for _, m := range doc.Result.Messages {
+		ids = append(ids, m.OpenMessageID)
+	}
+	return ids
+}
+
+// 复现 #430：上游 newer/forward 返回 createTime >= 锚点，调用方把边界消息的
+// createTime 作为下一页 --time 传入时，该边界消息会被原样重复返回。去重应丢弃它。
+func TestDedupChatMessageBoundary_ForwardNewerDropsAnchorMessage(t *testing.T) {
+	raw := `{"result":{"messages":[` +
+		`{"openMessageId":"m1","createTime":"2026-05-22 09:30:00"},` +
+		`{"openMessageId":"m2","createTime":"2026-05-22 09:26:59"},` +
+		`{"openMessageId":"m3","createTime":"2026-05-22 09:26:59"}` + // 与锚点相等的重复边界
+		`],"hasMore":true}}`
+	got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59")
+	if ids := messageIDsFrom(t, got); len(ids) != 1 || ids[0] != "m1" {
+		t.Fatalf("expected only [m1] to remain, got %v", ids)
+	}
+}
+
+// older 方向同样存在边界重复（<= 锚点），去重方向无关，只看 createTime 是否等于锚点。
+func TestDedupChatMessageBoundary_OlderDirectionDropsAnchorMessage(t *testing.T) {
+	raw := `{"result":{"messages":[` +
+		`{"openMessageId":"m1","createTime":"2026-05-22 09:26:59"},` + // 边界，等于锚点
+		`{"openMessageId":"m2","createTime":"2026-05-22 08:00:00"}` +
+		`]}}`
+	got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59")
+	if ids := messageIDsFrom(t, got); len(ids) != 1 || ids[0] != "m2" {
+		t.Fatalf("expected only [m2] to remain, got %v", ids)
+	}
+}
+
+// 没有命中锚点的消息时，必须原样返回（字节不变），保证非翻页场景零副作用。
+func TestDedupChatMessageBoundary_NoMatchReturnsOriginalVerbatim(t *testing.T) {
+	raw := `{"result":{"messages":[{"openMessageId":"m1","createTime":"2026-05-22 09:30:00"}]}}`
+	got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59")
+	if got != raw {
+		t.Fatalf("expected verbatim original, got %q", got)
+	}
+}
+
+func TestDedupChatMessageBoundary_EmptyAnchorIsNoOp(t *testing.T) {
+	raw := `{"result":{"messages":[{"openMessageId":"m1","createTime":""}]}}`
+	if got := dedupChatMessageBoundary(raw, ""); got != raw {
+		t.Fatalf("empty anchor must return original verbatim, got %q", got)
+	}
+}
+
+func TestDedupChatMessageBoundary_EmptyMessagesIsNoOp(t *testing.T) {
+	raw := `{"result":{"messages":[]}}`
+	if got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59"); got != raw {
+		t.Fatalf("empty messages must return original verbatim, got %q", got)
+	}
+}
+
+func TestDedupChatMessageBoundary_MissingResultIsNoOp(t *testing.T) {
+	raw := `{"success":true,"data":[1,2,3]}`
+	if got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59"); got != raw {
+		t.Fatalf("missing result must return original verbatim, got %q", got)
+	}
+}
+
+func TestDedupChatMessageBoundary_InvalidJSONIsNoOp(t *testing.T) {
+	raw := `not-json-at-all`
+	if got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59"); got != raw {
+		t.Fatalf("invalid json must return original verbatim, got %q", got)
+	}
+}
+
+// 关键安全保证：只去重顶层 result.messages，绝不递归进嵌套的 forwardMessages，
+// 即便其 createTime 恰好等于锚点（转发消息体不是翻页边界）。
+func TestDedupChatMessageBoundary_DoesNotTouchNestedForwardMessages(t *testing.T) {
+	raw := `{"result":{"messages":[` +
+		// m1 自身 createTime 等于锚点 → 应被丢弃；其 forwardMessages 随之消失属正常
+		`{"openMessageId":"m1","createTime":"2026-05-22 09:26:59","forwardMessages":[` +
+		`{"openMessageId":"f1","createTime":"2026-05-22 09:26:59"}]},` +
+		// m2 自身不等于锚点 → 保留；其内部 createTime==锚点 的转发消息必须原样保留
+		`{"openMessageId":"m2","createTime":"2026-05-22 08:00:00","forwardMessages":[` +
+		`{"openMessageId":"f2","createTime":"2026-05-22 09:26:59"}]}` +
+		`]}}`
+	got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59")
+
+	var doc struct {
+		Result struct {
+			Messages []struct {
+				OpenMessageID   string `json:"openMessageId"`
+				ForwardMessages []struct {
+					OpenMessageID string `json:"openMessageId"`
+					CreateTime    string `json:"createTime"`
+				} `json:"forwardMessages"`
+			} `json:"messages"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(got), &doc); err != nil {
+		t.Fatalf("output not valid json: %v", err)
+	}
+	if len(doc.Result.Messages) != 1 || doc.Result.Messages[0].OpenMessageID != "m2" {
+		t.Fatalf("expected only m2 to remain at top level, got %+v", doc.Result.Messages)
+	}
+	fwd := doc.Result.Messages[0].ForwardMessages
+	if len(fwd) != 1 || fwd[0].OpenMessageID != "f2" || fwd[0].CreateTime != "2026-05-22 09:26:59" {
+		t.Fatalf("nested forwardMessage f2 must be preserved unchanged, got %+v", fwd)
+	}
+}
+
+// 锚点周围的空白不影响精确匹配（调用方可能传入带空格的时间串）。
+func TestDedupChatMessageBoundary_TrimsWhitespaceAroundAnchor(t *testing.T) {
+	raw := `{"result":{"messages":[{"openMessageId":"m1","createTime":"2026-05-22 09:26:59"}]}}`
+	got := dedupChatMessageBoundary(raw, "  2026-05-22 09:26:59  ")
+	if ids := messageIDsFrom(t, got); len(ids) != 0 {
+		t.Fatalf("expected m1 dropped after trimming anchor, got %v", ids)
+	}
+}
+
+// 非 string 的 createTime（理论上不会出现，但防御）不应 panic，且该元素被原样保留。
+func TestDedupChatMessageBoundary_NonStringCreateTimeKeepsElement(t *testing.T) {
+	raw := `{"result":{"messages":[{"openMessageId":"m1","createTime":1779000000000}]}}`
+	got := dedupChatMessageBoundary(raw, "1779000000000")
+	if ids := messageIDsFrom(t, got); len(ids) != 1 || ids[0] != "m1" {
+		t.Fatalf("non-string createTime must be left intact, got %v", ids)
+	}
+}
+
+// result.messages 不是数组（畸形响应）时，原样返回，不 panic。
+func TestDedupChatMessageBoundary_MessagesNotArrayIsNoOp(t *testing.T) {
+	raw := `{"result":{"messages":"not-an-array"}}`
+	if got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59"); got != raw {
+		t.Fatalf("non-array messages must return original verbatim, got %q", got)
+	}
+}
+
+// messages 数组中混入非对象元素（防御）时，该元素原样保留，命中锚点的对象元素仍被去重。
+func TestDedupChatMessageBoundary_NonObjectElementKeptAndOthersDeduped(t *testing.T) {
+	raw := `{"result":{"messages":["str",{"openMessageId":"m1","createTime":"2026-05-22 09:26:59"}]}}`
+	got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59")
+	var doc struct {
+		Result struct {
+			Messages []any `json:"messages"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(got), &doc); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(doc.Result.Messages) != 1 || doc.Result.Messages[0] != "str" {
+		t.Fatalf("expected only the non-object element \"str\" to remain, got %v", doc.Result.Messages)
+	}
+}
+
+// 去重后其它字段（hasMore、result 外层字段）保持不变。
+func TestDedupChatMessageBoundary_PreservesOtherFields(t *testing.T) {
+	raw := `{"requestId":"abc","result":{"messages":[{"openMessageId":"m1","createTime":"2026-05-22 09:26:59"}],"hasMore":true}}`
+	got := dedupChatMessageBoundary(raw, "2026-05-22 09:26:59")
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(got), &doc); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if doc["requestId"] != "abc" {
+		t.Fatalf("requestId not preserved: %v", doc["requestId"])
+	}
+	result, _ := doc["result"].(map[string]any)
+	if result["hasMore"] != true {
+		t.Fatalf("hasMore not preserved: %v", result["hasMore"])
+	}
+	if msgs, _ := result["messages"].([]any); len(msgs) != 0 {
+		t.Fatalf("expected empty messages after dedup, got %v", msgs)
+	}
+}
+
+// 端到端：callMCPToolDedupBoundary 经由 callMCPToolInternalOptsPost 的 post 钩子，
+// 在 --format json 输出中真正去掉了边界消息（fake caller 模拟服务端响应）。
+func TestCallMCPToolDedupBoundary_AppliesPostProcessInJSONOutput(t *testing.T) {
+	caller := &helpersCoreCaller{
+		format: "json",
+		result: textToolResult(`{"result":{"messages":[` +
+			`{"openMessageId":"m1","createTime":"2026-05-22 09:30:00"},` +
+			`{"openMessageId":"m2","createTime":"2026-05-22 09:26:59"}],"hasMore":true}}`),
+	}
+	out, _ := installHelpersCoreDeps(t, caller)
+
+	if err := callMCPToolDedupBoundary("list_conversation_message_v2", map[string]any{"time": "2026-05-22 09:26:59"}, "2026-05-22 09:26:59"); err != nil {
+		t.Fatalf("callMCPToolDedupBoundary returned error: %v", err)
+	}
+	if ids := messageIDsFrom(t, out.String()); len(ids) != 1 || ids[0] != "m1" {
+		t.Fatalf("expected boundary message m2 removed from output, got %v", ids)
+	}
+	var doc struct {
+		Result struct {
+			HasMore bool `json:"hasMore"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &doc); err != nil {
+		t.Fatalf("output not valid json: %v", err)
+	}
+	if !doc.Result.HasMore {
+		t.Fatalf("hasMore should be preserved in output: %s", out.String())
+	}
+}
+
+// 端到端：没有命中时，输出与普通 callMCPTool 完全一致（零回归）。
+func TestCallMCPToolDedupBoundary_NoOpMatchesPlainCallMCPTool(t *testing.T) {
+	resp := `{"result":{"messages":[{"openMessageId":"m1","createTime":"2026-05-22 09:30:00"}],"hasMore":false}}`
+
+	callerA := &helpersCoreCaller{format: "json", result: textToolResult(resp)}
+	outA, _ := installHelpersCoreDeps(t, callerA)
+	if err := callMCPTool("list_conversation_message_v2", nil); err != nil {
+		t.Fatalf("callMCPTool error: %v", err)
+	}
+	plain := outA.String()
+
+	callerB := &helpersCoreCaller{format: "json", result: textToolResult(resp)}
+	outB, _ := installHelpersCoreDeps(t, callerB)
+	if err := callMCPToolDedupBoundary("list_conversation_message_v2", nil, "2026-05-22 09:26:59"); err != nil {
+		t.Fatalf("callMCPToolDedupBoundary error: %v", err)
+	}
+	if outB.String() != plain {
+		t.Fatalf("no-match dedup output differs from plain callMCPTool:\nplain: %s\ndedup: %s", plain, outB.String())
+	}
+}

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -231,20 +231,28 @@ func MustGetStringFlag(cmd *cobra.Command, name string) string {
 	return val
 }
 
-// callMCPToolInternalOpts 是所有 MCP 工具调用的核心实现。
+// callMCPToolInternalOpts 是所有 MCP 工具调用的入口，等价于 post=nil 的
+// callMCPToolInternalOptsPost（成功响应文本原样输出，不做后处理）。
+func callMCPToolInternalOpts(explicitServerID, toolName string, args map[string]any, unescapeHTML bool) error {
+	return callMCPToolInternalOptsPost(explicitServerID, toolName, args, unescapeHTML, nil)
+}
+
+// callMCPToolInternalOptsPost 是所有 MCP 工具调用的核心实现。
 //
 // 参数说明：
 //   - explicitServerID: 显式指定的 MCP Server ID，为空时自动路由
 //   - toolName:         MCP 工具名称（如 "create_upload_session"）
 //   - args:             工具调用参数，会被序列化为 JSON 传给 MCP Server
 //   - unescapeHTML:     是否禁用 JSON 输出的 HTML 转义（仅影响最终输出格式）
+//   - post:             成功响应文本的后处理函数（如 chat 翻页边界去重），nil 表示原样输出
 //
 // 执行流程：
 //  1. DryRun 模式：仅打印工具名和参数，不实际调用
 //  2. 调用 MCP Server 获取结果
 //  3. 错误分类：网关错误 → 未登录 → PAT 错误 → 业务错误
-//  4. 根据 --format 标志选择输出格式（json / table / raw）
-func callMCPToolInternalOpts(explicitServerID, toolName string, args map[string]any, unescapeHTML bool) error {
+//  4. 对成功响应文本应用 post（若非 nil）
+//  5. 根据 --format 标志选择输出格式（json / table / raw）
+func callMCPToolInternalOptsPost(explicitServerID, toolName string, args map[string]any, unescapeHTML bool, post func(string) string) error {
 	ctx := context.Background()
 
 	// DryRun 模式：仅预览工具名和参数，不实际调用 MCP Server
@@ -314,16 +322,22 @@ func callMCPToolInternalOpts(explicitServerID, toolName string, args map[string]
 				}
 			}
 
+			// 对成功响应文本应用后处理（如 chat 翻页边界去重）。post 为 nil 时无操作。
+			text := c.Text
+			if post != nil {
+				text = post(text)
+			}
+
 			// JSON 格式输出：解析后使用选定的 printJSON 函数输出
 			if flagFormat == "json" {
 				var parsed any
-				if err := json.Unmarshal([]byte(c.Text), &parsed); err == nil {
+				if err := json.Unmarshal([]byte(text), &parsed); err == nil {
 					return printJSON(parsed)
 				}
 			}
 			// 特殊处理：开放平台文档搜索结果的表格格式输出
 			if toolName == "search_open_platform_docs" && flagFormat == "table" {
-				if formatted := formatDevdocSearchTable(c.Text); formatted {
+				if formatted := formatDevdocSearchTable(text); formatted {
 					return nil
 				}
 			}
@@ -333,11 +347,11 @@ func callMCPToolInternalOpts(explicitServerID, toolName string, args map[string]
 			// PrintJSONUnescaped 输出，保证 & 不被二次转义。
 			if unescapeHTML {
 				var parsed any
-				if err := json.Unmarshal([]byte(c.Text), &parsed); err == nil {
+				if err := json.Unmarshal([]byte(text), &parsed); err == nil {
 					return printJSON(parsed)
 				}
 			}
-			deps.Out.PrintRaw(c.Text)
+			deps.Out.PrintRaw(text)
 			return nil
 		}
 	}


### PR DESCRIPTION
## Summary

- **What changed?** Re-implement the `chat message list` pagination boundary de-duplication on the current static chat handler (`internal/helpers/chat.go`), so that paginating by feeding the previous page's boundary `createTime` back as the next `--time` no longer loops forever. The de-dup drops entries in `result.messages` whose `createTime` equals the `--time` anchor, applied to `chat message list`, `chat message list-direct`, and `chat message list-topic-replies`. The shared MCP-call core gains a nil-safe `post` text hook (`callMCPToolInternalOptsPost`) so the response is filtered before rendering, preserving DryRun / `--format json|table|raw` / error-classification behavior exactly.
- **Why is this change needed?** Closes #430. The upstream IM API uses an inclusive time boundary (`>=` for `newer`/`forward=true`, `<=` for `older`/`forward=false`). The skill docs (written by #572) tell the caller to reuse the boundary `createTime` as the next `--time`; that exact-boundary message is then re-served on every subsequent page, so `chat message list --direction older` (or `--forward`) pagination loops, returning the same message again and again. #572 mitigated this by recommending `--direction older`, but the strict boundary de-dup still had to be (re-)done on the static handler.

This re-submits the intent of the closed #461, whose implementation lived on `internal/compat/chat_hooks.go` / `dynamic_commands.go` — those files were removed by the #565 static-runtime refactor, so that PR could no longer merge. The dedup logic itself is relocated onto the current handler (`internal/helpers/chat.go`) and the new shared `post` hook, with no dependency on the deleted `compat` package.

## Verification

Exact `CHANGELOG.md`-only check: `N/A` (this is a code change).

- [x] `make build` — `scripts/dev/build.sh` (`go build -o dws ./cmd`) succeeds; `dws` binary builds. Also ran `go build ./...` (whole module) clean.
- [x] `make lint` — `gofmt` clean on all changed files; `go vet ./internal/helpers/` clean. (`staticcheck` is not installed in my local env; left to CI.)
- [~] `make test` — **partial locally; full suite left to CI.** I ran the targeted set on Windows + Go 1.25.11:
  - 12 new tests in `chat_dedup_test.go` (de-dup logic + end-to-end via fake caller): all PASS
  - core `callMCPToolInternalOpts` coverage in `helpers_core_test.go` / `helpers_coverage_more_test.go` (json/table/raw/devdoc, DryRun, unescape, error classification): all PASS
  - all `Chat`/`Message`/`ChatRecord`-related tests in `internal/helpers/`: PASS (3.77s)
  - The full `go test ./...` was not completed locally — the `internal/helpers` package alone exceeds my local run budget on Windows (some pre-existing tests are slow). CI (Linux) runs the full suite.
- [~] `make policy` — not run as a whole locally. `./scripts/policy/check-command-surface.sh --strict` PASSes (command surface unchanged: no new commands/flags/help text).
- [ ] `./scripts/policy/check-generated-drift.sh` — **pre-existing failure on clean `origin/main`, not introduced here.** On a clean checkout of `origin/main` (my changes stashed) this check already reports `internal/cli/schema_agent_metadata is stale` across all products (aisearch/aitable/.../chat/contact/wiki…), so it is unrelated to this PR, which changes no `CommandRegistry`/command definition. Likely a Windows CRLF/path artifact or genuinely stale committed schemas; expecting Linux CI to match its current main behavior.
- [x] `./scripts/policy/check-command-surface.sh --strict` — PASS (covered above).

## Notes

- **Scope: CLI handlers only.** The shortcut layer (`internal/shortcut/chat`, `internal/shortcut/smart`) calls these same tools via `rt.CallMCPData` (a separate path, not `callMCPTool`) and only reshapes a single page — it does not loop internally — so it is intentionally out of scope for #430 (which is about the `dws chat message list` CLI command). `internal/helpers/connect_chatrecord.go` calls `list_conversation_message_v2` only to resolve records by id, not as a user-facing pagination surface.
- **Why de-dup both directions.** `--direction newer` (`forward=true`) is fundamentally not paginatable toward older history (it always re-serves the newest N at/after `T`); the de-dup's real value is on `--direction older` (`forward=false`), where pagination is valid except for the single exact-boundary repeat. The de-dup is applied uniformly (harmless on `newer`), and is an exact-string match (`createTime` == anchor, after trim) so it only ever drops the verbatim-boundary message — i.e. precisely the loop case.
- **Safe by construction.** `dedupChatMessageBoundary` only inspects top-level `result.messages` (never recurses into nested `forwardMessages`, whose `createTime` is a forwarded body, not a pagination boundary) and returns the original text verbatim on any parse/shape mismatch, so it is safe to apply unconditionally.
- **Skill-doc note deferred.** I did not edit `skills/.../chat.md` in this PR: the generated `internal/cli/schema_agent_metadata/index.json` carries a `source_hash` over the skill markdown, so even a one-line doc change forces a `make generate-schema` regeneration, and that hash is not reliably reproducible on Windows (raw-byte hash, no CRLF normalization). The existing docs (from #572) already recommend `--direction older`; the new auto-dedup behavior is documented in the code comments and this PR description. Happy to follow up with the doc line (+ regenerated schema) if you'd like it included here.
