### PR TITLE
feat(report): support delegated sender submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and this project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Delegated report submission** (#406) — `dws report entry submit --sender-user-id <userId>` and the deprecated `dws report create` alias can submit through DingTalk OAPI `POST /topapi/report/create` with the requested sender. Ordinary submissions still use MCP `report.create_report`; delegated failures never fall back to MCP, dry-run does not resolve credentials, and the OAPI route requires the caller's own AppKey/AppSecret plus the “管理员工日志数据” permission.
+
 ## [1.0.55-beta.3] - 2026-07-24
 
 This beta validates the HR Brain command surface, smoother guarded release

--- a/internal/app/legacy.go
+++ b/internal/app/legacy.go
@@ -29,7 +29,7 @@ import (
 
 func newLegacyPublicCommands(runner executor.Runner, caller edition.ToolCaller, loadUserShortcuts bool) []*cobra.Command {
 	injectStaticServers()
-	helpers.InitDeps(caller)
+	helpers.InitDeps(caller, helpers.WithReportSenderSubmitter(newReportSenderOAPISubmitter()))
 	commands := helpers.NewPublicCommands(runner)
 	// Load user-defined shortcuts (~/.dws/shortcuts/*.yaml) BEFORE compiling the
 	// command tree, so distilled high-frequency operations mount alongside the

--- a/internal/app/report_sender_submitter.go
+++ b/internal/app/report_sender_submitter.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/apiclient"
+	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const reportCreateOAPIURL = "https://oapi.dingtalk.com/topapi/report/create"
+
+type reportSenderAPICaller interface {
+	Do(context.Context, apiclient.RawAPIRequest) (*apiclient.RawAPIResponse, error)
+}
+
+type reportSenderOAPISubmitter struct {
+	resolveToken func(context.Context) (string, error)
+	newClient    func(string) reportSenderAPICaller
+}
+
+func newReportSenderOAPISubmitter() *reportSenderOAPISubmitter {
+	return &reportSenderOAPISubmitter{
+		resolveToken: resolveReportSenderToken,
+		newClient: func(token string) reportSenderAPICaller {
+			return apiclient.NewClient(token, apiclient.LegacyBaseURL)
+		},
+	}
+}
+
+func (s *reportSenderOAPISubmitter) Submit(ctx context.Context, cmd *cobra.Command, submission helpers.ReportSenderSubmission) error {
+	body, err := helpers.BuildReportCreateOAPIRequest(submission)
+	if err != nil {
+		return err
+	}
+	request := apiclient.RawAPIRequest{
+		Method: http.MethodPost,
+		Path:   reportCreateOAPIURL,
+		Data:   body,
+	}
+
+	// Dry-run intentionally happens before token resolution. The preview never
+	// fetches, caches, or prints an application access token.
+	if submission.DryRun || reportCommandBoolFlag(cmd, "dry-run") {
+		return output.WriteCommandPayload(cmd, map[string]any{
+			"dry_run": true,
+			"route":   "dingtalk_oapi",
+			"request": map[string]any{
+				"method": request.Method,
+				"url":    request.Path,
+				"body":   request.Data,
+			},
+		}, output.FormatJSON)
+	}
+
+	if s == nil || s.resolveToken == nil || s.newClient == nil {
+		return apperrors.NewInternal(
+			"report sender OAPI submitter is not configured",
+			apperrors.WithOperation("report.create.delegated"),
+		)
+	}
+	token, err := s.resolveToken(ctx)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(token) == "" {
+		return apperrors.NewAuth(
+			"获取到的应用级 access token 为空",
+			apperrors.WithOperation("report.create.delegated"),
+			apperrors.WithReason("empty_app_access_token"),
+			apperrors.WithHint("检查自有应用 AppKey/AppSecret 后重试"),
+		)
+	}
+	client := s.newClient(token)
+	if client == nil {
+		return apperrors.NewInternal(
+			"report sender OAPI client is not configured",
+			apperrors.WithOperation("report.create.delegated"),
+		)
+	}
+	if concrete, ok := client.(*apiclient.APIClient); ok {
+		if timeout := reportCommandIntFlag(cmd, "timeout"); timeout > 0 {
+			concrete.HTTPClient.Timeout = time.Duration(timeout) * time.Second
+		}
+	}
+	response, err := client.Do(ctx, request)
+	if err != nil {
+		return apperrors.NewAPI(
+			fmt.Sprintf("代提交日志 OAPI 请求失败: %v", err),
+			apperrors.WithOperation("report.create.delegated"),
+			apperrors.WithReason("delegated_report_request_failed"),
+			apperrors.WithHint("检查网络、自有应用凭证和“管理员工日志数据”权限；该路径不会回退 MCP"),
+			apperrors.WithCause(err),
+		)
+	}
+	if response == nil {
+		return apperrors.NewAPI(
+			"代提交日志 OAPI 返回空响应",
+			apperrors.WithOperation("report.create.delegated"),
+			apperrors.WithReason("empty_api_response"),
+			apperrors.WithHint("稍后重试；该路径不会回退 MCP"),
+		)
+	}
+	if err := apiclient.HandleResponse(response, apiclient.ResponseOptions{
+		Format: output.ResolveFormat(cmd, output.FormatJSON),
+		JqExpr: output.ResolveJQ(cmd),
+		Fields: output.ResolveFields(cmd),
+		Out:    cmd.OutOrStdout(),
+		ErrOut: cmd.ErrOrStderr(),
+	}); err != nil {
+		return apperrors.NewAPI(
+			fmt.Sprintf("代提交日志 OAPI 返回错误: %v", err),
+			apperrors.WithOperation("report.create.delegated"),
+			apperrors.WithReason("delegated_report_api_error"),
+			apperrors.WithHint("确认 sender userId 属于当前企业且应用已开通“管理员工日志数据”权限；不要改走 MCP 重试"),
+			apperrors.WithCause(err),
+		)
+	}
+	return nil
+}
+
+func resolveReportSenderToken(ctx context.Context) (string, error) {
+	appKey := strings.TrimSpace(authpkg.ClientID())
+	appSecret := strings.TrimSpace(authpkg.ClientSecret())
+	if appKey == "" || appSecret == "" || strings.HasPrefix(appKey, "<") || strings.HasPrefix(appSecret, "<") {
+		return "", apperrors.NewAuth(
+			"--sender-user-id 代提交日志需要自有应用的 AppKey/AppSecret",
+			apperrors.WithOperation("report.create.delegated"),
+			apperrors.WithReason("app_credentials_required"),
+			apperrors.WithHint("通过 --client-id/--client-secret、DWS_CLIENT_ID/DWS_CLIENT_SECRET 或 dws auth login 配置；应用还需“管理员工日志数据”权限"),
+		)
+	}
+	provider := &authpkg.AppTokenProvider{AppKey: appKey, AppSecret: appSecret}
+	token, err := provider.GetToken(ctx)
+	if err != nil {
+		return "", apperrors.NewAuth(
+			fmt.Sprintf("获取代提交日志所需的应用级 access token 失败: %v", err),
+			apperrors.WithOperation("report.create.delegated"),
+			apperrors.WithReason("app_token_failed"),
+			apperrors.WithHint("检查自有应用凭证及网络后重试"),
+			apperrors.WithCause(err),
+		)
+	}
+	return strings.TrimSpace(token), nil
+}
+
+func reportCommandBoolFlag(cmd *cobra.Command, name string) bool {
+	for _, flags := range reportCommandFlagSets(cmd) {
+		if flags.Lookup(name) == nil {
+			continue
+		}
+		value, err := flags.GetBool(name)
+		if err == nil {
+			return value
+		}
+	}
+	return false
+}
+
+func reportCommandIntFlag(cmd *cobra.Command, name string) int {
+	for _, flags := range reportCommandFlagSets(cmd) {
+		if flags.Lookup(name) == nil {
+			continue
+		}
+		value, err := flags.GetInt(name)
+		if err == nil {
+			return value
+		}
+	}
+	return 0
+}
+
+func reportCommandFlagSets(cmd *cobra.Command) []*pflag.FlagSet {
+	if cmd == nil {
+		return nil
+	}
+	sets := []*pflag.FlagSet{cmd.Flags(), cmd.InheritedFlags()}
+	if root := cmd.Root(); root != nil {
+		sets = append(sets, root.PersistentFlags())
+	}
+	return sets
+}

--- a/internal/app/report_sender_submitter_test.go
+++ b/internal/app/report_sender_submitter_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/apiclient"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
+	"github.com/spf13/cobra"
+)
+
+type recordingReportAPICaller struct {
+	calls int
+	req   apiclient.RawAPIRequest
+	resp  *apiclient.RawAPIResponse
+	err   error
+}
+
+func (c *recordingReportAPICaller) Do(_ context.Context, req apiclient.RawAPIRequest) (*apiclient.RawAPIResponse, error) {
+	c.calls++
+	c.req = req
+	return c.resp, c.err
+}
+
+func TestReportSenderOAPISubmitterPostsLegacyCreateRequest(t *testing.T) {
+	t.Parallel()
+
+	caller := &recordingReportAPICaller{resp: reportSenderTestResponse(`{"errcode":0,"result":"report-1"}`)}
+	tokenCalls := 0
+	submitter := &reportSenderOAPISubmitter{
+		resolveToken: func(context.Context) (string, error) {
+			tokenCalls++
+			return "token-1", nil
+		},
+		newClient: func(token string) reportSenderAPICaller {
+			if token != "token-1" {
+				t.Fatalf("client token = %q, want token-1", token)
+			}
+			return caller
+		},
+	}
+	cmd, out := newReportSenderSubmitterTestCommand(false)
+
+	err := submitter.Submit(context.Background(), cmd, helpers.ReportSenderSubmission{
+		SenderUserID: "sender-1",
+		TemplateID:   "template-1",
+		Contents: []map[string]any{{
+			"key":         "x",
+			"sort":        "0",
+			"type":        "1",
+			"contentType": "markdown",
+			"content":     "done",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if tokenCalls != 1 || caller.calls != 1 {
+		t.Fatalf("token calls = %d, API calls = %d, want 1/1", tokenCalls, caller.calls)
+	}
+	if caller.req.Method != http.MethodPost || caller.req.Path != reportCreateOAPIURL {
+		t.Fatalf("request = %s %s, want POST %s", caller.req.Method, caller.req.Path, reportCreateOAPIURL)
+	}
+	body, ok := caller.req.Data.(map[string]any)
+	if !ok || body["create_report_param"] == nil {
+		t.Fatalf("request body = %#v", caller.req.Data)
+	}
+	if !strings.Contains(out.String(), "report-1") {
+		t.Fatalf("output missing report id: %q", out.String())
+	}
+}
+
+func TestReportSenderOAPISubmitterDryRunSkipsCredentialsAndHTTP(t *testing.T) {
+	t.Parallel()
+
+	caller := &recordingReportAPICaller{}
+	tokenCalls := 0
+	submitter := &reportSenderOAPISubmitter{
+		resolveToken: func(context.Context) (string, error) {
+			tokenCalls++
+			return "token-1", nil
+		},
+		newClient: func(string) reportSenderAPICaller { return caller },
+	}
+	cmd, out := newReportSenderSubmitterTestCommand(true)
+
+	err := submitter.Submit(context.Background(), cmd, helpers.ReportSenderSubmission{
+		SenderUserID: "sender-1",
+		TemplateID:   "template-1",
+		Contents:     reportSenderValidContents(),
+	})
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if tokenCalls != 0 || caller.calls != 0 {
+		t.Fatalf("dry-run token calls = %d, API calls = %d, want 0/0", tokenCalls, caller.calls)
+	}
+	outputText := out.String()
+	if !strings.Contains(outputText, `"sender-1"`) ||
+		!strings.Contains(outputText, `"dry_run": true`) ||
+		strings.Contains(outputText, "token-1") ||
+		strings.Contains(outputText, "access_token") {
+		t.Fatalf("unsafe or incomplete dry-run output: %q", outputText)
+	}
+}
+
+func TestReportSenderOAPISubmitterReturnsBusinessErrorWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	caller := &recordingReportAPICaller{resp: reportSenderTestResponse(`{"errcode":60011,"errmsg":"no permission"}`)}
+	submitter := &reportSenderOAPISubmitter{
+		resolveToken: func(context.Context) (string, error) { return "token-1", nil },
+		newClient:    func(string) reportSenderAPICaller { return caller },
+	}
+	cmd, _ := newReportSenderSubmitterTestCommand(false)
+
+	err := submitter.Submit(context.Background(), cmd, helpers.ReportSenderSubmission{
+		SenderUserID: "sender-1",
+		TemplateID:   "template-1",
+		Contents:     reportSenderValidContents(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "60011") {
+		t.Fatalf("Submit() error = %v, want business error 60011", err)
+	}
+	if caller.calls != 1 {
+		t.Fatalf("business error API calls = %d, want exactly 1", caller.calls)
+	}
+}
+
+func TestReportSenderOAPISubmitterWrapsTransportFailure(t *testing.T) {
+	t.Parallel()
+
+	caller := &recordingReportAPICaller{err: errors.New("network down")}
+	submitter := &reportSenderOAPISubmitter{
+		resolveToken: func(context.Context) (string, error) { return "token-1", nil },
+		newClient:    func(string) reportSenderAPICaller { return caller },
+	}
+	cmd, _ := newReportSenderSubmitterTestCommand(false)
+	err := submitter.Submit(context.Background(), cmd, helpers.ReportSenderSubmission{
+		SenderUserID: "sender-1",
+		TemplateID:   "template-1",
+		Contents:     reportSenderValidContents(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "network down") {
+		t.Fatalf("Submit() error = %v, want transport failure", err)
+	}
+}
+
+func TestReportSenderOAPISubmitterCredentialFailureSkipsHTTP(t *testing.T) {
+	t.Parallel()
+
+	caller := &recordingReportAPICaller{}
+	submitter := &reportSenderOAPISubmitter{
+		resolveToken: func(context.Context) (string, error) {
+			return "", errors.New("own app credentials required")
+		},
+		newClient: func(string) reportSenderAPICaller { return caller },
+	}
+	cmd, _ := newReportSenderSubmitterTestCommand(false)
+	err := submitter.Submit(context.Background(), cmd, helpers.ReportSenderSubmission{
+		SenderUserID: "sender-1",
+		TemplateID:   "template-1",
+		Contents:     reportSenderValidContents(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "own app credentials required") {
+		t.Fatalf("Submit() error = %v, want credential error", err)
+	}
+	if caller.calls != 0 {
+		t.Fatalf("credential failure API calls = %d, want 0", caller.calls)
+	}
+}
+
+func newReportSenderSubmitterTestCommand(dryRun bool) (*cobra.Command, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	root := &cobra.Command{Use: "dws"}
+	root.PersistentFlags().Bool("dry-run", dryRun, "")
+	root.PersistentFlags().String("format", "json", "")
+	root.PersistentFlags().String("fields", "", "")
+	root.PersistentFlags().String("jq", "", "")
+	root.PersistentFlags().Int("timeout", 30, "")
+	cmd := &cobra.Command{Use: "submit"}
+	root.AddCommand(cmd)
+	cmd.SetOut(out)
+	cmd.SetErr(&bytes.Buffer{})
+	return cmd, out
+}
+
+func reportSenderTestResponse(body string) *apiclient.RawAPIResponse {
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	return &apiclient.RawAPIResponse{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       []byte(body),
+	}
+}
+
+func reportSenderValidContents() []map[string]any {
+	return []map[string]any{{
+		"key":         "x",
+		"sort":        "0",
+		"content":     "done",
+		"contentType": "markdown",
+		"type":        "1",
+	}}
+}

--- a/internal/cli/schema_agent_metadata/index.json
+++ b/internal/cli/schema_agent_metadata/index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "source_hash": "sha256:bda812c0b48f221a70f9c710d56a4dead5916bf425a9b153e7b275d15365f1a0",
+  "source_hash": "sha256:77860a44806639f8d37a8eaf44971dee231041158160f139d4c59c899a0718cf",
   "surface_hash": "sha256:8eef4235b4391a6a865c180ebd3a65ca3531a84c6985b37811f23fff9daf2e3a",
   "coverage": {
     "surface_products": 25,

--- a/internal/cli/schema_agent_metadata/report.json
+++ b/internal/cli/schema_agent_metadata/report.json
@@ -534,34 +534,36 @@
       ]
     },
     "report entry submit": {
-      "agent_summary": "按模版提交一份新日报",
+      "agent_summary": "按模版以当前用户或显式指定员工为发送人提交一份新日报",
       "agent_summary_source": "dws-agent-selection/report",
       "availability": "available",
       "avoid_when": [
         "尚未读取模板字段时先用 dws report template list / template get",
-        "只需查看已有日志正文时改用 dws report entry get"
+        "只需查看已有日志正文时改用 dws report entry get",
+        "不要根据接收人、姓名或上下文猜测 --sender-user-id；--to-user-ids 仅表示接收人",
+        "没有自有应用 AppKey/AppSecret 或管理员工日志权限时不要选择委托提交路径"
       ],
       "confirmation": "not_required",
       "effect": "write",
       "effect_source": "command-verb",
       "examples": [
         "dws report entry submit --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json",
-        "dws report entry submit --template-id \u003ctemplateId\u003e --contents '[{\"key\":\"今日完成\",\"sort\":\"0\",\"content\":\"完成了需求评审\",\"contentType\":\"markdown\",\"type\":\"1\"}]' --format json"
+        "dws report entry submit --sender-user-id \u003cemployeeUserId\u003e --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json"
       ],
       "field_provenance": {
         "agent_summary": {
-          "value": "按模版提交一份新日报",
+          "value": "按模版以当前用户或显式指定员工为发送人提交一份新日报",
           "source": "internal/cli/schema_hints/selection/report.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+          "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
           "candidates": [
             {
-              "value": "按模版提交一份新日报",
+              "value": "按模版以当前用户或显式指定员工为发送人提交一份新日报",
               "source": "internal/cli/schema_hints/selection/report.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。"
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。"
             }
           ]
         },
@@ -570,14 +572,14 @@
           "source": "internal/cli/schema_hints/metadata/report.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+          "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
           "candidates": [
             {
               "value": "available",
               "source": "internal/cli/schema_hints/metadata/report.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report."
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure."
             },
             {
               "value": "available",
@@ -590,22 +592,26 @@
         "avoid_when": {
           "value": [
             "尚未读取模板字段时先用 dws report template list / template get",
-            "只需查看已有日志正文时改用 dws report entry get"
+            "只需查看已有日志正文时改用 dws report entry get",
+            "不要根据接收人、姓名或上下文猜测 --sender-user-id；--to-user-ids 仅表示接收人",
+            "没有自有应用 AppKey/AppSecret 或管理员工日志权限时不要选择委托提交路径"
           ],
           "source": "internal/cli/schema_hints/selection/report.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+          "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
           "candidates": [
             {
               "value": [
                 "尚未读取模板字段时先用 dws report template list / template get",
-                "只需查看已有日志正文时改用 dws report entry get"
+                "只需查看已有日志正文时改用 dws report entry get",
+                "不要根据接收人、姓名或上下文猜测 --sender-user-id；--to-user-ids 仅表示接收人",
+                "没有自有应用 AppKey/AppSecret 或管理员工日志权限时不要选择委托提交路径"
               ],
               "source": "internal/cli/schema_hints/selection/report.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。"
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。"
             }
           ]
         },
@@ -614,14 +620,14 @@
           "source": "internal/cli/schema_hints/metadata/report.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+          "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
           "candidates": [
             {
               "value": "not_required",
               "source": "internal/cli/schema_hints/metadata/report.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report."
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure."
             },
             {
               "value": "not_required",
@@ -648,22 +654,22 @@
         "examples": {
           "value": [
             "dws report entry submit --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json",
-            "dws report entry submit --template-id \u003ctemplateId\u003e --contents '[{\"key\":\"今日完成\",\"sort\":\"0\",\"content\":\"完成了需求评审\",\"contentType\":\"markdown\",\"type\":\"1\"}]' --format json"
+            "dws report entry submit --sender-user-id \u003cemployeeUserId\u003e --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json"
           ],
           "source": "internal/cli/schema_hints/selection/report.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+          "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
           "candidates": [
             {
               "value": [
                 "dws report entry submit --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json",
-                "dws report entry submit --template-id \u003ctemplateId\u003e --contents '[{\"key\":\"今日完成\",\"sort\":\"0\",\"content\":\"完成了需求评审\",\"contentType\":\"markdown\",\"type\":\"1\"}]' --format json"
+                "dws report entry submit --sender-user-id \u003cemployeeUserId\u003e --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json"
               ],
               "source": "internal/cli/schema_hints/selection/report.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。"
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。"
             }
           ]
         },
@@ -686,14 +692,14 @@
           "source": "internal/cli/schema_hints/metadata/report.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+          "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
           "candidates": [
             {
               "value": "mcp",
               "source": "internal/cli/schema_hints/metadata/report.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report."
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure."
             },
             {
               "value": "mcp",
@@ -728,21 +734,21 @@
           "source": "internal/cli/schema_hints/metadata/report.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+          "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
           "candidates": [
             {
               "value": true,
               "source": "internal/cli/schema_hints/metadata/report.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report."
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure."
             },
             {
               "value": true,
               "source": "internal/cli/schema_hints/selection/report.json",
               "precedence": "reviewed_explicit",
               "selected": false,
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。"
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。"
             }
           ]
         },
@@ -762,21 +768,23 @@
         },
         "use_when": {
           "value": [
-            "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时"
+            "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时",
+            "用户明确要求以某个员工 userId 为发送人代提交，且已有自有应用凭证和“管理员工日志数据”权限时，使用 --sender-user-id"
           ],
           "source": "internal/cli/schema_hints/selection/report.json",
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+          "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
           "candidates": [
             {
               "value": [
-                "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时"
+                "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时",
+                "用户明确要求以某个员工 userId 为发送人代提交，且已有自有应用凭证和“管理员工日志数据”权限时，使用 --sender-user-id"
               ],
               "source": "internal/cli/schema_hints/selection/report.json",
               "precedence": "reviewed_explicit",
               "selected": true,
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。"
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。"
             }
           ]
         }
@@ -804,7 +812,8 @@
         "structured-hint:internal/cli/schema_hints/selection-review.json#report.create_report"
       ],
       "use_when": [
-        "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时"
+        "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时",
+        "用户明确要求以某个员工 userId 为发送人代提交，且已有自有应用凭证和“管理员工日志数据”权限时，使用 --sender-user-id"
       ]
     },
     "report inbox list": {

--- a/internal/cli/schema_agent_metadata_audit.json
+++ b/internal/cli/schema_agent_metadata_audit.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "source_hash": "sha256:bda812c0b48f221a70f9c710d56a4dead5916bf425a9b153e7b275d15365f1a0",
+  "source_hash": "sha256:77860a44806639f8d37a8eaf44971dee231041158160f139d4c59c899a0718cf",
   "surface_hash": "sha256:8eef4235b4391a6a865c180ebd3a65ca3531a84c6985b37811f23fff9daf2e3a",
   "source_files": 158,
   "hint_files": 52,

--- a/internal/cli/schema_catalog.json
+++ b/internal/cli/schema_catalog.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
-  "source_hash": "sha256:46412dbee4c24a4c7cbd322a78b7d54b05b255fe5dbe9fe9b6ee049422572a9f",
+  "source_hash": "sha256:190b6abd13ef55b68db6a0c7ee2680b4b6abf608560f187248482022ef64a3ca",
   "surface_hash": "sha256:8eef4235b4391a6a865c180ebd3a65ca3531a84c6985b37811f23fff9daf2e3a",
   "catalog": {
     "agent_metadata": {
       "products_with_metadata": 25,
       "source": "embedded-skill-metadata",
-      "source_hash": "sha256:bda812c0b48f221a70f9c710d56a4dead5916bf425a9b153e7b275d15365f1a0",
+      "source_hash": "sha256:77860a44806639f8d37a8eaf44971dee231041158160f139d4c59c899a0718cf",
       "surface_hash": "sha256:8eef4235b4391a6a865c180ebd3a65ca3531a84c6985b37811f23fff9daf2e3a",
       "surface_products": 25,
       "surface_tools": 603,
@@ -16227,7 +16227,7 @@
         "tools": [
           {
             "agent_metadata_source": "embedded-skill-metadata",
-            "agent_summary": "按模版提交一份新日报",
+            "agent_summary": "按模版以当前用户或显式指定员工为发送人提交一份新日报",
             "agent_summary_source": "dws-agent-selection/report",
             "aliases": [
               "report create"
@@ -16235,13 +16235,15 @@
             "availability": "available",
             "avoid_when": [
               "尚未读取模板字段时先用 dws report template list / template get",
-              "只需查看已有日志正文时改用 dws report entry get"
+              "只需查看已有日志正文时改用 dws report entry get",
+              "不要根据接收人、姓名或上下文猜测 --sender-user-id；--to-user-ids 仅表示接收人",
+              "没有自有应用 AppKey/AppSecret 或管理员工日志权限时不要选择委托提交路径"
             ],
             "canonical_path": "report.create_report",
             "cli_name": "submit",
             "cli_path": "report entry submit",
             "confirmation": "not_required",
-            "description": "按模版提交一份日报。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，\n与远程 create_report 一致；可先通过 report template list / template get 取得 templateId 与控件定义。\n\n长内容（含中文换行 / Markdown）建议走 --contents-file 避免 shell 引号问题；\n也可用 --contents - 从 stdin 读取。\n提交成功后会自动反查详情，并在返回中追加 dingtalkOpenUrl / dingtalkOpenMarkdownLink 跳转链接字段。",
+            "description": "按模版提交一份日报。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，\n与远程 create_report 一致；可先通过 report template list / template get 取得 templateId 与控件定义。\n\n长内容（含中文换行 / Markdown）建议走 --contents-file 避免 shell 引号问题；\n也可用 --contents - 从 stdin 读取。\n默认通过 MCP 以当前登录用户提交，成功后会自动反查详情并追加钉钉跳转链接。\n显式传入非空 --sender-user-id 时，改用自有应用凭证通过钉钉 OAPI 代指定员工提交；\n该路径需要“管理员工日志数据”权限，且失败时不会回退 MCP。",
             "effect": "write",
             "group": "entry",
             "idempotency": "unknown",
@@ -16257,7 +16259,8 @@
             "risk": "medium",
             "title": "提交一份新日报（按模版）",
             "use_when": [
-              "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时"
+              "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时",
+              "用户明确要求以某个员工 userId 为发送人代提交，且已有自有应用凭证和“管理员工日志数据”权限时，使用 --sender-user-id"
             ]
           },
           {
@@ -370109,7 +370112,7 @@
         "structured-hint:internal/cli/schema_hints/imported/wukong.json#report.create_report",
         "structured-hint:internal/cli/schema_hints/selection-review.json#report.create_report"
       ],
-      "agent_summary": "按模版提交一份新日报",
+      "agent_summary": "按模版以当前用户或显式指定员工为发送人提交一份新日报",
       "agent_summary_source": "dws-agent-selection/report",
       "aliases": [
         "report create"
@@ -370117,7 +370120,9 @@
       "availability": "available",
       "avoid_when": [
         "尚未读取模板字段时先用 dws report template list / template get",
-        "只需查看已有日志正文时改用 dws report entry get"
+        "只需查看已有日志正文时改用 dws report entry get",
+        "不要根据接收人、姓名或上下文猜测 --sender-user-id；--to-user-ids 仅表示接收人",
+        "没有自有应用 AppKey/AppSecret 或管理员工日志权限时不要选择委托提交路径"
       ],
       "canonical_path": "report.create_report",
       "cli_name": "submit",
@@ -370131,36 +370136,36 @@
           ]
         ]
       },
-      "description": "按模版提交一份日报。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，\n与远程 create_report 一致；可先通过 report template list / template get 取得 templateId 与控件定义。\n\n长内容（含中文换行 / Markdown）建议走 --contents-file 避免 shell 引号问题；\n也可用 --contents - 从 stdin 读取。\n提交成功后会自动反查详情，并在返回中追加 dingtalkOpenUrl / dingtalkOpenMarkdownLink 跳转链接字段。",
+      "description": "按模版提交一份日报。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，\n与远程 create_report 一致；可先通过 report template list / template get 取得 templateId 与控件定义。\n\n长内容（含中文换行 / Markdown）建议走 --contents-file 避免 shell 引号问题；\n也可用 --contents - 从 stdin 读取。\n默认通过 MCP 以当前登录用户提交，成功后会自动反查详情并追加钉钉跳转链接。\n显式传入非空 --sender-user-id 时，改用自有应用凭证通过钉钉 OAPI 代指定员工提交；\n该路径需要“管理员工日志数据”权限，且失败时不会回退 MCP。",
       "display": "钉钉日志（OA 周报应用 / 日志模版填报）",
       "effect": "write",
       "effect_source": "command-verb",
       "examples": [
         "dws report entry submit --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json",
-        "dws report entry submit --template-id \u003ctemplateId\u003e --contents '[{\"key\":\"今日完成\",\"sort\":\"0\",\"content\":\"完成了需求评审\",\"contentType\":\"markdown\",\"type\":\"1\"}]' --format json"
+        "dws report entry submit --sender-user-id \u003cemployeeUserId\u003e --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json"
       ],
       "field_provenance": {
         "agent_summary": {
           "candidates": [
             {
               "precedence": "reviewed_explicit",
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
               "selected": true,
               "source": "internal/cli/schema_hints/selection/report.json",
-              "value": "按模版提交一份新日报"
+              "value": "按模版以当前用户或显式指定员工为发送人提交一份新日报"
             }
           ],
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+          "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
           "source": "internal/cli/schema_hints/selection/report.json",
-          "value": "按模版提交一份新日报"
+          "value": "按模版以当前用户或显式指定员工为发送人提交一份新日报"
         },
         "availability": {
           "candidates": [
             {
               "precedence": "reviewed_explicit",
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
               "selected": true,
               "source": "internal/cli/schema_hints/metadata/report.json",
               "value": "available"
@@ -370174,7 +370179,7 @@
           ],
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+          "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
           "source": "internal/cli/schema_hints/metadata/report.json",
           "value": "available"
         },
@@ -370182,22 +370187,26 @@
           "candidates": [
             {
               "precedence": "reviewed_explicit",
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
               "selected": true,
               "source": "internal/cli/schema_hints/selection/report.json",
               "value": [
                 "尚未读取模板字段时先用 dws report template list / template get",
-                "只需查看已有日志正文时改用 dws report entry get"
+                "只需查看已有日志正文时改用 dws report entry get",
+                "不要根据接收人、姓名或上下文猜测 --sender-user-id；--to-user-ids 仅表示接收人",
+                "没有自有应用 AppKey/AppSecret 或管理员工日志权限时不要选择委托提交路径"
               ]
             }
           ],
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+          "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
           "source": "internal/cli/schema_hints/selection/report.json",
           "value": [
             "尚未读取模板字段时先用 dws report template list / template get",
-            "只需查看已有日志正文时改用 dws report entry get"
+            "只需查看已有日志正文时改用 dws report entry get",
+            "不要根据接收人、姓名或上下文猜测 --sender-user-id；--to-user-ids 仅表示接收人",
+            "没有自有应用 AppKey/AppSecret 或管理员工日志权限时不要选择委托提交路径"
           ]
         },
         "canonical_path": {
@@ -370211,7 +370220,7 @@
             },
             {
               "precedence": "reviewed_manual",
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
               "selected": false,
               "source": "reviewed_manual_hint",
               "source_ref": "report entry submit",
@@ -370228,7 +370237,7 @@
           "candidates": [
             {
               "precedence": "reviewed_explicit",
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
               "selected": true,
               "source": "internal/cli/schema_hints/metadata/report.json",
               "value": "not_required"
@@ -370242,7 +370251,7 @@
           ],
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+          "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
           "source": "internal/cli/schema_hints/metadata/report.json",
           "value": "not_required"
         },
@@ -370252,7 +370261,7 @@
               "precedence": "cobra_help",
               "selected": true,
               "source": "cobra_help",
-              "value": "按模版提交一份日报。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，\n与远程 create_report 一致；可先通过 report template list / template get 取得 templateId 与控件定义。\n\n长内容（含中文换行 / Markdown）建议走 --contents-file 避免 shell 引号问题；\n也可用 --contents - 从 stdin 读取。\n提交成功后会自动反查详情，并在返回中追加 dingtalkOpenUrl / dingtalkOpenMarkdownLink 跳转链接字段。"
+              "value": "按模版提交一份日报。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，\n与远程 create_report 一致；可先通过 report template list / template get 取得 templateId 与控件定义。\n\n长内容（含中文换行 / Markdown）建议走 --contents-file 避免 shell 引号问题；\n也可用 --contents - 从 stdin 读取。\n默认通过 MCP 以当前登录用户提交，成功后会自动反查详情并追加钉钉跳转链接。\n显式传入非空 --sender-user-id 时，改用自有应用凭证通过钉钉 OAPI 代指定员工提交；\n该路径需要“管理员工日志数据”权限，且失败时不会回退 MCP。"
             },
             {
               "precedence": "mcp_metadata",
@@ -370264,7 +370273,7 @@
           "precedence": "cobra_help",
           "resolution": "highest_precedence",
           "source": "cobra_help",
-          "value": "按模版提交一份日报。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，\n与远程 create_report 一致；可先通过 report template list / template get 取得 templateId 与控件定义。\n\n长内容（含中文换行 / Markdown）建议走 --contents-file 避免 shell 引号问题；\n也可用 --contents - 从 stdin 读取。\n提交成功后会自动反查详情，并在返回中追加 dingtalkOpenUrl / dingtalkOpenMarkdownLink 跳转链接字段。"
+          "value": "按模版提交一份日报。--contents 为 JSON 数组，每项需含 key、sort、content、contentType、type，\n与远程 create_report 一致；可先通过 report template list / template get 取得 templateId 与控件定义。\n\n长内容（含中文换行 / Markdown）建议走 --contents-file 避免 shell 引号问题；\n也可用 --contents - 从 stdin 读取。\n默认通过 MCP 以当前登录用户提交，成功后会自动反查详情并追加钉钉跳转链接。\n显式传入非空 --sender-user-id 时，改用自有应用凭证通过钉钉 OAPI 代指定员工提交；\n该路径需要“管理员工日志数据”权限，且失败时不会回退 MCP。"
         },
         "effect": {
           "candidates": [
@@ -370284,22 +370293,22 @@
           "candidates": [
             {
               "precedence": "reviewed_explicit",
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
               "selected": true,
               "source": "internal/cli/schema_hints/selection/report.json",
               "value": [
                 "dws report entry submit --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json",
-                "dws report entry submit --template-id \u003ctemplateId\u003e --contents '[{\"key\":\"今日完成\",\"sort\":\"0\",\"content\":\"完成了需求评审\",\"contentType\":\"markdown\",\"type\":\"1\"}]' --format json"
+                "dws report entry submit --sender-user-id \u003cemployeeUserId\u003e --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json"
               ]
             }
           ],
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+          "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
           "source": "internal/cli/schema_hints/selection/report.json",
           "value": [
             "dws report entry submit --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json",
-            "dws report entry submit --template-id \u003ctemplateId\u003e --contents '[{\"key\":\"今日完成\",\"sort\":\"0\",\"content\":\"完成了需求评审\",\"contentType\":\"markdown\",\"type\":\"1\"}]' --format json"
+            "dws report entry submit --sender-user-id \u003cemployeeUserId\u003e --template-id \u003ctemplateId\u003e --contents-file ./report.json --format json"
           ]
         },
         "idempotency": {
@@ -370320,7 +370329,7 @@
           "candidates": [
             {
               "precedence": "reviewed_explicit",
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
               "selected": true,
               "source": "internal/cli/schema_hints/metadata/report.json",
               "value": "mcp"
@@ -370334,7 +370343,7 @@
           ],
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+          "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
           "source": "internal/cli/schema_hints/metadata/report.json",
           "value": "mcp"
         },
@@ -370382,14 +370391,14 @@
           "candidates": [
             {
               "precedence": "reviewed_explicit",
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
               "selected": true,
               "source": "internal/cli/schema_hints/metadata/report.json",
               "value": true
             },
             {
               "precedence": "reviewed_explicit",
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
               "selected": false,
               "source": "internal/cli/schema_hints/selection/report.json",
               "value": true
@@ -370397,7 +370406,7 @@
           ],
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+          "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
           "source": "internal/cli/schema_hints/metadata/report.json",
           "value": true
         },
@@ -370439,20 +370448,22 @@
           "candidates": [
             {
               "precedence": "reviewed_explicit",
-              "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+              "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
               "selected": true,
               "source": "internal/cli/schema_hints/selection/report.json",
               "value": [
-                "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时"
+                "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时",
+                "用户明确要求以某个员工 userId 为发送人代提交，且已有自有应用凭证和“管理员工日志数据”权限时，使用 --sender-user-id"
               ]
             }
           ],
           "precedence": "reviewed_explicit",
           "resolution": "highest_precedence",
-          "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+          "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
           "source": "internal/cli/schema_hints/selection/report.json",
           "value": [
-            "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时"
+            "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时",
+            "用户明确要求以某个员工 userId 为发送人代提交，且已有自有应用凭证和“管理员工日志数据”权限时，使用 --sender-user-id"
           ]
         }
       },
@@ -370467,7 +370478,7 @@
       "is_alias": false,
       "metadata_source": "embedded-mcp-metadata",
       "name": "create_report",
-      "parameter_count": 6,
+      "parameter_count": 7,
       "parameters": {
         "contents": {
           "description": "日志内容 JSON 数组 (必填，或用 --contents-file)，每项含 key/sort/content/contentType/type；传 - 表示从 stdin 读取",
@@ -370842,6 +370853,126 @@
           "required": false,
           "type": "string"
         },
+        "sender-user-id": {
+          "description": "日志发送人 userId；设置后使用自有应用凭证通过钉钉 OAPI 代提交",
+          "example": "employeeUserId",
+          "field_provenance": {
+            "description": {
+              "candidates": [
+                {
+                  "precedence": "cobra_contract",
+                  "selected": true,
+                  "source": "cobra_usage",
+                  "value": "日志发送人 userId；设置后使用自有应用凭证通过钉钉 OAPI 代提交"
+                },
+                {
+                  "precedence": "default",
+                  "selected": false,
+                  "source": "default",
+                  "value": ""
+                }
+              ],
+              "precedence": "cobra_contract",
+              "resolution": "highest_precedence",
+              "source": "cobra_usage",
+              "value": "日志发送人 userId；设置后使用自有应用凭证通过钉钉 OAPI 代提交"
+            },
+            "example": {
+              "candidates": [
+                {
+                  "precedence": "typed_metadata",
+                  "selected": true,
+                  "source": "typed_parameter_metadata",
+                  "value": "employeeUserId"
+                },
+                {
+                  "precedence": "default",
+                  "selected": false,
+                  "source": "default",
+                  "value": ""
+                }
+              ],
+              "precedence": "typed_metadata",
+              "resolution": "highest_precedence",
+              "source": "typed_parameter_metadata",
+              "value": "employeeUserId"
+            },
+            "property": {
+              "candidates": [
+                {
+                  "precedence": "reviewed_mapping_exclusion",
+                  "review_reason": "conditional adapter route selector mapped to DingTalk OAPI create_report_param.userid; it is not a property of the ordinary MCP report/create_report request",
+                  "selected": true,
+                  "source": "reviewed_mapping_exclusion",
+                  "value": ""
+                },
+                {
+                  "precedence": "inference",
+                  "selected": false,
+                  "source": "flag_name_inference",
+                  "value": "senderUserId"
+                }
+              ],
+              "precedence": "reviewed_mapping_exclusion",
+              "resolution": "highest_precedence",
+              "review_reason": "conditional adapter route selector mapped to DingTalk OAPI create_report_param.userid; it is not a property of the ordinary MCP report/create_report request",
+              "source": "reviewed_mapping_exclusion",
+              "value": ""
+            },
+            "required": {
+              "candidates": [
+                {
+                  "precedence": "reviewed_manual",
+                  "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
+                  "selected": true,
+                  "source": "reviewed_manual_hint",
+                  "value": false
+                },
+                {
+                  "precedence": "default",
+                  "selected": false,
+                  "source": "default",
+                  "value": false
+                }
+              ],
+              "precedence": "reviewed_manual",
+              "resolution": "highest_precedence",
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
+              "source": "reviewed_manual_hint",
+              "value": false
+            },
+            "required_when": {
+              "candidates": [
+                {
+                  "precedence": "default",
+                  "selected": true,
+                  "source": "default",
+                  "value": ""
+                }
+              ],
+              "precedence": "default",
+              "resolution": "highest_precedence",
+              "source": "default",
+              "value": ""
+            },
+            "type": {
+              "candidates": [
+                {
+                  "precedence": "cobra_contract",
+                  "selected": true,
+                  "source": "cobra_flag_type",
+                  "value": "string"
+                }
+              ],
+              "precedence": "cobra_contract",
+              "resolution": "highest_precedence",
+              "source": "cobra_flag_type",
+              "value": "string"
+            }
+          },
+          "required": false,
+          "type": "string"
+        },
         "template-id": {
           "description": "日志模版 ID (必填)",
           "field_provenance": {
@@ -370992,7 +371123,7 @@
               "candidates": [
                 {
                   "precedence": "reviewed_manual",
-                  "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+                  "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
                   "selected": true,
                   "source": "reviewed_manual_hint",
                   "value": false
@@ -371012,7 +371143,7 @@
               ],
               "precedence": "reviewed_manual",
               "resolution": "highest_precedence",
-              "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+              "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
               "source": "reviewed_manual_hint",
               "value": false
             },
@@ -371171,7 +371302,8 @@
       "source": "reviewed_command_registry",
       "title": "提交一份新日报（按模版）",
       "use_when": [
-        "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时"
+        "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时",
+        "用户明确要求以某个员工 userId 为发送人代提交，且已有自有应用凭证和“管理员工日志数据”权限时，使用 --sender-user-id"
       ]
     },
     "report.get_available_report_templates": {

--- a/internal/cli/schema_hints/metadata/report.json
+++ b/internal/cli/schema_hints/metadata/report.json
@@ -13,11 +13,14 @@
       "availability": "available",
       "reviewed": true,
       "parameters": {
+        "sender-user-id": {
+          "required": false
+        },
         "to-chat": {
           "required": false
         }
       },
-      "review_reason": "The reviewed optional --to-chat switch defaults to false and only controls post-submit delivery; it is not required to create a report.",
+      "review_reason": "The reviewed command remains pinned to its backwards-compatible default MCP report/create_report interface and is a non-idempotent medium-risk write with no runtime confirmation gate. --sender-user-id is an explicitly excluded conditional adapter input: a non-empty value selects the application-authenticated OAPI route, which never falls back to MCP after failure.",
       "cli_path": "report entry submit",
       "runtime_gate": "none",
       "confirmation": "not_required"

--- a/internal/cli/schema_hints/selection/report.json
+++ b/internal/cli/schema_hints/selection/report.json
@@ -9,20 +9,23 @@
   },
   "tools": {
     "report.create_report": {
-      "agent_summary": "按模版提交一份新日报",
+      "agent_summary": "按模版以当前用户或显式指定员工为发送人提交一份新日报",
       "use_when": [
-        "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时"
+        "已取得 templateId 与字段定义，需要按模版提交日报/周报（contents[].key 必须等于模板 field_name）时",
+        "用户明确要求以某个员工 userId 为发送人代提交，且已有自有应用凭证和“管理员工日志数据”权限时，使用 --sender-user-id"
       ],
       "avoid_when": [
         "尚未读取模板字段时先用 dws report template list / template get",
-        "只需查看已有日志正文时改用 dws report entry get"
+        "只需查看已有日志正文时改用 dws report entry get",
+        "不要根据接收人、姓名或上下文猜测 --sender-user-id；--to-user-ids 仅表示接收人",
+        "没有自有应用 AppKey/AppSecret 或管理员工日志权限时不要选择委托提交路径"
       ],
       "examples": [
         "dws report entry submit --template-id <templateId> --contents-file ./report.json --format json",
-        "dws report entry submit --template-id <templateId> --contents '[{\"key\":\"今日完成\",\"sort\":\"0\",\"content\":\"完成了需求评审\",\"contentType\":\"markdown\",\"type\":\"1\"}]' --format json"
+        "dws report entry submit --sender-user-id <employeeUserId> --template-id <templateId> --contents-file ./report.json --format json"
       ],
       "reviewed": true,
-      "review_reason": "结合本机 dws schema 实时描述、Skill 与 Cobra 手写选型；pinned schema_mcp_metadata 仅对照。",
+      "review_reason": "结合当前静态 Cobra handler、条件 MCP/OAPI 路由、安全边界与 Skill 手写选型；委托发送人必须由用户显式提供，且失败不得降级为当前用户提交。",
       "source_refs": [
         "CommandRegistry:canonical_path=report.create_report",
         "cobra-help:dws report entry submit",

--- a/internal/cli/schema_parameter_bindings.json
+++ b/internal/cli/schema_parameter_bindings.json
@@ -1807,6 +1807,7 @@
     "pat.batch_grant --products": "aggregate/two-stage wrapper: --products is merged with all product/domain flags into productCodes for pat.batch_plan; only the plan's selectedScopes are later sent to pat.batch_grant.scopes",
     "pat.batch_grant --recommend": "two-stage conditional wrapper: --recommend is sent to pat.batch_plan, and pat.batch_grant receives only the plan-selected scopes; it is not a pat.batch_grant RPC property",
     "report.create_report --contents-file": "local JSON file input used to populate contents",
+    "report.create_report --sender-user-id": "conditional adapter route selector mapped to DingTalk OAPI create_report_param.userid; it is not a property of the ordinary MCP report/create_report request",
     "sheet.batch_update --continue-on-error": "Reviewed unpinned adapter: sheet.batch_update has no singular pinned interface_ref; --continue-on-error is a CLI wrapper input and does not publish a direct interface property.",
     "sheet.batch_update --node": "Reviewed unpinned adapter: sheet.batch_update has no singular pinned interface_ref; --node is a CLI wrapper input and does not publish a direct interface property.",
     "sheet.batch_update --operations": "Reviewed unpinned adapter: sheet.batch_update has no singular pinned interface_ref; --operations is a CLI wrapper input and does not publish a direct interface property.",

--- a/internal/cli/schema_parameters_runtime.go
+++ b/internal/cli/schema_parameters_runtime.go
@@ -226,7 +226,8 @@ func init() {
 	RegisterRuntimeSchemaParameterMetadata("report.create_report", RuntimeSchemaParameterMetadata{
 		Formats: map[string]string{"contents": "json"},
 		Examples: map[string]string{
-			"contents": `[{"content":"schema smoke","sort":"0","key":"work","contentType":"markdown","type":"1"}]`,
+			"contents":       `[{"content":"schema smoke","sort":"0","key":"work","contentType":"markdown","type":"1"}]`,
+			"sender-user-id": "employeeUserId",
 		},
 	})
 	RegisterRuntimeSchemaParameterMetadata("sheet.batch_update", RuntimeSchemaParameterMetadata{

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -37,8 +37,20 @@ var (
 
 // Deps holds shared dependencies injected from the host application.
 type Deps struct {
-	Caller edition.ToolCaller
-	Out    *Formatter
+	Caller                edition.ToolCaller
+	Out                   *Formatter
+	ReportSenderSubmitter ReportSenderSubmitter
+}
+
+// DepsOption configures an optional helper dependency.
+type DepsOption func(*Deps)
+
+// WithReportSenderSubmitter configures the transport used only when report
+// submission explicitly selects --sender-user-id.
+func WithReportSenderSubmitter(submitter ReportSenderSubmitter) DepsOption {
+	return func(target *Deps) {
+		target.ReportSenderSubmitter = submitter
+	}
 }
 
 // deps is the package-level dependency holder, set during registration.
@@ -47,10 +59,15 @@ var deps *Deps
 // InitDeps initializes shared dependencies for all product commands.
 // Must be called before any product command's RunE executes (typically
 // during command tree construction in newLegacyPublicCommands).
-func InitDeps(caller edition.ToolCaller) {
+func InitDeps(caller edition.ToolCaller, options ...DepsOption) {
 	deps = &Deps{
 		Caller: caller,
 		Out:    NewFormatter(),
+	}
+	for _, option := range options {
+		if option != nil {
+			option(deps)
+		}
 	}
 }
 

--- a/internal/helpers/report.go
+++ b/internal/helpers/report.go
@@ -127,13 +127,17 @@ func newReportCommand() *cobra.Command {
 
 长内容（含中文换行 / Markdown）建议走 --contents-file 避免 shell 引号问题；
 也可用 --contents - 从 stdin 读取。
-提交成功后会自动反查详情，并在返回中追加 dingtalkOpenUrl / dingtalkOpenMarkdownLink 跳转链接字段。`,
+默认通过 MCP 以当前登录用户提交，成功后会自动反查详情并追加钉钉跳转链接。
+显式传入非空 --sender-user-id 时，改用自有应用凭证通过钉钉 OAPI 代指定员工提交；
+该路径需要“管理员工日志数据”权限，且失败时不会回退 MCP。`,
 		Example: `  dws report entry submit --template-id TPL_ID --contents '[{"content":"完成开发","sort":"0","key":"今日完成","contentType":"markdown","type":"1"}]'
   # 推荐：长内容走文件
   dws report entry submit --template-id TPL_ID --contents-file ./report.json
   # 或 stdin
   cat report.json | dws report entry submit --template-id TPL_ID --contents -
-  dws report entry submit --template-id TPL_ID --contents '[...]' --to-chat --to-user-ids userId1,userId2`,
+  dws report entry submit --template-id TPL_ID --contents '[...]' --to-chat --to-user-ids userId1,userId2
+  # 代指定员工提交；建议先加 --dry-run 预览
+  dws report entry submit --sender-user-id employeeUserId --template-id TPL_ID --contents-file ./report.json --dry-run`,
 		RunE: runReportCreate,
 	}
 	addReportCreateFlags(entrySubmitCmd)
@@ -319,14 +323,45 @@ func runReportCreate(cmd *cobra.Command, args []string) error {
 		ddFrom = "dws"
 	}
 	toChat, _ := cmd.Flags().GetBool("to-chat")
+	toUserIDs := parseReportUserIDs(mustGetFlag(cmd, "to-user-ids"))
+	senderUserID, _ := cmd.Flags().GetString("sender-user-id")
+	senderUserID = strings.TrimSpace(senderUserID)
+	if cmd.Flags().Changed("sender-user-id") {
+		if senderUserID == "" {
+			return &CLIError{
+				Code:       CodeMissingParam,
+				Message:    "flag --sender-user-id requires a non-empty value",
+				Suggestion: "传入要作为日志发送人的员工 userId；如需以当前登录用户提交，请完全移除 --sender-user-id",
+				Operation:  "report.create.delegated",
+			}
+		}
+		if deps == nil || deps.ReportSenderSubmitter == nil {
+			return &CLIError{
+				Code:       CodeUnclassified,
+				Message:    "delegated report submission transport is not configured",
+				Suggestion: "请使用完整的 dws CLI 运行该命令；不要通过未注入应用传输层的 helper 测试壳执行",
+				Operation:  "report.create.delegated",
+			}
+		}
+		return deps.ReportSenderSubmitter.Submit(cmd.Context(), cmd, ReportSenderSubmission{
+			SenderUserID: senderUserID,
+			TemplateID:   tplID,
+			Contents:     contents,
+			DDFrom:       ddFrom,
+			ToChat:       toChat,
+			ToUserIDs:    toUserIDs,
+			DryRun:       deps.Caller != nil && deps.Caller.DryRun(),
+		})
+	}
+
 	toolArgs := map[string]any{
 		"templateId": tplID,
 		"contents":   contents,
 		"ddFrom":     ddFrom,
 		"toChat":     toChat,
 	}
-	if v, _ := cmd.Flags().GetString("to-user-ids"); v != "" {
-		toolArgs["toUserIds"] = parseReportUserIDs(v)
+	if len(toUserIDs) > 0 {
+		toolArgs["toUserIds"] = toUserIDs
 	}
 	return callReportCreateWithDetailURL(toolArgs)
 }
@@ -487,6 +522,7 @@ func addReportCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().String("contents", "", "日志内容 JSON 数组 (必填，或用 --contents-file)，每项含 key/sort/content/contentType/type；传 - 表示从 stdin 读取")
 	cmd.Flags().String("contents-file", "", "从文件读取 contents JSON（推荐用于含中文/换行/Markdown 的长内容，避免 shell 引号转义；优先级：--contents-file > --contents - (stdin) > --contents '<json>'）")
 	cmd.Flags().String("dd-from", "dws", "创建来源标识")
+	cmd.Flags().String("sender-user-id", "", "日志发送人 userId；设置后使用自有应用凭证通过钉钉 OAPI 代提交")
 	cmd.Flags().Bool("to-chat", false, "是否发送到日志接收人单聊")
 	cmd.Flags().String("to-user-ids", "", "接收人 userId，逗号分隔 (可选)")
 }

--- a/internal/helpers/report_sender.go
+++ b/internal/helpers/report_sender.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// ReportSenderSubmitter executes the delegated report submission route. The
+// application owns authentication and HTTP transport so helpers does not
+// depend on internal/auth (which already imports helpers).
+type ReportSenderSubmitter interface {
+	Submit(context.Context, *cobra.Command, ReportSenderSubmission) error
+}
+
+// ReportSenderSubmission is the validated, transport-neutral input for
+// submitting a report on behalf of an employee.
+type ReportSenderSubmission struct {
+	SenderUserID string
+	TemplateID   string
+	Contents     []map[string]any
+	DDFrom       string
+	ToChat       bool
+	ToUserIDs    []string
+	DryRun       bool
+}
+
+// BuildReportCreateOAPIRequest converts the shared report input into the
+// legacy DingTalk OAPI body accepted by POST /topapi/report/create.
+func BuildReportCreateOAPIRequest(submission ReportSenderSubmission) (map[string]any, error) {
+	sender := strings.TrimSpace(submission.SenderUserID)
+	if sender == "" {
+		return nil, &CLIError{
+			Code:       CodeMissingParam,
+			Message:    "flag --sender-user-id requires a non-empty value",
+			Suggestion: "传入要作为日志发送人的员工 userId；如需以当前登录用户提交，请完全移除 --sender-user-id",
+			Operation:  "report.create.delegated",
+		}
+	}
+	templateID := strings.TrimSpace(submission.TemplateID)
+	if templateID == "" {
+		return nil, &CLIError{
+			Code:      CodeMissingParam,
+			Message:   "flag --template-id is required",
+			Operation: "report.create.delegated",
+		}
+	}
+	normalizedContents := make([]map[string]any, 0, len(submission.Contents))
+	for _, item := range submission.Contents {
+		if item == nil {
+			normalizedContents = append(normalizedContents, nil)
+			continue
+		}
+		copied := make(map[string]any, len(item))
+		for key, value := range item {
+			copied[key] = value
+		}
+		normalizedContents = append(normalizedContents, copied)
+	}
+	if err := validateAndNormalizeReportContents(normalizedContents); err != nil {
+		return nil, err
+	}
+
+	contents := make([]map[string]any, 0, len(normalizedContents))
+	for _, item := range normalizedContents {
+		mapped := make(map[string]any, len(item))
+		for key, value := range item {
+			switch key {
+			case "contentType":
+				mapped["content_type"] = value
+			default:
+				mapped[key] = value
+			}
+		}
+		contents = append(contents, mapped)
+	}
+
+	ddFrom := strings.TrimSpace(submission.DDFrom)
+	if ddFrom == "" {
+		ddFrom = "dws"
+	}
+	param := map[string]any{
+		"userid":      sender,
+		"template_id": templateID,
+		"contents":    contents,
+		"dd_from":     ddFrom,
+		"to_chat":     submission.ToChat,
+	}
+	if len(submission.ToUserIDs) > 0 {
+		param["to_userids"] = append([]string(nil), submission.ToUserIDs...)
+	}
+	return map[string]any{"create_report_param": param}, nil
+}

--- a/internal/helpers/report_sender_test.go
+++ b/internal/helpers/report_sender_test.go
@@ -1,0 +1,202 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+type recordingReportSenderSubmitter struct {
+	calls      int
+	submission ReportSenderSubmission
+	err        error
+}
+
+func (s *recordingReportSenderSubmitter) Submit(_ context.Context, _ *cobra.Command, submission ReportSenderSubmission) error {
+	s.calls++
+	s.submission = submission
+	return s.err
+}
+
+func TestReportCreateDelegatedRouteReusesCurrentValidationAndSkipsMCP(t *testing.T) {
+	caller := &reportTestCaller{dry: true, format: "json", response: `{"ok":true}`}
+	submitter := &recordingReportSenderSubmitter{}
+	previous := deps
+	t.Cleanup(func() { deps = previous })
+	InitDeps(caller, WithReportSenderSubmitter(submitter))
+
+	cmd := &cobra.Command{Use: "submit"}
+	addReportCreateFlags(cmd)
+	setReportCreateTestFlags(t, cmd,
+		"template-id", "template-1",
+		"contents", `[{"key":" Done ","sort":0,"content":"work","contentType":"text","type":"text"}]`,
+		"sender-user-id", " sender-1 ",
+		"to-user-ids", " receiver-1, ,receiver-2 ",
+	)
+	if err := cmd.Flags().Set("to-chat", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runReportCreate(cmd, nil); err != nil {
+		t.Fatalf("runReportCreate() error = %v", err)
+	}
+	if submitter.calls != 1 {
+		t.Fatalf("delegated submitter calls = %d, want 1", submitter.calls)
+	}
+	if len(caller.calls) != 0 {
+		t.Fatalf("delegated route called MCP tools: %#v", caller.calls)
+	}
+	got := submitter.submission
+	if got.SenderUserID != "sender-1" || got.TemplateID != "template-1" || !got.ToChat || !got.DryRun {
+		t.Fatalf("delegated submission identity = %#v", got)
+	}
+	if len(got.ToUserIDs) != 2 || got.ToUserIDs[0] != "receiver-1" || got.ToUserIDs[1] != "receiver-2" {
+		t.Fatalf("delegated recipients = %#v", got.ToUserIDs)
+	}
+	if len(got.Contents) != 1 ||
+		got.Contents[0]["key"] != "Done" ||
+		got.Contents[0]["sort"] != "0" ||
+		got.Contents[0]["contentType"] != "markdown" ||
+		got.Contents[0]["type"] != "1" {
+		t.Fatalf("delegated contents were not normalized by current report validation: %#v", got.Contents)
+	}
+}
+
+func TestReportCreateExplicitEmptySenderNeverFallsBackToCurrentUser(t *testing.T) {
+	caller := &reportTestCaller{dry: true, format: "json", response: `{"ok":true}`}
+	submitter := &recordingReportSenderSubmitter{}
+	previous := deps
+	t.Cleanup(func() { deps = previous })
+	InitDeps(caller, WithReportSenderSubmitter(submitter))
+
+	cmd := &cobra.Command{Use: "submit"}
+	addReportCreateFlags(cmd)
+	setReportCreateTestFlags(t, cmd,
+		"template-id", "template-1",
+		"contents", `[{"key":"Done","sort":"0","content":"work","contentType":"markdown","type":"1"}]`,
+		"sender-user-id", "   ",
+	)
+	err := runReportCreate(cmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "--sender-user-id") {
+		t.Fatalf("runReportCreate() error = %v, want sender validation", err)
+	}
+	if submitter.calls != 0 || len(caller.calls) != 0 {
+		t.Fatalf("empty sender routed remotely: submitter=%d MCP=%#v", submitter.calls, caller.calls)
+	}
+}
+
+func TestReportCreateWithoutSenderKeepsMCPRoute(t *testing.T) {
+	caller := &reportTestCaller{
+		format:   "json",
+		response: `{"reportId":"report-1","url":"dingtalk://report-1"}`,
+	}
+	installReportTestDeps(t, caller)
+	previousArgs := os.Args
+	os.Args = []string{"dws", "report", "entry", "submit"}
+	t.Cleanup(func() { os.Args = previousArgs })
+
+	cmd := &cobra.Command{Use: "submit"}
+	addReportCreateFlags(cmd)
+	setReportCreateTestFlags(t, cmd,
+		"template-id", "template-1",
+		"contents", `[{"key":"Done","sort":"0","content":"work","contentType":"markdown","type":"1"}]`,
+		"to-user-ids", "receiver-1",
+	)
+	if err := runReportCreate(cmd, nil); err != nil {
+		t.Fatalf("runReportCreate() error = %v", err)
+	}
+	if len(caller.calls) != 1 || caller.calls[0] != "create_report" {
+		t.Fatalf("MCP calls = %#v, want create_report", caller.calls)
+	}
+	if _, exists := caller.lastArgs["senderUserId"]; exists {
+		t.Fatalf("sender leaked into MCP args: %#v", caller.lastArgs)
+	}
+	if recipients, ok := caller.lastArgs["toUserIds"].([]string); !ok || len(recipients) != 1 || recipients[0] != "receiver-1" {
+		t.Fatalf("MCP recipients = %#v", caller.lastArgs["toUserIds"])
+	}
+}
+
+func TestReportCreateCanonicalAndDeprecatedAliasExposeSenderFlag(t *testing.T) {
+	root := newReportCommand()
+	canonical, _, err := root.Find([]string{"entry", "submit"})
+	if err != nil || canonical == nil {
+		t.Fatalf("find canonical report submit: %v", err)
+	}
+	alias, _, err := root.Find([]string{"create"})
+	if err != nil || alias == nil {
+		t.Fatalf("find deprecated report create: %v", err)
+	}
+	for _, cmd := range []*cobra.Command{canonical, alias} {
+		if cmd.Flags().Lookup("sender-user-id") == nil {
+			t.Fatalf("%s missing --sender-user-id", cmd.CommandPath())
+		}
+	}
+}
+
+func TestBuildReportCreateOAPIRequestMapsValidatedFields(t *testing.T) {
+	request, err := BuildReportCreateOAPIRequest(ReportSenderSubmission{
+		SenderUserID: "sender-1",
+		TemplateID:   "template-1",
+		DDFrom:       "automation",
+		ToChat:       true,
+		ToUserIDs:    []string{"receiver-1", "receiver-2"},
+		Contents: []map[string]any{{
+			"key":         "今日完成",
+			"sort":        "0",
+			"content":     "完成 CLI 开发",
+			"contentType": "markdown",
+			"type":        "1",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BuildReportCreateOAPIRequest() error = %v", err)
+	}
+	param, ok := request["create_report_param"].(map[string]any)
+	if !ok {
+		t.Fatalf("create_report_param = %T", request["create_report_param"])
+	}
+	if param["userid"] != "sender-1" || param["template_id"] != "template-1" ||
+		param["dd_from"] != "automation" || param["to_chat"] != true {
+		t.Fatalf("OAPI identity/body = %#v", param)
+	}
+	contents, ok := param["contents"].([]map[string]any)
+	if !ok || len(contents) != 1 || contents[0]["content_type"] != "markdown" {
+		t.Fatalf("OAPI contents = %#v", param["contents"])
+	}
+	if _, exists := contents[0]["contentType"]; exists {
+		t.Fatalf("camelCase contentType leaked to OAPI: %#v", contents[0])
+	}
+
+	if _, err := BuildReportCreateOAPIRequest(ReportSenderSubmission{
+		SenderUserID: "sender-1",
+		TemplateID:   "template-1",
+		Contents:     []map[string]any{{"key": "missing-current-required-fields"}},
+	}); err == nil {
+		t.Fatal("delegated OAPI builder accepted contents rejected by current report validation")
+	}
+}
+
+func setReportCreateTestFlags(t *testing.T, cmd *cobra.Command, pairs ...string) {
+	t.Helper()
+	for index := 0; index < len(pairs); index += 2 {
+		if err := cmd.Flags().Set(pairs[index], pairs[index+1]); err != nil {
+			t.Fatalf("set --%s: %v", pairs[index], err)
+		}
+	}
+}

--- a/internal/helpers/report_test.go
+++ b/internal/helpers/report_test.go
@@ -22,10 +22,12 @@ type reportTestCaller struct {
 	response string
 	err      error
 	calls    []string
+	lastArgs map[string]any
 }
 
-func (c *reportTestCaller) CallTool(_ context.Context, _, tool string, _ map[string]any) (*edition.ToolResult, error) {
+func (c *reportTestCaller) CallTool(_ context.Context, _, tool string, args map[string]any) (*edition.ToolResult, error) {
 	c.calls = append(c.calls, tool)
+	c.lastArgs = args
 	if c.err != nil {
 		return nil, c.err
 	}

--- a/skills/mono/references/products/report.md
+++ b/skills/mono/references/products/report.md
@@ -176,14 +176,26 @@ Example:
   dws report entry submit --template-id <templateId> \
     --contents '[{"key":"今日完成","sort":"0","content":"完成了需求评审","contentType":"markdown","type":"1"}]' \
     --format json
+
+  # 以指定员工为发送人代提交（需要自有应用凭证和“管理员工日志数据”权限）
+  dws report entry submit --sender-user-id <userId> \
+    --template-id <templateId> --contents-file ./report.json --format json
 Flags:
       --template-id string    日志模版 ID (必填)，从 template list 返回中取
       --contents string       日志内容 JSON 数组 (必填，或用 --contents-file)；传 `-` 表示从 stdin 读取
       --contents-file string  从文件读取 contents JSON（推荐用于含中文/换行/Markdown 的长内容）
       --dd-from string        创建来源标识 (默认 dws)
+      --sender-user-id string 日志发送人 userId；设置后使用自有应用凭证通过钉钉 OAPI 代提交
       --to-chat               是否发送到日志接收人单聊 (默认 false，传本 flag 则为 true)
       --to-user-ids string    接收人 userId，逗号分隔 (可选)
 ```
+
+**发送人路由与安全规则**：
+
+- 不传 `--sender-user-id`：保持原行为，通过 MCP `report.create_report` 以当前登录用户提交。
+- 显式传入非空 `--sender-user-id`：通过钉钉 OAPI `POST /topapi/report/create` 代指定员工提交；空值会报错，OAPI 失败也不会回退 MCP，避免日志显示为错误发送人。
+- `--sender-user-id` 只能来自用户明确给出的员工 userId；`--to-user-ids` 仅表示接收人，不能据此推断发送人。
+- OAPI 路径需要自有应用 AppKey/AppSecret（`--client-id` / `--client-secret`、环境变量或 `dws auth login`）和“管理员工日志数据”权限。可先加 `--dry-run` 预览请求；预览不会读取或输出 access token。
 
 
 **`contents` 数组元素**（与 MCP `create_report` 一致）：

--- a/skills/multi/dingtalk-report/SKILL.md
+++ b/skills/multi/dingtalk-report/SKILL.md
@@ -41,6 +41,7 @@ metadata:
 | "今天收到的日志" | `python scripts/report_received_today.py` |
 | "看日志模版" | `dws report template list` → `dws report template get --name "<模版名>"` |
 | "提交日报 / 周报（按模版）" | `dws report entry submit --template-id <id> --contents-file <CWD 下的 .json>` |
+| "以指定员工为发送人提交日志" | `dws report entry submit --sender-user-id <userId> --template-id <id> --contents-file <CWD 下的 .json>` |
 | "我收到的日志" | `dws report inbox list --start <ISO> --end <ISO> --cursor 0 --size 20` |
 | "我已发送的日志" | `dws report outbox list --cursor 0 --size 20` |
 | "查看某条日志正文" | `dws report entry get --report-id <id>` |
@@ -54,6 +55,13 @@ metadata:
 - 查“收到的日志”必须用 `dws report inbox list --start "<ISO>" --end "<ISO>" --cursor 0 --size 20 --format json`，并把“今天 / 最近 30 天”等时间词先展开成完整 ISO 起止时间；查“我发出的日志”用 `dws report outbox list --cursor 0 --size 20 --format json`。
 - 列表返回后，后续 `entry get` / `entry stats` 必须复用同一个 `reportId`（在返回的 `_internalDetailCommands[].command` 里）；不要重新挑选、猜测或改用标题。
 - 用户要正文时用 `dws report entry get --report-id <reportId>`；用户要已读/统计时用 `dws report entry stats --report-id <reportId>`。
+
+## 指定发送人提交
+
+- 只有用户明确给出要作为发送人的员工 userId 时才传 `--sender-user-id`；`--to-user-ids` 是接收人，不能当作发送人。
+- 不传 `--sender-user-id` 时继续通过 MCP `report.create_report` 以当前登录用户提交。
+- 传入非空 `--sender-user-id` 时改走钉钉 OAPI `POST /topapi/report/create`；OAPI 失败后禁止改走 MCP 重试，避免日志被静默提交成当前用户。
+- 委托提交需要自有应用 AppKey/AppSecret（命令行、环境变量或登录配置）和“管理员工日志数据”权限。可先加 `--dry-run` 查看不含 access token 的请求预览。
 
 ## 跨产品协作
 

--- a/skills/multi/dingtalk-report/references/report.md
+++ b/skills/multi/dingtalk-report/references/report.md
@@ -176,14 +176,26 @@ Example:
   dws report entry submit --template-id <templateId> \
     --contents '[{"key":"今日完成","sort":"0","content":"完成了需求评审","contentType":"markdown","type":"1"}]' \
     --format json
+
+  # 以指定员工为发送人代提交（需要自有应用凭证和“管理员工日志数据”权限）
+  dws report entry submit --sender-user-id <userId> \
+    --template-id <templateId> --contents-file ./report.json --format json
 Flags:
       --template-id string    日志模版 ID (必填)，从 template list 返回中取
       --contents string       日志内容 JSON 数组 (必填，或用 --contents-file)；传 `-` 表示从 stdin 读取
       --contents-file string  从文件读取 contents JSON（推荐用于含中文/换行/Markdown 的长内容）
       --dd-from string        创建来源标识 (默认 dws)
+      --sender-user-id string 日志发送人 userId；设置后使用自有应用凭证通过钉钉 OAPI 代提交
       --to-chat               是否发送到日志接收人单聊 (默认 false，传本 flag 则为 true)
       --to-user-ids string    接收人 userId，逗号分隔 (可选)
 ```
+
+**发送人路由与安全规则**：
+
+- 不传 `--sender-user-id`：保持原行为，通过 MCP `report.create_report` 以当前登录用户提交。
+- 显式传入非空 `--sender-user-id`：通过钉钉 OAPI `POST /topapi/report/create` 代指定员工提交；空值会报错，OAPI 失败也不会回退 MCP，避免日志显示为错误发送人。
+- `--sender-user-id` 只能来自用户明确给出的员工 userId；`--to-user-ids` 仅表示接收人，不能据此推断发送人。
+- OAPI 路径需要自有应用 AppKey/AppSecret（`--client-id` / `--client-secret`、环境变量或 `dws auth login`）和“管理员工日志数据”权限。可先加 `--dry-run` 预览请求；预览不会读取或输出 access token。
 
 
 **`contents` 数组元素**（与 MCP `create_report` 一致）：


### PR DESCRIPTION
## What changed

- add `--sender-user-id` to `dws report entry submit` and the deprecated `dws report create` alias
- route delegated submissions through DingTalk OAPI `POST /topapi/report/create` using the caller's own application credentials
- preserve the existing MCP `report.create_report` path when no sender is specified
- reuse the current report content loading, normalization, path-safety, symlink, and size-limit checks
- update schema metadata, parameter bindings, generated catalogs, command guidance, and report skills
- add helper and application tests for routing, field mapping, dry-run credential isolation, and failure handling

## Why

PR #408 was closed after the report helper and schema contracts changed, while #406 remained open. This reimplements the requested delegated-sender behavior on top of the current static `internal/helpers/report.go` flow and current schema/security requirements.

## Behavior and safety

- an explicitly empty `--sender-user-id` is rejected
- delegated OAPI failures never fall back to MCP, preventing a report from being silently submitted as the current user
- delegated submission requires AppKey/AppSecret and the “管理员工日志数据” permission
- `--dry-run` does not resolve, fetch, cache, or print an access token
- ordinary submissions remain backward compatible

## Validation

- `go test ./internal/helpers -run Report -count=1`
- `go test ./internal/app -run '^(TestReportSender|TestManualAgentExamplesContract)' -count=1`
- `go test ./internal/cli -count=1`
- `go vet ./internal/helpers ./internal/app ./internal/cli`
- generated-drift, schema registry, runtime-confirmation, schema catalog, schema binary, skill command, and authoritative schema compatibility checks
- end-to-end dry-run verification for both delegated OAPI and ordinary MCP routes

Closes #406.
Supersedes #408.
