### PR TITLE
feat(leaf): unify LeafSpec with declarative constraints and bool/slice kinds

### DIFF
--- a/internal/helpers/leaf.go
+++ b/internal/helpers/leaf.go
@@ -14,6 +14,7 @@
 package helpers
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strconv"
@@ -93,6 +94,28 @@ type LeafFlag struct {
 	Trim bool
 }
 
+// LeafRisk 声明叶子命令的副作用等级，取值与 shortcut 框架的 Risk 逐字
+// 一致（helpers 不能反向依赖 internal/shortcut——shortcut/builtin 依赖
+// helpers 会形成环——故本地声明同名语义）。
+type LeafRisk string
+
+const (
+	// LeafRiskRead 只读操作，从不提示。空值即视为 LeafRiskRead。
+	LeafRiskRead LeafRisk = "read"
+	// LeafRiskWrite 变更状态；未加 --yes 时提示确认。
+	LeafRiskWrite LeafRisk = "write"
+	// LeafRiskHighWrite 破坏性/不可逆操作；未加 --yes 时提示确认。
+	LeafRiskHighWrite LeafRisk = "high-risk-write"
+)
+
+// effective 返回有效副作用等级，空值降级为只读。
+func (r LeafRisk) effective() LeafRisk {
+	if r == "" {
+		return LeafRiskRead
+	}
+	return r
+}
+
 // LeafConstraintKind 是跨 flag 关系约束的类型，取值与 shortcut 框架的
 // ConstraintKind 逐字一致（helpers 不能反向依赖 internal/shortcut——
 // shortcut/builtin 依赖 helpers 会形成环——故本地声明同名语义）。
@@ -136,6 +159,12 @@ type LeafSpec struct {
 	// 框架统一校验并投影到 Runtime Schema 与 --help。复杂的条件式校验
 	// 仍放 Validate 钩子。
 	Constraints []LeafConstraint
+
+	// Risk 声明副作用等级，驱动执行前的写确认（对齐 shortcut 框架的
+	// Risk 语义）。默认 LeafRiskRead：只读，从不提示。LeafRiskWrite /
+	// LeafRiskHighWrite 在未加 --yes 且非 --dry-run 时提示确认，用户拒绝
+	// 则中止且不派发。confirmation 语义与 shortcut 的 confirmRisk 逐字一致。
+	Risk LeafRisk
 
 	// Call 是可插拔派发函数，非空时替代默认的 callMCPTool/callMCPToolOnServer。
 	// 供非 MCP 直连命令（如 devapp 走 executor.Runner）复用本框架：调用方用
@@ -203,6 +232,9 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 		toolArgs, err := leafArgs(cmd, spec)
 		if err != nil {
 			return err
+		}
+		if !leafConfirmRisk(cmd, spec) {
+			return apperrors.NewValidation("用户取消了操作")
 		}
 		if spec.Call != nil {
 			return spec.Call(cmd, spec.Tool, toolArgs)
@@ -525,6 +557,43 @@ func leafValidateConstraints(cmd *cobra.Command, spec LeafSpec) error {
 		}
 	}
 	return nil
+}
+
+// leafConfirmRisk 复现 shortcut 框架 confirmRisk 的写确认语义：只读、
+// --dry-run 或 --yes 直接放行；写/高危操作在交互态提示确认，用户拒绝返回
+// false。提示文案与 shortcut 逐字一致（以命令路径替代 shortcut 的
+// Service+Command），保证 atomic command 与 smart shortcut 的确认体验统一。
+func leafConfirmRisk(cmd *cobra.Command, spec LeafSpec) bool {
+	if spec.Risk.effective() == LeafRiskRead || commandDryRun(cmd) || leafYesFlag(cmd) {
+		return true
+	}
+	output := cmd.ErrOrStderr()
+	fmt.Fprintf(output, "即将执行 %s（%s），确认继续？(yes/no): ", cmd.CommandPath(), spec.Risk.effective())
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "yes" || answer == "y"
+}
+
+// leafYesFlag 稳健读取 --yes：依次尝试本命令、继承 flag、根持久 flag，
+// 兼容根注入的全局 --yes。
+func leafYesFlag(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	getters := []func(string) (bool, error){
+		cmd.Flags().GetBool,
+		cmd.InheritedFlags().GetBool,
+	}
+	if root := cmd.Root(); root != nil {
+		getters = append(getters, root.PersistentFlags().GetBool)
+	}
+	for _, get := range getters {
+		if v, err := get("yes"); err == nil {
+			return v
+		}
+	}
+	return false
 }
 
 // leafAnnotateConstraints 把关系约束投影到 Agent Runtime Schema：

--- a/internal/helpers/leaf.go
+++ b/internal/helpers/leaf.go
@@ -20,6 +20,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 )
 
 // leaf.go 是叶子命令的统一构建框架。
@@ -45,6 +48,13 @@ const (
 	// LeafInt 整型 flag（注册为 cobra Int）；仅在值 != 0 时进入 toolArgs，
 	// 对应手写「putInt 仅在非零才入参」语义（如 devapp app-group-id）。
 	LeafInt
+	// LeafBool 布尔 flag（注册为 cobra Bool）；仅在用户显式提供（Changed）
+	// 时进入 toolArgs，对应手写「Changed 才透传，显式 false 也下发」语义。
+	// 布尔不参与别名/env 回退链（true/false 无「空值」可回退）。
+	LeafBool
+	// LeafStringSlice 字符串列表 flag（注册为 cobra StringSlice）；仅在存在
+	// 非空元素时进入 toolArgs，元素恒 TrimSpace 后过滤空串。
+	LeafStringSlice
 )
 
 // LeafFlag 声明一个 flag 的注册方式与到 MCP toolArgs 的绑定。
@@ -83,6 +93,33 @@ type LeafFlag struct {
 	Trim bool
 }
 
