### PR TITLE
docs(release): prepare v1.0.55-beta.6 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,27 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.55-beta.6] - 2026-07-29
+
+This beta validates the Wukong capability and multi-Skill synchronization,
+declarative command and Schema delivery, hardened Chat shortcuts, external
+contact resolution, and Agent product identity on top of the
+`v1.0.55-beta.5` baseline.
+
 ### Added
 
-- **Wukong internal command sync** (#621) — ports roughly 30 leaf commands from the internal wukong repository into the open-source CLI: Drive gains `star`, `cover`, `revert`, `download-version`, `permission transfer-owner`/`apply-info`/`apply`, and `list --depth`/`--versions`; Doc gains `style cover`/`style background`; Sheet gains the `comment`, `version`, and `formula-verify` command groups plus `info --include`; Chat gains `message update-text-emotion`, the `location`/`profile` message types, and group `user-settings`/`get-mute-config`. Every new leaf is registered in the Agent-visible Runtime Schema.
-- **In-place text-emotion updates** — adds `dws chat message update-text-emotion`, mapping the seven required conversation, message, old/new emotion, name, text, and background parameters to Wukong's proven `im/update_text_emotion` capability so status transitions can avoid remove-then-add flicker and duplicate network calls ([hugozhu/dingtalk-opencode-tag#85](https://github.com/hugozhu/dingtalk-opencode-tag/issues/85)).
+- **Wukong capability and multi-Skill synchronization** (#621) — ports roughly 30 reviewed leaf commands into the open-source CLI across Drive, Doc, Sheet, and Chat, including in-place text-emotion updates, Drive version and permission operations, document styling, and Sheet comment/version/formula verification. The bundled multi-Skill framework is reorganized into progressive product references and routing guidance while retaining current open-source command, response, safety, and Runtime Schema contracts.
+- **Declarative leaf commands and unified metadata delivery** (#676) — adds the reusable `LeafSpec` command framework and migrates 27 DevApp commands without changing their paths or flags. Runtime consumers now resolve identity, safety, and selection through one embedded Catalog-backed API, and guarded Help output publishes the command's safety/confirmation annotation.
 - **Agent product identity** (#816) — adds the optional `DWS_AGENT_PRODUCT` override for the existing HTTP `claw-type` header while preserving each edition's default when unset. Product and runtime labels are caller-declared signals, not authentication credentials; services must validate supported values and must not grant access solely from them. The override does not change the separate IM message-display `clawType` parameter controlled by the edition and `--ai-tag`.
 
 ### Changed
 
+- **Reviewed Chat shortcut delivery** (#815) — publishes 88 currently available Chat shortcuts after real-business validation, keeps three confirmed lower-service failures unavailable, strengthens semantic availability and dry-run contracts, and adds safe message-resource download plus group-member listing. Conversation filtering, IM routing/reporting, and member mute resolution are aligned with the validated backend identities.
 - **Agent identity label hardening** (#816) — limits `DWS_AGENT_PRODUCT` and `DWS_AGENT_HOST` to 64 ASCII bytes, trims only surrounding ASCII spaces and tabs, and rejects other control or Unicode whitespace. QwenWork integrations should report the two dimensions separately as `DWS_AGENT_PRODUCT=qwenwork` plus `DWS_AGENT_HOST=cloud` or `desktop`; previously used combined Host labels such as `qwenwork_cloud` remain syntactically valid for compatibility.
 
 ### Fixed
 
-- **Name→ID resolution kept external contacts** — the shared contact resolver (`chat +dm`, `+broadcast`, …) no longer drops `search_contact_by_key_word` rows that carry only an `openDingTalkId` (external / cross-org contacts have an empty `userId`), so those people are found instead of reported missing or collapsed into a wrong single match; the display name also falls back through `nick`/`showName`/`flowerName`/`staffName`/`userName`.
-- **`chat +messages-resource-url` flag aliases** — the media download-URL shortcut now accepts `--msg-id` / `--open-message-id` as aliases for `--message-id` (matching the `openMessageId`/`msgId` output field), so agents chaining from a message list no longer hit "unknown flag".
+- **External-contact and message-resource chaining** (#757) — the shared name-to-ID resolver keeps external or cross-organization contacts that expose only `openDingTalkId`, applies reviewed display-name fallbacks, and preserves organization-only filtering for commands that require `userId`. `chat +messages-resource-url` now accepts `--msg-id` and `--open-message-id` as aliases for `--message-id`, matching message-list response fields.
 
 ## [1.0.55-beta.5] - 2026-07-28
 


### PR DESCRIPTION
## 变更

- 新增 `v1.0.55-beta.6` 精确发布章节。
- 发布说明覆盖本次封板范围：#621、#676、#757、#815、#816。
- 清空已归档到该版本章节的 `Unreleased` 内容。

## 原因

云端 Release plan 已在最新 `main` 上确认下一候选版本为 `v1.0.55-beta.6`。发布 workflow 要求精确、唯一、非空且无 TODO/TBD 的 CHANGELOG 章节合入 `main` 后才能执行 publish。

## 影响

仅更新发布说明，不改变 CLI、Schema、构建或运行时行为。

## 验证

- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`
- `open-source audit: ok`
- `CHANGELOG PR check: ok (mode=fast-path release_sections=1 unreleased_changed=1)`
