### PR TITLE
docs(release): restore beta.6 main admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [1.0.55-beta.6] - 2026-07-29
 
-This beta validates the Wukong capability and multi-Skill synchronization,
-declarative command and Schema delivery, hardened Chat shortcuts, external
-contact resolution, and Agent product identity on top of the
-`v1.0.55-beta.5` baseline.
+This beta packages PRs #621, #676, #757, #815, and #816, validating the Wukong
+capability and multi-Skill synchronization, declarative command and Schema
+delivery, hardened Chat shortcuts, external contact resolution, and Agent
+product identity on top of the `v1.0.55-beta.5` baseline.
 
 ### Added
 


### PR DESCRIPTION
## 变更

- 在既有 `v1.0.55-beta.6` 章节中显式列出 #621、#676、#757、#815、#816。
- 不改变发布内容、CLI、Schema、构建或运行时行为。

## 原因

PR #818 由 reviewer-router 使用 `GITHUB_TOKEN` 开启的 auto-merge 合入，merge commit `579eed81` 由 `github-actions[bot]` 创建。GitHub 因此没有触发 `main` push CI，首次 publish run `30436670419` 在封 tag 前因精确 merge SHA 缺少九项 Code Admission contexts 而安全失败。

本 PR 保持 CHANGELOG-only fast path，但必须在同行批准后由真实用户执行 squash merge，不能再次由 bot auto-merge，以便正常触发 `main` push CI。

## 验证

- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`
- `open-source audit: ok`
- `CHANGELOG PR check: ok (mode=fast-path release_sections=1 unreleased_changed=0)`
