### PR TITLE
fix(schema): drop corpus hashes that serialize concurrent product PRs

### DIFF
--- a/internal/cli/schema_agent_metadata.go
+++ b/internal/cli/schema_agent_metadata.go
@@ -29,7 +29,6 @@ const embeddedAgentMetadataSource = "embedded-skill-metadata"
 
 type embeddedAgentMetadata struct {
 	Version     int                             `json:"version"`
-	SourceHash  string                          `json:"source_hash"`
 	SurfaceHash string                          `json:"surface_hash,omitempty"`
 	Coverage    embeddedAgentMetadataCoverage   `json:"coverage"`
 	Products    map[string]agentProductMetadata `json:"products"`
@@ -343,7 +342,6 @@ func agentMetadataSummaryFrom(metadata embeddedAgentMetadata) map[string]any {
 	summary := map[string]any{
 		"source":                 embeddedAgentMetadataSource,
 		"version":                metadata.Version,
-		"source_hash":            strings.TrimSpace(metadata.SourceHash),
 		"products_with_metadata": len(metadata.Products),
 		"tools_with_metadata":    len(metadata.Tools),
 	}

--- a/internal/cli/schema_agent_metadata/index.json
+++ b/internal/cli/schema_agent_metadata/index.json
@@ -1,6 +1,5 @@
 {
   "version": 1,
-  "source_hash": "sha256:eb6e44775a6e85f92ca31c90c876f67543ab928d8a8bda04f07a33dc802f7028",
   "surface_hash": "sha256:29d4f5f43688cc01bc2277a4528b597de4fbab89a7b2f13fe2e56df85d1c66c4",
   "coverage": {
     "surface_products": 26,

--- a/internal/cli/schema_agent_metadata_audit.json
+++ b/internal/cli/schema_agent_metadata_audit.json
@@ -1,6 +1,5 @@
 {
   "version": 1,
-  "source_hash": "sha256:eb6e44775a6e85f92ca31c90c876f67543ab928d8a8bda04f07a33dc802f7028",
   "surface_hash": "sha256:29d4f5f43688cc01bc2277a4528b597de4fbab89a7b2f13fe2e56df85d1c66c4",
   "source_files": 160,
   "hint_files": 54,

--- a/internal/cli/schema_agent_metadata_test.go
+++ b/internal/cli/schema_agent_metadata_test.go
@@ -307,8 +307,7 @@ func TestAgentProductSelectionUsesTypedAccessor(t *testing.T) {
 
 func TestRuntimeSchemaIncludesEmbeddedAgentMetadata(t *testing.T) {
 	agentFixture := embeddedAgentMetadata{
-		Version:    1,
-		SourceHash: "sha256:test",
+		Version: 1,
 		Products: map[string]agentProductMetadata{
 			"doc": {
 				AgentSummary:       "创建、读取和维护钉钉文档",
@@ -353,8 +352,11 @@ func TestRuntimeSchemaIncludesEmbeddedAgentMetadata(t *testing.T) {
 		t.Fatalf("runtimeSchemaPayloadForTest(catalog): %v", err)
 	}
 	summary, _ := catalog["agent_metadata"].(map[string]any)
-	if summary["source_hash"] != "sha256:test" {
+	if summary["source"] != embeddedAgentMetadataSource {
 		t.Fatalf("catalog Agent metadata summary = %#v", summary)
+	}
+	if _, hasSourceHash := summary["source_hash"]; hasSourceHash {
+		t.Fatalf("agent_metadata must not expose source_hash: %#v", summary)
 	}
 	products, _ := catalog["products"].([]map[string]any)
 	doc := findSchemaProduct(products, "doc")

--- a/internal/cli/schema_catalog.go
+++ b/internal/cli/schema_catalog.go
@@ -36,8 +36,8 @@ const SchemaCatalogSnapshotVersion = 1
 //	schema_catalog/catalog.json        global envelope + Catalog map
 //	schema_catalog/tools/<product>.json   that product's leaf ToolSpecs
 //
-// The loader reassembles the exact same SchemaCatalogSnapshot, so the
-// source_hash integrity check is identical to the single-file layout.
+// The loader reassembles the same SchemaCatalogSnapshot and derives
+// source_hash from the full payload (it is not stored in catalog.json).
 //
 //go:embed schema_catalog/catalog.json
 var embeddedSchemaCatalogEnvelopeJSON []byte
@@ -87,12 +87,13 @@ func embeddedSchemaCatalog() loadedSchemaCatalog {
 }
 
 // schemaCatalogEnvelope is the global half of the split release Catalog. It
-// mirrors the generator's envelope struct; the Catalog map and release hashes
-// do not partition by product and stay in one file.
+// mirrors the generator's envelope struct; the Catalog map and surface_hash
+// do not partition by product and stay in one file. source_hash is derived at
+// load time from the reassembled payload so concurrent product PRs do not
+// collide on a whole-corpus hash line.
 type schemaCatalogEnvelope struct {
 	Version     int            `json:"version"`
 	SurfaceHash string         `json:"surface_hash,omitempty"`
-	SourceHash  string         `json:"source_hash"`
 	Catalog     map[string]any `json:"catalog"`
 }
 
@@ -105,9 +106,9 @@ type schemaCatalogToolShard struct {
 
 // assembleEmbeddedSchemaCatalog reassembles the split release Catalog shards
 // into the same SchemaCatalogSnapshot the single-file layout produced, then
-// validates it through the production loader. source_hash still covers the
-// whole payload: if any shard is missing, stale, or tampered, the content hash
-// check in loadSchemaCatalogSnapshot fails exactly as before.
+// validates it through the production loader. source_hash is derived from the
+// reassembled payload so a missing or tampered shard still changes the hash
+// exposed as catalog_hash.
 func assembleEmbeddedSchemaCatalog() (loadedSchemaCatalog, error) {
 	snapshot, err := assembleSchemaCatalogSnapshot(embeddedSchemaCatalogEnvelopeJSON, embeddedSchemaCatalogTools, "schema_catalog/tools")
 	if err != nil {
@@ -146,13 +147,14 @@ func assembleSchemaCatalogSnapshot(envelopeJSON []byte, shards fs.FS, dir string
 			tools[canonical] = spec
 		}
 	}
-	return SchemaCatalogSnapshot{
+	snapshot := SchemaCatalogSnapshot{
 		Version:     envelope.Version,
 		SurfaceHash: envelope.SurfaceHash,
-		SourceHash:  envelope.SourceHash,
 		Catalog:     envelope.Catalog,
 		Tools:       tools,
-	}, nil
+	}
+	snapshot.SourceHash = schemaCatalogSnapshotHash(snapshot)
+	return snapshot, nil
 }
 
 func embeddedSchemaCatalogError() error {
@@ -269,8 +271,12 @@ func loadSchemaCatalogSnapshot(snapshot SchemaCatalogSnapshot) (loadedSchemaCata
 	if len(snapshot.Catalog) == 0 || len(snapshot.Tools) == 0 {
 		return loadedSchemaCatalog{}, fmt.Errorf("schema Catalog snapshot is empty")
 	}
-	if snapshot.SourceHash == "" || snapshot.SourceHash != schemaCatalogSnapshotHash(snapshot) {
-		return loadedSchemaCatalog{}, fmt.Errorf("schema Catalog snapshot source_hash does not match its content")
+	// source_hash is derived from content rather than trusted from storage.
+	// Committed envelopes no longer persist it; in-memory round-trips that
+	// still carry a value are overwritten with the canonical content hash.
+	snapshot.SourceHash = schemaCatalogSnapshotHash(snapshot)
+	if snapshot.SourceHash == "" {
+		return loadedSchemaCatalog{}, fmt.Errorf("schema Catalog snapshot source_hash could not be derived")
 	}
 	registry, index, err := schemaRegistryFromSnapshot(snapshot)
 	if err != nil {

--- a/internal/cli/schema_catalog/catalog.json
+++ b/internal/cli/schema_catalog/catalog.json
@@ -1,12 +1,10 @@
 {
   "version": 1,
   "surface_hash": "sha256:29d4f5f43688cc01bc2277a4528b597de4fbab89a7b2f13fe2e56df85d1c66c4",
-  "source_hash": "sha256:c71b9bacfe2d73f5ad45151fada6fdc18bac69b266058a8b05647b6847c99835",
   "catalog": {
     "agent_metadata": {
       "products_with_metadata": 26,
       "source": "embedded-skill-metadata",
-      "source_hash": "sha256:eb6e44775a6e85f92ca31c90c876f67543ab928d8a8bda04f07a33dc802f7028",
       "surface_hash": "sha256:29d4f5f43688cc01bc2277a4528b597de4fbab89a7b2f13fe2e56df85d1c66c4",
       "surface_products": 26,
       "surface_tools": 840,

--- a/internal/cli/schema_catalog_coverage_more_test.go
+++ b/internal/cli/schema_catalog_coverage_more_test.go
@@ -88,8 +88,12 @@ func TestCrossPlatformCoverageLoadSchemaCatalogSnapshotGateFailures(t *testing.T
 	}
 	badHash := cloneSnapshotForCoverage(t, base)
 	badHash.SourceHash = "wrong"
-	if _, err := loadSchemaCatalogSnapshot(badHash); err == nil {
-		t.Fatal("bad snapshot hash succeeded")
+	loadedBadHash, err := loadSchemaCatalogSnapshot(badHash)
+	if err != nil {
+		t.Fatalf("loadSchemaCatalogSnapshot(wrong stored hash) error = %v", err)
+	}
+	if loadedBadHash.Snapshot.SourceHash != base.SourceHash {
+		t.Fatalf("derived source_hash = %q, want %q", loadedBadHash.Snapshot.SourceHash, base.SourceHash)
 	}
 	badTyped := cloneSnapshotForCoverage(t, base)
 	badTyped.Catalog["unknown"] = true

--- a/internal/cli/schema_shards_coverage_test.go
+++ b/internal/cli/schema_shards_coverage_test.go
@@ -35,7 +35,7 @@ func (f failingReadFS) ReadFile(name string) ([]byte, error) {
 }
 
 func TestAssembleSchemaCatalogSnapshotMergesShards(t *testing.T) {
-	envelope := []byte(`{"version":1,"surface_hash":"sha256:s","source_hash":"sha256:c","catalog":{"kind":"schema"}}`)
+	envelope := []byte(`{"version":1,"surface_hash":"sha256:s","catalog":{"kind":"schema"}}`)
 	shards := fstest.MapFS{
 		"tools/doc.json":   {Data: []byte(`{"product":"doc","tools":{"doc.copy":{"title":"复制"}}}`)},
 		"tools/sheet.json": {Data: []byte(`{"product":"sheet","tools":{"sheet.get":{"title":"读取"}}}`)},
@@ -45,7 +45,7 @@ func TestAssembleSchemaCatalogSnapshotMergesShards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("assembleSchemaCatalogSnapshot() error = %v", err)
 	}
-	if snapshot.Version != 1 || snapshot.SurfaceHash != "sha256:s" || snapshot.SourceHash != "sha256:c" {
+	if snapshot.Version != 1 || snapshot.SurfaceHash != "sha256:s" || snapshot.SourceHash == "" {
 		t.Fatalf("envelope fields lost: %+v", snapshot)
 	}
 	if len(snapshot.Tools) != 2 || snapshot.Tools["doc.copy"] == nil || snapshot.Tools["sheet.get"] == nil {
@@ -54,7 +54,7 @@ func TestAssembleSchemaCatalogSnapshotMergesShards(t *testing.T) {
 }
 
 func TestAssembleSchemaCatalogSnapshotFailureModes(t *testing.T) {
-	valid := []byte(`{"version":1,"source_hash":"sha256:c","catalog":{}}`)
+	valid := []byte(`{"version":1,"catalog":{}}`)
 	if _, err := assembleSchemaCatalogSnapshot([]byte("{bad"), fstest.MapFS{}, "tools"); err == nil || !strings.Contains(err.Error(), "decode embedded schema catalog.json") {
 		t.Fatalf("bad envelope err = %v", err)
 	}

--- a/internal/generator/agentmetadata/metadata.go
+++ b/internal/generator/agentmetadata/metadata.go
@@ -15,8 +15,6 @@ package agentmetadata
 
 import (
 	"bufio"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -33,7 +31,6 @@ const CurrentVersion = 1
 
 type File struct {
 	Version     int                        `json:"version"`
-	SourceHash  string                     `json:"source_hash"`
 	SurfaceHash string                     `json:"surface_hash,omitempty"`
 	Coverage    Coverage                   `json:"coverage"`
 	Products    map[string]ProductMetadata `json:"products"`
@@ -318,7 +315,6 @@ type ReferenceReview struct {
 // from the runtime Agent metadata contract.
 type Audit struct {
 	Version                       int                     `json:"version"`
-	SourceHash                    string                  `json:"source_hash"`
 	SurfaceHash                   string                  `json:"surface_hash,omitempty"`
 	SourceFiles                   int                     `json:"source_files"`
 	HintFiles                     int                     `json:"hint_files,omitempty"`
@@ -391,7 +387,6 @@ func generateFromSources(opts Options) (File, Stats, error) {
 
 	out := File{
 		Version:     CurrentVersion,
-		SourceHash:  hashSources(files),
 		SurfaceHash: strings.TrimSpace(opts.SurfaceHash),
 		Products:    map[string]ProductMetadata{},
 		Tools:       map[string]ToolMetadata{},
@@ -540,7 +535,6 @@ func generateFromSources(opts Options) (File, Stats, error) {
 func BuildAudit(file File, stats Stats) Audit {
 	return Audit{
 		Version:                       CurrentVersion,
-		SourceHash:                    file.SourceHash,
 		SurfaceHash:                   file.SurfaceHash,
 		SourceFiles:                   stats.SourceFiles,
 		HintFiles:                     stats.HintFiles,
@@ -1953,17 +1947,6 @@ func displayPath(root, path string) string {
 		return filepath.ToSlash(filepath.Clean(path))
 	}
 	return filepath.ToSlash(rel)
-}
-
-func hashSources(files []sourceFile) string {
-	h := sha256.New()
-	for _, file := range files {
-		_, _ = h.Write([]byte(file.display))
-		_, _ = h.Write([]byte{0})
-		_, _ = h.Write(file.data)
-		_, _ = h.Write([]byte{0})
-	}
-	return "sha256:" + hex.EncodeToString(h.Sum(nil))
 }
 
 func parseProductRouting(out *File, body, source string) {

--- a/internal/generator/agentmetadata/metadata_test.go
+++ b/internal/generator/agentmetadata/metadata_test.go
@@ -68,7 +68,7 @@ func TestGenerateCompilesSkillSemantics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Generate() error = %v", err)
 	}
-	if metadata.Version != CurrentVersion || metadata.SourceHash == "" {
+	if metadata.Version != CurrentVersion {
 		t.Fatalf("metadata header = %#v", metadata)
 	}
 	if got := metadata.Products["calendar"].UseWhen; len(got) != 1 || got[0] != "日程/会议室" {
@@ -118,8 +118,8 @@ func TestGenerateCompilesSkillSemantics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second Generate() error = %v", err)
 	}
-	if again.SourceHash != metadata.SourceHash {
-		t.Fatalf("source hash is not deterministic: %q != %q", again.SourceHash, metadata.SourceHash)
+	if again.Coverage.ToolsWithMetadata != metadata.Coverage.ToolsWithMetadata {
+		t.Fatalf("coverage is not deterministic: %#v != %#v", again.Coverage, metadata.Coverage)
 	}
 }
 

--- a/internal/generator/agentmetadata/production_pipeline_external_test.go
+++ b/internal/generator/agentmetadata/production_pipeline_external_test.go
@@ -67,7 +67,7 @@ func TestCrossPlatformCoverageGenerateProductionAgentMetadataPipeline(t *testing
 	if len(metadata.Tools) != len(canonicalToolPaths) || stats.Tools == 0 {
 		t.Fatalf("generated metadata mismatch: tools=%d registry=%d stats=%d", len(metadata.Tools), len(canonicalToolPaths), stats.Tools)
 	}
-	if audit := agentmetadata.BuildAudit(metadata, stats); audit.SourceHash == "" {
-		t.Fatal("generated audit has an empty source hash")
+	if audit := agentmetadata.BuildAudit(metadata, stats); audit.SurfaceHash == "" {
+		t.Fatal("generated audit has an empty surface hash")
 	}
 }

--- a/internal/generator/cmd_schema_agent_metadata/main.go
+++ b/internal/generator/cmd_schema_agent_metadata/main.go
@@ -207,7 +207,6 @@ func writeAuditFile(path string, audit agentmetadata.Audit) error {
 
 type agentMetadataIndex struct {
 	Version     int                                      `json:"version"`
-	SourceHash  string                                   `json:"source_hash"`
 	SurfaceHash string                                   `json:"surface_hash,omitempty"`
 	Coverage    agentmetadata.Coverage                   `json:"coverage"`
 	Products    map[string]agentmetadata.ProductMetadata `json:"products"`
@@ -265,7 +264,6 @@ func writeMetadataDirectory(dir string, metadata agentmetadata.File) error {
 	sort.Strings(domains)
 	index := agentMetadataIndex{
 		Version:     metadata.Version,
-		SourceHash:  metadata.SourceHash,
 		SurfaceHash: metadata.SurfaceHash,
 		Coverage:    metadata.Coverage,
 		Products:    metadata.Products,

--- a/internal/generator/cmd_schema_agent_metadata/main_test.go
+++ b/internal/generator/cmd_schema_agent_metadata/main_test.go
@@ -108,8 +108,7 @@ func TestWriteMetadataDirectorySplitsDomains(t *testing.T) {
 		t.Fatalf("WriteFile(stale) error = %v", err)
 	}
 	metadata := agentmetadata.File{
-		Version:    1,
-		SourceHash: "sha256:test",
+		Version: 1,
 		Products: map[string]agentmetadata.ProductMetadata{
 			"calendar": {UseWhen: []string{"日程"}},
 			"contact":  {UseWhen: []string{"联系人"}},

--- a/internal/generator/cmd_schema_catalog/main.go
+++ b/internal/generator/cmd_schema_catalog/main.go
@@ -134,12 +134,14 @@ func generateSchemaCatalogWithResolver(root *cobra.Command, surfacePath, outputP
 }
 
 // schemaCatalogEnvelope is the global half of the split catalog. It carries
-// the release envelope (version + integrity hashes) and the Catalog map, whose
+// the release envelope (version + surface_hash) and the Catalog map, whose
 // products array and cross-product aggregates do not partition by product.
+// source_hash is not stored: the loader derives it from {version, surface_hash,
+// catalog, tools} so concurrent product PRs do not collide on a whole-corpus
+// hash line.
 type schemaCatalogEnvelope struct {
 	Version     int            `json:"version"`
 	SurfaceHash string         `json:"surface_hash,omitempty"`
-	SourceHash  string         `json:"source_hash"`
 	Catalog     map[string]any `json:"catalog"`
 }
 
@@ -154,8 +156,8 @@ type schemaCatalogToolShard struct {
 // writeSchemaCatalogShards partitions a validated snapshot into a release
 // directory: catalog.json holds the global envelope + Catalog map, and
 // tools/<product>.json holds each product's leaf ToolSpecs keyed by canonical
-// path. The split is a storage concern only: the loader reassembles the exact
-// same SchemaCatalogSnapshot, so source_hash still validates the whole payload.
+// path. The split is a storage concern only: the loader reassembles the same
+// SchemaCatalogSnapshot and derives source_hash from the full payload.
 func writeSchemaCatalogShards(snapshot cli.SchemaCatalogSnapshot, outputDir string) error {
 	if err := os.RemoveAll(outputDir); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("clear stale schema catalog output: %w", err)
@@ -168,7 +170,6 @@ func writeSchemaCatalogShards(snapshot cli.SchemaCatalogSnapshot, outputDir stri
 	envelope := schemaCatalogEnvelope{
 		Version:     snapshot.Version,
 		SurfaceHash: snapshot.SurfaceHash,
-		SourceHash:  snapshot.SourceHash,
 		Catalog:     snapshot.Catalog,
 	}
 	if err := writeSchemaCatalogJSON(filepath.Join(outputDir, "catalog.json"), envelope); err != nil {

--- a/internal/generator/cmd_schema_catalog/main_test.go
+++ b/internal/generator/cmd_schema_catalog/main_test.go
@@ -166,7 +166,6 @@ func loadSplitSchemaCatalogSnapshot(t *testing.T, dir string) cli.SchemaCatalogS
 	var envelope struct {
 		Version     int            `json:"version"`
 		SurfaceHash string         `json:"surface_hash,omitempty"`
-		SourceHash  string         `json:"source_hash"`
 		Catalog     map[string]any `json:"catalog"`
 	}
 	envData, err := os.ReadFile(filepath.Join(dir, "catalog.json"))
@@ -179,7 +178,6 @@ func loadSplitSchemaCatalogSnapshot(t *testing.T, dir string) cli.SchemaCatalogS
 	snapshot := cli.SchemaCatalogSnapshot{
 		Version:     envelope.Version,
 		SurfaceHash: envelope.SurfaceHash,
-		SourceHash:  envelope.SourceHash,
 		Catalog:     envelope.Catalog,
 		Tools:       map[string]map[string]any{},
 	}

--- a/scripts/policy/check-schema-binary.sh
+++ b/scripts/policy/check-schema-binary.sh
@@ -54,8 +54,9 @@ if ! jq -e -n \
   $vector.registry_hash == $catalog.surface_hash and
   $list.surface_hash == $vector.registry_hash and
   $all.surface_hash == $vector.registry_hash and
-  $list.catalog_hash == $catalog.source_hash and
-  $all.catalog_hash == $catalog.source_hash and
+  ($list.catalog_hash | type) == "string" and
+  ($list.catalog_hash | test("^sha256:[0-9a-f]{64}$")) and
+  $list.catalog_hash == $all.catalog_hash and
   ($vector.commands | map(.canonical_path) | sort) == ($catalog.tools | keys | sort) and
   ($vector.commands | map(.canonical_path) | sort) ==
   ([$all.products[].tools[].canonical_path] | sort) and
@@ -73,7 +74,11 @@ fi
 # still has to be the exact typed projection of the same embedded Catalog.
 # Derive the expected overview without invoking another Schema code path so a
 # release binary cannot hide loader/query drift behind two identical helpers.
-jq -S '
+# catalog_hash is injected by the binary at query time from the derived
+# content hash; take it from the actual list so the overview projection check
+# stays focused on Catalog content. Byte-for-byte Catalog freshness is covered
+# by check-generated-drift.sh.
+jq -S --slurpfile list "$tmp/list.json" '
   def nonempty: type == "string" and (gsub("^\\s+|\\s+$"; "") | length) > 0;
   . as $snapshot |
   $snapshot.catalog as $catalog |
@@ -102,7 +107,7 @@ jq -S '
   (if (($catalog.source // "") | type == "string" and length > 0) then {source: $catalog.source} else {} end) +
   (if $catalog | has("interface_metadata") then {interface_metadata: $catalog.interface_metadata} else {} end) +
   (if $catalog | has("agent_metadata") then {agent_metadata: $catalog.agent_metadata} else {} end) +
-  {catalog_hash: $snapshot.source_hash} +
+  {catalog_hash: $list[0].catalog_hash} +
   (if (($snapshot.surface_hash // "") | nonempty) then {surface_hash: $snapshot.surface_hash} else {} end)
 ' "$catalog_combined" >"$tmp/expected-list.json"
 jq -S . "$tmp/list.json" >"$tmp/actual-list.json"

--- a/scripts/policy/check-schema-catalog.sh
+++ b/scripts/policy/check-schema-catalog.sh
@@ -8,8 +8,9 @@ cd "$ROOT"
 policy_prepare_runtime "$ROOT"
 
 # The release Catalog is committed as a per-product split; reassemble it into
-# the single-document shape (version + surface_hash + source_hash + catalog +
-# tools) that the jq queries below consume.
+# the single-document shape (version + surface_hash + catalog + tools) that the
+# jq queries below consume. source_hash is derived by the Go loader and is not
+# present in the reassembled document.
 catalog="$(mktemp)"
 trap 'rm -f "$catalog"' EXIT HUP INT TERM
 scripts/policy/with-catalog.sh >"$catalog"

--- a/scripts/policy/with-catalog.sh
+++ b/scripts/policy/with-catalog.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # Reassemble the split release Catalog shards back into the single JSON
-# document shape (version + surface_hash + source_hash + catalog + tools) that
-# the policy jq queries consume.
+# document shape (version + surface_hash + catalog + tools) that the policy
+# jq queries consume. source_hash is intentionally omitted: the Go loader
+# derives it from the reassembled payload, and jq cannot reproduce that hash.
 #
 # The Catalog is a committed global file (schema_catalog/catalog.json); each
 # product's leaf ToolSpecs live in their own shard (schema_catalog/tools/*.json)
@@ -17,7 +18,6 @@ jq -s '
   ($envelope.surface_hash // null) as $surface |
   {
     version: $envelope.version,
-    source_hash: $envelope.source_hash,
     catalog: $envelope.catalog,
     tools: (reduce .[1:][] as $shard ({}; . + ($shard.tools // {})))
   } +


### PR DESCRIPTION
## Summary
- Stop storing whole-corpus `source_hash` in `schema_catalog/catalog.json`; the loader derives it from `{version, surface_hash, catalog, tools}` so `dws schema` still exposes a stable `catalog_hash`.
- Remove Agent metadata input-provenance hashes from `index.json`, `schema_agent_metadata_audit.json`, and the `agent_metadata` summary (zero functional consumers; `surface_hash` remains the reviewed-registry anchor).
- Update policy helpers (`with-catalog.sh`, `check-schema-binary.sh`) so Catalog freshness stays covered by `check-generated-drift.sh`.

This removes the 4 unmergeable hash lines that forced concurrent product PRs to serialize on rebase+regenerate.

## Test plan
- [x] `go test ./internal/generator/... ./internal/cli/ -count=1`
- [x] `make generate-schema` + `./scripts/policy/check-generated-drift.sh`
- [x] `dws schema list --format json` still returns `catalog_hash` (`sha256:…`) and no longer exposes `agent_metadata.source_hash`
- [x] Simulated doc vs sheet PRs: 3-way merge of `catalog.json` / `index.json` / `audit.json` reports **0 conflicts**


Made with [Cursor](https://cursor.com)