### PR TITLE
chore(release): prepare v1.0.55-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,19 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.55-beta.4] - 2026-07-27
+
+This beta validates the shortcut projection fixes for group bots, bot search,
+and mail threads, together with hardened release delivery to Gitee and npm on
+top of the `v1.0.55-beta.3` baseline.
+
 ### Fixed
 
 - **Shortcut projection fixes** (#795) — `chat +chat-bots` no longer projects a non-empty `list_group_bots` response to an empty list, `+bot-find` recognizes the `search_bots` response shape (`result.bots` entries with `botOpenDingTalkId`), and mail thread listings keep `lastUpdated` when the backend returns `lastModifiedDateTime`.
+
+### Changed
+
+- **Hardened release delivery** — the Gitee mirror workflow can synchronize a specific release's assets on demand, release lookup tolerates Gitee's HTTP 200 null-body response for missing releases, npm dist-tag verification waits through slow registry CDN propagation with incremental backoff, and beta/stable release operations are role-enforced (#791).
 
 ## [1.0.55-beta.3] - 2026-07-24
 


### PR DESCRIPTION
## Summary

- Converts the accumulated `[Unreleased]` entry into the `## [1.0.55-beta.4] - 2026-07-27` release section and keeps an empty `[Unreleased]` heading for future PRs
- Covers the #795 shortcut projection fixes (chat +chat-bots, +bot-find, mail thread `lastUpdated`) and the release-delivery hardening merged since `v1.0.55-beta.3` (on-demand Gitee asset sync, Gitee 200-null tolerance, npm CDN propagation backoff, #791 release role enforcement)

## Test plan

- [x] CHANGELOG-only diff (`git diff --name-only` shows only `CHANGELOG.md`)
- [ ] Policy fast-path CHANGELOG validation passes in CI