+// LeafConstraintKind 是跨 flag 关系约束的类型，取值与 shortcut 框架的
+// ConstraintKind 逐字一致（helpers 不能反向依赖 internal/shortcut——
+// shortcut/builtin 依赖 helpers 会形成环——故本地声明同名语义）。
+type LeafConstraintKind string
+
+const (
+	// LeafAtLeastOne 要求 Flags 至少提供一个。
+	LeafAtLeastOne LeafConstraintKind = "at_least_one"
+	// LeafExactlyOne 要求 Flags 必须且只能提供一个。
+	LeafExactlyOne LeafConstraintKind = "exactly_one"
+	// LeafMutuallyExclusive 允许 Flags 中最多提供一个。
+	LeafMutuallyExclusive LeafConstraintKind = "mutually_exclusive"
+)
+
+// LeafConstraint 声明一组 flag 的关系约束。框架在 required 校验之后、
+// Validate 钩子之前统一执行；「是否提供」的判定复用 LeafSpec 的有效值
+// 回退链（显式主 flag → 别名 → env），即只传兼容别名同样视为已提供——
+// 这是 shortcut 裸 Changed 判定所没有的能力。约束同时投影到 Agent
+// Runtime Schema（mutually_exclusive / require_one_of）并渲染进 --help
+// 的「参数约束」段：一次声明，运行时校验、Schema、帮助三处生效。
+type LeafConstraint struct {
+	Kind  LeafConstraintKind
+	Flags []string
+	// Description 非空时替换 --help 中该约束的默认文案。
+	Description string
+}
+
 // LeafSpec 声明一个 MCP 直连叶子命令。
 type LeafSpec struct {
 	Use     string
@@ -95,6 +132,10 @@ type LeafSpec struct {
 	Server string
 	Tool   string
 	Flags  []LeafFlag
+	// Constraints 是跨 flag 的关系约束（至少一个 / 恰好一个 / 互斥），
+	// 框架统一校验并投影到 Runtime Schema 与 --help。复杂的条件式校验
+	// 仍放 Validate 钩子。
+	Constraints []LeafConstraint
 
 	// Call 是可插拔派发函数，非空时替代默认的 callMCPTool/callMCPToolOnServer。
 	// 供非 MCP 直连命令（如 devapp 走 executor.Runner）复用本框架：调用方用
@@ -125,25 +166,20 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 		Example: spec.Example,
 	}
 	for _, flag := range spec.Flags {
-		switch flag.Kind {
-		case LeafInt:
-			cmd.Flags().Int(flag.Name, 0, flag.Usage)
-		default:
-			cmd.Flags().String(flag.Name, flag.Default, flag.Usage)
-		}
+		leafRegisterFlag(cmd, flag.Kind, flag.Name, flag.Default, flag.Usage)
 		// 别名按主 flag 的 Kind 注册，否则整型别名的值永远读不到（静默丢弃）。
 		for _, alias := range flag.Aliases {
-			switch flag.Kind {
-			case LeafInt:
-				cmd.Flags().Int(alias, 0, flag.Usage+" (alias)")
-			default:
-				cmd.Flags().String(alias, "", flag.Usage+" (alias)")
-			}
+			leafRegisterFlag(cmd, flag.Kind, alias, "", flag.Usage+" (alias)")
 			_ = cmd.Flags().MarkHidden(alias)
 		}
 		if flag.MarkRequired {
 			_ = cmd.MarkFlagRequired(flag.Name)
 		}
+	}
+	leafValidateConstraintDecls(spec)
+	leafAnnotateConstraints(cmd, spec)
+	if help := leafConstraintHelp(spec.Constraints); help != "" {
+		cmd.Long = strings.TrimRight(cmd.Long, "\n") + help
 	}
 	if spec.PostMount != nil {
 		spec.PostMount(cmd)
@@ -154,6 +190,9 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 	}
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := leafValidateRequired(cmd, spec); err != nil {
+			return err
+		}
+		if err := leafValidateConstraints(cmd, spec); err != nil {
 			return err
 		}
 		if spec.Validate != nil {
@@ -174,6 +213,21 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 		return callMCPTool(spec.Tool, toolArgs)
 	}
 	return cmd
+}
+
+// leafRegisterFlag 按 Kind 注册 flag；注册默认值仅 LeafString 使用（其余
+// Kind 的 Default 只作为回退链链尾兜底，与既有 LeafInt 行为一致）。
+func leafRegisterFlag(cmd *cobra.Command, kind LeafFlagKind, name, def, usage string) {
+	switch kind {
+	case LeafInt:
+		cmd.Flags().Int(name, 0, usage)
+	case LeafBool:
+		cmd.Flags().Bool(name, false, usage)
+	case LeafStringSlice:
+		cmd.Flags().StringSlice(name, nil, usage)
+	default:
+		cmd.Flags().String(name, def, usage)
+	}
 }
 
 // leafValidateRequired 复现手写命令的 required 语义：普通 Required 统一报
@@ -206,18 +260,46 @@ func leafValidateRequired(cmd *cobra.Command, spec LeafSpec) error {
 }
 
 // leafHasEffectiveValue 判定 Required 是否满足，标准与 leafArgs 的入参判定
