### PR TITLE
docs(release): add v1.0.55 stable notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.55] - 2026-07-29
+
+This release promotes the validated `v1.0.55-beta.7` baseline to stable. It
+expands the public Workspace command surface and personal event consumption,
+makes the full built-in shortcut catalog available to Agents, and hardens
+multi-account routing, authentication compatibility, command safety, and
+response projection across the CLI.
+
+### Added
+
+- **Broader Workspace command surface** (#621, #676) — adds roughly 30 reviewed Drive, Doc, Sheet, and Chat leaf commands synchronized from Wukong, including Drive version and permission operations, document styling, Sheet comment/version/formula verification, and in-place text-emotion updates. A reusable declarative `LeafSpec` framework now delivers command identity, safety, selection, and guarded Help metadata consistently.
+- **Complete Agent-visible shortcut delivery** (#802, #815) — publishes all 210 built-in shortcuts as reviewed Runtime Schema leaves across 16 products, including 88 validated Chat shortcuts, with executable paths, parameters, constraints, selection guidance, dry-run capabilities, and runtime-aligned confirmation semantics.
+- **Expanded enterprise and event capabilities** (#790) — adds the HR Brain talent-pool, employee-profile, and structured-search command families; `dws mcp url get` resolves MCP Market endpoints; personal event consumption supports eight additional IM event keys, multi-key consumers, and targeted shutdown.
+- **Agent integration identity** (#804, #816) — adds validated `DWS_AGENT_HOST` and `DWS_AGENT_PRODUCT` labels for observability and product attribution while keeping them separate from authentication and authorization.
+
+### Changed
+
+- **Progressive multi-Skill guidance and account safety** (#621, #821) — reorganizes bundled product guidance for progressive discovery and restores the mandatory rule that Agents must not guess an account when a multi-account organization has no unique current default.
+- **Supported Chat file delivery** — retires the legacy AppKey/AppSecret-backed `chat media upload` command from discovery and routes local files through `chat message send --msg-type file --file-path`, while callers with an existing media ID can continue sending images directly.
+- **Guarded release delivery** (#791) — strengthens immutable GitHub, npm, Homebrew, optional mirror, recovery, and version-allocation checks while keeping beta and stable publication role-gated and auditable.
+
+### Fixed
+
+- **Shortcut and message projection correctness** (#706, #783, #795) — prevents successful read shortcuts from silently projecting non-empty backend responses to empty results, renders rich, forwarded, and encrypted message forms safely, and fixes group-bot, bot-search, mail-thread, media-ID alias, and Todo paging response handling.
+- **Command contract edge cases** (#803) — makes approval revocation and document rollback honor dry-run before confirmation or preflight, fixes Drive and Doc rename semantics, restores Drive-specific metadata, and validates Todo reminder rules.
+- **Authentication and external-contact compatibility** (#756, #757) — migrates legacy global and organization-scoped credentials without cross-account token borrowing, preserves contacts that expose only `openDingTalkId`, and aligns message-resource flags with message-list output fields.
+
 ## [1.0.55-beta.7] - 2026-07-29
 
 This beta supersedes the unpublished `v1.0.55-beta.6` candidate and packages


### PR DESCRIPTION
## Summary

- add the exact `1.0.55` stable release section promoting `v1.0.55-beta.7`
- consolidate the final user-visible additions, behavior changes, and fixes delivered across the `1.0.55` beta line
- keep the change scoped to `CHANGELOG.md` so it can use the reviewed release fast path

## Release context

- stable plan: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/30452363911
- promoted beta: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/releases/tag/v1.0.55-beta.7
- allocator result: `release_version=v1.0.55`, `from_beta=v1.0.55-beta.7`

The beta's immutable GitHub Release and eight expected assets are present. Its
original publish run is red only at the Gitee mirror and final delivery gate;
channel repair remains separate from this CHANGELOG-only PR and must be
resolved before stable publication can satisfy the delivery proof.

## Validation

- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`
- `./scripts/release/next-release-version.sh --channel stable --bump patch`
- `git diff --check origin/main...HEAD`

All checks pass, and the PR modifies only `CHANGELOG.md`.
