### PR TITLE
fix(auth): harden OAuth loopback login and credential handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+### Fixed
+
+- **OAuth loopback login and credential handling hardening** — the browser login flow now sends an RFC 6749 `state` parameter and rejects callbacks whose state does not match the login session (login CSRF); the loopback `/api/*` endpoints require a per-login page token embedded only in the served page, the state-changing `/api/sendApply` endpoint is POST-only, and the callback server enforces read/write timeouts so trickling connections cannot stall login. MCP token-exchange errors no longer embed raw response bodies that could carry token material into terminals and logs, and `mcp_url`/`terminal_url` overrides are honored only for HTTPS or loopback HTTP addresses, falling back to production defaults otherwise.
+
 ## [1.0.55-beta.4] - 2026-07-27
 
 This beta validates the shortcut projection fixes for group bots, bot search,

--- a/internal/app/coverage_edges_test.go
+++ b/internal/app/coverage_edges_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/safety"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/transport"
 	upgradepkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/upgrade"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/config"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/mcptypes"
 	tea "github.com/charmbracelet/bubbletea"
@@ -1541,6 +1542,14 @@ func TestCrossPlatformCoveragePersonalEventPureCoverage(t *testing.T) {
 	}
 	if configuredMCPBaseURL(emptyDir) != "https://mcp.test/" || personalEventMCPBaseURL(emptyDir) != "https://mcp.test" {
 		t.Fatal("configured MCP URL mismatch")
+	}
+	// Non-HTTPS non-loopback overrides are rejected by the shared trust-root
+	// validation and fall back to the production default.
+	if err := os.WriteFile(filepath.Join(emptyDir, "mcp_url"), []byte("http://evil.example.com"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if configuredMCPBaseURL(emptyDir) != "" || personalEventMCPBaseURL(emptyDir) != config.DefaultMCPBaseURL {
+		t.Fatal("invalid MCP URL override must be rejected")
 	}
 
 	var rendered bytes.Buffer

--- a/internal/app/coverage_edges_test.go
+++ b/internal/app/coverage_edges_test.go
@@ -1792,7 +1792,10 @@ func TestCrossPlatformCoverageDoctorCommandCoverage(t *testing.T) {
 
 	badConfig := t.TempDir()
 	t.Setenv("DWS_CONFIG_DIR", badConfig)
-	if err := os.WriteFile(filepath.Join(badConfig, "mcp_url"), []byte("://bad"), 0o600); err != nil {
+	// Use an unreachable-but-valid URL: invalid overrides now fall back to the
+	// production MCP base URL, which must not make this failure-path check
+	// depend on outbound network access to the real service.
+	if err := os.WriteFile(filepath.Join(badConfig, "mcp_url"), []byte("https://127.0.0.1:1"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if got := doctorCheckNetwork(context.Background(), io.Discard, false, time.Second); got.Status != statusFail {

--- a/internal/app/doctor_command.go
+++ b/internal/app/doctor_command.go
@@ -35,6 +35,7 @@ var (
 	doctorAuthStatus         = (*authpkg.OAuthProvider).Status
 	doctorAuthAccessToken    = (*authpkg.OAuthProvider).GetAccessToken
 	doctorHTTPDo             = (*http.Client).Do
+	doctorNewRequest         = http.NewRequestWithContext
 	doctorFetchLatestRelease = func() (*upgrade.ReleaseInfo, error) { return upgrade.NewClient().FetchLatestRelease() }
 	doctorNeedsUpgrade       = upgrade.NeedsUpgrade
 )
@@ -256,7 +257,7 @@ func doctorCheckNetwork(ctx context.Context, w io.Writer, jsonOut bool, timeout 
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, baseURL, nil)
+	req, err := doctorNewRequest(reqCtx, http.MethodGet, baseURL, nil)
 	if err != nil {
 		r := checkResult{
 			Name:    "network",

--- a/internal/app/doctor_full_coverage_test.go
+++ b/internal/app/doctor_full_coverage_test.go
@@ -24,6 +24,7 @@ func TestCrossPlatformCoverageDoctorRemainingCoverage(t *testing.T) {
 	oldStatus := doctorAuthStatus
 	oldAccess := doctorAuthAccessToken
 	oldHTTP := doctorHTTPDo
+	oldNewRequest := doctorNewRequest
 	oldLatest := doctorFetchLatestRelease
 	oldNeeds := doctorNeedsUpgrade
 	oldRead := timingReadFile
@@ -33,6 +34,7 @@ func TestCrossPlatformCoverageDoctorRemainingCoverage(t *testing.T) {
 		doctorAuthStatus = oldStatus
 		doctorAuthAccessToken = oldAccess
 		doctorHTTPDo = oldHTTP
+		doctorNewRequest = oldNewRequest
 		doctorFetchLatestRelease = oldLatest
 		doctorNeedsUpgrade = oldNeeds
 		timingReadFile = oldRead
@@ -90,6 +92,15 @@ func TestCrossPlatformCoverageDoctorRemainingCoverage(t *testing.T) {
 	if got := doctorCheckNetwork(context.Background(), buf, false, time.Second); got.Status != statusFail {
 		t.Fatalf("network failure = %#v", got)
 	}
+	// Keep the request-build failure branch covered: validated base URLs can
+	// no longer reach it through mcp_url, so it is exercised via injection.
+	doctorNewRequest = func(context.Context, string, string, io.Reader) (*http.Request, error) {
+		return nil, errors.New("bad request")
+	}
+	if got := doctorCheckNetwork(context.Background(), buf, false, time.Second); got.Status != statusFail {
+		t.Fatalf("request-build failure = %#v", got)
+	}
+	doctorNewRequest = oldNewRequest
 	doctorHTTPDo = func(*http.Client, *http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}, nil
 	}

--- a/internal/app/doctor_full_coverage_test.go
+++ b/internal/app/doctor_full_coverage_test.go
@@ -74,11 +74,14 @@ func TestCrossPlatformCoverageDoctorRemainingCoverage(t *testing.T) {
 
 	configDir := t.TempDir()
 	t.Setenv("DWS_CONFIG_DIR", configDir)
-	if err := os.WriteFile(filepath.Join(configDir, "mcp_url"), []byte(":"), 0o600); err != nil {
+	// Invalid mcp_url values now fall back to the production default, so an
+	// unreachable-but-valid address is used to cover the dial-failure branch
+	// without depending on outbound access to the real MCP service.
+	if err := os.WriteFile(filepath.Join(configDir, "mcp_url"), []byte("https://127.0.0.1:1"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if got := doctorCheckNetwork(context.Background(), buf, false, time.Second); got.Status != statusFail {
-		t.Fatalf("invalid network URL = %#v", got)
+		t.Fatalf("unreachable network URL = %#v", got)
 	}
 	if err := os.WriteFile(filepath.Join(configDir, "mcp_url"), []byte("https://example.test"), 0o600); err != nil {
 		t.Fatal(err)

--- a/internal/app/event_personal_command.go
+++ b/internal/app/event_personal_command.go
@@ -1004,5 +1004,12 @@ func configuredMCPBaseURL(configDir string) string {
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(data))
+	raw := strings.TrimSpace(string(data))
+	// Apply the same trust-root validation as config.GetMCPBaseURL: the MCP
+	// base URL receives user tokens, so non-HTTPS non-loopback overrides are
+	// ignored rather than honored.
+	if !config.IsAllowedPlatformURLOverride(raw) {
+		return ""
+	}
+	return raw
 }

--- a/internal/auth/access_token_snapshot_test.go
+++ b/internal/auth/access_token_snapshot_test.go
@@ -59,7 +59,7 @@ func TestCrossPlatformCoverageOAuthProviderLoginReauthorizesAfterLoadFailureAndR
 		if err != nil {
 			return err
 		}
-		callbackURL := parsed.Query().Get("redirect_uri") + "?code=reauthorize"
+		callbackURL := parsed.Query().Get("redirect_uri") + "?code=reauthorize&state=" + url.QueryEscape(parsed.Query().Get("state"))
 		response, err := (&http.Client{Timeout: 5 * time.Second}).Get(callbackURL)
 		if err != nil {
 			return err

--- a/internal/auth/auth_extra_test.go
+++ b/internal/auth/auth_extra_test.go
@@ -418,9 +418,12 @@ func TestParseMCPTokenResponseCorpNameFallbacks(t *testing.T) {
 }
 
 func TestBuildAuthURLIncludesTargetCorpID(t *testing.T) {
-	authURL := buildAuthURL("client-id", "http://127.0.0.1:1234/callback", "ding-target")
+	authURL := buildAuthURL("client-id", "http://127.0.0.1:1234/callback", "ding-target", "state-123")
 	if !strings.Contains(authURL, "corpId=ding-target") {
 		t.Fatalf("auth URL missing target corpId: %s", authURL)
+	}
+	if !strings.Contains(authURL, "state=state-123") {
+		t.Fatalf("auth URL missing state: %s", authURL)
 	}
 }
 

--- a/internal/auth/login_persistence_preflight_test.go
+++ b/internal/auth/login_persistence_preflight_test.go
@@ -345,6 +345,10 @@ func installHalfMigratedBrowserLogin(
 		}
 		query := callbackURL.Query()
 		query.Set("code", "half-migrated-repair")
+		// Mirror the real authorization server: state is echoed back verbatim.
+		if state := parsed.Query().Get("state"); state != "" {
+			query.Set("state", state)
+		}
 		callbackURL.RawQuery = query.Encode()
 		request, err := http.NewRequest(http.MethodGet, callbackURL.String(), nil)
 		if err != nil {

--- a/internal/auth/oauth_helpers.go
+++ b/internal/auth/oauth_helpers.go
@@ -330,14 +330,16 @@ func (p *OAuthProvider) parseMCPTokenResponse(body []byte) (*TokenData, error) {
 		ErrorMsg  string `json:"errorMsg,omitempty"`
 	}
 	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("parsing MCP token response: %w (body: %s)", err, string(body))
+		// Never embed the raw body: it may carry token material or PII that
+		// would end up in terminals, log files, and issue reports.
+		return nil, fmt.Errorf("parsing MCP token response: %w (body bytes: %d)", err, len(body))
 	}
 	// Check for error response
 	if resp.ErrorCode != "" || resp.ErrorMsg != "" {
 		return nil, &MCPTokenExchangeError{Code: resp.ErrorCode, Message: resp.ErrorMsg}
 	}
 	if resp.AccessToken == "" {
-		return nil, fmt.Errorf("MCP token response missing accessToken (body: %s)", string(body))
+		return nil, fmt.Errorf("MCP token response missing accessToken (body bytes: %d)", len(body))
 	}
 
 	now := time.Now()
@@ -370,7 +372,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func buildAuthURL(clientID, redirectURI, targetCorpID string) string {
+func buildAuthURL(clientID, redirectURI, targetCorpID, state string) string {
 	params := url.Values{
 		"client_id":     {clientID},
 		"redirect_uri":  {redirectURI},
@@ -381,7 +383,21 @@ func buildAuthURL(clientID, redirectURI, targetCorpID string) string {
 	if targetCorpID = strings.TrimSpace(targetCorpID); targetCorpID != "" {
 		params.Set("corpId", targetCorpID)
 	}
+	// RFC 6749 §10.12: bind the authorization redirect to this login session.
+	if state = strings.TrimSpace(state); state != "" {
+		params.Set("state", state)
+	}
 	return AuthorizeURL + "?" + params.Encode()
+}
+
+// callbackPageTokenPlaceholder is replaced with the per-login page token when
+// the loopback server serves the not-enabled page. Cross-origin pages cannot
+// read the token (same-origin policy), so guarding /api/* on it blocks
+// cross-site request forgery against the local callback server.
+const callbackPageTokenPlaceholder = "__DWS_PAGE_TOKEN__"
+
+func renderCallbackPage(pageHTML, pageToken string) string {
+	return strings.ReplaceAll(pageHTML, callbackPageTokenPlaceholder, pageToken)
 }
 
 const successHTML = `<!doctype html>
@@ -790,6 +806,7 @@ const notEnabledHTML = `<!doctype html>
       const errorMsg = document.getElementById("errorMsg");
       const backLink = document.getElementById("backLink");
 
+      const pageToken = "__DWS_PAGE_TOKEN__";
       let admins = [];
       let clientId = "";
       let applySent = false;
@@ -887,7 +904,7 @@ const notEnabledHTML = `<!doctype html>
 
       async function checkAuthStatus() {
         try {
-          const res = await fetch("/api/cliAuthEnabled");
+          const res = await fetch("/api/cliAuthEnabled?pageToken=" + encodeURIComponent(pageToken));
           const data = await res.json();
           if (data.success && data.result && data.result.cliAuthEnabled) {
             stopPolling();
@@ -900,7 +917,7 @@ const notEnabledHTML = `<!doctype html>
 
       async function loadAdmins() {
         try {
-          const res = await fetch("/api/superAdmin");
+          const res = await fetch("/api/superAdmin?pageToken=" + encodeURIComponent(pageToken));
           const data = await res.json();
           if (data.success && data.result && data.result.length > 0) {
             admins = data.result;
@@ -932,7 +949,7 @@ const notEnabledHTML = `<!doctype html>
 
       async function init() {
         try {
-          const statusRes = await fetch("/api/status");
+          const statusRes = await fetch("/api/status?pageToken=" + encodeURIComponent(pageToken));
           const status = await statusRes.json();
           clientId = status.clientId || "";
           applySent = status.applySent || false;
@@ -948,7 +965,8 @@ const notEnabledHTML = `<!doctype html>
               clientId +
               "&prompt=consent&redirect_uri=" +
               redirectUri +
-              "&response_type=code&scope=openid+corpid";
+              "&response_type=code&scope=openid+corpid" +
+              (status.state ? "&state=" + encodeURIComponent(status.state) : "");
           }
 
           if (applySent) {
@@ -985,7 +1003,8 @@ const notEnabledHTML = `<!doctype html>
         hideError();
         try {
           const res = await fetch(
-            "/api/sendApply?adminStaffId=" + encodeURIComponent(value)
+            "/api/sendApply?adminStaffId=" + encodeURIComponent(value) + "&pageToken=" + encodeURIComponent(pageToken),
+            { method: "POST" }
           );
           const data = await res.json();
           if (data.success && data.result) {

--- a/internal/auth/oauth_provider.go
+++ b/internal/auth/oauth_provider.go
@@ -15,6 +15,8 @@ package auth
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -66,7 +68,19 @@ var (
 		return p.refreshWithRefreshToken(ctx, data)
 	}
 	oauthSleep = time.Sleep
+	// oauthRandomToken generates URL-safe random tokens for the OAuth state
+	// parameter and the loopback page token. Injectable for tests.
+	oauthRandomToken = generateOAuthRandomToken
 )
+
+// generateOAuthRandomToken returns a 128-bit crypto-random URL-safe token.
+func generateOAuthRandomToken() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generating OAuth login token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}
 
 // OAuthProvider handles the DingTalk OAuth 2.0 authorization code flow.
 type OAuthProvider struct {
@@ -77,6 +91,13 @@ type OAuthProvider struct {
 	httpClient   *http.Client
 	NoBrowser    bool
 	TargetCorpID string
+	// loginState binds the browser authorization redirect to this login
+	// session (RFC 6749 §10.12 login-CSRF protection). pageToken guards the
+	// loopback /api/* endpoints against cross-site requests from malicious
+	// web pages while the callback server is listening. Both are generated
+	// fresh at the start of every Login call.
+	loginState string
+	pageToken  string
 	// IdentityEnricher resolves userId/userName/corpName while the freshly
 	// exchanged access token is still only in memory.
 	IdentityEnricher func(context.Context, *TokenData) error
@@ -184,6 +205,19 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 		}
 	}
 
+	// Generate the per-login OAuth state (login-CSRF protection) and the
+	// loopback page token (CSRF protection for the local /api/* endpoints).
+	loginState, err := oauthRandomToken()
+	if err != nil {
+		return nil, err
+	}
+	p.loginState = loginState
+	pageToken, err := oauthRandomToken()
+	if err != nil {
+		return nil, err
+	}
+	p.pageToken = pageToken
+
 	// Find a free port for the callback server.
 	listener, err := oauthListen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -222,6 +256,21 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 		callbackTokenMu         sync.Mutex
 	)
 
+	// requirePageToken rejects cross-site requests to the loopback API that
+	// did not come from the page served by this login session. The token is
+	// only embedded in the HTML page, which cross-origin pages cannot read
+	// due to the same-origin policy.
+	requirePageToken := func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Query().Get("pageToken") == p.pageToken {
+			return true
+		}
+		logging.AuthDebug("auth.login.oauth.api.page_token_rejected", "callback_port", port, "path", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"success":false,"errorMsg":"forbidden"}`))
+		return false
+	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc(CallbackPath, func(w http.ResponseWriter, r *http.Request) {
 		// Get code first to check if this is a new authorization or page refresh
@@ -235,6 +284,20 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 			"has_authorization_code", code != "",
 		)
 
+		// RFC 6749 §10.12: the authorization server returns the state we sent;
+		// a mismatch means the redirect was not triggered by this login session
+		// (login CSRF), so the code must never be exchanged. Requests without a
+		// code fall through to the regular missing-code handling so a failed or
+		// cancelled authorization still unblocks the waiting login.
+		stateOK := r.URL.Query().Get("state") == p.loginState
+		if code != "" && !stateOK {
+			logging.AuthDebug("auth.login.oauth.callback.state_mismatch", "callback_port", port)
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprint(w, i18n.T("授权状态校验失败，请从终端重新发起登录"))
+			return
+		}
+
 		// Check state and handle page refresh or concurrent requests
 		callbackTokenMu.Lock()
 		processedCode := callbackProcessedCode
@@ -247,7 +310,7 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 			callbackTokenMu.Unlock()
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			if processedAuthDisabled {
-				_, _ = fmt.Fprint(w, notEnabledHTML)
+				_, _ = fmt.Fprint(w, renderCallbackPage(notEnabledHTML, p.pageToken))
 			} else {
 				_, _ = fmt.Fprint(w, successHTML)
 			}
@@ -262,12 +325,16 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 			return
 		}
 
-		// Case 3: No code but we have a processed token - show cached page
-		if code == "" && hasToken {
+		// Case 3: No code but we have a processed token - show the cached page.
+		// The not-enabled page embeds the page token, so it is only served to
+		// requests that carry the session state (e.g. a browser refreshing the
+		// full post-redirect URL); anything else falls through to the
+		// missing-code error instead of leaking the token.
+		if code == "" && hasToken && stateOK {
 			callbackTokenMu.Unlock()
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			if processedAuthDisabled {
-				_, _ = fmt.Fprint(w, notEnabledHTML)
+				_, _ = fmt.Fprint(w, renderCallbackPage(notEnabledHTML, p.pageToken))
 			} else {
 				_, _ = fmt.Fprint(w, successHTML)
 			}
@@ -378,7 +445,7 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 		case denialReason == "enterprise_not_authorized":
 			_, _ = fmt.Fprint(w, renderEnterpriseDeniedHTML(serverMsg))
 		default:
-			_, _ = fmt.Fprint(w, notEnabledHTML)
+			_, _ = fmt.Fprint(w, renderCallbackPage(notEnabledHTML, p.pageToken))
 		}
 		// Ensure response is flushed to client
 		if f, ok := w.(http.Flusher); ok {
@@ -394,6 +461,9 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 	// API endpoint: get super admins
 	mux.HandleFunc("/api/superAdmin", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if !requirePageToken(w, r) {
+			return
+		}
 		callbackTokenMu.Lock()
 		token := callbackToken
 		callbackTokenMu.Unlock()
@@ -410,9 +480,19 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 		_, _ = w.Write(data)
 	})
 
-	// API endpoint: send CLI auth apply
+	// API endpoint: send CLI auth apply. POST-only: a state-changing action
+	// must not be triggerable by cross-site navigations or <img> requests.
 	mux.HandleFunc("/api/sendApply", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = w.Write([]byte(`{"success":false,"errorMsg":"method not allowed"}`))
+			return
+		}
+		if !requirePageToken(w, r) {
+			return
+		}
 		adminStaffID := r.URL.Query().Get("adminStaffId")
 		if adminStaffID == "" {
 			_, _ = w.Write([]byte(`{"success":false,"errorMsg":"缺少 adminStaffId 参数"}`))
@@ -441,19 +521,34 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 		_, _ = w.Write(data)
 	})
 
-	// API endpoint: get current status (clientId, applySent, selectedAdminId)
+	// API endpoint: get current status (clientId, applySent, selectedAdminId).
+	// state is exposed so the in-page "switch organization" re-authorization
+	// link can carry the login-CSRF token of this session; the endpoint itself
+	// is page-token guarded and unreachable for cross-origin readers.
 	mux.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if !requirePageToken(w, r) {
+			return
+		}
 		callbackTokenMu.Lock()
 		applySent := callbackApplySent
 		selectedAdminId := callbackSelectedAdminId
 		callbackTokenMu.Unlock()
-		_, _ = fmt.Fprintf(w, `{"clientId":"%s","applySent":%t,"selectedAdminId":"%s"}`, p.clientID, applySent, selectedAdminId)
+		data, _ := json.Marshal(map[string]any{
+			"clientId":        p.clientID,
+			"applySent":       applySent,
+			"selectedAdminId": selectedAdminId,
+			"state":           p.loginState,
+		})
+		_, _ = w.Write(data)
 	})
 
 	// API endpoint: check CLI auth enabled status
 	mux.HandleFunc("/api/cliAuthEnabled", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if !requirePageToken(w, r) {
+			return
+		}
 		callbackTokenMu.Lock()
 		token := callbackToken
 		callbackTokenMu.Unlock()
@@ -476,7 +571,17 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 		_, _ = fmt.Fprint(w, successHTML)
 	})
 
-	server := &http.Server{Handler: mux}
+	server := &http.Server{
+		Handler: mux,
+		// Bound slow-client attacks against the loopback listener: without
+		// timeouts a trickling connection could stall the whole login flow.
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		// The callback handler may perform token exchange plus retried status
+		// checks before responding; keep headroom above those budgets.
+		WriteTimeout: 120 * time.Second,
+		IdleTimeout:  30 * time.Second,
+	}
 	go func() {
 		if serveErr := server.Serve(listener); !errors.Is(serveErr, http.ErrServerClosed) {
 			select {
@@ -491,7 +596,7 @@ func (p *OAuthProvider) Login(ctx context.Context, force bool) (*TokenData, erro
 		_ = server.Shutdown(shutCtx)
 	}()
 
-	authURL := buildAuthURL(p.clientID, redirectURI, p.TargetCorpID)
+	authURL := buildAuthURL(p.clientID, redirectURI, p.TargetCorpID, p.loginState)
 	if p.logger != nil {
 		p.logger.Debug("authorization URL", "url", authURL)
 	}

--- a/internal/auth/oauth_provider.go
+++ b/internal/auth/oauth_provider.go
@@ -68,6 +68,8 @@ var (
 		return p.refreshWithRefreshToken(ctx, data)
 	}
 	oauthSleep = time.Sleep
+	// oauthRandRead is the entropy source for login tokens. Injectable for tests.
+	oauthRandRead = rand.Read
 	// oauthRandomToken generates URL-safe random tokens for the OAuth state
 	// parameter and the loopback page token. Injectable for tests.
 	oauthRandomToken = generateOAuthRandomToken
@@ -76,7 +78,7 @@ var (
 // generateOAuthRandomToken returns a 128-bit crypto-random URL-safe token.
 func generateOAuthRandomToken() (string, error) {
 	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
+	if _, err := oauthRandRead(b[:]); err != nil {
 		return "", fmt.Errorf("generating OAuth login token: %w", err)
 	}
 	return base64.RawURLEncoding.EncodeToString(b[:]), nil

--- a/internal/auth/oauth_provider_coverage_test.go
+++ b/internal/auth/oauth_provider_coverage_test.go
@@ -345,6 +345,58 @@ func TestCrossPlatformCoverageOAuthLoginCallbackAndAPIs(t *testing.T) {
 // loopback-API protections: a callback with a missing/mismatched state must
 // never reach token exchange, the /api/* endpoints must reject requests
 // without the per-login page token, and sendApply must require POST.
+func TestCrossPlatformCoverageGenerateOAuthRandomToken(t *testing.T) {
+	first, err := generateOAuthRandomToken()
+	if err != nil || first == "" {
+		t.Fatalf("generateOAuthRandomToken = %q, %v", first, err)
+	}
+	second, err := generateOAuthRandomToken()
+	if err != nil || second == "" || second == first {
+		t.Fatalf("generateOAuthRandomToken uniqueness = %q vs %q, %v", first, second, err)
+	}
+
+	oldRandRead := oauthRandRead
+	oauthRandRead = func([]byte) (int, error) { return 0, errors.New("entropy") }
+	t.Cleanup(func() { oauthRandRead = oldRandRead })
+	if _, err := generateOAuthRandomToken(); err == nil || !strings.Contains(err.Error(), "entropy") {
+		t.Fatalf("generateOAuthRandomToken error = %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageOAuthLoginRandomTokenFailure(t *testing.T) {
+	isolateOAuthPersistence(t)
+	SetClientID("client")
+	SetClientSecret("secret")
+	t.Cleanup(func() {
+		SetClientID("")
+		SetClientSecret("")
+	})
+	oldRandomToken := oauthRandomToken
+	t.Cleanup(func() { oauthRandomToken = oldRandomToken })
+
+	failAt := 1
+	calls := 0
+	oauthRandomToken = func() (string, error) {
+		calls++
+		if calls == failAt {
+			return "", errors.New("entropy")
+		}
+		return "token", nil
+	}
+
+	p := &OAuthProvider{configDir: t.TempDir(), Output: io.Discard}
+	if _, err := p.Login(context.Background(), true); err == nil || !strings.Contains(err.Error(), "entropy") {
+		t.Fatalf("login state failure = %v", err)
+	}
+
+	// First call succeeds (login state), second fails (page token).
+	calls = 0
+	failAt = 2
+	if _, err := p.Login(context.Background(), true); err == nil || !strings.Contains(err.Error(), "entropy") {
+		t.Fatalf("page token failure = %v", err)
+	}
+}
+
 func TestCrossPlatformCoverageOAuthLoginCSRFGuards(t *testing.T) {
 	// CLI auth disabled renders the not-enabled page, which is the only page
 	// that must embed the page token for its own fetch calls.

--- a/internal/auth/oauth_provider_coverage_test.go
+++ b/internal/auth/oauth_provider_coverage_test.go
@@ -22,6 +22,11 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/keychain"
 )
 
+const (
+	fixtureLoginState = "test-login-state"
+	fixturePageToken  = "test-page-token"
+)
+
 type oauthLoginFixture struct {
 	configDir       string
 	callbackBase    string
@@ -117,6 +122,20 @@ func newOAuthLoginFixture(t *testing.T, status func(int32) CLIAuthStatus) *oauth
 		resetClientIDFromMCP()
 	})
 
+	// Deterministic login state / page token: Login generates the state first
+	// and the page token second, and the alternation keeps the roles correct
+	// even if a test drives more than one Login through this fixture.
+	oldRandomToken := oauthRandomToken
+	tokenCalls := 0
+	oauthRandomToken = func() (string, error) {
+		tokenCalls++
+		if tokenCalls%2 == 1 {
+			return fixtureLoginState, nil
+		}
+		return fixturePageToken, nil
+	}
+	t.Cleanup(func() { oauthRandomToken = oldRandomToken })
+
 	f := &oauthLoginFixture{
 		exchangeEntered: make(chan struct{}),
 		exchangeRelease: make(chan struct{}),
@@ -202,6 +221,21 @@ func httpGetBody(t *testing.T, rawURL string) (int, string) {
 	return result.status, result.body
 }
 
+func httpPostBody(t *testing.T, rawURL string) (int, string) {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Post(rawURL, "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST %s: %v", rawURL, err)
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("POST %s read body: %v", rawURL, err)
+	}
+	return resp.StatusCode, string(data)
+}
+
 func getHTTPBody(rawURL string) oauthHTTPResult {
 	client := &http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Get(rawURL)
@@ -223,17 +257,21 @@ func TestCrossPlatformCoverageOAuthLoginCallbackAndAPIs(t *testing.T) {
 
 	loginDone := startOAuthLogin(t, context.Background(), f)
 
-	for _, path := range []string{"/api/superAdmin", "/api/sendApply?adminStaffId=admin-1", "/api/cliAuthEnabled"} {
-		_, body := httpGetBody(t, f.callbackBase+path)
+	for _, path := range []string{"/api/superAdmin", "/api/cliAuthEnabled"} {
+		_, body := httpGetBody(t, f.callbackBase+path+"?pageToken="+fixturePageToken)
 		if !strings.Contains(body, "授权尚未完成") {
 			t.Fatalf("pre-auth %s = %q", path, body)
 		}
 	}
-	_, body := httpGetBody(t, f.callbackBase+"/api/sendApply")
+	_, body := httpPostBody(t, f.callbackBase+"/api/sendApply?adminStaffId=admin-1&pageToken="+fixturePageToken)
+	if !strings.Contains(body, "授权尚未完成") {
+		t.Fatalf("pre-auth sendApply = %q", body)
+	}
+	_, body = httpPostBody(t, f.callbackBase+"/api/sendApply?pageToken="+fixturePageToken)
 	if !strings.Contains(body, "adminStaffId") {
 		t.Fatalf("missing admin response = %q", body)
 	}
-	_, body = httpGetBody(t, f.callbackBase+"/api/status")
+	_, body = httpGetBody(t, f.callbackBase+"/api/status?pageToken="+fixturePageToken)
 	if !strings.Contains(body, "test-client") {
 		t.Fatalf("initial status = %q", body)
 	}
@@ -243,37 +281,37 @@ func TestCrossPlatformCoverageOAuthLoginCallbackAndAPIs(t *testing.T) {
 
 	callbackDone := make(chan oauthHTTPResult, 1)
 	go func() {
-		callbackDone <- getHTTPBody(f.callbackBase + CallbackPath + "?code=good")
+		callbackDone <- getHTTPBody(f.callbackBase + CallbackPath + "?code=good&state=" + fixtureLoginState)
 	}()
 	waitOAuthSignal(t, f.exchangeEntered, loginDone, "token exchange")
-	_, body = httpGetBody(t, f.callbackBase+CallbackPath+"?authCode=good")
+	_, body = httpGetBody(t, f.callbackBase+CallbackPath+"?authCode=good&state="+fixtureLoginState)
 	if !strings.Contains(body, "正在处理授权") {
 		t.Fatalf("concurrent callback = %q", body)
 	}
 	closeOAuthRelease(f.exchangeRelease)
 	waitOAuthSignal(t, f.statusEntered, loginDone, "CLI auth status check")
 
-	_, body = httpGetBody(t, f.callbackBase+CallbackPath+"?code=good")
+	_, body = httpGetBody(t, f.callbackBase+CallbackPath+"?code=good&state="+fixtureLoginState)
 	if !strings.Contains(body, "<html") {
 		t.Fatalf("cached callback = %q", body)
 	}
-	_, body = httpGetBody(t, f.callbackBase+CallbackPath)
+	_, body = httpGetBody(t, f.callbackBase+CallbackPath+"?state="+fixtureLoginState)
 	if !strings.Contains(body, "<html") {
 		t.Fatalf("cached no-code callback = %q", body)
 	}
-	_, body = httpGetBody(t, f.callbackBase+"/api/superAdmin")
+	_, body = httpGetBody(t, f.callbackBase+"/api/superAdmin?pageToken="+fixturePageToken)
 	if !strings.Contains(body, "admin-1") {
 		t.Fatalf("super admins = %q", body)
 	}
-	_, body = httpGetBody(t, f.callbackBase+"/api/sendApply?adminStaffId=admin-1")
+	_, body = httpPostBody(t, f.callbackBase+"/api/sendApply?adminStaffId=admin-1&pageToken="+fixturePageToken)
 	if !strings.Contains(body, "true") {
 		t.Fatalf("send apply = %q", body)
 	}
-	_, body = httpGetBody(t, f.callbackBase+"/api/status")
+	_, body = httpGetBody(t, f.callbackBase+"/api/status?pageToken="+fixturePageToken)
 	if !strings.Contains(body, "admin-1") || !strings.Contains(body, "true") {
 		t.Fatalf("updated status = %q", body)
 	}
-	_, body = httpGetBody(t, f.callbackBase+"/api/cliAuthEnabled")
+	_, body = httpGetBody(t, f.callbackBase+"/api/cliAuthEnabled?pageToken="+fixturePageToken)
 	if !strings.Contains(body, "cliAuthEnabled") {
 		t.Fatalf("auth enabled API = %q", body)
 	}
@@ -300,6 +338,94 @@ func TestCrossPlatformCoverageOAuthLoginCallbackAndAPIs(t *testing.T) {
 	}
 	if err := f.provider.Logout(); err != nil {
 		t.Fatalf("Logout: %v", err)
+	}
+}
+
+// TestCrossPlatformCoverageOAuthLoginCSRFGuards verifies the login-CSRF and
+// loopback-API protections: a callback with a missing/mismatched state must
+// never reach token exchange, the /api/* endpoints must reject requests
+// without the per-login page token, and sendApply must require POST.
+func TestCrossPlatformCoverageOAuthLoginCSRFGuards(t *testing.T) {
+	// CLI auth disabled renders the not-enabled page, which is the only page
+	// that must embed the page token for its own fetch calls.
+	f := newOAuthLoginFixture(t, func(int32) CLIAuthStatus {
+		return CLIAuthStatus{Success: true, Result: &CLIAuthResult{CLIAuthEnabled: false}}
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	loginDone := startOAuthLogin(t, ctx, f)
+
+	// A forged callback (login CSRF attempt) is rejected before exchange.
+	status, body := httpGetBody(t, f.callbackBase+CallbackPath+"?code=attacker-code&state=attacker-state")
+	if status != http.StatusBadRequest {
+		t.Fatalf("mismatched state status = %d body = %q", status, body)
+	}
+	select {
+	case <-f.exchangeEntered:
+		t.Fatal("token exchange reached with mismatched state")
+	default:
+	}
+	status, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=attacker-code")
+	if status != http.StatusBadRequest {
+		t.Fatalf("missing state status = %d", status)
+	}
+	select {
+	case <-f.exchangeEntered:
+		t.Fatal("token exchange reached with missing state")
+	default:
+	}
+
+	// Loopback API endpoints reject missing and wrong page tokens.
+	for _, path := range []string{"/api/superAdmin", "/api/cliAuthEnabled", "/api/status"} {
+		if status, _ := httpGetBody(t, f.callbackBase+path); status != http.StatusForbidden {
+			t.Fatalf("%s without pageToken status = %d", path, status)
+		}
+		if status, _ := httpGetBody(t, f.callbackBase+path+"?pageToken=wrong"); status != http.StatusForbidden {
+			t.Fatalf("%s with wrong pageToken status = %d", path, status)
+		}
+	}
+
+	// sendApply additionally requires POST and rejects cross-site GETs.
+	if status, _ := httpGetBody(t, f.callbackBase+"/api/sendApply?adminStaffId=admin-1&pageToken="+fixturePageToken); status != http.StatusMethodNotAllowed {
+		t.Fatalf("sendApply GET status = %d", status)
+	}
+	if status, _ := httpPostBody(t, f.callbackBase+"/api/sendApply?adminStaffId=admin-1"); status != http.StatusForbidden {
+		t.Fatalf("sendApply POST without pageToken status = %d", status)
+	}
+
+	// The not-enabled page embeds the page token for its own fetch calls.
+	callbackDone := make(chan oauthHTTPResult, 1)
+	go func() {
+		callbackDone <- getHTTPBody(f.callbackBase + CallbackPath + "?code=good&state=" + fixtureLoginState)
+	}()
+	waitOAuthSignal(t, f.exchangeEntered, loginDone, "token exchange")
+	closeOAuthRelease(f.exchangeRelease)
+	waitOAuthSignal(t, f.statusEntered, loginDone, "CLI auth status check")
+	closeOAuthRelease(f.statusRelease)
+	select {
+	case callback := <-callbackDone:
+		if callback.err != nil {
+			t.Fatalf("callback: %v", callback.err)
+		}
+		if strings.Contains(callback.body, callbackPageTokenPlaceholder) {
+			t.Fatalf("callback page still contains the page-token placeholder")
+		}
+		if !strings.Contains(callback.body, fixturePageToken) {
+			t.Fatalf("not-enabled page does not embed the page token")
+		}
+	case <-time.After(oauthTestWaitTimeout):
+		t.Fatal("timed out waiting for OAuth callback")
+	}
+
+	// A wrong page token is still rejected after the callback completed.
+	if status, _ := httpGetBody(t, f.callbackBase+"/api/superAdmin?pageToken=wrong"); status != http.StatusForbidden {
+		t.Fatalf("post-callback wrong pageToken status = %d", status)
+	}
+
+	// The login keeps waiting for admin approval; cancel it to finish.
+	cancel()
+	if result := awaitOAuthLogin(t, loginDone); !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("canceled login = %v", result.err)
 	}
 }
 
@@ -342,7 +468,7 @@ func TestOAuthForcedLoginIgnoresUnreadableUnrelatedProfile(t *testing.T) {
 	loginDone := startOAuthLogin(t, context.Background(), f)
 	callbackDone := make(chan oauthHTTPResult, 1)
 	go func() {
-		callbackDone <- getHTTPBody(f.callbackBase + CallbackPath + "?code=unrelated-safe")
+		callbackDone <- getHTTPBody(f.callbackBase + CallbackPath + "?code=unrelated-safe&state=" + fixtureLoginState)
 	}()
 	waitOAuthSignal(t, f.exchangeEntered, loginDone, "token exchange")
 	closeOAuthRelease(f.exchangeRelease)
@@ -532,13 +658,19 @@ func TestCrossPlatformCoverageOAuthPersistConfigEdges(t *testing.T) {
 }
 
 func TestCrossPlatformCoverageBuildOAuthAuthURLTarget(t *testing.T) {
-	raw := buildAuthURL("client", "http://localhost/callback", "corp")
+	raw := buildAuthURL("client", "http://localhost/callback", "corp", "test-state")
 	parsed, err := url.Parse(raw)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if parsed.Query().Get("corpId") != "corp" {
 		t.Fatalf("auth URL = %q", raw)
+	}
+	if parsed.Query().Get("state") != "test-state" {
+		t.Fatalf("auth URL missing state = %q", raw)
+	}
+	if raw := buildAuthURL("client", "http://localhost/callback", "", "  "); strings.Contains(raw, "state=") {
+		t.Fatalf("empty state must be omitted = %q", raw)
 	}
 }
 
@@ -573,7 +705,7 @@ func TestCrossPlatformCoverageOAuthLoginDenialAndPolling(t *testing.T) {
 			closeOAuthRelease(f.statusRelease)
 			f.provider.NoBrowser = false
 			done := startOAuthLogin(t, context.Background(), f)
-			_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=denied")
+			_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=denied&state="+fixtureLoginState)
 			if result := awaitOAuthLogin(t, done); result.err == nil {
 				t.Fatal("denied login succeeded")
 			}
@@ -588,7 +720,7 @@ func TestCrossPlatformCoverageOAuthLoginDenialAndPolling(t *testing.T) {
 		closeOAuthRelease(f.exchangeRelease)
 		closeOAuthRelease(f.statusRelease)
 		done := startOAuthLogin(t, context.Background(), f)
-		_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=denied")
+		_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=denied&state="+fixtureLoginState)
 		if result := awaitOAuthLogin(t, done); result.err == nil {
 			t.Fatal("channel-denied login succeeded")
 		}
@@ -602,7 +734,7 @@ func TestCrossPlatformCoverageOAuthLoginDenialAndPolling(t *testing.T) {
 		closeOAuthRelease(f.exchangeRelease)
 		closeOAuthRelease(f.statusRelease)
 		done := startOAuthLogin(t, context.Background(), f)
-		_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=pending")
+		_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=pending&state="+fixtureLoginState)
 		if result := awaitOAuthLogin(t, done); result.err == nil {
 			t.Fatal("approval timeout login succeeded")
 		}
@@ -616,7 +748,7 @@ func TestCrossPlatformCoverageOAuthLoginDenialAndPolling(t *testing.T) {
 		closeOAuthRelease(f.exchangeRelease)
 		closeOAuthRelease(f.statusRelease)
 		done := startOAuthLogin(t, context.Background(), f)
-		_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=pending")
+		_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=pending&state="+fixtureLoginState)
 		if result := awaitOAuthLogin(t, done); result.err != nil {
 			t.Fatalf("poll-enabled login failed: %v", result.err)
 		}
@@ -630,7 +762,7 @@ func TestCrossPlatformCoverageOAuthLoginDenialAndPolling(t *testing.T) {
 		closeOAuthRelease(f.statusRelease)
 		ctx, cancel := context.WithCancel(context.Background())
 		done := startOAuthLogin(t, ctx, f)
-		_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=pending")
+		_, _ = httpGetBody(t, f.callbackBase+CallbackPath+"?code=pending&state="+fixtureLoginState)
 		cancel()
 		if result := awaitOAuthLogin(t, done); result.err == nil {
 			t.Fatal("canceled pending login succeeded")
@@ -646,7 +778,7 @@ func TestCrossPlatformCoverageOAuthLoginExchangeFailure(t *testing.T) {
 	closeOAuthRelease(f.exchangeRelease)
 	closeOAuthRelease(f.statusRelease)
 	done := startOAuthLogin(t, context.Background(), f)
-	_, body := httpGetBody(t, f.callbackBase+CallbackPath+"?code=bad")
+	_, body := httpGetBody(t, f.callbackBase+CallbackPath+"?code=bad&state="+fixtureLoginState)
 	if !strings.Contains(body, "failed") {
 		t.Fatalf("exchange failure page = %q", body)
 	}
@@ -929,7 +1061,7 @@ func TestCrossPlatformCoverageOAuthCallbackRemainingEdges(t *testing.T) {
 		t.Helper()
 		bodyCh := make(chan oauthHTTPResult, 1)
 		go func() {
-			bodyCh <- getHTTPBody(f.callbackBase + CallbackPath + "?code=" + url.QueryEscape(code))
+			bodyCh <- getHTTPBody(f.callbackBase + CallbackPath + "?code=" + url.QueryEscape(code) + "&state=" + fixtureLoginState)
 		}()
 		waitOAuthSignal(t, f.exchangeEntered, done, "token exchange")
 		closeOAuthRelease(f.exchangeRelease)
@@ -959,13 +1091,13 @@ func TestCrossPlatformCoverageOAuthCallbackRemainingEdges(t *testing.T) {
 		if body := finishExchange(t, f, done, "first"); !strings.Contains(body, "<html") {
 			t.Fatalf("disabled callback body = %q", body)
 		}
-		if _, body := httpGetBody(t, f.callbackBase+CallbackPath+"?code=first"); !strings.Contains(body, "<html") {
+		if _, body := httpGetBody(t, f.callbackBase+CallbackPath+"?code=first&state="+fixtureLoginState); !strings.Contains(body, "<html") {
 			t.Fatalf("cached disabled callback = %q", body)
 		}
-		if _, body := httpGetBody(t, f.callbackBase+CallbackPath); !strings.Contains(body, "<html") {
+		if _, body := httpGetBody(t, f.callbackBase+CallbackPath+"?state="+fixtureLoginState); !strings.Contains(body, "<html") {
 			t.Fatalf("cached disabled no-code callback = %q", body)
 		}
-		if _, body := httpGetBody(t, f.callbackBase+CallbackPath+"?code=second"); !strings.Contains(body, "<html") {
+		if _, body := httpGetBody(t, f.callbackBase+CallbackPath+"?code=second&state="+fixtureLoginState); !strings.Contains(body, "<html") {
 			t.Fatalf("switched callback = %q", body)
 		}
 		result := awaitOAuthLogin(t, done)
@@ -984,10 +1116,13 @@ func TestCrossPlatformCoverageOAuthCallbackRemainingEdges(t *testing.T) {
 		f := newOAuthLoginFixture(t, func(int32) CLIAuthStatus { return CLIAuthStatus{} })
 		done := startOAuthLogin(t, ctx, f)
 		finishExchange(t, f, done, "errors")
-		for _, path := range []string{"/api/superAdmin", "/api/sendApply?adminStaffId=admin", "/api/cliAuthEnabled"} {
-			if _, body := httpGetBody(t, f.callbackBase+path); !strings.Contains(body, "hook failure") {
+		for _, path := range []string{"/api/superAdmin", "/api/cliAuthEnabled"} {
+			if _, body := httpGetBody(t, f.callbackBase+path+"?pageToken="+fixturePageToken); !strings.Contains(body, "hook failure") {
 				t.Fatalf("API error %s = %q", path, body)
 			}
+		}
+		if _, body := httpPostBody(t, f.callbackBase+"/api/sendApply?adminStaffId=admin&pageToken="+fixturePageToken); !strings.Contains(body, "hook failure") {
+			t.Fatalf("API error sendApply = %q", body)
 		}
 		cancel()
 		if result := awaitOAuthLogin(t, done); !errors.Is(result.err, context.Canceled) {
@@ -1009,7 +1144,7 @@ func TestCrossPlatformCoverageOAuthCallbackRemainingEdges(t *testing.T) {
 		f.provider.Output = &output
 		done := startOAuthLogin(t, ctx, f)
 		finishExchange(t, f, done, "apply")
-		if _, body := httpGetBody(t, f.callbackBase+"/api/sendApply?adminStaffId=admin"); !strings.Contains(body, "true") {
+		if _, body := httpPostBody(t, f.callbackBase+"/api/sendApply?adminStaffId=admin&pageToken="+fixturePageToken); !strings.Contains(body, "true") {
 			t.Fatalf("apply response = %q", body)
 		}
 		time.Sleep(20 * time.Millisecond)

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -17,6 +17,8 @@
 package config
 
 import (
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -191,26 +193,58 @@ func DefaultConfigDir() string {
 //  1. ~/.dws/mcp_url file content (for custom environment)
 //  2. Default value (https://mcp.dingtalk.com)
 func GetMCPBaseURL() string {
-	mcpURLPath := filepath.Join(DefaultConfigDir(), "mcp_url")
-	if data, err := os.ReadFile(mcpURLPath); err == nil {
-		if u := strings.TrimSpace(string(data)); u != "" {
-			return u
-		}
-	}
-	return DefaultMCPBaseURL
+	return readPlatformURLOverride("mcp_url", DefaultMCPBaseURL)
 }
 
 // GetTerminalBaseURL returns the terminal base URL with priority:
 //  1. ~/.dws/terminal_url file content (for pre-release environment)
 //  2. Default value (https://open-dev.dingtalk.com)
 func GetTerminalBaseURL() string {
-	terminalURLPath := filepath.Join(DefaultConfigDir(), "terminal_url")
-	if data, err := os.ReadFile(terminalURLPath); err == nil {
-		if u := strings.TrimSpace(string(data)); u != "" {
-			return u
-		}
+	return readPlatformURLOverride("terminal_url", DefaultTerminalBaseURL)
+}
+
+// readPlatformURLOverride reads a platform base-URL override from the config
+// directory. The override file is a trust root: the MCP base URL receives
+// user access tokens and refresh tokens, so the value is accepted only when
+// it is HTTPS, or plain HTTP bound to a loopback host (local development).
+// Anything else is ignored and the production default applies.
+func readPlatformURLOverride(fileName, fallback string) string {
+	data, err := os.ReadFile(filepath.Join(DefaultConfigDir(), fileName))
+	if err != nil {
+		return fallback
 	}
-	return DefaultTerminalBaseURL
+	u := strings.TrimSpace(string(data))
+	if u == "" || !IsAllowedPlatformURLOverride(u) {
+		return fallback
+	}
+	return u
+}
+
+// IsAllowedPlatformURLOverride reports whether a platform base-URL override is
+// safe to honor: HTTPS to any host, or plain HTTP bound to a loopback host
+// (local development). Callers that read mcp_url/terminal_url outside of
+// GetMCPBaseURL/GetTerminalBaseURL must apply the same check.
+func IsAllowedPlatformURLOverride(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "https":
+		return parsed.Host != ""
+	case "http":
+		return isLoopbackHostname(parsed.Hostname())
+	default:
+		return false
+	}
+}
+
+func isLoopbackHostname(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // GetDeveloperSettingsURL returns the full URL to the organization developer

--- a/pkg/config/constants_test.go
+++ b/pkg/config/constants_test.go
@@ -219,7 +219,9 @@ func TestGetMCPBaseURLUsesConfigFile(t *testing.T) {
 	}
 }
 
-func TestPlatformURLOverrideValidation(t *testing.T) {
+// The name must keep the TestCrossPlatformCoverage prefix: the CI platform
+// coverage gate only executes tests matching that pattern.
+func TestCrossPlatformCoveragePlatformURLOverrideValidation(t *testing.T) {
 	cases := []struct {
 		name     string
 		value    string

--- a/pkg/config/constants_test.go
+++ b/pkg/config/constants_test.go
@@ -219,6 +219,50 @@ func TestGetMCPBaseURLUsesConfigFile(t *testing.T) {
 	}
 }
 
+func TestPlatformURLOverrideValidation(t *testing.T) {
+	cases := []struct {
+		name     string
+		value    string
+		wantURL  string
+		fallback bool
+	}{
+		{name: "https remote allowed", value: "https://pre-mcp-gw.dingtalk.com", wantURL: "https://pre-mcp-gw.dingtalk.com"},
+		{name: "http loopback ip allowed", value: "http://127.0.0.1:8080", wantURL: "http://127.0.0.1:8080"},
+		{name: "http localhost allowed", value: "http://localhost:9090", wantURL: "http://localhost:9090"},
+		{name: "http ipv6 loopback allowed", value: "http://[::1]:8080", wantURL: "http://[::1]:8080"},
+		{name: "http remote rejected", value: "http://evil.example.com", fallback: true},
+		{name: "http remote ip rejected", value: "http://203.0.113.10", fallback: true},
+		{name: "no scheme rejected", value: "mcp.dingtalk.com", fallback: true},
+		{name: "non-http scheme rejected", value: "file:///etc/passwd", fallback: true},
+		{name: "empty rejected", value: "   ", fallback: true},
+		{name: "garbage rejected", value: "http://%zz", fallback: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("DWS_CONFIG_DIR", dir)
+			if err := os.WriteFile(filepath.Join(dir, "mcp_url"), []byte(tc.value+"\n"), FilePerm); err != nil {
+				t.Fatalf("WriteFile(mcp_url) error = %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "terminal_url"), []byte(tc.value+"\n"), FilePerm); err != nil {
+				t.Fatalf("WriteFile(terminal_url) error = %v", err)
+			}
+			wantMCP := tc.wantURL
+			wantTerminal := tc.wantURL
+			if tc.fallback {
+				wantMCP = DefaultMCPBaseURL
+				wantTerminal = DefaultTerminalBaseURL
+			}
+			if got := GetMCPBaseURL(); got != wantMCP {
+				t.Fatalf("GetMCPBaseURL() = %q, want %q", got, wantMCP)
+			}
+			if got := GetTerminalBaseURL(); got != wantTerminal {
+				t.Fatalf("GetTerminalBaseURL() = %q, want %q", got, wantTerminal)
+			}
+		})
+	}
+}
+
 func TestMaxUploadFileSize(t *testing.T) {
 	t.Parallel()
 	var want int64 = 100 * 1024 * 1024


### PR DESCRIPTION
## Summary

登录/授权安全审查后的加固修复（最近三天 upstream/main 无登录相关新变更，以下为存量缺陷，已在最新 main 上逐项核实存在）：

- **Login CSRF（高危）**：OAuth loopback 授权 URL 未携带 `state`，回调处理器对任何投递到 `/callback?authCode=...` 的请求都直接交换 token。本机恶意进程或被恶意网页驱动的浏览器可在 5 分钟监听窗口内把受害者登录成攻击者身份。现按 RFC 6749 §10.12 生成每次登录随机的 `state` 并严格校验，不匹配即 400 且永不触及 token 交换。
- **Loopback API 无防护（高危）**：回调服务器上的 `/api/sendApply` 用 GET 执行有副作用的服务端申请并自动携带受害者 access token；`/api/status` 明文泄露 clientId；各 `/api/*` 可被本机任意进程/跨域网页滥用。现为每次登录生成独立 `pageToken`（仅注入所服务页面，跨域页面受同源策略读取不到）保护全部 `/api/*`，`/api/sendApply` 改为仅接受 POST，`/api/status` 改用 `json.Marshal` 输出并携带 `state` 供页内“换组织重新授权”链接使用。
- **慢连接 DoS**：回调 `http.Server` 无任何超时，trickling 连接可拖死登录流程。现加 `ReadHeaderTimeout/ReadTimeout/WriteTimeout/IdleTimeout`。
- **错误泄露（中危）**：`parseMCPTokenResponse` 失败时把完整响应体塞进 error，可能将 token/PII 带入终端、日志与 issue。现仅记录 body 长度（与同文件 `postJSON` 的 `truncateBody` 脱敏惯例一致）。
- **信任根可重定向（高危）**：`~/.dws/mcp_url` / `terminal_url` 文件内容此前不经任何校验即作为 MCP 控制面地址（承载 `/cli/clientId`、token 交换/刷新及 `x-user-access-token` 转发）。现仅接受 HTTPS 或 loopback HTTP，其余一律回退生产默认；`event` 命令绕过 `GetMCPBaseURL` 直接读文件的旁路（`configuredMCPBaseURL`）同步接入同一校验（`config.IsAllowedPlatformURLOverride` 导出复用）。

## Risk tier

- [x] High-risk: workflow/policy, package graph, generated Schema/registry, platform, auth/keychain, installer, packaging, release, transport, recovery, or another fail-closed infrastructure change

## Verification

- [x] Exact in-place `CHANGELOG.md`-only check: `./scripts/policy/check-changelog-pr.sh --fast-path "$(git merge-base HEAD upstream/main)" HEAD` → exit 0
- [x] Targeted test/check commands and results: `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/auth ./internal/app ./pkg/config -count=1` → 全部 ok（auth 116s / app 99s / config 0.5s）
- [x] Behavior evidence:
  - 新增 `TestCrossPlatformCoverageOAuthLoginCSRFGuards`：伪造 state 的回调在 token 交换前被 400 拒绝；缺失/错误 pageToken 的 `/api/*` 返回 403；`/api/sendApply` GET 返回 405；not-enabled 页面正确注入 pageToken
  - 新增 `TestPlatformURLOverrideValidation`（10 用例）：https 远程放行、loopback http（IP/localhost/[::1]）放行、http 远程/无 scheme/file scheme/空值/非法 URL 全部回退默认
  - `TestCrossPlatformCoverageBuildOAuthAuthURLTarget` / `TestBuildAuthURLIncludesTargetCorpID` 更新并验证 state 写入授权 URL；mock 浏览器 fixture 改为透传 state，验证端到端回传链路
- [x] Documentation links/content/rendering checked: N/A（CHANGELOG 已补 Unreleased 条目）
- [x] Full local suite run because the change is high-risk: `DWS_PACKAGE_VERSION=0.0.0-test go test ./... -count=1` → 仅 `TestCrossPlatformCoverageOAuthLoginTimeoutAndServerError` 失败，已用 `git stash` 双向验证该失败在 upstream/main 基线上同样存在（中文 locale 下断言 `timeout` 子串的既有问题，与本 PR 无关）；`TestReconcileGiteeAssets...` 全量跑时偶发失败、单跑通过（flaky，与改动无交集）
- [x] `./scripts/policy/check-generated-drift.sh` → ok（registry_commands=603 tools=603）
- [x] `./scripts/policy/check-command-surface.sh --strict`: N/A（未变更 CLI 命令表面；`/api/*` 为登录期 loopback 回调内部端点）
- [x] `./scripts/release/verify-package-managers.sh`: N/A（未触及 packaging/installer）

## Notes

- **兼容性**：钉钉授权端点按 OAuth2 规范回传 `state`（与现有 `corpId`/`prompt` 参数同链路）；mock 浏览器测试已按真实回传行为验证。页内“换组织重新授权”链接经 `/api/status` 获取同一会话 `state`，流程不受影响。
- **行为变化**：非法 `mcp_url`（如 `://bad`）不再让 `doctor` 网络检查误报失败，而是回退生产地址；两处 doctor 测试改用不可达合法地址（`https://127.0.0.1:1`）保留失败分支覆盖。
- **有意范围裁剪**（后续 PR）：PKCE（需确认服务端支持）；direct 模式 logout 后 refresh token 服务端撤销语义；Linux libsecret 集成替代 file-DEK；`auth export` 加密导出。
- 基线已知问题：`TestCrossPlatformCoverageOAuthLoginTimeoutAndServerError` 在中文 locale 下失败（断言依赖英文文案），非本 PR 引入，建议单独修复。