-// 一致（LeafInt 需非零、字符串需非空）：否则会出现校验声称有效、toolArgs
-// 却缺参的分裂。整型解析失败视为已提供，让 leafArgs 报出更精确的
-// invalid integer 错误。
+// 一致（LeafInt 需非零、字符串需非空、LeafBool 需显式提供、LeafStringSlice
+// 需存在非空元素）：否则会出现校验声称有效、toolArgs 却缺参的分裂。整型解析
+// 失败视为已提供，让 leafArgs 报出更精确的 invalid integer 错误。
 func leafHasEffectiveValue(cmd *cobra.Command, flag LeafFlag) bool {
-	if flag.Kind == LeafInt {
+	switch flag.Kind {
+	case LeafInt:
 		v, err := leafIntegerValue(cmd, flag)
 		if err != nil {
 			return true
 		}
 		return v != 0
+	case LeafBool:
+		return cmd.Flags().Changed(flag.Name)
+	case LeafStringSlice:
+		return leafSliceValue(cmd, flag) != nil
 	}
 	return leafEffectiveValue(cmd, flag) != ""
+}
+
+// leafSliceValue 按「显式主 flag → 显式别名」顺序取列表 flag 的有效值：
+// 元素统一 TrimSpace 并过滤空串，全空视为未提供（返回 nil）。列表不参与
+// env/Default 回退链。
+func leafSliceValue(cmd *cobra.Command, flag LeafFlag) []string {
+	names := append([]string{flag.Name}, flag.Aliases...)
+	for _, name := range names {
+		if !cmd.Flags().Changed(name) {
+			continue
+		}
+		raw, _ := cmd.Flags().GetStringSlice(name)
+		var out []string
+		for _, value := range raw {
+			if value = strings.TrimSpace(value); value != "" {
+				out = append(out, value)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return nil
 }
 
 // leafArgs 按绑定关系装配 toolArgs。
@@ -236,6 +318,20 @@ func leafArgs(cmd *cobra.Command, spec LeafSpec) (map[string]any, error) {
 			// 保持「非零才入参」（putInt 语义）。
 			if v != 0 {
 				toolArgs[bind] = int(v)
+			}
+			continue
+		}
+		if flag.Kind == LeafBool {
+			// Changed 才入参：显式 false 同样下发（对应手写「Changed 才透传」语义）。
+			if cmd.Flags().Changed(flag.Name) {
+				v, _ := cmd.Flags().GetBool(flag.Name)
+				toolArgs[bind] = v
+			}
+			continue
+		}
+		if flag.Kind == LeafStringSlice {
+			if v := leafSliceValue(cmd, flag); v != nil {
+				toolArgs[bind] = v
 			}
 			continue
 		}
@@ -328,4 +424,166 @@ func leafIntegerValue(cmd *cobra.Command, flag LeafFlag) (int64, error) {
 		return 0, fmt.Errorf("flag --%s: invalid integer value %q", flag.Name, raw)
 	}
 	return v, nil
+}
+
+// leafValidateConstraintDecls 在构建期校验约束声明：未知类型、空 flag 组或
+// 引用未声明 flag 都是编程错误，直接 panic 让任何测试/启动路径第一时间失败，
+// 而不是等到用户命中运行时才暴露。
+func leafValidateConstraintDecls(spec LeafSpec) {
+	declared := map[string]bool{}
+	for _, flag := range spec.Flags {
+		declared[flag.Name] = true
+	}
+	for _, constraint := range spec.Constraints {
+		switch constraint.Kind {
+		case LeafAtLeastOne, LeafExactlyOne, LeafMutuallyExclusive:
+		default:
+			panic(fmt.Sprintf("leaf %q: unknown constraint kind %q", spec.Use, constraint.Kind))
+		}
+		if len(constraint.Flags) < 2 {
+			panic(fmt.Sprintf("leaf %q: constraint %s needs at least two flags", spec.Use, constraint.Kind))
+		}
+		for _, name := range constraint.Flags {
+			if !declared[name] {
+				panic(fmt.Sprintf("leaf %q: constraint %s references undeclared flag %q", spec.Use, constraint.Kind, name))
+			}
+		}
+	}
+}
+
+// leafConstraintProvided 判定约束语义下 flag 是否「已提供」：显式主 flag、
+// 显式别名或环境变量任一命中即视为提供；注册默认值/ArgDefault 不算——否则
+// 带默认值的 flag 会恒满足 at_least_one 并恒触发 mutually_exclusive。
+// LeafBool 只认 Changed（布尔无别名/env 回退语义）。
+func leafConstraintProvided(cmd *cobra.Command, flag LeafFlag) bool {
+	switch flag.Kind {
+	case LeafBool:
+		return cmd.Flags().Changed(flag.Name)
+	case LeafStringSlice:
+		if cmd.Flags().Changed(flag.Name) {
+			if v, _ := cmd.Flags().GetStringSlice(flag.Name); leafSliceHasValue(v) {
+				return true
+			}
+		}
+		for _, alias := range flag.Aliases {
+			if !cmd.Flags().Changed(alias) {
+				continue
+			}
+			if v, _ := cmd.Flags().GetStringSlice(alias); leafSliceHasValue(v) {
+				return true
+			}
+		}
+		return false
+	}
+	usable := func(v string) bool { return strings.TrimSpace(v) != "" }
+	if cmd.Flags().Changed(flag.Name) && usable(leafFlagString(cmd, flag.Kind, flag.Name)) {
+		return true
+	}
+	for _, alias := range flag.Aliases {
+		if cmd.Flags().Changed(alias) && usable(leafFlagString(cmd, flag.Kind, alias)) {
+			return true
+		}
+	}
+	return flag.EnvVar != "" && usable(os.Getenv(flag.EnvVar))
+}
+
+// leafValidateConstraints 执行关系约束。报错文案与 shortcut 框架的
+// RuntimeContext.AtLeastOne/ExactlyOne/MutuallyExclusive 逐字一致，保证
+// atomic command 与 smart shortcut 面向用户/Agent 的失败形态统一。
+func leafValidateConstraints(cmd *cobra.Command, spec LeafSpec) error {
+	flagsByName := map[string]LeafFlag{}
+	for _, flag := range spec.Flags {
+		flagsByName[flag.Name] = flag
+	}
+	for _, constraint := range spec.Constraints {
+		var set []string
+		for _, name := range constraint.Flags {
+			if leafConstraintProvided(cmd, flagsByName[name]) {
+				set = append(set, name)
+			}
+		}
+		switch constraint.Kind {
+		case LeafAtLeastOne:
+			if len(set) == 0 {
+				return apperrors.NewValidation(fmt.Sprintf(
+					"请至少指定 %s 之一", leafDashed(constraint.Flags)))
+			}
+		case LeafExactlyOne:
+			switch len(set) {
+			case 1:
+			case 0:
+				return apperrors.NewValidation(fmt.Sprintf("请指定 %s 之一", leafDashed(constraint.Flags)))
+			default:
+				return apperrors.NewValidation(fmt.Sprintf(
+					"参数 %s 只能指定其一（当前指定了 %s）", leafDashed(constraint.Flags), leafDashed(set)))
+			}
+		case LeafMutuallyExclusive:
+			if len(set) > 1 {
+				return apperrors.NewValidation(fmt.Sprintf(
+					"参数 %s 互斥，只能指定其一（当前指定了 %s）", leafDashed(constraint.Flags), leafDashed(set)))
+			}
+		}
+	}
+	return nil
+}
+
+// leafAnnotateConstraints 把关系约束投影到 Agent Runtime Schema：
+// exactly_one 分解为 require_one_of + mutually_exclusive（与手写命令对
+// AnnotateRuntimeConstraints 的既有用法一致）。
+func leafAnnotateConstraints(cmd *cobra.Command, spec LeafSpec) {
+	var projected cli.RuntimeSchemaConstraints
+	for _, constraint := range spec.Constraints {
+		flags := append([]string(nil), constraint.Flags...)
+		switch constraint.Kind {
+		case LeafAtLeastOne:
+			projected.RequireOneOf = append(projected.RequireOneOf, flags)
+		case LeafExactlyOne:
+			projected.RequireOneOf = append(projected.RequireOneOf, flags)
+			projected.MutuallyExclusive = append(projected.MutuallyExclusive, flags)
+		case LeafMutuallyExclusive:
+			projected.MutuallyExclusive = append(projected.MutuallyExclusive, flags)
+		}
+	}
+	cli.AnnotateRuntimeConstraints(cmd, projected)
+}
+
+// leafConstraintHelp 渲染 --help 的「参数约束」段，形态与 shortcut 叶子
+// 帮助一致；无约束时返回空串。
+func leafConstraintHelp(constraints []LeafConstraint) string {
+	if len(constraints) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(constraints))
+	for _, constraint := range constraints {
+		text := strings.TrimSpace(constraint.Description)
+		if text == "" {
+			switch constraint.Kind {
+			case LeafAtLeastOne:
+				text = fmt.Sprintf("%s 至少指定一个", leafDashed(constraint.Flags))
+			case LeafExactlyOne:
+				text = fmt.Sprintf("%s 必须且只能指定一个", leafDashed(constraint.Flags))
+			case LeafMutuallyExclusive:
+				text = fmt.Sprintf("%s 互斥，最多指定一个", leafDashed(constraint.Flags))
+			}
+		}
+		lines = append(lines, "  - "+text)
+	}
+	return "\n\n参数约束：\n" + strings.Join(lines, "\n")
+}
+
+func leafDashed(flags []string) string {
+	out := make([]string, len(flags))
+	for i, f := range flags {
+		out[i] = "--" + f
+	}
+	return strings.Join(out, "、")
+}
+
+func leafSliceHasValue(values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/helpers/leaf_constraints_test.go
+++ b/internal/helpers/leaf_constraints_test.go
@@ -1,0 +1,478 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func leafConstraintTestSpec(captured *map[string]any) LeafSpec {
+	return LeafSpec{
+		Use:   "route",
+		Short: "路由",
+		Tool:  "route_thing",
+		Flags: []LeafFlag{
+			{Name: "group", Usage: "群 ID", Aliases: []string{"chat"}},
+			{Name: "user", Usage: "用户 ID", EnvVar: "DWS_LEAF_CONSTRAINT_TEST_USER"},
+			{Name: "channel", Usage: "频道", Default: "main"},
+			{Name: "verbose", Usage: "详细输出", Kind: LeafBool, Bind: "verboseOutput"},
+			{Name: "tags", Usage: "标签列表", Kind: LeafStringSlice, Aliases: []string{"labels"}, Bind: "tagList"},
+		},
+		Constraints: []LeafConstraint{
+			{Kind: LeafExactlyOne, Flags: []string{"group", "user"}},
+			{Kind: LeafMutuallyExclusive, Flags: []string{"verbose", "tags"}},
+		},
+		Call: func(_ *cobra.Command, _ string, args map[string]any) error {
+			*captured = args
+			return nil
+		},
+	}
+}
+
+func leafConstraintExecute(t *testing.T, args ...string) (map[string]any, error) {
+	t.Helper()
+	var captured map[string]any
+	cmd := NewLeafCommand(leafConstraintTestSpec(&captured))
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return captured, err
+}
+
+func TestCrossPlatformCoverageLeafConstraintExactlyOne(t *testing.T) {
+	if _, err := leafConstraintExecute(t); err == nil ||
+		!strings.Contains(err.Error(), "请指定 --group、--user 之一") {
+		t.Fatalf("zero provided err = %v", err)
+	}
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--user", "u1"); err == nil ||
+		!strings.Contains(err.Error(), "参数 --group、--user 只能指定其一（当前指定了 --group、--user）") {
+		t.Fatalf("both provided err = %v", err)
+	}
+	if _, err := leafConstraintExecute(t, "--group", "g1"); err != nil {
+		t.Fatalf("exactly one err = %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintAliasAndEnvCountAsProvided(t *testing.T) {
+	// 隐藏别名 --chat 命中 group：满足 exactly_one。
+	if _, err := leafConstraintExecute(t, "--chat", "g1"); err != nil {
+		t.Fatalf("alias provided err = %v", err)
+	}
+	// 环境变量命中 user：同样满足。
+	t.Setenv("DWS_LEAF_CONSTRAINT_TEST_USER", "u-env")
+	if _, err := leafConstraintExecute(t); err != nil {
+		t.Fatalf("env provided err = %v", err)
+	}
+	// env 提供 user + 显式 group：应触发 exactly_one 冲突。
+	if _, err := leafConstraintExecute(t, "--group", "g1"); err == nil ||
+		!strings.Contains(err.Error(), "只能指定其一") {
+		t.Fatalf("env + explicit err = %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintDefaultNotCounted(t *testing.T) {
+	// channel 有注册默认值 "main"，但未显式提供时不得参与约束判定：
+	// 用仅含 at_least_one(channel, group) 的 spec 验证默认值不算提供。
+	var captured map[string]any
+	spec := LeafSpec{
+		Use:  "pick",
+		Tool: "pick_thing",
+		Flags: []LeafFlag{
+			{Name: "channel", Usage: "频道", Default: "main"},
+			{Name: "group", Usage: "群 ID"},
+		},
+		Constraints: []LeafConstraint{
+			{Kind: LeafAtLeastOne, Flags: []string{"channel", "group"}},
+		},
+		Call: func(_ *cobra.Command, _ string, args map[string]any) error {
+			captured = args
+			return nil
+		},
+	}
+	cmd := NewLeafCommand(spec)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(nil)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "请至少指定 --channel、--group 之一") {
+		t.Fatalf("default counted as provided: err = %v, captured = %#v", err, captured)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintMutuallyExclusive(t *testing.T) {
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--verbose", "--tags", "a,b"); err == nil ||
+		!strings.Contains(err.Error(), "参数 --verbose、--tags 互斥，只能指定其一（当前指定了 --verbose、--tags）") {
+		t.Fatalf("mutually exclusive err = %v", err)
+	}
+	// 各自单独提供均合法。
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--verbose"); err != nil {
+		t.Fatalf("verbose alone err = %v", err)
+	}
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--tags", "a"); err != nil {
+		t.Fatalf("tags alone err = %v", err)
+	}
+	// 空白元素的列表视为未提供，不触发互斥。
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--verbose", "--tags", " "); err != nil {
+		t.Fatalf("blank slice counted as provided: err = %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageLeafBoolAndSliceArgs(t *testing.T) {
+	captured, err := leafConstraintExecute(t, "--group", "g1", "--verbose=false")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured["verboseOutput"] != false {
+		t.Fatalf("explicit false not delivered: %#v", captured)
+	}
+
+	captured, err = leafConstraintExecute(t, "--group", "g1", "--tags", "a, ,b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(captured["tagList"], []string{"a", "b"}) {
+		t.Fatalf("tagList = %#v, want trimmed non-empty elements", captured["tagList"])
+	}
+	if _, ok := captured["verboseOutput"]; ok {
+		t.Fatalf("unchanged bool leaked into args: %#v", captured)
+	}
+
+	// 别名 --labels 提供列表同样入参。
+	captured, err = leafConstraintExecute(t, "--group", "g1", "--labels", "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(captured["tagList"], []string{"x"}) {
+		t.Fatalf("alias slice = %#v", captured["tagList"])
+	}
+}
+
+func TestCrossPlatformCoverageLeafBoolSliceRequired(t *testing.T) {
+	var captured map[string]any
+	spec := LeafSpec{
+		Use:  "need",
+		Tool: "need_thing",
+		Flags: []LeafFlag{
+			{Name: "confirm", Usage: "确认", Kind: LeafBool, Required: true},
+			{Name: "ids", Usage: "ID 列表", Kind: LeafStringSlice, Required: true},
+		},
+		Call: func(_ *cobra.Command, _ string, args map[string]any) error {
+			captured = args
+			return nil
+		},
+	}
+	run := func(args ...string) error {
+		cmd := NewLeafCommand(spec)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs(args)
+		return cmd.Execute()
+	}
+	if err := run("--ids", "a"); err == nil || !strings.Contains(err.Error(), "confirm") {
+		t.Fatalf("missing bool err = %v", err)
+	}
+	if err := run("--confirm", "--ids", " "); err == nil || !strings.Contains(err.Error(), "ids") {
+		t.Fatalf("blank slice err = %v", err)
+	}
+	if err := run("--confirm=false", "--ids", "a"); err != nil {
+		t.Fatalf("explicit false should satisfy required: %v", err)
+	}
+	if captured["confirm"] != false || !reflect.DeepEqual(captured["ids"], []string{"a"}) {
+		t.Fatalf("captured = %#v", captured)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintSchemaAndHelp(t *testing.T) {
+	var captured map[string]any
+	cmd := NewLeafCommand(leafConstraintTestSpec(&captured))
+	encoded := cmd.Annotations["dws.schema.constraints"]
+	if !strings.Contains(encoded, `"require_one_of":[["group","user"]]`) {
+		t.Fatalf("schema constraints missing require_one_of: %s", encoded)
+	}
+	if !strings.Contains(encoded, `["group","user"]`) || !strings.Contains(encoded, `["verbose","tags"]`) {
+		t.Fatalf("schema constraints incomplete: %s", encoded)
+	}
+	if !strings.Contains(cmd.Long, "参数约束：") ||
+		!strings.Contains(cmd.Long, "--group、--user 必须且只能指定一个") ||
+		!strings.Contains(cmd.Long, "--verbose、--tags 互斥，最多指定一个") {
+		t.Fatalf("constraint help missing: %q", cmd.Long)
+	}
+
+	withDesc := LeafSpec{
+		Use:  "desc",
+		Tool: "desc_thing",
+		Flags: []LeafFlag{
+			{Name: "a", Usage: "A"},
+			{Name: "b", Usage: "B"},
+		},
+		Constraints: []LeafConstraint{
+			{Kind: LeafAtLeastOne, Flags: []string{"a", "b"}, Description: "自定义文案"},
+		},
+	}
+	if long := NewLeafCommand(withDesc).Long; !strings.Contains(long, "  - 自定义文案") {
+		t.Fatalf("custom description missing: %q", long)
+	}
+	atLeast := LeafSpec{
+		Use:  "least",
+		Tool: "least_thing",
+		Flags: []LeafFlag{
+			{Name: "a", Usage: "A"},
+			{Name: "b", Usage: "B"},
+		},
+		Constraints: []LeafConstraint{{Kind: LeafAtLeastOne, Flags: []string{"a", "b"}}},
+	}
+	if long := NewLeafCommand(atLeast).Long; !strings.Contains(long, "--a、--b 至少指定一个") {
+		t.Fatalf("at_least_one help missing: %q", long)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintDeclPanics(t *testing.T) {
+	mustPanic := func(name string, spec LeafSpec, needle string) {
+		t.Helper()
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatalf("%s: expected panic", name)
+			}
+			if msg, _ := r.(string); !strings.Contains(msg, needle) {
+				t.Fatalf("%s: panic = %v, want %q", name, r, needle)
+			}
+		}()
+		NewLeafCommand(spec)
+	}
+	base := []LeafFlag{{Name: "a", Usage: "A"}, {Name: "b", Usage: "B"}}
+	mustPanic("unknown kind", LeafSpec{
+		Use: "x", Tool: "t", Flags: base,
+		Constraints: []LeafConstraint{{Kind: "bogus", Flags: []string{"a", "b"}}},
+	}, "unknown constraint kind")
+	mustPanic("too few flags", LeafSpec{
+		Use: "x", Tool: "t", Flags: base,
+		Constraints: []LeafConstraint{{Kind: LeafExactlyOne, Flags: []string{"a"}}},
+	}, "needs at least two flags")
+	mustPanic("undeclared flag", LeafSpec{
+		Use: "x", Tool: "t", Flags: base,
+		Constraints: []LeafConstraint{{Kind: LeafExactlyOne, Flags: []string{"a", "missing"}}},
+	}, "references undeclared flag")
+}
+
+func TestCrossPlatformCoverageLeafConstraintRunsBeforeValidateHook(t *testing.T) {
+	hookRan := false
+	spec := LeafSpec{
+		Use:  "order",
+		Tool: "order_thing",
+		Flags: []LeafFlag{
+			{Name: "a", Usage: "A"},
+			{Name: "b", Usage: "B"},
+		},
+		Constraints: []LeafConstraint{{Kind: LeafExactlyOne, Flags: []string{"a", "b"}}},
+		Validate: func(*cobra.Command, []string) error {
+			hookRan = true
+			return nil
+		},
+		Call: func(*cobra.Command, string, map[string]any) error { return nil },
+	}
+	cmd := NewLeafCommand(spec)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("constraint should fail before Validate")
+	}
+	if hookRan {
+		t.Fatal("Validate hook ran despite constraint failure")
+	}
+}
+
+// TestCrossPlatformCoverageLeafSpecCorePaths exercises the LeafSpec paths that
+// the framework shares between constrained and unconstrained leaves
+// (MarkRequired, RunE escape hatch, Server routing, LeafInt assembly, Transform
+// and EnvVar-backed required hints). leaf_test.go asserts the same behaviour but
+// its names sit outside the platform coverage runner's filter.
+func TestCrossPlatformCoverageLeafSpecCorePaths(t *testing.T) {
+	markRequired := NewLeafCommand(LeafSpec{
+		Use:   "mark",
+		Tool:  "mark_thing",
+		Flags: []LeafFlag{{Name: "id", Usage: "ID", MarkRequired: true}},
+	})
+	if ann := markRequired.Flags().Lookup("id").Annotations[cobra.BashCompOneRequiredFlag]; len(ann) == 0 {
+		t.Fatal("MarkRequired did not reach cobra")
+	}
+
+	escaped := false
+	escape := NewLeafCommand(LeafSpec{
+		Use:  "escape",
+		Tool: "escape_thing",
+		RunE: func(*cobra.Command, []string) error {
+			escaped = true
+			return nil
+		},
+	})
+	escape.SetArgs(nil)
+	if err := escape.Execute(); err != nil || !escaped {
+		t.Fatalf("RunE escape hatch not used: err = %v", err)
+	}
+
+	caller := &guardedMutationCaller{}
+	serverRouted := func() error {
+		previous := deps
+		t.Cleanup(func() { deps = previous })
+		InitDeps(caller)
+		deps.Out.w = io.Discard
+		cmd := NewLeafCommand(LeafSpec{
+			Use:    "route-server",
+			Tool:   "route_tool",
+			Server: "im",
+			Flags: []LeafFlag{
+				{Name: "count", Usage: "数量", Kind: LeafInt, Bind: "count"},
+				{Name: "scope", Usage: "范围", ArgDefault: "ALL", Bind: "scope"},
+				{Name: "note", Usage: "备注", OmitEmpty: true},
+			},
+		})
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"--count", "3"})
+		return cmd.Execute()
+	}
+	if err := serverRouted(); err != nil {
+		t.Fatalf("server routing err = %v", err)
+	}
+	if len(caller.calls) != 1 || caller.calls[0].productID != "im" || caller.calls[0].toolName != "route_tool" {
+		t.Fatalf("server routing call = %#v", caller.calls)
+	}
+	if caller.calls[0].args["count"] != 3 || caller.calls[0].args["scope"] != "ALL" {
+		t.Fatalf("server routing args = %#v", caller.calls[0].args)
+	}
+	if _, ok := caller.calls[0].args["note"]; ok {
+		t.Fatalf("OmitEmpty flag leaked: %#v", caller.calls[0].args)
+	}
+
+	intSpec := LeafSpec{
+		Use:   "count",
+		Tool:  "count_thing",
+		Flags: []LeafFlag{{Name: "n", Usage: "N", Kind: LeafInt, EnvVar: "DWS_LEAF_CORE_TEST_N"}},
+		Call:  func(*cobra.Command, string, map[string]any) error { return nil },
+	}
+	t.Setenv("DWS_LEAF_CORE_TEST_N", "not-a-number")
+	badInt := NewLeafCommand(intSpec)
+	badInt.SilenceErrors = true
+	badInt.SilenceUsage = true
+	badInt.SetArgs(nil)
+	if err := badInt.Execute(); err == nil || !strings.Contains(err.Error(), "invalid integer value") {
+		t.Fatalf("invalid env integer err = %v", err)
+	}
+
+	transformFail := NewLeafCommand(LeafSpec{
+		Use:  "transform",
+		Tool: "transform_thing",
+		Flags: []LeafFlag{{Name: "raw", Usage: "RAW", Transform: func(string) (any, error) {
+			return nil, errTransformTest
+		}}},
+		Call: func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	transformFail.SilenceErrors = true
+	transformFail.SilenceUsage = true
+	transformFail.SetArgs([]string{"--raw", "x"})
+	if err := transformFail.Execute(); err == nil || !strings.Contains(err.Error(), "transform failed") {
+		t.Fatalf("transform error not surfaced: %v", err)
+	}
+
+	hinted := NewLeafCommand(LeafSpec{
+		Use:  "hint",
+		Tool: "hint_thing",
+		Flags: []LeafFlag{{
+			Name: "token", Usage: "令牌", Required: true,
+			EnvVar: "DWS_LEAF_CORE_TEST_TOKEN", RequiredHint: "flag --token is required (or set DWS_LEAF_CORE_TEST_TOKEN)",
+		}},
+		Call: func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	hinted.SilenceErrors = true
+	hinted.SilenceUsage = true
+	hinted.SetArgs(nil)
+	if err := hinted.Execute(); err == nil || !strings.Contains(err.Error(), "DWS_LEAF_CORE_TEST_TOKEN") {
+		t.Fatalf("required hint err = %v", err)
+	}
+
+	// 默认 product 路由（无 Server）+ LeafInt Required（走 leafHasEffectiveValue
+	// 的 LeafInt 分支）+ Transform 返回 (nil,nil) 跳过键。
+	defaultRouted := func() error {
+		previous := deps
+		t.Cleanup(func() { deps = previous })
+		oldArgs := os.Args
+		os.Args = []string{"dws", "chat"}
+		t.Cleanup(func() { os.Args = oldArgs })
+		InitDeps(caller)
+		deps.Out.w = io.Discard
+		caller.calls = nil
+		cmd := NewLeafCommand(LeafSpec{
+			Use:  "default-route",
+			Tool: "im_default_tool",
+			Flags: []LeafFlag{
+				{Name: "n", Usage: "N", Kind: LeafInt, Required: true, Bind: "n"},
+				{Name: "opt", Usage: "OPT", Transform: func(string) (any, error) { return nil, nil }},
+			},
+		})
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"--n", "5", "--opt", "ignored"})
+		return cmd.Execute()
+	}
+	if err := defaultRouted(); err != nil {
+		t.Fatalf("default route err = %v", err)
+	}
+	if len(caller.calls) != 1 {
+		t.Fatalf("default route call = %#v", caller.calls)
+	}
+	if caller.calls[0].args["n"] != 5 {
+		t.Fatalf("int required arg = %#v", caller.calls[0].args)
+	}
+	if _, ok := caller.calls[0].args["opt"]; ok {
+		t.Fatalf("Transform nil should skip key: %#v", caller.calls[0].args)
+	}
+	// LeafInt Required 缺失（值为 0）应报缺参。
+	missingInt := NewLeafCommand(LeafSpec{
+		Use:   "need-int",
+		Tool:  "need_int_tool",
+		Flags: []LeafFlag{{Name: "n", Usage: "N", Kind: LeafInt, Required: true}},
+		Call:  func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	missingInt.SilenceErrors = true
+	missingInt.SilenceUsage = true
+	missingInt.SetArgs(nil)
+	if err := missingInt.Execute(); err == nil || !strings.Contains(err.Error(), "n") {
+		t.Fatalf("missing int required err = %v", err)
+	}
+	// 带 EnvVar 但 RequiredHint 为空：走默认 'flag --x is required' 文案。
+	envDefaultHint := NewLeafCommand(LeafSpec{
+		Use:   "env-default-hint",
+		Tool:  "env_hint_tool",
+		Flags: []LeafFlag{{Name: "key", Usage: "KEY", Required: true, EnvVar: "DWS_LEAF_CORE_TEST_MISSING"}},
+		Call:  func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	envDefaultHint.SilenceErrors = true
+	envDefaultHint.SilenceUsage = true
+	envDefaultHint.SetArgs(nil)
+	if err := envDefaultHint.Execute(); err == nil || !strings.Contains(err.Error(), "flag --key is required") {
+		t.Fatalf("env default hint err = %v", err)
+	}
+}
+
+var errTransformTest = errors.New("transform failed")

--- a/internal/helpers/leaf_constraints_test.go
+++ b/internal/helpers/leaf_constraints_test.go
@@ -476,3 +476,111 @@ func TestCrossPlatformCoverageLeafSpecCorePaths(t *testing.T) {
 }
 
 var errTransformTest = errors.New("transform failed")
+
+func leafRiskSpec(risk LeafRisk, called *bool) LeafSpec {
+	return LeafSpec{
+		Use:   "danger",
+		Short: "危险",
+		Tool:  "danger_thing",
+		Risk:  risk,
+		Flags: []LeafFlag{{Name: "id", Usage: "ID"}},
+		Call: func(*cobra.Command, string, map[string]any) error {
+			*called = true
+			return nil
+		},
+	}
+}
+
+func leafRiskRun(t *testing.T, risk LeafRisk, stdin string, args ...string) (bool, error) {
+	t.Helper()
+	called := false
+	cmd := NewLeafCommand(leafRiskSpec(risk, &called))
+	// 注入根级 --yes/--dry-run 持久 flag，模拟真实根命令。
+	cmd.PersistentFlags().Bool("yes", false, "")
+	cmd.PersistentFlags().Bool("dry-run", false, "")
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	if stdin != "" {
+		cmd.SetIn(strings.NewReader(stdin))
+	}
+	cmd.SetArgs(args)
+	return called, cmd.Execute()
+}
+
+func TestCrossPlatformCoverageLeafRiskReadNeverPrompts(t *testing.T) {
+	// 只读：无 stdin 也直接派发。
+	if called, err := leafRiskRun(t, LeafRiskRead, "", "--id", "x"); err != nil || !called {
+		t.Fatalf("read risk err = %v called = %v", err, called)
+	}
+	// 空 Risk 等价只读。
+	if called, err := leafRiskRun(t, "", "", "--id", "x"); err != nil || !called {
+		t.Fatalf("empty risk err = %v called = %v", err, called)
+	}
+}
+
+func TestCrossPlatformCoverageLeafRiskWriteConfirmation(t *testing.T) {
+	// 拒绝：不派发，返回取消错误。
+	called, err := leafRiskRun(t, LeafRiskWrite, "no\n", "--id", "x")
+	if called {
+		t.Fatal("declined write should not dispatch")
+	}
+	if err == nil || !strings.Contains(err.Error(), "用户取消了操作") {
+		t.Fatalf("declined write err = %v", err)
+	}
+	// 同意：派发。
+	if called, err := leafRiskRun(t, LeafRiskWrite, "yes\n", "--id", "x"); err != nil || !called {
+		t.Fatalf("confirmed write err = %v called = %v", err, called)
+	}
+	// 高危同样走确认链。
+	if called, err := leafRiskRun(t, LeafRiskHighWrite, "y\n", "--id", "x"); err != nil || !called {
+		t.Fatalf("confirmed high-write err = %v called = %v", err, called)
+	}
+}
+
+func TestCrossPlatformCoverageLeafRiskYesAndDryRunBypass(t *testing.T) {
+	// --yes 跳过提示直接派发（无 stdin）。
+	if called, err := leafRiskRun(t, LeafRiskHighWrite, "", "--id", "x", "--yes"); err != nil || !called {
+		t.Fatalf("--yes bypass err = %v called = %v", err, called)
+	}
+	// --dry-run 跳过提示直接派发（无 stdin）。
+	if called, err := leafRiskRun(t, LeafRiskWrite, "", "--id", "x", "--dry-run"); err != nil || !called {
+		t.Fatalf("--dry-run bypass err = %v called = %v", err, called)
+	}
+}
+
+func TestCrossPlatformCoverageLeafYesFlagAndIntEdges(t *testing.T) {
+	if leafYesFlag(nil) {
+		t.Fatal("nil cmd should not report --yes")
+	}
+
+	// Required LeafInt 的 env 值不可解析：leafHasEffectiveValue 视为已提供
+	// （err→true 分支），required 通过后由 leafArgs 报 invalid integer。
+	t.Setenv("DWS_LEAF_INT_EDGE", "not-an-int")
+	badInt := NewLeafCommand(LeafSpec{
+		Use:   "int-edge",
+		Tool:  "int_edge_tool",
+		Flags: []LeafFlag{{Name: "n", Usage: "N", Kind: LeafInt, Required: true, EnvVar: "DWS_LEAF_INT_EDGE"}},
+		Call:  func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	badInt.SilenceErrors = true
+	badInt.SilenceUsage = true
+	badInt.SetArgs(nil)
+	if err := badInt.Execute(); err == nil || !strings.Contains(err.Error(), "invalid integer value") {
+		t.Fatalf("unparseable int env err = %v", err)
+	}
+
+	// 写风险但全局无 --yes flag 注册：leafYesFlag 各 getter 均报错走兜底 false，
+	// 于是进入提示；stdin "no" 取消。
+	called := false
+	noYes := NewLeafCommand(leafRiskSpec(LeafRiskWrite, &called))
+	noYes.SilenceErrors = true
+	noYes.SilenceUsage = true
+	noYes.SetIn(strings.NewReader("no\n"))
+	noYes.SetArgs([]string{"--id", "x"})
+	if err := noYes.Execute(); err == nil || !strings.Contains(err.Error(), "用户取消了操作") {
+		t.Fatalf("no-yes-flag cancel err = %v", err)
+	}
+	if called {
+		t.Fatal("declined write dispatched despite no --yes flag")
+	}
+}


### PR DESCRIPTION
## Summary
Addresses the "dual-framework split" review note: LeafSpec (atomic `dws <product> <cmd>`) and Shortcut (`dws <product> +<cmd>`) evolved separate constraint systems. This lands the recommended convergence — LeafSpec now carries the shortcut framework's declarative constraints and the bool/string-slice flag kinds — so both share one flag-registration + validation base, differing only in dispatch path.

- **New flag kinds** `LeafBool` / `LeafStringSlice`: registration, effective-value detection, required semantics, and toolArgs assembly. Bool delivers on `Changed` (explicit `--flag=false` is transmitted); slice trims elements and drops empties.
- **`LeafConstraint`** (`at_least_one` / `exactly_one` / `mutually_exclusive`) on `LeafSpec`, validated between required checks and the `Validate` hook. Error wording is byte-for-byte identical to the shortcut runner's `RuntimeContext` validators, so atomic commands and smart shortcuts fail identically for users and agents. Crucially, "provided" reuses LeafSpec's `主 flag → 别名 → env` fallback chain (registration defaults excluded) — a capability the shortcut framework's bare `Changed` check lacks.
- **Schema + help projection**: constraints project to the Agent Runtime Schema (`exactly_one` → `require_one_of` + `mutually_exclusive`) and render a `参数约束` help section matching shortcut leaf help. Malformed constraint declarations panic at build time.
- No existing leaf behaviour changes (no current LeafSpec sets `Constraints`); this is additive infrastructure. Migrating the 29 LeafSpec call sites and the shortcut fleet onto the shared base is left to follow-ups.

## Test plan
- [x] `go test ./internal/helpers/ -run TestCrossPlatformCoverageLeaf` — new suite (constraints, alias/env provided-detection, default-not-counted, bool/slice args + required, schema+help projection, decl panics, ordering, core paths)
- [x] `go test ./internal/helpers/ ./internal/app/` — full suites pass
- [x] `make coverage-gate-platform` — 100% changed-code coverage
- [x] `make policy` — pass (schema/catalog/drift clean; no leaf currently declares constraints so zero catalog drift)