### PR TITLE
refactor(cmdcore): extract shared leaf base (Phase 1, zero behavior change)

### DIFF
--- a/internal/cmdcore/cmdcore.go
+++ b/internal/cmdcore/cmdcore.go
@@ -1,0 +1,596 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmdcore is the shared, dispatch-agnostic base for building leaf
+// commands. It concentrates flag registration, the alias/env/default effective
+// value fallback chain, required validation, cross-flag constraint declaration
+// checks + runtime enforcement, Risk-driven write confirmation, toolArgs
+// assembly, and Agent Runtime Schema projection.
+//
+// It is deliberately dispatch-agnostic: it never calls an MCP tool. The
+// LeafSpec framework (internal/helpers) and, later, the Shortcut framework wrap
+// these primitives and supply their own dispatch (single-step MCP / multi-step
+// orchestration / escape hatch). Extracting the primitives here lets both
+// frameworks share one flag + constraint + risk + schema base, differing only
+// in how they dispatch — the first step toward a single typed command registry.
+//
+// Behavioral contract: this package is a pure extraction of the logic that
+// previously lived in internal/helpers/leaf.go. Flag registration, value
+// fallback, required/constraint semantics, risk wording, and schema projection
+// must remain byte-for-byte equivalent; check-generated-drift (catalog
+// unchanged) and the leaf unit tests are the proof.
+package cmdcore
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/cmdutil"
+)
+
+// FlagKind is the value type of a flag.
+type FlagKind int
+
+const (
+	// KindString is a string flag (default).
+	KindString FlagKind = iota
+	// KindInt is an integer flag (registered as cobra Int); it enters toolArgs
+	// only when the value is non-zero, matching the handwritten "putInt only
+	// when non-zero" semantics (e.g. devapp app-group-id).
+	KindInt
+	// KindBool is a boolean flag (registered as cobra Bool); it enters toolArgs
+	// only when the user explicitly provided it (Changed), matching the
+	// handwritten "transmit on Changed, explicit false is still sent" semantics.
+	// Booleans do not participate in the alias/env fallback chain.
+	KindBool
+	// KindStringSlice is a string-list flag (registered as cobra StringSlice);
+	// it enters toolArgs only when a non-empty element exists, elements are
+	// always TrimSpace'd and empties dropped.
+	KindStringSlice
+)
+
+// FlagSpec declares how a flag is registered and bound into MCP toolArgs. Its
+// fields intentionally mirror the former helpers.LeafFlag one-for-one so that
+// helpers can alias to it without touching any call site.
+type FlagSpec struct {
+	Name    string   // flag name (kebab-case)
+	Usage   string   // registration usage text
+	Kind    FlagKind // value type, defaults to KindString
+	Default string   // registration default (only KindString uses it at registration; as a fallback-chain tail it applies to all kinds without shadowing aliases/env)
+
+	// Required, when true, validates a non-empty effective value in RunE. Plain
+	// Required flags aggregate into a cmdutil.ValidateRequiredFlags-compatible
+	// error; when EnvVar is configured the env var is a fallback and, still
+	// empty, RequiredHint (or a default hint) is reported.
+	Required     bool
+	RequiredHint string
+	// MarkRequired, when true, calls cobra MarkFlagRequired (the hard floor for
+	// the catalog required projection); cobra errors before RunE.
+	MarkRequired bool
+
+	Aliases []string // hidden aliases, registered with the main flag's Kind; used in order when the main flag is not explicitly provided
+	EnvVar  string   // environment variable consulted when the effective value is empty (an integer flag's env value must be parseable)
+	// ArgDefault covers the case where the registration default is empty but
+	// toolArgs still needs a fallback; used as the arg value when the effective
+	// value is empty.
+	ArgDefault string
+	// Bind is the toolArgs key; empty uses Name.
+	Bind string
+	// Transform converts a string effective value into the arg value; nil sends
+	// it as-is. Returning (nil, nil) skips the key (for "nullable numeric: skip
+	// on empty or parse failure" semantics).
+	Transform func(raw string) (any, error)
+	// OmitEmpty, when true, drops an empty effective value from toolArgs (KindInt
+	// is always "non-zero only" and ignores this field).
+	OmitEmpty bool
+	// Trim, when true, TrimSpace's the effective value (main flag/alias/env
+	// alike) and makes a whitespace-only value count as empty in required checks.
+	Trim bool
+}
+
+// Risk declares a leaf command's side-effect level, driving pre-dispatch write
+// confirmation. Values match the shortcut framework's Risk verbatim.
+type Risk string
+
+const (
+	// RiskRead is a read-only operation; never prompts. Empty value == RiskRead.
+	RiskRead Risk = "read"
+	// RiskWrite mutates state; prompts unless --yes.
+	RiskWrite Risk = "write"
+	// RiskHighWrite is a destructive/irreversible operation; prompts unless --yes.
+	RiskHighWrite Risk = "high-risk-write"
+)
+
+// Effective returns the effective risk, defaulting an empty value to read-only.
+func (r Risk) Effective() Risk {
+	if r == "" {
+		return RiskRead
+	}
+	return r
+}
+
+// ConstraintKind is the type of a cross-flag relationship constraint. Values
+// match the shortcut framework's ConstraintKind verbatim.
+type ConstraintKind string
+
+const (
+	// AtLeastOne requires at least one of Flags to be provided.
+	AtLeastOne ConstraintKind = "at_least_one"
+	// ExactlyOne requires exactly one of Flags to be provided.
+	ExactlyOne ConstraintKind = "exactly_one"
+	// MutuallyExclusive allows at most one of Flags.
+	MutuallyExclusive ConstraintKind = "mutually_exclusive"
+)
+
+// Constraint declares a relationship over a group of flags. It is enforced
+// after required validation and before the framework's Validate hook;
+// "provided" reuses the effective-value fallback chain (explicit main flag →
+// alias → env), so passing a compatible alias counts as provided — a capability
+// the shortcut framework's bare Changed check lacks. The constraint is also
+// projected into the Agent Runtime Schema (mutually_exclusive / require_one_of)
+// and rendered into the --help "参数约束" section.
+type Constraint struct {
+	Kind  ConstraintKind
+	Flags []string
+	// Description, when non-empty, replaces the constraint's default help text.
+	Description string
+}
+
+// RegisterFlags registers every flag (plus hidden aliases and MarkFlagRequired)
+// declared by the spec set onto cmd.
+func RegisterFlags(cmd *cobra.Command, flags []FlagSpec) {
+	for _, flag := range flags {
+		RegisterFlag(cmd, flag.Kind, flag.Name, flag.Default, flag.Usage)
+		// Aliases are registered with the main flag's Kind, otherwise an integer
+		// alias's value would never be readable (silently dropped).
+		for _, alias := range flag.Aliases {
+			RegisterFlag(cmd, flag.Kind, alias, "", flag.Usage+" (alias)")
+			_ = cmd.Flags().MarkHidden(alias)
+		}
+		if flag.MarkRequired {
+			_ = cmd.MarkFlagRequired(flag.Name)
+		}
+	}
+}
+
+// RegisterFlag registers one flag by Kind; the registration default is only used
+// by KindString (other kinds treat Default purely as a fallback-chain tail,
+// matching the existing KindInt behavior).
+func RegisterFlag(cmd *cobra.Command, kind FlagKind, name, def, usage string) {
+	switch kind {
+	case KindInt:
+		cmd.Flags().Int(name, 0, usage)
+	case KindBool:
+		cmd.Flags().Bool(name, false, usage)
+	case KindStringSlice:
+		cmd.Flags().StringSlice(name, nil, usage)
+	default:
+		cmd.Flags().String(name, def, usage)
+	}
+}
+
+// ValidateRequired reproduces the handwritten required semantics: plain Required
+// flags report a unified "missing required flag(s)" error; Required flags with
+// EnvVar/RequiredHint report their hint separately. The plain group is checked
+// before the env group to preserve the handwritten order. Both groups use the
+// declared "main flag → alias → env" fallback: a compatible alias counts as
+// provided.
+func ValidateRequired(cmd *cobra.Command, flags []FlagSpec) error {
+	var plain []string
+	for _, flag := range flags {
+		if flag.Required && flag.EnvVar == "" && flag.RequiredHint == "" && !hasEffectiveValue(cmd, flag) {
+			plain = append(plain, flag.Name)
+		}
+	}
+	if err := cmdutil.MissingRequiredFlagsError(cmd, plain...); err != nil {
+		return err
+	}
+	for _, flag := range flags {
+		if !flag.Required || (flag.EnvVar == "" && flag.RequiredHint == "") {
+			continue
+		}
+		if !hasEffectiveValue(cmd, flag) {
+			hint := flag.RequiredHint
+			if hint == "" {
+				hint = fmt.Sprintf("flag --%s is required", flag.Name)
+			}
+			return fmt.Errorf("%s", hint)
+		}
+	}
+	return nil
+}
+
+// hasEffectiveValue decides whether a Required flag is satisfied, matching the
+// BuildArgs entry predicate (KindInt non-zero, string non-empty, KindBool
+// explicitly provided, KindStringSlice has a non-empty element). Integer parse
+// failure counts as provided so BuildArgs reports the precise invalid-integer
+// error.
+func hasEffectiveValue(cmd *cobra.Command, flag FlagSpec) bool {
+	switch flag.Kind {
+	case KindInt:
+		v, err := integerValue(cmd, flag)
+		if err != nil {
+			return true
+		}
+		return v != 0
+	case KindBool:
+		return cmd.Flags().Changed(flag.Name)
+	case KindStringSlice:
+		return sliceValue(cmd, flag) != nil
+	}
+	return EffectiveValue(cmd, flag) != ""
+}
+
+// sliceValue reads a list flag's effective value by "explicit main flag →
+// explicit alias" order: elements are TrimSpace'd and empties dropped, and an
+// all-empty result counts as not provided (returns nil). Lists do not
+// participate in the env/Default fallback chain.
+func sliceValue(cmd *cobra.Command, flag FlagSpec) []string {
+	names := append([]string{flag.Name}, flag.Aliases...)
+	for _, name := range names {
+		if !cmd.Flags().Changed(name) {
+			continue
+		}
+		raw, _ := cmd.Flags().GetStringSlice(name)
+		var out []string
+		for _, value := range raw {
+			if value = strings.TrimSpace(value); value != "" {
+				out = append(out, value)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return nil
+}
+
+// BuildArgs assembles toolArgs from the flag set by binding relationship.
+func BuildArgs(cmd *cobra.Command, flags []FlagSpec) (map[string]any, error) {
+	toolArgs := map[string]any{}
+	for _, flag := range flags {
+		bind := flag.Bind
+		if bind == "" {
+			bind = flag.Name
+		}
+		if flag.Kind == KindInt {
+			v, err := integerValue(cmd, flag)
+			if err != nil {
+				return nil, err
+			}
+			// Keep "non-zero only" (putInt semantics).
+			if v != 0 {
+				toolArgs[bind] = int(v)
+			}
+			continue
+		}
+		if flag.Kind == KindBool {
+			// Enter on Changed only: explicit false is still sent (matching the
+			// handwritten "transmit on Changed" semantics).
+			if cmd.Flags().Changed(flag.Name) {
+				v, _ := cmd.Flags().GetBool(flag.Name)
+				toolArgs[bind] = v
+			}
+			continue
+		}
+		if flag.Kind == KindStringSlice {
+			if v := sliceValue(cmd, flag); v != nil {
+				toolArgs[bind] = v
+			}
+			continue
+		}
+		effective := EffectiveValue(cmd, flag)
+		if effective == "" && flag.ArgDefault != "" {
+			effective = flag.ArgDefault
+		}
+		if effective == "" && flag.OmitEmpty {
+			continue
+		}
+		if flag.Transform != nil {
+			value, err := flag.Transform(effective)
+			if err != nil {
+				return nil, err
+			}
+			if value == nil {
+				continue
+			}
+			toolArgs[bind] = value
+			continue
+		}
+		toolArgs[bind] = effective
+	}
+	return toolArgs, nil
+}
+
+// effectiveValue reads the value by "explicit main flag → alias → env →
+// registration default" order (string form, integers uniformly formatted);
+// Trim TrimSpace's the result.
+func EffectiveValue(cmd *cobra.Command, flag FlagSpec) string {
+	v := rawValue(cmd, flag)
+	if flag.Trim {
+		v = strings.TrimSpace(v)
+	}
+	return v
+}
+
+// rawValue reads the un-trimmed effective value. The main flag wins only when
+// explicitly provided (Changed) and non-empty; the registration default is
+// demoted to a chain tail and no longer shadows aliases/env. When Trim is set,
+// candidates are judged empty after trimming, so whitespace-only and empty fall
+// through to the next fallback level.
+func rawValue(cmd *cobra.Command, flag FlagSpec) string {
+	usable := func(v string) bool {
+		if flag.Trim {
+			v = strings.TrimSpace(v)
+		}
+		return v != ""
+	}
+	if cmd.Flags().Changed(flag.Name) {
+		if v := flagString(cmd, flag.Kind, flag.Name); usable(v) {
+			return v
+		}
+	}
+	for _, alias := range flag.Aliases {
+		if !cmd.Flags().Changed(alias) {
+			continue
+		}
+		if v := flagString(cmd, flag.Kind, alias); usable(v) {
+			return v
+		}
+	}
+	if flag.EnvVar != "" {
+		if v := os.Getenv(flag.EnvVar); usable(v) {
+			return v
+		}
+	}
+	return flag.Default
+}
+
+// flagString reads a flag by registered type and normalizes to string form so
+// integer flags can reuse the same fallback chain (required checks, aliases, env).
+func flagString(cmd *cobra.Command, kind FlagKind, name string) string {
+	switch kind {
+	case KindInt:
+		v, _ := cmd.Flags().GetInt(name)
+		return strconv.Itoa(v)
+	default:
+		return cmdutil.MustGetFlag(cmd, name)
+	}
+}
+
+// integerValue reads an integer flag's effective value by the fallback chain; an
+// env-provided string must be parseable, otherwise it errors rather than
+// silently dropping.
+func integerValue(cmd *cobra.Command, flag FlagSpec) (int64, error) {
+	raw := EffectiveValue(cmd, flag)
+	if raw == "" {
+		return 0, nil
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("flag --%s: invalid integer value %q", flag.Name, raw)
+	}
+	return v, nil
+}
+
+// ValidateConstraintDecls validates constraint declarations at build time: an
+// unknown kind, an under-sized flag group, or a reference to an undeclared flag
+// is a programming error and panics so any test/startup path fails immediately
+// rather than at user runtime. use is only used for the panic message.
+func ValidateConstraintDecls(use string, flags []FlagSpec, constraints []Constraint) {
+	declared := map[string]bool{}
+	for _, flag := range flags {
+		declared[flag.Name] = true
+	}
+	for _, constraint := range constraints {
+		switch constraint.Kind {
+		case AtLeastOne, ExactlyOne, MutuallyExclusive:
+		default:
+			panic(fmt.Sprintf("leaf %q: unknown constraint kind %q", use, constraint.Kind))
+		}
+		if len(constraint.Flags) < 2 {
+			panic(fmt.Sprintf("leaf %q: constraint %s needs at least two flags", use, constraint.Kind))
+		}
+		for _, name := range constraint.Flags {
+			if !declared[name] {
+				panic(fmt.Sprintf("leaf %q: constraint %s references undeclared flag %q", use, constraint.Kind, name))
+			}
+		}
+	}
+}
+
+// constraintProvided decides whether a flag is "provided" for constraint
+// purposes: an explicit main flag, explicit alias, or env var counts; the
+// registration default/ArgDefault does not — otherwise a defaulted flag would
+// always satisfy at_least_one and always trip mutually_exclusive. KindBool only
+// counts Changed (booleans have no alias/env fallback semantics).
+func constraintProvided(cmd *cobra.Command, flag FlagSpec) bool {
+	switch flag.Kind {
+	case KindBool:
+		return cmd.Flags().Changed(flag.Name)
+	case KindStringSlice:
+		if cmd.Flags().Changed(flag.Name) {
+			if v, _ := cmd.Flags().GetStringSlice(flag.Name); sliceHasValue(v) {
+				return true
+			}
+		}
+		for _, alias := range flag.Aliases {
+			if !cmd.Flags().Changed(alias) {
+				continue
+			}
+			if v, _ := cmd.Flags().GetStringSlice(alias); sliceHasValue(v) {
+				return true
+			}
+		}
+		return false
+	}
+	usable := func(v string) bool { return strings.TrimSpace(v) != "" }
+	if cmd.Flags().Changed(flag.Name) && usable(flagString(cmd, flag.Kind, flag.Name)) {
+		return true
+	}
+	for _, alias := range flag.Aliases {
+		if cmd.Flags().Changed(alias) && usable(flagString(cmd, flag.Kind, alias)) {
+			return true
+		}
+	}
+	return flag.EnvVar != "" && usable(os.Getenv(flag.EnvVar))
+}
+
+// ValidateConstraints enforces the relationship constraints. Error wording
+// matches the shortcut framework's RuntimeContext.AtLeastOne/ExactlyOne/
+// MutuallyExclusive verbatim, so atomic commands and smart shortcuts fail
+// identically for users and agents.
+func ValidateConstraints(cmd *cobra.Command, flags []FlagSpec, constraints []Constraint) error {
+	flagsByName := map[string]FlagSpec{}
+	for _, flag := range flags {
+		flagsByName[flag.Name] = flag
+	}
+	for _, constraint := range constraints {
+		var set []string
+		for _, name := range constraint.Flags {
+			if constraintProvided(cmd, flagsByName[name]) {
+				set = append(set, name)
+			}
+		}
+		switch constraint.Kind {
+		case AtLeastOne:
+			if len(set) == 0 {
+				return apperrors.NewValidation(fmt.Sprintf(
+					"请至少指定 %s 之一", dashed(constraint.Flags)))
+			}
+		case ExactlyOne:
+			switch len(set) {
+			case 1:
+			case 0:
+				return apperrors.NewValidation(fmt.Sprintf("请指定 %s 之一", dashed(constraint.Flags)))
+			default:
+				return apperrors.NewValidation(fmt.Sprintf(
+					"参数 %s 只能指定其一（当前指定了 %s）", dashed(constraint.Flags), dashed(set)))
+			}
+		case MutuallyExclusive:
+			if len(set) > 1 {
+				return apperrors.NewValidation(fmt.Sprintf(
+					"参数 %s 互斥，只能指定其一（当前指定了 %s）", dashed(constraint.Flags), dashed(set)))
+			}
+		}
+	}
+	return nil
+}
+
+// ConfirmRisk reproduces the shortcut framework's confirmRisk write-confirmation
+// semantics: read-only, --dry-run, or --yes pass through; write/high-risk-write
+// prompt in interactive mode and return false when the user declines. The prompt
+// wording matches the shortcut runner verbatim (command path substitutes the
+// shortcut's Service+Command), keeping atomic-command and smart-shortcut
+// confirmation identical.
+func ConfirmRisk(cmd *cobra.Command, risk Risk) bool {
+	if risk.Effective() == RiskRead || BoolFlag(cmd, "dry-run") || BoolFlag(cmd, "yes") {
+		return true
+	}
+	output := cmd.ErrOrStderr()
+	fmt.Fprintf(output, "即将执行 %s（%s），确认继续？(yes/no): ", cmd.CommandPath(), risk.Effective())
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "yes" || answer == "y"
+}
+
+// boolFlag robustly reads a bool flag that may live on the command, its
+// inherited flags, or the root's persistent flags (e.g. root-injected global
+// --yes / --dry-run). Returns the first flagset that resolves the name.
+func BoolFlag(cmd *cobra.Command, name string) bool {
+	if cmd == nil {
+		return false
+	}
+	getters := []func(string) (bool, error){
+		cmd.Flags().GetBool,
+		cmd.InheritedFlags().GetBool,
+	}
+	if root := cmd.Root(); root != nil {
+		getters = append(getters, root.PersistentFlags().GetBool)
+	}
+	for _, get := range getters {
+		if v, err := get(name); err == nil {
+			return v
+		}
+	}
+	return false
+}
+
+// AnnotateConstraints projects the relationship constraints into the Agent
+// Runtime Schema: exactly_one decomposes into require_one_of + mutually_exclusive
+// (matching the handwritten commands' use of AnnotateRuntimeConstraints).
+func AnnotateConstraints(cmd *cobra.Command, constraints []Constraint) {
+	var projected cli.RuntimeSchemaConstraints
+	for _, constraint := range constraints {
+		flags := append([]string(nil), constraint.Flags...)
+		switch constraint.Kind {
+		case AtLeastOne:
+			projected.RequireOneOf = append(projected.RequireOneOf, flags)
+		case ExactlyOne:
+			projected.RequireOneOf = append(projected.RequireOneOf, flags)
+			projected.MutuallyExclusive = append(projected.MutuallyExclusive, flags)
+		case MutuallyExclusive:
+			projected.MutuallyExclusive = append(projected.MutuallyExclusive, flags)
+		}
+	}
+	cli.AnnotateRuntimeConstraints(cmd, projected)
+}
+
+// ConstraintHelp renders the --help "参数约束" section, matching the shortcut
+// leaf help shape; returns "" when there are no constraints.
+func ConstraintHelp(constraints []Constraint) string {
+	if len(constraints) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(constraints))
+	for _, constraint := range constraints {
+		text := strings.TrimSpace(constraint.Description)
+		if text == "" {
+			switch constraint.Kind {
+			case AtLeastOne:
+				text = fmt.Sprintf("%s 至少指定一个", dashed(constraint.Flags))
+			case ExactlyOne:
+				text = fmt.Sprintf("%s 必须且只能指定一个", dashed(constraint.Flags))
+			case MutuallyExclusive:
+				text = fmt.Sprintf("%s 互斥，最多指定一个", dashed(constraint.Flags))
+			}
+		}
+		lines = append(lines, "  - "+text)
+	}
+	return "\n\n参数约束：\n" + strings.Join(lines, "\n")
+}
+
+func dashed(flags []string) string {
+	out := make([]string, len(flags))
+	for i, f := range flags {
+		out[i] = "--" + f
+	}
+	return strings.Join(out, "、")
+}
+
+func sliceHasValue(values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/helpers/leaf.go
+++ b/internal/helpers/leaf.go
@@ -14,6 +14,7 @@
 package helpers
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strconv"
@@ -93,6 +94,28 @@ type LeafFlag struct {
 	Trim bool
 }
 
+// LeafRisk 声明叶子命令的副作用等级，取值与 shortcut 框架的 Risk 逐字
+// 一致（helpers 不能反向依赖 internal/shortcut——shortcut/builtin 依赖
+// helpers 会形成环——故本地声明同名语义）。
+type LeafRisk string
+
+const (
+	// LeafRiskRead 只读操作，从不提示。空值即视为 LeafRiskRead。
+	LeafRiskRead LeafRisk = "read"
+	// LeafRiskWrite 变更状态；未加 --yes 时提示确认。
+	LeafRiskWrite LeafRisk = "write"
+	// LeafRiskHighWrite 破坏性/不可逆操作；未加 --yes 时提示确认。
+	LeafRiskHighWrite LeafRisk = "high-risk-write"
+)
+
+// effective 返回有效副作用等级，空值降级为只读。
+func (r LeafRisk) effective() LeafRisk {
+	if r == "" {
+		return LeafRiskRead
+	}
+	return r
+}
+
 // LeafConstraintKind 是跨 flag 关系约束的类型，取值与 shortcut 框架的
 // ConstraintKind 逐字一致（helpers 不能反向依赖 internal/shortcut——
 // shortcut/builtin 依赖 helpers 会形成环——故本地声明同名语义）。
@@ -136,6 +159,12 @@ type LeafSpec struct {
 	// 框架统一校验并投影到 Runtime Schema 与 --help。复杂的条件式校验
 	// 仍放 Validate 钩子。
 	Constraints []LeafConstraint
+
+	// Risk 声明副作用等级，驱动执行前的写确认（对齐 shortcut 框架的
+	// Risk 语义）。默认 LeafRiskRead：只读，从不提示。LeafRiskWrite /
+	// LeafRiskHighWrite 在未加 --yes 且非 --dry-run 时提示确认，用户拒绝
+	// 则中止且不派发。confirmation 语义与 shortcut 的 confirmRisk 逐字一致。
+	Risk LeafRisk
 
 	// Call 是可插拔派发函数，非空时替代默认的 callMCPTool/callMCPToolOnServer。
 	// 供非 MCP 直连命令（如 devapp 走 executor.Runner）复用本框架：调用方用
@@ -203,6 +232,9 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 		toolArgs, err := leafArgs(cmd, spec)
 		if err != nil {
 			return err
+		}
+		if !leafConfirmRisk(cmd, spec) {
+			return apperrors.NewValidation("用户取消了操作")
 		}
 		if spec.Call != nil {
 			return spec.Call(cmd, spec.Tool, toolArgs)
@@ -525,6 +557,43 @@ func leafValidateConstraints(cmd *cobra.Command, spec LeafSpec) error {
 		}
 	}
 	return nil
+}
+
+// leafConfirmRisk 复现 shortcut 框架 confirmRisk 的写确认语义：只读、
+// --dry-run 或 --yes 直接放行；写/高危操作在交互态提示确认，用户拒绝返回
+// false。提示文案与 shortcut 逐字一致（以命令路径替代 shortcut 的
+// Service+Command），保证 atomic command 与 smart shortcut 的确认体验统一。
+func leafConfirmRisk(cmd *cobra.Command, spec LeafSpec) bool {
+	if spec.Risk.effective() == LeafRiskRead || commandDryRun(cmd) || leafYesFlag(cmd) {
+		return true
+	}
+	output := cmd.ErrOrStderr()
+	fmt.Fprintf(output, "即将执行 %s（%s），确认继续？(yes/no): ", cmd.CommandPath(), spec.Risk.effective())
+	reader := bufio.NewReader(cmd.InOrStdin())
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	return answer == "yes" || answer == "y"
+}
+
+// leafYesFlag 稳健读取 --yes：依次尝试本命令、继承 flag、根持久 flag，
+// 兼容根注入的全局 --yes。
+func leafYesFlag(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+	getters := []func(string) (bool, error){
+		cmd.Flags().GetBool,
+		cmd.InheritedFlags().GetBool,
+	}
+	if root := cmd.Root(); root != nil {
+		getters = append(getters, root.PersistentFlags().GetBool)
+	}
+	for _, get := range getters {
+		if v, err := get("yes"); err == nil {
+			return v
+		}
+	}
+	return false
 }
 
 // leafAnnotateConstraints 把关系约束投影到 Agent Runtime Schema：

--- a/internal/helpers/leaf.go
+++ b/internal/helpers/leaf.go
@@ -20,6 +20,9 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 )
 
 // leaf.go 是叶子命令的统一构建框架。
@@ -45,6 +48,13 @@ const (
 	// LeafInt 整型 flag（注册为 cobra Int）；仅在值 != 0 时进入 toolArgs，
 	// 对应手写「putInt 仅在非零才入参」语义（如 devapp app-group-id）。
 	LeafInt
+	// LeafBool 布尔 flag（注册为 cobra Bool）；仅在用户显式提供（Changed）
+	// 时进入 toolArgs，对应手写「Changed 才透传，显式 false 也下发」语义。
+	// 布尔不参与别名/env 回退链（true/false 无「空值」可回退）。
+	LeafBool
+	// LeafStringSlice 字符串列表 flag（注册为 cobra StringSlice）；仅在存在
+	// 非空元素时进入 toolArgs，元素恒 TrimSpace 后过滤空串。
+	LeafStringSlice
 )
 
 // LeafFlag 声明一个 flag 的注册方式与到 MCP toolArgs 的绑定。
@@ -83,6 +93,33 @@ type LeafFlag struct {
 	Trim bool
 }
 
+// LeafConstraintKind 是跨 flag 关系约束的类型，取值与 shortcut 框架的
+// ConstraintKind 逐字一致（helpers 不能反向依赖 internal/shortcut——
+// shortcut/builtin 依赖 helpers 会形成环——故本地声明同名语义）。
+type LeafConstraintKind string
+
+const (
+	// LeafAtLeastOne 要求 Flags 至少提供一个。
+	LeafAtLeastOne LeafConstraintKind = "at_least_one"
+	// LeafExactlyOne 要求 Flags 必须且只能提供一个。
+	LeafExactlyOne LeafConstraintKind = "exactly_one"
+	// LeafMutuallyExclusive 允许 Flags 中最多提供一个。
+	LeafMutuallyExclusive LeafConstraintKind = "mutually_exclusive"
+)
+
+// LeafConstraint 声明一组 flag 的关系约束。框架在 required 校验之后、
+// Validate 钩子之前统一执行；「是否提供」的判定复用 LeafSpec 的有效值
+// 回退链（显式主 flag → 别名 → env），即只传兼容别名同样视为已提供——
+// 这是 shortcut 裸 Changed 判定所没有的能力。约束同时投影到 Agent
+// Runtime Schema（mutually_exclusive / require_one_of）并渲染进 --help
+// 的「参数约束」段：一次声明，运行时校验、Schema、帮助三处生效。
+type LeafConstraint struct {
+	Kind  LeafConstraintKind
+	Flags []string
+	// Description 非空时替换 --help 中该约束的默认文案。
+	Description string
+}
+
 // LeafSpec 声明一个 MCP 直连叶子命令。
 type LeafSpec struct {
 	Use     string
@@ -95,6 +132,10 @@ type LeafSpec struct {
 	Server string
 	Tool   string
 	Flags  []LeafFlag
+	// Constraints 是跨 flag 的关系约束（至少一个 / 恰好一个 / 互斥），
+	// 框架统一校验并投影到 Runtime Schema 与 --help。复杂的条件式校验
+	// 仍放 Validate 钩子。
+	Constraints []LeafConstraint
 
 	// Call 是可插拔派发函数，非空时替代默认的 callMCPTool/callMCPToolOnServer。
 	// 供非 MCP 直连命令（如 devapp 走 executor.Runner）复用本框架：调用方用
@@ -125,25 +166,20 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 		Example: spec.Example,
 	}
 	for _, flag := range spec.Flags {
-		switch flag.Kind {
-		case LeafInt:
-			cmd.Flags().Int(flag.Name, 0, flag.Usage)
-		default:
-			cmd.Flags().String(flag.Name, flag.Default, flag.Usage)
-		}
+		leafRegisterFlag(cmd, flag.Kind, flag.Name, flag.Default, flag.Usage)
 		// 别名按主 flag 的 Kind 注册，否则整型别名的值永远读不到（静默丢弃）。
 		for _, alias := range flag.Aliases {
-			switch flag.Kind {
-			case LeafInt:
-				cmd.Flags().Int(alias, 0, flag.Usage+" (alias)")
-			default:
-				cmd.Flags().String(alias, "", flag.Usage+" (alias)")
-			}
+			leafRegisterFlag(cmd, flag.Kind, alias, "", flag.Usage+" (alias)")
 			_ = cmd.Flags().MarkHidden(alias)
 		}
 		if flag.MarkRequired {
 			_ = cmd.MarkFlagRequired(flag.Name)
 		}
+	}
+	leafValidateConstraintDecls(spec)
+	leafAnnotateConstraints(cmd, spec)
+	if help := leafConstraintHelp(spec.Constraints); help != "" {
+		cmd.Long = strings.TrimRight(cmd.Long, "\n") + help
 	}
 	if spec.PostMount != nil {
 		spec.PostMount(cmd)
@@ -154,6 +190,9 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 	}
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if err := leafValidateRequired(cmd, spec); err != nil {
+			return err
+		}
+		if err := leafValidateConstraints(cmd, spec); err != nil {
 			return err
 		}
 		if spec.Validate != nil {
@@ -174,6 +213,21 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 		return callMCPTool(spec.Tool, toolArgs)
 	}
 	return cmd
+}
+
+// leafRegisterFlag 按 Kind 注册 flag；注册默认值仅 LeafString 使用（其余
+// Kind 的 Default 只作为回退链链尾兜底，与既有 LeafInt 行为一致）。
+func leafRegisterFlag(cmd *cobra.Command, kind LeafFlagKind, name, def, usage string) {
+	switch kind {
+	case LeafInt:
+		cmd.Flags().Int(name, 0, usage)
+	case LeafBool:
+		cmd.Flags().Bool(name, false, usage)
+	case LeafStringSlice:
+		cmd.Flags().StringSlice(name, nil, usage)
+	default:
+		cmd.Flags().String(name, def, usage)
+	}
 }
 
 // leafValidateRequired 复现手写命令的 required 语义：普通 Required 统一报
@@ -206,18 +260,46 @@ func leafValidateRequired(cmd *cobra.Command, spec LeafSpec) error {
 }
 
 // leafHasEffectiveValue 判定 Required 是否满足，标准与 leafArgs 的入参判定
-// 一致（LeafInt 需非零、字符串需非空）：否则会出现校验声称有效、toolArgs
-// 却缺参的分裂。整型解析失败视为已提供，让 leafArgs 报出更精确的
-// invalid integer 错误。
+// 一致（LeafInt 需非零、字符串需非空、LeafBool 需显式提供、LeafStringSlice
+// 需存在非空元素）：否则会出现校验声称有效、toolArgs 却缺参的分裂。整型解析
+// 失败视为已提供，让 leafArgs 报出更精确的 invalid integer 错误。
 func leafHasEffectiveValue(cmd *cobra.Command, flag LeafFlag) bool {
-	if flag.Kind == LeafInt {
+	switch flag.Kind {
+	case LeafInt:
 		v, err := leafIntegerValue(cmd, flag)
 		if err != nil {
 			return true
 		}
 		return v != 0
+	case LeafBool:
+		return cmd.Flags().Changed(flag.Name)
+	case LeafStringSlice:
+		return leafSliceValue(cmd, flag) != nil
 	}
 	return leafEffectiveValue(cmd, flag) != ""
+}
+
+// leafSliceValue 按「显式主 flag → 显式别名」顺序取列表 flag 的有效值：
+// 元素统一 TrimSpace 并过滤空串，全空视为未提供（返回 nil）。列表不参与
+// env/Default 回退链。
+func leafSliceValue(cmd *cobra.Command, flag LeafFlag) []string {
+	names := append([]string{flag.Name}, flag.Aliases...)
+	for _, name := range names {
+		if !cmd.Flags().Changed(name) {
+			continue
+		}
+		raw, _ := cmd.Flags().GetStringSlice(name)
+		var out []string
+		for _, value := range raw {
+			if value = strings.TrimSpace(value); value != "" {
+				out = append(out, value)
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return nil
 }
 
 // leafArgs 按绑定关系装配 toolArgs。
@@ -236,6 +318,20 @@ func leafArgs(cmd *cobra.Command, spec LeafSpec) (map[string]any, error) {
 			// 保持「非零才入参」（putInt 语义）。
 			if v != 0 {
 				toolArgs[bind] = int(v)
+			}
+			continue
+		}
+		if flag.Kind == LeafBool {
+			// Changed 才入参：显式 false 同样下发（对应手写「Changed 才透传」语义）。
+			if cmd.Flags().Changed(flag.Name) {
+				v, _ := cmd.Flags().GetBool(flag.Name)
+				toolArgs[bind] = v
+			}
+			continue
+		}
+		if flag.Kind == LeafStringSlice {
+			if v := leafSliceValue(cmd, flag); v != nil {
+				toolArgs[bind] = v
 			}
 			continue
 		}
@@ -328,4 +424,166 @@ func leafIntegerValue(cmd *cobra.Command, flag LeafFlag) (int64, error) {
 		return 0, fmt.Errorf("flag --%s: invalid integer value %q", flag.Name, raw)
 	}
 	return v, nil
+}
+
+// leafValidateConstraintDecls 在构建期校验约束声明：未知类型、空 flag 组或
+// 引用未声明 flag 都是编程错误，直接 panic 让任何测试/启动路径第一时间失败，
+// 而不是等到用户命中运行时才暴露。
+func leafValidateConstraintDecls(spec LeafSpec) {
+	declared := map[string]bool{}
+	for _, flag := range spec.Flags {
+		declared[flag.Name] = true
+	}
+	for _, constraint := range spec.Constraints {
+		switch constraint.Kind {
+		case LeafAtLeastOne, LeafExactlyOne, LeafMutuallyExclusive:
+		default:
+			panic(fmt.Sprintf("leaf %q: unknown constraint kind %q", spec.Use, constraint.Kind))
+		}
+		if len(constraint.Flags) < 2 {
+			panic(fmt.Sprintf("leaf %q: constraint %s needs at least two flags", spec.Use, constraint.Kind))
+		}
+		for _, name := range constraint.Flags {
+			if !declared[name] {
+				panic(fmt.Sprintf("leaf %q: constraint %s references undeclared flag %q", spec.Use, constraint.Kind, name))
+			}
+		}
+	}
+}
+
+// leafConstraintProvided 判定约束语义下 flag 是否「已提供」：显式主 flag、
+// 显式别名或环境变量任一命中即视为提供；注册默认值/ArgDefault 不算——否则
+// 带默认值的 flag 会恒满足 at_least_one 并恒触发 mutually_exclusive。
+// LeafBool 只认 Changed（布尔无别名/env 回退语义）。
+func leafConstraintProvided(cmd *cobra.Command, flag LeafFlag) bool {
+	switch flag.Kind {
+	case LeafBool:
+		return cmd.Flags().Changed(flag.Name)
+	case LeafStringSlice:
+		if cmd.Flags().Changed(flag.Name) {
+			if v, _ := cmd.Flags().GetStringSlice(flag.Name); leafSliceHasValue(v) {
+				return true
+			}
+		}
+		for _, alias := range flag.Aliases {
+			if !cmd.Flags().Changed(alias) {
+				continue
+			}
+			if v, _ := cmd.Flags().GetStringSlice(alias); leafSliceHasValue(v) {
+				return true
+			}
+		}
+		return false
+	}
+	usable := func(v string) bool { return strings.TrimSpace(v) != "" }
+	if cmd.Flags().Changed(flag.Name) && usable(leafFlagString(cmd, flag.Kind, flag.Name)) {
+		return true
+	}
+	for _, alias := range flag.Aliases {
+		if cmd.Flags().Changed(alias) && usable(leafFlagString(cmd, flag.Kind, alias)) {
+			return true
+		}
+	}
+	return flag.EnvVar != "" && usable(os.Getenv(flag.EnvVar))
+}
+
+// leafValidateConstraints 执行关系约束。报错文案与 shortcut 框架的
+// RuntimeContext.AtLeastOne/ExactlyOne/MutuallyExclusive 逐字一致，保证
+// atomic command 与 smart shortcut 面向用户/Agent 的失败形态统一。
+func leafValidateConstraints(cmd *cobra.Command, spec LeafSpec) error {
+	flagsByName := map[string]LeafFlag{}
+	for _, flag := range spec.Flags {
+		flagsByName[flag.Name] = flag
+	}
+	for _, constraint := range spec.Constraints {
+		var set []string
+		for _, name := range constraint.Flags {
+			if leafConstraintProvided(cmd, flagsByName[name]) {
+				set = append(set, name)
+			}
+		}
+		switch constraint.Kind {
+		case LeafAtLeastOne:
+			if len(set) == 0 {
+				return apperrors.NewValidation(fmt.Sprintf(
+					"请至少指定 %s 之一", leafDashed(constraint.Flags)))
+			}
+		case LeafExactlyOne:
+			switch len(set) {
+			case 1:
+			case 0:
+				return apperrors.NewValidation(fmt.Sprintf("请指定 %s 之一", leafDashed(constraint.Flags)))
+			default:
+				return apperrors.NewValidation(fmt.Sprintf(
+					"参数 %s 只能指定其一（当前指定了 %s）", leafDashed(constraint.Flags), leafDashed(set)))
+			}
+		case LeafMutuallyExclusive:
+			if len(set) > 1 {
+				return apperrors.NewValidation(fmt.Sprintf(
+					"参数 %s 互斥，只能指定其一（当前指定了 %s）", leafDashed(constraint.Flags), leafDashed(set)))
+			}
+		}
+	}
+	return nil
+}
+
+// leafAnnotateConstraints 把关系约束投影到 Agent Runtime Schema：
+// exactly_one 分解为 require_one_of + mutually_exclusive（与手写命令对
+// AnnotateRuntimeConstraints 的既有用法一致）。
+func leafAnnotateConstraints(cmd *cobra.Command, spec LeafSpec) {
+	var projected cli.RuntimeSchemaConstraints
+	for _, constraint := range spec.Constraints {
+		flags := append([]string(nil), constraint.Flags...)
+		switch constraint.Kind {
+		case LeafAtLeastOne:
+			projected.RequireOneOf = append(projected.RequireOneOf, flags)
+		case LeafExactlyOne:
+			projected.RequireOneOf = append(projected.RequireOneOf, flags)
+			projected.MutuallyExclusive = append(projected.MutuallyExclusive, flags)
+		case LeafMutuallyExclusive:
+			projected.MutuallyExclusive = append(projected.MutuallyExclusive, flags)
+		}
+	}
+	cli.AnnotateRuntimeConstraints(cmd, projected)
+}
+
+// leafConstraintHelp 渲染 --help 的「参数约束」段，形态与 shortcut 叶子
+// 帮助一致；无约束时返回空串。
+func leafConstraintHelp(constraints []LeafConstraint) string {
+	if len(constraints) == 0 {
+		return ""
+	}
+	lines := make([]string, 0, len(constraints))
+	for _, constraint := range constraints {
+		text := strings.TrimSpace(constraint.Description)
+		if text == "" {
+			switch constraint.Kind {
+			case LeafAtLeastOne:
+				text = fmt.Sprintf("%s 至少指定一个", leafDashed(constraint.Flags))
+			case LeafExactlyOne:
+				text = fmt.Sprintf("%s 必须且只能指定一个", leafDashed(constraint.Flags))
+			case LeafMutuallyExclusive:
+				text = fmt.Sprintf("%s 互斥，最多指定一个", leafDashed(constraint.Flags))
+			}
+		}
+		lines = append(lines, "  - "+text)
+	}
+	return "\n\n参数约束：\n" + strings.Join(lines, "\n")
+}
+
+func leafDashed(flags []string) string {
+	out := make([]string, len(flags))
+	for i, f := range flags {
+		out[i] = "--" + f
+	}
+	return strings.Join(out, "、")
+}
+
+func leafSliceHasValue(values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/helpers/leaf.go
+++ b/internal/helpers/leaf.go
@@ -14,15 +14,11 @@
 package helpers
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cmdcore"
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 )
 
@@ -36,114 +32,71 @@ import (
 // 复用同一套 flag/校验/装配逻辑。复杂命令可通过 LeafSpec.RunE 完全自定义
 // （逃生舱），不在框架适用范围内强行套用。
 //
+// 收敛纪律（Phase 1）：flag 注册、有效值回退链、required 校验、约束校验/声明
+// 检查、Risk 写确认、toolArgs 装配、Runtime Schema 投影、帮助渲染均已下沉到
+// internal/cmdcore 共享基座；本文件只保留 LeafSpec 外壳（含 MCP dispatch 字段）
+// 与 NewLeafCommand 编排。dispatch（callMCPTool/callMCPToolOnServer/Call）仍留
+// 在 helpers。由 check-generated-drift（catalog 零漂移）与命令兼容性检查兜底
+// 证明等价——cmdcore 是纯抽取，行为逐字保持不变。
+//
 // 迁移纪律：从手写命令迁移到 LeafSpec 时，flag 名、默认值、usage 文案、
-// MarkFlagRequired、required 错误格式、toolArgs 键与值必须逐字保持一致，
-// 由 check-generated-drift（catalog 零漂移）与命令兼容性检查兜底证明等价。
+// MarkFlagRequired、required 错误格式、toolArgs 键与值必须逐字保持一致。
 
-// LeafFlagKind 是 flag 的值类型。
-type LeafFlagKind int
+// LeafFlagKind 是 flag 的值类型（cmdcore.FlagKind 的别名）。
+type LeafFlagKind = cmdcore.FlagKind
 
 const (
 	// LeafString 字符串 flag（默认）。
-	LeafString LeafFlagKind = iota
-	// LeafInt 整型 flag（注册为 cobra Int）；仅在值 != 0 时进入 toolArgs，
-	// 对应手写「putInt 仅在非零才入参」语义（如 devapp app-group-id）。
-	LeafInt
-	// LeafBool 布尔 flag（注册为 cobra Bool）；仅在用户显式提供（Changed）
-	// 时进入 toolArgs，对应手写「Changed 才透传，显式 false 也下发」语义。
-	// 布尔不参与别名/env 回退链（true/false 无「空值」可回退）。
-	LeafBool
-	// LeafStringSlice 字符串列表 flag（注册为 cobra StringSlice）；仅在存在
-	// 非空元素时进入 toolArgs，元素恒 TrimSpace 后过滤空串。
-	LeafStringSlice
+	LeafString = cmdcore.KindString
+	// LeafInt 整型 flag；仅在值 != 0 时进入 toolArgs（putInt 语义）。
+	LeafInt = cmdcore.KindInt
+	// LeafBool 布尔 flag；仅在用户显式提供（Changed）时进入 toolArgs，显式
+	// false 也下发；不参与别名/env 回退链。
+	LeafBool = cmdcore.KindBool
+	// LeafStringSlice 字符串列表 flag；仅在存在非空元素时进入 toolArgs，元素
+	// 恒 TrimSpace 后过滤空串。
+	LeafStringSlice = cmdcore.KindStringSlice
 )
 
-// LeafFlag 声明一个 flag 的注册方式与到 MCP toolArgs 的绑定。
-type LeafFlag struct {
-	Name    string       // flag 名（kebab-case）
-	Usage   string       // 注册 usage 文案
-	Kind    LeafFlagKind // 值类型，默认 LeafString
-	Default string       // 注册默认值（cobra 注册仅 LeafString 使用；回退链链尾对所有 Kind 生效，不遮蔽别名/env）
+// LeafFlag 声明一个 flag 的注册方式与到 MCP toolArgs 的绑定
+// （cmdcore.FlagSpec 的别名，字段含义见 cmdcore 定义）。
+type LeafFlag = cmdcore.FlagSpec
 
-	// Required 为 true 时在 RunE 期校验有效值非空。普通 Required 汇聚为
-	// cmdutil.ValidateRequiredFlags 兼容的统一报错；配置 EnvVar 时回退读
-	// 环境变量，仍为空则报 RequiredHint（或默认文案）。
-	Required     bool
-	RequiredHint string
-	// MarkRequired 为 true 时调用 cobra MarkFlagRequired（catalog required
-	// 投影的硬下限），cobra 会在 RunE 之前先行报错。
-	MarkRequired bool
-
-	Aliases []string // 隐藏别名，按主 flag 的 Kind 注册；主 flag 未显式提供时按序回退
-	EnvVar  string   // 有效值为空时回退读取的环境变量（整型 flag 的 env 值必须可解析）
-	// ArgDefault：注册默认值为空、但 toolArgs 需要兜底的场景（如 list type
-	// 注册默认 "ALL" 之外的旧命令）；有效值为空时以 ArgDefault 入参。
-	ArgDefault string
-	// Bind 是 toolArgs 的键；为空时使用 Name。
-	Bind string
-	// Transform 把字符串有效值转为入参值；nil 时原样入参。返回
-	// (nil, nil) 表示跳过该键（用于「可空数值：为空或解析失败都不入参」
-	// 的手写语义）。
-	Transform func(raw string) (any, error)
-	// OmitEmpty 为 true 时有效值为空则不进入 toolArgs（LeafInt 恒为
-	// 「非零才入参」，忽略此字段）。
-	OmitEmpty bool
-	// Trim 为 true 时对有效值做 strings.TrimSpace（主 flag/别名/env 统一），
-	// 对应手写 devAppStringFlag 恒 trim 的语义；亦使「纯空白」值在 required
-	// 校验中视为空。
-	Trim bool
-}
-
-// LeafRisk 声明叶子命令的副作用等级，取值与 shortcut 框架的 Risk 逐字
-// 一致（helpers 不能反向依赖 internal/shortcut——shortcut/builtin 依赖
-// helpers 会形成环——故本地声明同名语义）。
-type LeafRisk string
+// LeafRisk 声明叶子命令的副作用等级（cmdcore.Risk 的别名）。取值与 shortcut
+// 框架的 Risk 逐字一致。
+type LeafRisk = cmdcore.Risk
 
 const (
 	// LeafRiskRead 只读操作，从不提示。空值即视为 LeafRiskRead。
-	LeafRiskRead LeafRisk = "read"
+	LeafRiskRead = cmdcore.RiskRead
 	// LeafRiskWrite 变更状态；未加 --yes 时提示确认。
-	LeafRiskWrite LeafRisk = "write"
+	LeafRiskWrite = cmdcore.RiskWrite
 	// LeafRiskHighWrite 破坏性/不可逆操作；未加 --yes 时提示确认。
-	LeafRiskHighWrite LeafRisk = "high-risk-write"
+	LeafRiskHighWrite = cmdcore.RiskHighWrite
 )
 
-// effective 返回有效副作用等级，空值降级为只读。
-func (r LeafRisk) effective() LeafRisk {
-	if r == "" {
-		return LeafRiskRead
-	}
-	return r
-}
-
-// LeafConstraintKind 是跨 flag 关系约束的类型，取值与 shortcut 框架的
-// ConstraintKind 逐字一致（helpers 不能反向依赖 internal/shortcut——
-// shortcut/builtin 依赖 helpers 会形成环——故本地声明同名语义）。
-type LeafConstraintKind string
+// LeafConstraintKind 是跨 flag 关系约束的类型（cmdcore.ConstraintKind 的
+// 别名）。取值与 shortcut 框架的 ConstraintKind 逐字一致。
+type LeafConstraintKind = cmdcore.ConstraintKind
 
 const (
 	// LeafAtLeastOne 要求 Flags 至少提供一个。
-	LeafAtLeastOne LeafConstraintKind = "at_least_one"
+	LeafAtLeastOne = cmdcore.AtLeastOne
 	// LeafExactlyOne 要求 Flags 必须且只能提供一个。
-	LeafExactlyOne LeafConstraintKind = "exactly_one"
+	LeafExactlyOne = cmdcore.ExactlyOne
 	// LeafMutuallyExclusive 允许 Flags 中最多提供一个。
-	LeafMutuallyExclusive LeafConstraintKind = "mutually_exclusive"
+	LeafMutuallyExclusive = cmdcore.MutuallyExclusive
 )
 
-// LeafConstraint 声明一组 flag 的关系约束。框架在 required 校验之后、
-// Validate 钩子之前统一执行；「是否提供」的判定复用 LeafSpec 的有效值
-// 回退链（显式主 flag → 别名 → env），即只传兼容别名同样视为已提供——
-// 这是 shortcut 裸 Changed 判定所没有的能力。约束同时投影到 Agent
-// Runtime Schema（mutually_exclusive / require_one_of）并渲染进 --help
-// 的「参数约束」段：一次声明，运行时校验、Schema、帮助三处生效。
-type LeafConstraint struct {
-	Kind  LeafConstraintKind
-	Flags []string
-	// Description 非空时替换 --help 中该约束的默认文案。
-	Description string
-}
+// LeafConstraint 声明一组 flag 的关系约束（cmdcore.Constraint 的别名）。框架
+// 在 required 校验之后、Validate 钩子之前统一执行；「是否提供」的判定复用有效
+// 值回退链（显式主 flag → 别名 → env），即只传兼容别名同样视为已提供。约束
+// 同时投影到 Agent Runtime Schema 并渲染进 --help 的「参数约束」段。
+type LeafConstraint = cmdcore.Constraint
 
-// LeafSpec 声明一个 MCP 直连叶子命令。
+// LeafSpec 声明一个 MCP 直连叶子命令。契约字段（Flags/Constraints/Risk）由
+// cmdcore 共享基座统一处理；dispatch 字段（Server/Tool/Call/RunE）与
+// PostMount/Validate 编排逻辑留在 helpers。
 type LeafSpec struct {
 	Use     string
 	Short   string
@@ -155,15 +108,15 @@ type LeafSpec struct {
 	Server string
 	Tool   string
 	Flags  []LeafFlag
-	// Constraints 是跨 flag 的关系约束（至少一个 / 恰好一个 / 互斥），
-	// 框架统一校验并投影到 Runtime Schema 与 --help。复杂的条件式校验
+	// Constraints 是跨 flag 的关系约束（至少一个 / 恰好一个 / 互斥），由
+	// cmdcore 统一校验并投影到 Runtime Schema 与 --help。复杂的条件式校验
 	// 仍放 Validate 钩子。
 	Constraints []LeafConstraint
 
 	// Risk 声明副作用等级，驱动执行前的写确认（对齐 shortcut 框架的
 	// Risk 语义）。默认 LeafRiskRead：只读，从不提示。LeafRiskWrite /
 	// LeafRiskHighWrite 在未加 --yes 且非 --dry-run 时提示确认，用户拒绝
-	// 则中止且不派发。confirmation 语义与 shortcut 的 confirmRisk 逐字一致。
+	// 则中止且不派发。
 	Risk LeafRisk
 
 	// Call 是可插拔派发函数，非空时替代默认的 callMCPTool/callMCPToolOnServer。
@@ -186,7 +139,9 @@ type LeafSpec struct {
 	PostMount func(cmd *cobra.Command)
 }
 
-// NewLeafCommand 按 LeafSpec 构建叶子命令。
+// NewLeafCommand 按 LeafSpec 构建叶子命令：flag 注册、约束声明检查、Schema
+// 投影、帮助渲染、required/约束校验、Risk 写确认、toolArgs 装配全部委托
+// cmdcore；本函数只负责编排顺序与 MCP dispatch（callMCPTool/OnServer/Call）。
 func NewLeafCommand(spec LeafSpec) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     spec.Use,
@@ -194,20 +149,10 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 		Long:    spec.Long,
 		Example: spec.Example,
 	}
-	for _, flag := range spec.Flags {
-		leafRegisterFlag(cmd, flag.Kind, flag.Name, flag.Default, flag.Usage)
-		// 别名按主 flag 的 Kind 注册，否则整型别名的值永远读不到（静默丢弃）。
-		for _, alias := range flag.Aliases {
-			leafRegisterFlag(cmd, flag.Kind, alias, "", flag.Usage+" (alias)")
-			_ = cmd.Flags().MarkHidden(alias)
-		}
-		if flag.MarkRequired {
-			_ = cmd.MarkFlagRequired(flag.Name)
-		}
-	}
-	leafValidateConstraintDecls(spec)
-	leafAnnotateConstraints(cmd, spec)
-	if help := leafConstraintHelp(spec.Constraints); help != "" {
+	cmdcore.RegisterFlags(cmd, spec.Flags)
+	cmdcore.ValidateConstraintDecls(spec.Use, spec.Flags, spec.Constraints)
+	cmdcore.AnnotateConstraints(cmd, spec.Constraints)
+	if help := cmdcore.ConstraintHelp(spec.Constraints); help != "" {
 		cmd.Long = strings.TrimRight(cmd.Long, "\n") + help
 	}
 	if spec.PostMount != nil {
@@ -218,10 +163,10 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 		return cmd
 	}
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if err := leafValidateRequired(cmd, spec); err != nil {
+		if err := cmdcore.ValidateRequired(cmd, spec.Flags); err != nil {
 			return err
 		}
-		if err := leafValidateConstraints(cmd, spec); err != nil {
+		if err := cmdcore.ValidateConstraints(cmd, spec.Flags, spec.Constraints); err != nil {
 			return err
 		}
 		if spec.Validate != nil {
@@ -229,11 +174,11 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 				return err
 			}
 		}
-		toolArgs, err := leafArgs(cmd, spec)
+		toolArgs, err := cmdcore.BuildArgs(cmd, spec.Flags)
 		if err != nil {
 			return err
 		}
-		if !leafConfirmRisk(cmd, spec) {
+		if !cmdcore.ConfirmRisk(cmd, spec.Risk) {
 			return apperrors.NewValidation("用户取消了操作")
 		}
 		if spec.Call != nil {
@@ -245,414 +190,4 @@ func NewLeafCommand(spec LeafSpec) *cobra.Command {
 		return callMCPTool(spec.Tool, toolArgs)
 	}
 	return cmd
-}
-
-// leafRegisterFlag 按 Kind 注册 flag；注册默认值仅 LeafString 使用（其余
-// Kind 的 Default 只作为回退链链尾兜底，与既有 LeafInt 行为一致）。
-func leafRegisterFlag(cmd *cobra.Command, kind LeafFlagKind, name, def, usage string) {
-	switch kind {
-	case LeafInt:
-		cmd.Flags().Int(name, 0, usage)
-	case LeafBool:
-		cmd.Flags().Bool(name, false, usage)
-	case LeafStringSlice:
-		cmd.Flags().StringSlice(name, nil, usage)
-	default:
-		cmd.Flags().String(name, def, usage)
-	}
-}
-
-// leafValidateRequired 复现手写命令的 required 语义：普通 Required 统一报
-// 「missing required flag(s)」；带 EnvVar 的 Required 单独报 RequiredHint。
-// 普通组先于环境变量组校验，保持与手写顺序一致。两组都按声明的
-// 「主 flag → 别名 → env」回退取有效值：只传兼容别名同样视为已提供。
-func leafValidateRequired(cmd *cobra.Command, spec LeafSpec) error {
-	var plain []string
-	for _, flag := range spec.Flags {
-		if flag.Required && flag.EnvVar == "" && flag.RequiredHint == "" && !leafHasEffectiveValue(cmd, flag) {
-			plain = append(plain, flag.Name)
-		}
-	}
-	if err := missingRequiredFlagsError(cmd, plain...); err != nil {
-		return err
-	}
-	for _, flag := range spec.Flags {
-		if !flag.Required || (flag.EnvVar == "" && flag.RequiredHint == "") {
-			continue
-		}
-		if !leafHasEffectiveValue(cmd, flag) {
-			hint := flag.RequiredHint
-			if hint == "" {
-				hint = fmt.Sprintf("flag --%s is required", flag.Name)
-			}
-			return fmt.Errorf("%s", hint)
-		}
-	}
-	return nil
-}
-
-// leafHasEffectiveValue 判定 Required 是否满足，标准与 leafArgs 的入参判定
-// 一致（LeafInt 需非零、字符串需非空、LeafBool 需显式提供、LeafStringSlice
-// 需存在非空元素）：否则会出现校验声称有效、toolArgs 却缺参的分裂。整型解析
-// 失败视为已提供，让 leafArgs 报出更精确的 invalid integer 错误。
-func leafHasEffectiveValue(cmd *cobra.Command, flag LeafFlag) bool {
-	switch flag.Kind {
-	case LeafInt:
-		v, err := leafIntegerValue(cmd, flag)
-		if err != nil {
-			return true
-		}
-		return v != 0
-	case LeafBool:
-		return cmd.Flags().Changed(flag.Name)
-	case LeafStringSlice:
-		return leafSliceValue(cmd, flag) != nil
-	}
-	return leafEffectiveValue(cmd, flag) != ""
-}
-
-// leafSliceValue 按「显式主 flag → 显式别名」顺序取列表 flag 的有效值：
-// 元素统一 TrimSpace 并过滤空串，全空视为未提供（返回 nil）。列表不参与
-// env/Default 回退链。
-func leafSliceValue(cmd *cobra.Command, flag LeafFlag) []string {
-	names := append([]string{flag.Name}, flag.Aliases...)
-	for _, name := range names {
-		if !cmd.Flags().Changed(name) {
-			continue
-		}
-		raw, _ := cmd.Flags().GetStringSlice(name)
-		var out []string
-		for _, value := range raw {
-			if value = strings.TrimSpace(value); value != "" {
-				out = append(out, value)
-			}
-		}
-		if len(out) > 0 {
-			return out
-		}
-	}
-	return nil
-}
-
-// leafArgs 按绑定关系装配 toolArgs。
-func leafArgs(cmd *cobra.Command, spec LeafSpec) (map[string]any, error) {
-	toolArgs := map[string]any{}
-	for _, flag := range spec.Flags {
-		bind := flag.Bind
-		if bind == "" {
-			bind = flag.Name
-		}
-		if flag.Kind == LeafInt {
-			v, err := leafIntegerValue(cmd, flag)
-			if err != nil {
-				return nil, err
-			}
-			// 保持「非零才入参」（putInt 语义）。
-			if v != 0 {
-				toolArgs[bind] = int(v)
-			}
-			continue
-		}
-		if flag.Kind == LeafBool {
-			// Changed 才入参：显式 false 同样下发（对应手写「Changed 才透传」语义）。
-			if cmd.Flags().Changed(flag.Name) {
-				v, _ := cmd.Flags().GetBool(flag.Name)
-				toolArgs[bind] = v
-			}
-			continue
-		}
-		if flag.Kind == LeafStringSlice {
-			if v := leafSliceValue(cmd, flag); v != nil {
-				toolArgs[bind] = v
-			}
-			continue
-		}
-		effective := leafEffectiveValue(cmd, flag)
-		if effective == "" && flag.ArgDefault != "" {
-			effective = flag.ArgDefault
-		}
-		if effective == "" && flag.OmitEmpty {
-			continue
-		}
-		if flag.Transform != nil {
-			value, err := flag.Transform(effective)
-			if err != nil {
-				return nil, err
-			}
-			if value == nil {
-				continue
-			}
-			toolArgs[bind] = value
-			continue
-		}
-		toolArgs[bind] = effective
-	}
-	return toolArgs, nil
-}
-
-// leafEffectiveValue 按「显式主 flag → 别名 → 环境变量 → 注册默认值」顺序取
-// 有效值（字符串形态，整型 flag 统一格式化）；Trim 为 true 时对结果统一
-// TrimSpace。
-func leafEffectiveValue(cmd *cobra.Command, flag LeafFlag) string {
-	v := leafRawValue(cmd, flag)
-	if flag.Trim {
-		v = strings.TrimSpace(v)
-	}
-	return v
-}
-
-// leafRawValue 取未 trim 的原始有效值。主 flag 仅在用户显式提供（Changed）
-// 且非空时命中；注册默认值降级为链尾兜底，不再遮蔽别名与环境变量。Trim 为
-// true 时候选值按 trim 后判空，纯空白与空串同样落入下一级回退。
-func leafRawValue(cmd *cobra.Command, flag LeafFlag) string {
-	usable := func(v string) bool {
-		if flag.Trim {
-			v = strings.TrimSpace(v)
-		}
-		return v != ""
-	}
-	if cmd.Flags().Changed(flag.Name) {
-		if v := leafFlagString(cmd, flag.Kind, flag.Name); usable(v) {
-			return v
-		}
-	}
-	for _, alias := range flag.Aliases {
-		if !cmd.Flags().Changed(alias) {
-			continue
-		}
-		if v := leafFlagString(cmd, flag.Kind, alias); usable(v) {
-			return v
-		}
-	}
-	if flag.EnvVar != "" {
-		if v := os.Getenv(flag.EnvVar); usable(v) {
-			return v
-		}
-	}
-	return flag.Default
-}
-
-// leafFlagString 按注册类型读取 flag 并统一为字符串形态，使整型 flag 能复用
-// 同一条回退链（required 校验、别名、env）。
-func leafFlagString(cmd *cobra.Command, kind LeafFlagKind, name string) string {
-	switch kind {
-	case LeafInt:
-		v, _ := cmd.Flags().GetInt(name)
-		return strconv.Itoa(v)
-	default:
-		return mustGetFlag(cmd, name)
-	}
-}
-
-// leafIntegerValue 按回退链取整型 flag 的有效值；环境变量提供的字符串必须
-// 可解析，否则报错而非静默丢弃。
-func leafIntegerValue(cmd *cobra.Command, flag LeafFlag) (int64, error) {
-	raw := leafEffectiveValue(cmd, flag)
-	if raw == "" {
-		return 0, nil
-	}
-	v, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("flag --%s: invalid integer value %q", flag.Name, raw)
-	}
-	return v, nil
-}
-
-// leafValidateConstraintDecls 在构建期校验约束声明：未知类型、空 flag 组或
-// 引用未声明 flag 都是编程错误，直接 panic 让任何测试/启动路径第一时间失败，
-// 而不是等到用户命中运行时才暴露。
-func leafValidateConstraintDecls(spec LeafSpec) {
-	declared := map[string]bool{}
-	for _, flag := range spec.Flags {
-		declared[flag.Name] = true
-	}
-	for _, constraint := range spec.Constraints {
-		switch constraint.Kind {
-		case LeafAtLeastOne, LeafExactlyOne, LeafMutuallyExclusive:
-		default:
-			panic(fmt.Sprintf("leaf %q: unknown constraint kind %q", spec.Use, constraint.Kind))
-		}
-		if len(constraint.Flags) < 2 {
-			panic(fmt.Sprintf("leaf %q: constraint %s needs at least two flags", spec.Use, constraint.Kind))
-		}
-		for _, name := range constraint.Flags {
-			if !declared[name] {
-				panic(fmt.Sprintf("leaf %q: constraint %s references undeclared flag %q", spec.Use, constraint.Kind, name))
-			}
-		}
-	}
-}
-
-// leafConstraintProvided 判定约束语义下 flag 是否「已提供」：显式主 flag、
-// 显式别名或环境变量任一命中即视为提供；注册默认值/ArgDefault 不算——否则
-// 带默认值的 flag 会恒满足 at_least_one 并恒触发 mutually_exclusive。
-// LeafBool 只认 Changed（布尔无别名/env 回退语义）。
-func leafConstraintProvided(cmd *cobra.Command, flag LeafFlag) bool {
-	switch flag.Kind {
-	case LeafBool:
-		return cmd.Flags().Changed(flag.Name)
-	case LeafStringSlice:
-		if cmd.Flags().Changed(flag.Name) {
-			if v, _ := cmd.Flags().GetStringSlice(flag.Name); leafSliceHasValue(v) {
-				return true
-			}
-		}
-		for _, alias := range flag.Aliases {
-			if !cmd.Flags().Changed(alias) {
-				continue
-			}
-			if v, _ := cmd.Flags().GetStringSlice(alias); leafSliceHasValue(v) {
-				return true
-			}
-		}
-		return false
-	}
-	usable := func(v string) bool { return strings.TrimSpace(v) != "" }
-	if cmd.Flags().Changed(flag.Name) && usable(leafFlagString(cmd, flag.Kind, flag.Name)) {
-		return true
-	}
-	for _, alias := range flag.Aliases {
-		if cmd.Flags().Changed(alias) && usable(leafFlagString(cmd, flag.Kind, alias)) {
-			return true
-		}
-	}
-	return flag.EnvVar != "" && usable(os.Getenv(flag.EnvVar))
-}
-
-// leafValidateConstraints 执行关系约束。报错文案与 shortcut 框架的
-// RuntimeContext.AtLeastOne/ExactlyOne/MutuallyExclusive 逐字一致，保证
-// atomic command 与 smart shortcut 面向用户/Agent 的失败形态统一。
-func leafValidateConstraints(cmd *cobra.Command, spec LeafSpec) error {
-	flagsByName := map[string]LeafFlag{}
-	for _, flag := range spec.Flags {
-		flagsByName[flag.Name] = flag
-	}
-	for _, constraint := range spec.Constraints {
-		var set []string
-		for _, name := range constraint.Flags {
-			if leafConstraintProvided(cmd, flagsByName[name]) {
-				set = append(set, name)
-			}
-		}
-		switch constraint.Kind {
-		case LeafAtLeastOne:
-			if len(set) == 0 {
-				return apperrors.NewValidation(fmt.Sprintf(
-					"请至少指定 %s 之一", leafDashed(constraint.Flags)))
-			}
-		case LeafExactlyOne:
-			switch len(set) {
-			case 1:
-			case 0:
-				return apperrors.NewValidation(fmt.Sprintf("请指定 %s 之一", leafDashed(constraint.Flags)))
-			default:
-				return apperrors.NewValidation(fmt.Sprintf(
-					"参数 %s 只能指定其一（当前指定了 %s）", leafDashed(constraint.Flags), leafDashed(set)))
-			}
-		case LeafMutuallyExclusive:
-			if len(set) > 1 {
-				return apperrors.NewValidation(fmt.Sprintf(
-					"参数 %s 互斥，只能指定其一（当前指定了 %s）", leafDashed(constraint.Flags), leafDashed(set)))
-			}
-		}
-	}
-	return nil
-}
-
-// leafConfirmRisk 复现 shortcut 框架 confirmRisk 的写确认语义：只读、
-// --dry-run 或 --yes 直接放行；写/高危操作在交互态提示确认，用户拒绝返回
-// false。提示文案与 shortcut 逐字一致（以命令路径替代 shortcut 的
-// Service+Command），保证 atomic command 与 smart shortcut 的确认体验统一。
-func leafConfirmRisk(cmd *cobra.Command, spec LeafSpec) bool {
-	if spec.Risk.effective() == LeafRiskRead || commandDryRun(cmd) || leafYesFlag(cmd) {
-		return true
-	}
-	output := cmd.ErrOrStderr()
-	fmt.Fprintf(output, "即将执行 %s（%s），确认继续？(yes/no): ", cmd.CommandPath(), spec.Risk.effective())
-	reader := bufio.NewReader(cmd.InOrStdin())
-	answer, _ := reader.ReadString('\n')
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	return answer == "yes" || answer == "y"
-}
-
-// leafYesFlag 稳健读取 --yes：依次尝试本命令、继承 flag、根持久 flag，
-// 兼容根注入的全局 --yes。
-func leafYesFlag(cmd *cobra.Command) bool {
-	if cmd == nil {
-		return false
-	}
-	getters := []func(string) (bool, error){
-		cmd.Flags().GetBool,
-		cmd.InheritedFlags().GetBool,
-	}
-	if root := cmd.Root(); root != nil {
-		getters = append(getters, root.PersistentFlags().GetBool)
-	}
-	for _, get := range getters {
-		if v, err := get("yes"); err == nil {
-			return v
-		}
-	}
-	return false
-}
-
-// leafAnnotateConstraints 把关系约束投影到 Agent Runtime Schema：
-// exactly_one 分解为 require_one_of + mutually_exclusive（与手写命令对
-// AnnotateRuntimeConstraints 的既有用法一致）。
-func leafAnnotateConstraints(cmd *cobra.Command, spec LeafSpec) {
-	var projected cli.RuntimeSchemaConstraints
-	for _, constraint := range spec.Constraints {
-		flags := append([]string(nil), constraint.Flags...)
-		switch constraint.Kind {
-		case LeafAtLeastOne:
-			projected.RequireOneOf = append(projected.RequireOneOf, flags)
-		case LeafExactlyOne:
-			projected.RequireOneOf = append(projected.RequireOneOf, flags)
-			projected.MutuallyExclusive = append(projected.MutuallyExclusive, flags)
-		case LeafMutuallyExclusive:
-			projected.MutuallyExclusive = append(projected.MutuallyExclusive, flags)
-		}
-	}
-	cli.AnnotateRuntimeConstraints(cmd, projected)
-}
-
-// leafConstraintHelp 渲染 --help 的「参数约束」段，形态与 shortcut 叶子
-// 帮助一致；无约束时返回空串。
-func leafConstraintHelp(constraints []LeafConstraint) string {
-	if len(constraints) == 0 {
-		return ""
-	}
-	lines := make([]string, 0, len(constraints))
-	for _, constraint := range constraints {
-		text := strings.TrimSpace(constraint.Description)
-		if text == "" {
-			switch constraint.Kind {
-			case LeafAtLeastOne:
-				text = fmt.Sprintf("%s 至少指定一个", leafDashed(constraint.Flags))
-			case LeafExactlyOne:
-				text = fmt.Sprintf("%s 必须且只能指定一个", leafDashed(constraint.Flags))
-			case LeafMutuallyExclusive:
-				text = fmt.Sprintf("%s 互斥，最多指定一个", leafDashed(constraint.Flags))
-			}
-		}
-		lines = append(lines, "  - "+text)
-	}
-	return "\n\n参数约束：\n" + strings.Join(lines, "\n")
-}
-
-func leafDashed(flags []string) string {
-	out := make([]string, len(flags))
-	for i, f := range flags {
-		out[i] = "--" + f
-	}
-	return strings.Join(out, "、")
-}
-
-func leafSliceHasValue(values []string) bool {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/helpers/leaf_constraints_test.go
+++ b/internal/helpers/leaf_constraints_test.go
@@ -1,0 +1,478 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func leafConstraintTestSpec(captured *map[string]any) LeafSpec {
+	return LeafSpec{
+		Use:   "route",
+		Short: "路由",
+		Tool:  "route_thing",
+		Flags: []LeafFlag{
+			{Name: "group", Usage: "群 ID", Aliases: []string{"chat"}},
+			{Name: "user", Usage: "用户 ID", EnvVar: "DWS_LEAF_CONSTRAINT_TEST_USER"},
+			{Name: "channel", Usage: "频道", Default: "main"},
+			{Name: "verbose", Usage: "详细输出", Kind: LeafBool, Bind: "verboseOutput"},
+			{Name: "tags", Usage: "标签列表", Kind: LeafStringSlice, Aliases: []string{"labels"}, Bind: "tagList"},
+		},
+		Constraints: []LeafConstraint{
+			{Kind: LeafExactlyOne, Flags: []string{"group", "user"}},
+			{Kind: LeafMutuallyExclusive, Flags: []string{"verbose", "tags"}},
+		},
+		Call: func(_ *cobra.Command, _ string, args map[string]any) error {
+			*captured = args
+			return nil
+		},
+	}
+}
+
+func leafConstraintExecute(t *testing.T, args ...string) (map[string]any, error) {
+	t.Helper()
+	var captured map[string]any
+	cmd := NewLeafCommand(leafConstraintTestSpec(&captured))
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return captured, err
+}
+
+func TestCrossPlatformCoverageLeafConstraintExactlyOne(t *testing.T) {
+	if _, err := leafConstraintExecute(t); err == nil ||
+		!strings.Contains(err.Error(), "请指定 --group、--user 之一") {
+		t.Fatalf("zero provided err = %v", err)
+	}
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--user", "u1"); err == nil ||
+		!strings.Contains(err.Error(), "参数 --group、--user 只能指定其一（当前指定了 --group、--user）") {
+		t.Fatalf("both provided err = %v", err)
+	}
+	if _, err := leafConstraintExecute(t, "--group", "g1"); err != nil {
+		t.Fatalf("exactly one err = %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintAliasAndEnvCountAsProvided(t *testing.T) {
+	// 隐藏别名 --chat 命中 group：满足 exactly_one。
+	if _, err := leafConstraintExecute(t, "--chat", "g1"); err != nil {
+		t.Fatalf("alias provided err = %v", err)
+	}
+	// 环境变量命中 user：同样满足。
+	t.Setenv("DWS_LEAF_CONSTRAINT_TEST_USER", "u-env")
+	if _, err := leafConstraintExecute(t); err != nil {
+		t.Fatalf("env provided err = %v", err)
+	}
+	// env 提供 user + 显式 group：应触发 exactly_one 冲突。
+	if _, err := leafConstraintExecute(t, "--group", "g1"); err == nil ||
+		!strings.Contains(err.Error(), "只能指定其一") {
+		t.Fatalf("env + explicit err = %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintDefaultNotCounted(t *testing.T) {
+	// channel 有注册默认值 "main"，但未显式提供时不得参与约束判定：
+	// 用仅含 at_least_one(channel, group) 的 spec 验证默认值不算提供。
+	var captured map[string]any
+	spec := LeafSpec{
+		Use:  "pick",
+		Tool: "pick_thing",
+		Flags: []LeafFlag{
+			{Name: "channel", Usage: "频道", Default: "main"},
+			{Name: "group", Usage: "群 ID"},
+		},
+		Constraints: []LeafConstraint{
+			{Kind: LeafAtLeastOne, Flags: []string{"channel", "group"}},
+		},
+		Call: func(_ *cobra.Command, _ string, args map[string]any) error {
+			captured = args
+			return nil
+		},
+	}
+	cmd := NewLeafCommand(spec)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(nil)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "请至少指定 --channel、--group 之一") {
+		t.Fatalf("default counted as provided: err = %v, captured = %#v", err, captured)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintMutuallyExclusive(t *testing.T) {
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--verbose", "--tags", "a,b"); err == nil ||
+		!strings.Contains(err.Error(), "参数 --verbose、--tags 互斥，只能指定其一（当前指定了 --verbose、--tags）") {
+		t.Fatalf("mutually exclusive err = %v", err)
+	}
+	// 各自单独提供均合法。
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--verbose"); err != nil {
+		t.Fatalf("verbose alone err = %v", err)
+	}
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--tags", "a"); err != nil {
+		t.Fatalf("tags alone err = %v", err)
+	}
+	// 空白元素的列表视为未提供，不触发互斥。
+	if _, err := leafConstraintExecute(t, "--group", "g1", "--verbose", "--tags", " "); err != nil {
+		t.Fatalf("blank slice counted as provided: err = %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageLeafBoolAndSliceArgs(t *testing.T) {
+	captured, err := leafConstraintExecute(t, "--group", "g1", "--verbose=false")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured["verboseOutput"] != false {
+		t.Fatalf("explicit false not delivered: %#v", captured)
+	}
+
+	captured, err = leafConstraintExecute(t, "--group", "g1", "--tags", "a, ,b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(captured["tagList"], []string{"a", "b"}) {
+		t.Fatalf("tagList = %#v, want trimmed non-empty elements", captured["tagList"])
+	}
+	if _, ok := captured["verboseOutput"]; ok {
+		t.Fatalf("unchanged bool leaked into args: %#v", captured)
+	}
+
+	// 别名 --labels 提供列表同样入参。
+	captured, err = leafConstraintExecute(t, "--group", "g1", "--labels", "x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(captured["tagList"], []string{"x"}) {
+		t.Fatalf("alias slice = %#v", captured["tagList"])
+	}
+}
+
+func TestCrossPlatformCoverageLeafBoolSliceRequired(t *testing.T) {
+	var captured map[string]any
+	spec := LeafSpec{
+		Use:  "need",
+		Tool: "need_thing",
+		Flags: []LeafFlag{
+			{Name: "confirm", Usage: "确认", Kind: LeafBool, Required: true},
+			{Name: "ids", Usage: "ID 列表", Kind: LeafStringSlice, Required: true},
+		},
+		Call: func(_ *cobra.Command, _ string, args map[string]any) error {
+			captured = args
+			return nil
+		},
+	}
+	run := func(args ...string) error {
+		cmd := NewLeafCommand(spec)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs(args)
+		return cmd.Execute()
+	}
+	if err := run("--ids", "a"); err == nil || !strings.Contains(err.Error(), "confirm") {
+		t.Fatalf("missing bool err = %v", err)
+	}
+	if err := run("--confirm", "--ids", " "); err == nil || !strings.Contains(err.Error(), "ids") {
+		t.Fatalf("blank slice err = %v", err)
+	}
+	if err := run("--confirm=false", "--ids", "a"); err != nil {
+		t.Fatalf("explicit false should satisfy required: %v", err)
+	}
+	if captured["confirm"] != false || !reflect.DeepEqual(captured["ids"], []string{"a"}) {
+		t.Fatalf("captured = %#v", captured)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintSchemaAndHelp(t *testing.T) {
+	var captured map[string]any
+	cmd := NewLeafCommand(leafConstraintTestSpec(&captured))
+	encoded := cmd.Annotations["dws.schema.constraints"]
+	if !strings.Contains(encoded, `"require_one_of":[["group","user"]]`) {
+		t.Fatalf("schema constraints missing require_one_of: %s", encoded)
+	}
+	if !strings.Contains(encoded, `["group","user"]`) || !strings.Contains(encoded, `["verbose","tags"]`) {
+		t.Fatalf("schema constraints incomplete: %s", encoded)
+	}
+	if !strings.Contains(cmd.Long, "参数约束：") ||
+		!strings.Contains(cmd.Long, "--group、--user 必须且只能指定一个") ||
+		!strings.Contains(cmd.Long, "--verbose、--tags 互斥，最多指定一个") {
+		t.Fatalf("constraint help missing: %q", cmd.Long)
+	}
+
+	withDesc := LeafSpec{
+		Use:  "desc",
+		Tool: "desc_thing",
+		Flags: []LeafFlag{
+			{Name: "a", Usage: "A"},
+			{Name: "b", Usage: "B"},
+		},
+		Constraints: []LeafConstraint{
+			{Kind: LeafAtLeastOne, Flags: []string{"a", "b"}, Description: "自定义文案"},
+		},
+	}
+	if long := NewLeafCommand(withDesc).Long; !strings.Contains(long, "  - 自定义文案") {
+		t.Fatalf("custom description missing: %q", long)
+	}
+	atLeast := LeafSpec{
+		Use:  "least",
+		Tool: "least_thing",
+		Flags: []LeafFlag{
+			{Name: "a", Usage: "A"},
+			{Name: "b", Usage: "B"},
+		},
+		Constraints: []LeafConstraint{{Kind: LeafAtLeastOne, Flags: []string{"a", "b"}}},
+	}
+	if long := NewLeafCommand(atLeast).Long; !strings.Contains(long, "--a、--b 至少指定一个") {
+		t.Fatalf("at_least_one help missing: %q", long)
+	}
+}
+
+func TestCrossPlatformCoverageLeafConstraintDeclPanics(t *testing.T) {
+	mustPanic := func(name string, spec LeafSpec, needle string) {
+		t.Helper()
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatalf("%s: expected panic", name)
+			}
+			if msg, _ := r.(string); !strings.Contains(msg, needle) {
+				t.Fatalf("%s: panic = %v, want %q", name, r, needle)
+			}
+		}()
+		NewLeafCommand(spec)
+	}
+	base := []LeafFlag{{Name: "a", Usage: "A"}, {Name: "b", Usage: "B"}}
+	mustPanic("unknown kind", LeafSpec{
+		Use: "x", Tool: "t", Flags: base,
+		Constraints: []LeafConstraint{{Kind: "bogus", Flags: []string{"a", "b"}}},
+	}, "unknown constraint kind")
+	mustPanic("too few flags", LeafSpec{
+		Use: "x", Tool: "t", Flags: base,
+		Constraints: []LeafConstraint{{Kind: LeafExactlyOne, Flags: []string{"a"}}},
+	}, "needs at least two flags")
+	mustPanic("undeclared flag", LeafSpec{
+		Use: "x", Tool: "t", Flags: base,
+		Constraints: []LeafConstraint{{Kind: LeafExactlyOne, Flags: []string{"a", "missing"}}},
+	}, "references undeclared flag")
+}
+
+func TestCrossPlatformCoverageLeafConstraintRunsBeforeValidateHook(t *testing.T) {
+	hookRan := false
+	spec := LeafSpec{
+		Use:  "order",
+		Tool: "order_thing",
+		Flags: []LeafFlag{
+			{Name: "a", Usage: "A"},
+			{Name: "b", Usage: "B"},
+		},
+		Constraints: []LeafConstraint{{Kind: LeafExactlyOne, Flags: []string{"a", "b"}}},
+		Validate: func(*cobra.Command, []string) error {
+			hookRan = true
+			return nil
+		},
+		Call: func(*cobra.Command, string, map[string]any) error { return nil },
+	}
+	cmd := NewLeafCommand(spec)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("constraint should fail before Validate")
+	}
+	if hookRan {
+		t.Fatal("Validate hook ran despite constraint failure")
+	}
+}
+
+// TestCrossPlatformCoverageLeafSpecCorePaths exercises the LeafSpec paths that
+// the framework shares between constrained and unconstrained leaves
+// (MarkRequired, RunE escape hatch, Server routing, LeafInt assembly, Transform
+// and EnvVar-backed required hints). leaf_test.go asserts the same behaviour but
+// its names sit outside the platform coverage runner's filter.
+func TestCrossPlatformCoverageLeafSpecCorePaths(t *testing.T) {
+	markRequired := NewLeafCommand(LeafSpec{
+		Use:   "mark",
+		Tool:  "mark_thing",
+		Flags: []LeafFlag{{Name: "id", Usage: "ID", MarkRequired: true}},
+	})
+	if ann := markRequired.Flags().Lookup("id").Annotations[cobra.BashCompOneRequiredFlag]; len(ann) == 0 {
+		t.Fatal("MarkRequired did not reach cobra")
+	}
+
+	escaped := false
+	escape := NewLeafCommand(LeafSpec{
+		Use:  "escape",
+		Tool: "escape_thing",
+		RunE: func(*cobra.Command, []string) error {
+			escaped = true
+			return nil
+		},
+	})
+	escape.SetArgs(nil)
+	if err := escape.Execute(); err != nil || !escaped {
+		t.Fatalf("RunE escape hatch not used: err = %v", err)
+	}
+
+	caller := &guardedMutationCaller{}
+	serverRouted := func() error {
+		previous := deps
+		t.Cleanup(func() { deps = previous })
+		InitDeps(caller)
+		deps.Out.w = io.Discard
+		cmd := NewLeafCommand(LeafSpec{
+			Use:    "route-server",
+			Tool:   "route_tool",
+			Server: "im",
+			Flags: []LeafFlag{
+				{Name: "count", Usage: "数量", Kind: LeafInt, Bind: "count"},
+				{Name: "scope", Usage: "范围", ArgDefault: "ALL", Bind: "scope"},
+				{Name: "note", Usage: "备注", OmitEmpty: true},
+			},
+		})
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"--count", "3"})
+		return cmd.Execute()
+	}
+	if err := serverRouted(); err != nil {
+		t.Fatalf("server routing err = %v", err)
+	}
+	if len(caller.calls) != 1 || caller.calls[0].productID != "im" || caller.calls[0].toolName != "route_tool" {
+		t.Fatalf("server routing call = %#v", caller.calls)
+	}
+	if caller.calls[0].args["count"] != 3 || caller.calls[0].args["scope"] != "ALL" {
+		t.Fatalf("server routing args = %#v", caller.calls[0].args)
+	}
+	if _, ok := caller.calls[0].args["note"]; ok {
+		t.Fatalf("OmitEmpty flag leaked: %#v", caller.calls[0].args)
+	}
+
+	intSpec := LeafSpec{
+		Use:   "count",
+		Tool:  "count_thing",
+		Flags: []LeafFlag{{Name: "n", Usage: "N", Kind: LeafInt, EnvVar: "DWS_LEAF_CORE_TEST_N"}},
+		Call:  func(*cobra.Command, string, map[string]any) error { return nil },
+	}
+	t.Setenv("DWS_LEAF_CORE_TEST_N", "not-a-number")
+	badInt := NewLeafCommand(intSpec)
+	badInt.SilenceErrors = true
+	badInt.SilenceUsage = true
+	badInt.SetArgs(nil)
+	if err := badInt.Execute(); err == nil || !strings.Contains(err.Error(), "invalid integer value") {
+		t.Fatalf("invalid env integer err = %v", err)
+	}
+
+	transformFail := NewLeafCommand(LeafSpec{
+		Use:  "transform",
+		Tool: "transform_thing",
+		Flags: []LeafFlag{{Name: "raw", Usage: "RAW", Transform: func(string) (any, error) {
+			return nil, errTransformTest
+		}}},
+		Call: func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	transformFail.SilenceErrors = true
+	transformFail.SilenceUsage = true
+	transformFail.SetArgs([]string{"--raw", "x"})
+	if err := transformFail.Execute(); err == nil || !strings.Contains(err.Error(), "transform failed") {
+		t.Fatalf("transform error not surfaced: %v", err)
+	}
+
+	hinted := NewLeafCommand(LeafSpec{
+		Use:  "hint",
+		Tool: "hint_thing",
+		Flags: []LeafFlag{{
+			Name: "token", Usage: "令牌", Required: true,
+			EnvVar: "DWS_LEAF_CORE_TEST_TOKEN", RequiredHint: "flag --token is required (or set DWS_LEAF_CORE_TEST_TOKEN)",
+		}},
+		Call: func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	hinted.SilenceErrors = true
+	hinted.SilenceUsage = true
+	hinted.SetArgs(nil)
+	if err := hinted.Execute(); err == nil || !strings.Contains(err.Error(), "DWS_LEAF_CORE_TEST_TOKEN") {
+		t.Fatalf("required hint err = %v", err)
+	}
+
+	// 默认 product 路由（无 Server）+ LeafInt Required（走 leafHasEffectiveValue
+	// 的 LeafInt 分支）+ Transform 返回 (nil,nil) 跳过键。
+	defaultRouted := func() error {
+		previous := deps
+		t.Cleanup(func() { deps = previous })
+		oldArgs := os.Args
+		os.Args = []string{"dws", "chat"}
+		t.Cleanup(func() { os.Args = oldArgs })
+		InitDeps(caller)
+		deps.Out.w = io.Discard
+		caller.calls = nil
+		cmd := NewLeafCommand(LeafSpec{
+			Use:  "default-route",
+			Tool: "im_default_tool",
+			Flags: []LeafFlag{
+				{Name: "n", Usage: "N", Kind: LeafInt, Required: true, Bind: "n"},
+				{Name: "opt", Usage: "OPT", Transform: func(string) (any, error) { return nil, nil }},
+			},
+		})
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{"--n", "5", "--opt", "ignored"})
+		return cmd.Execute()
+	}
+	if err := defaultRouted(); err != nil {
+		t.Fatalf("default route err = %v", err)
+	}
+	if len(caller.calls) != 1 {
+		t.Fatalf("default route call = %#v", caller.calls)
+	}
+	if caller.calls[0].args["n"] != 5 {
+		t.Fatalf("int required arg = %#v", caller.calls[0].args)
+	}
+	if _, ok := caller.calls[0].args["opt"]; ok {
+		t.Fatalf("Transform nil should skip key: %#v", caller.calls[0].args)
+	}
+	// LeafInt Required 缺失（值为 0）应报缺参。
+	missingInt := NewLeafCommand(LeafSpec{
+		Use:   "need-int",
+		Tool:  "need_int_tool",
+		Flags: []LeafFlag{{Name: "n", Usage: "N", Kind: LeafInt, Required: true}},
+		Call:  func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	missingInt.SilenceErrors = true
+	missingInt.SilenceUsage = true
+	missingInt.SetArgs(nil)
+	if err := missingInt.Execute(); err == nil || !strings.Contains(err.Error(), "n") {
+		t.Fatalf("missing int required err = %v", err)
+	}
+	// 带 EnvVar 但 RequiredHint 为空：走默认 'flag --x is required' 文案。
+	envDefaultHint := NewLeafCommand(LeafSpec{
+		Use:   "env-default-hint",
+		Tool:  "env_hint_tool",
+		Flags: []LeafFlag{{Name: "key", Usage: "KEY", Required: true, EnvVar: "DWS_LEAF_CORE_TEST_MISSING"}},
+		Call:  func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	envDefaultHint.SilenceErrors = true
+	envDefaultHint.SilenceUsage = true
+	envDefaultHint.SetArgs(nil)
+	if err := envDefaultHint.Execute(); err == nil || !strings.Contains(err.Error(), "flag --key is required") {
+		t.Fatalf("env default hint err = %v", err)
+	}
+}
+
+var errTransformTest = errors.New("transform failed")

--- a/internal/helpers/leaf_constraints_test.go
+++ b/internal/helpers/leaf_constraints_test.go
@@ -476,3 +476,111 @@ func TestCrossPlatformCoverageLeafSpecCorePaths(t *testing.T) {
 }
 
 var errTransformTest = errors.New("transform failed")
+
+func leafRiskSpec(risk LeafRisk, called *bool) LeafSpec {
+	return LeafSpec{
+		Use:   "danger",
+		Short: "危险",
+		Tool:  "danger_thing",
+		Risk:  risk,
+		Flags: []LeafFlag{{Name: "id", Usage: "ID"}},
+		Call: func(*cobra.Command, string, map[string]any) error {
+			*called = true
+			return nil
+		},
+	}
+}
+
+func leafRiskRun(t *testing.T, risk LeafRisk, stdin string, args ...string) (bool, error) {
+	t.Helper()
+	called := false
+	cmd := NewLeafCommand(leafRiskSpec(risk, &called))
+	// 注入根级 --yes/--dry-run 持久 flag，模拟真实根命令。
+	cmd.PersistentFlags().Bool("yes", false, "")
+	cmd.PersistentFlags().Bool("dry-run", false, "")
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	if stdin != "" {
+		cmd.SetIn(strings.NewReader(stdin))
+	}
+	cmd.SetArgs(args)
+	return called, cmd.Execute()
+}
+
+func TestCrossPlatformCoverageLeafRiskReadNeverPrompts(t *testing.T) {
+	// 只读：无 stdin 也直接派发。
+	if called, err := leafRiskRun(t, LeafRiskRead, "", "--id", "x"); err != nil || !called {
+		t.Fatalf("read risk err = %v called = %v", err, called)
+	}
+	// 空 Risk 等价只读。
+	if called, err := leafRiskRun(t, "", "", "--id", "x"); err != nil || !called {
+		t.Fatalf("empty risk err = %v called = %v", err, called)
+	}
+}
+
+func TestCrossPlatformCoverageLeafRiskWriteConfirmation(t *testing.T) {
+	// 拒绝：不派发，返回取消错误。
+	called, err := leafRiskRun(t, LeafRiskWrite, "no\n", "--id", "x")
+	if called {
+		t.Fatal("declined write should not dispatch")
+	}
+	if err == nil || !strings.Contains(err.Error(), "用户取消了操作") {
+		t.Fatalf("declined write err = %v", err)
+	}
+	// 同意：派发。
+	if called, err := leafRiskRun(t, LeafRiskWrite, "yes\n", "--id", "x"); err != nil || !called {
+		t.Fatalf("confirmed write err = %v called = %v", err, called)
+	}
+	// 高危同样走确认链。
+	if called, err := leafRiskRun(t, LeafRiskHighWrite, "y\n", "--id", "x"); err != nil || !called {
+		t.Fatalf("confirmed high-write err = %v called = %v", err, called)
+	}
+}
+
+func TestCrossPlatformCoverageLeafRiskYesAndDryRunBypass(t *testing.T) {
+	// --yes 跳过提示直接派发（无 stdin）。
+	if called, err := leafRiskRun(t, LeafRiskHighWrite, "", "--id", "x", "--yes"); err != nil || !called {
+		t.Fatalf("--yes bypass err = %v called = %v", err, called)
+	}
+	// --dry-run 跳过提示直接派发（无 stdin）。
+	if called, err := leafRiskRun(t, LeafRiskWrite, "", "--id", "x", "--dry-run"); err != nil || !called {
+		t.Fatalf("--dry-run bypass err = %v called = %v", err, called)
+	}
+}
+
+func TestCrossPlatformCoverageLeafYesFlagAndIntEdges(t *testing.T) {
+	if leafYesFlag(nil) {
+		t.Fatal("nil cmd should not report --yes")
+	}
+
+	// Required LeafInt 的 env 值不可解析：leafHasEffectiveValue 视为已提供
+	// （err→true 分支），required 通过后由 leafArgs 报 invalid integer。
+	t.Setenv("DWS_LEAF_INT_EDGE", "not-an-int")
+	badInt := NewLeafCommand(LeafSpec{
+		Use:   "int-edge",
+		Tool:  "int_edge_tool",
+		Flags: []LeafFlag{{Name: "n", Usage: "N", Kind: LeafInt, Required: true, EnvVar: "DWS_LEAF_INT_EDGE"}},
+		Call:  func(*cobra.Command, string, map[string]any) error { return nil },
+	})
+	badInt.SilenceErrors = true
+	badInt.SilenceUsage = true
+	badInt.SetArgs(nil)
+	if err := badInt.Execute(); err == nil || !strings.Contains(err.Error(), "invalid integer value") {
+		t.Fatalf("unparseable int env err = %v", err)
+	}
+
+	// 写风险但全局无 --yes flag 注册：leafYesFlag 各 getter 均报错走兜底 false，
+	// 于是进入提示；stdin "no" 取消。
+	called := false
+	noYes := NewLeafCommand(leafRiskSpec(LeafRiskWrite, &called))
+	noYes.SilenceErrors = true
+	noYes.SilenceUsage = true
+	noYes.SetIn(strings.NewReader("no\n"))
+	noYes.SetArgs([]string{"--id", "x"})
+	if err := noYes.Execute(); err == nil || !strings.Contains(err.Error(), "用户取消了操作") {
+		t.Fatalf("no-yes-flag cancel err = %v", err)
+	}
+	if called {
+		t.Fatal("declined write dispatched despite no --yes flag")
+	}
+}

--- a/internal/helpers/leaf_constraints_test.go
+++ b/internal/helpers/leaf_constraints_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cmdcore"
 )
 
 func leafConstraintTestSpec(captured *map[string]any) LeafSpec {
@@ -549,7 +551,7 @@ func TestCrossPlatformCoverageLeafRiskYesAndDryRunBypass(t *testing.T) {
 }
 
 func TestCrossPlatformCoverageLeafYesFlagAndIntEdges(t *testing.T) {
-	if leafYesFlag(nil) {
+	if cmdcore.BoolFlag(nil, "yes") {
 		t.Fatal("nil cmd should not report --yes")
 	}
 

--- a/internal/helpers/leaf_dispatch_test.go
+++ b/internal/helpers/leaf_dispatch_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cmdcore"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
 
@@ -111,7 +112,7 @@ func TestLeafValidateRequiredEnvDefaultHint(t *testing.T) {
 		Flags: []LeafFlag{{Name: "token", Usage: "令牌", Required: true, EnvVar: "DWS_LEAF_TEST_HINTLESS"}},
 	}
 	cmd := NewLeafCommand(spec)
-	err := leafValidateRequired(cmd, spec)
+	err := cmdcore.ValidateRequired(cmd, spec.Flags)
 	if err == nil || err.Error() != "flag --token is required" {
 		t.Fatalf("leafValidateRequired() = %v, want default hint", err)
 	}
@@ -130,10 +131,10 @@ func TestLeafIntRequiredAcceptsExplicitValue(t *testing.T) {
 	if err := cmd.Flags().Set("n", "5"); err != nil {
 		t.Fatal(err)
 	}
-	if err := leafValidateRequired(cmd, spec); err != nil {
+	if err := cmdcore.ValidateRequired(cmd, spec.Flags); err != nil {
 		t.Fatalf("leafValidateRequired() = %v, want nil for --n 5", err)
 	}
-	args, err := leafArgs(cmd, spec)
+	args, err := cmdcore.BuildArgs(cmd, spec.Flags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +143,7 @@ func TestLeafIntRequiredAcceptsExplicitValue(t *testing.T) {
 	}
 	// 未提供值时仍按主 flag 名报缺失。
 	missing := NewLeafCommand(spec)
-	if err := leafValidateRequired(missing, spec); err == nil || !strings.Contains(err.Error(), "missing required flag(s): --n") {
+	if err := cmdcore.ValidateRequired(missing, spec.Flags); err == nil || !strings.Contains(err.Error(), "missing required flag(s): --n") {
 		t.Fatalf("leafValidateRequired() = %v, want missing --n", err)
 	}
 }
@@ -159,7 +160,7 @@ func TestLeafIntAliasAndEnvFallback(t *testing.T) {
 	if err := cmd.Flags().Set("limit", "7"); err != nil {
 		t.Fatal(err)
 	}
-	args, err := leafArgs(cmd, spec)
+	args, err := cmdcore.BuildArgs(cmd, spec.Flags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +170,7 @@ func TestLeafIntAliasAndEnvFallback(t *testing.T) {
 	// env 提供值。
 	t.Setenv("DWS_LEAF_TEST_PAGE_SIZE", "9")
 	cmd = NewLeafCommand(spec)
-	args, err = leafArgs(cmd, spec)
+	args, err = cmdcore.BuildArgs(cmd, spec.Flags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +180,7 @@ func TestLeafIntAliasAndEnvFallback(t *testing.T) {
 	// env 值不可解析必须报错而非静默丢弃。
 	t.Setenv("DWS_LEAF_TEST_PAGE_SIZE", "not-a-number")
 	cmd = NewLeafCommand(spec)
-	if _, err := leafArgs(cmd, spec); err == nil || !strings.Contains(err.Error(), "invalid integer value") {
+	if _, err := cmdcore.BuildArgs(cmd, spec.Flags); err == nil || !strings.Contains(err.Error(), "invalid integer value") {
 		t.Fatalf("leafArgs() = %v, want parse error for garbage env", err)
 	}
 }
@@ -197,7 +198,7 @@ func TestLeafIntAliasRegisteredTyped(t *testing.T) {
 	if err := cmd.Flags().Set("offset", "11"); err != nil {
 		t.Fatal(err)
 	}
-	args, err := leafArgs(cmd, spec)
+	args, err := cmdcore.BuildArgs(cmd, spec.Flags)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,27 +217,27 @@ func TestLeafDefaultDoesNotShadowFallback(t *testing.T) {
 	// env 覆盖注册默认值。
 	t.Setenv("DWS_LEAF_TEST_TYPE", "from-env")
 	cmd := NewLeafCommand(spec)
-	if got := leafEffectiveValue(cmd, spec.Flags[0]); got != "from-env" {
+	if got := cmdcore.EffectiveValue(cmd, spec.Flags[0]); got != "from-env" {
 		t.Fatalf("effective = %q, want env to beat registered default", got)
 	}
 	// 别名覆盖 env 与默认值。
 	if err := cmd.Flags().Set("kind", "from-alias"); err != nil {
 		t.Fatal(err)
 	}
-	if got := leafEffectiveValue(cmd, spec.Flags[0]); got != "from-alias" {
+	if got := cmdcore.EffectiveValue(cmd, spec.Flags[0]); got != "from-alias" {
 		t.Fatalf("effective = %q, want alias to beat env", got)
 	}
 	// 显式主 flag 最高优先。
 	if err := cmd.Flags().Set("type", "explicit"); err != nil {
 		t.Fatal(err)
 	}
-	if got := leafEffectiveValue(cmd, spec.Flags[0]); got != "explicit" {
+	if got := cmdcore.EffectiveValue(cmd, spec.Flags[0]); got != "explicit" {
 		t.Fatalf("effective = %q, want explicit primary to win", got)
 	}
 	// 全部缺席时回落注册默认值。
 	bare := NewLeafCommand(spec)
 	t.Setenv("DWS_LEAF_TEST_TYPE", "")
-	if got := leafEffectiveValue(bare, spec.Flags[0]); got != "ALL" {
+	if got := cmdcore.EffectiveValue(bare, spec.Flags[0]); got != "ALL" {
 		t.Fatalf("effective = %q, want registered default as tail fallback", got)
 	}
 }
@@ -253,7 +254,7 @@ func TestLeafIntRequiredExplicitZeroReportsMissing(t *testing.T) {
 	if err := cmd.Flags().Set("n", "0"); err != nil {
 		t.Fatal(err)
 	}
-	if err := leafValidateRequired(cmd, spec); err == nil || !strings.Contains(err.Error(), "missing required flag(s): --n") {
+	if err := cmdcore.ValidateRequired(cmd, spec.Flags); err == nil || !strings.Contains(err.Error(), "missing required flag(s): --n") {
 		t.Fatalf("leafValidateRequired() = %v, want missing --n for explicit 0", err)
 	}
 
@@ -265,10 +266,10 @@ func TestLeafIntRequiredExplicitZeroReportsMissing(t *testing.T) {
 	}
 	t.Setenv("DWS_LEAF_TEST_REQ_GARBAGE", "not-a-number")
 	cmdEnv := NewLeafCommand(specEnv)
-	if err := leafValidateRequired(cmdEnv, specEnv); err != nil {
+	if err := cmdcore.ValidateRequired(cmdEnv, specEnv.Flags); err != nil {
 		t.Fatalf("leafValidateRequired() = %v, want nil for unparsable env (leafArgs reports it)", err)
 	}
-	if _, err := leafArgs(cmdEnv, specEnv); err == nil || !strings.Contains(err.Error(), "invalid integer value") {
+	if _, err := cmdcore.BuildArgs(cmdEnv, specEnv.Flags); err == nil || !strings.Contains(err.Error(), "invalid integer value") {
 		t.Fatalf("leafArgs() = %v, want invalid integer error", err)
 	}
 }
@@ -286,7 +287,7 @@ func TestLeafTrimWhitespaceFallsThroughChain(t *testing.T) {
 	if err := cmd.Flags().Set("type", "   "); err != nil {
 		t.Fatal(err)
 	}
-	if got := leafEffectiveValue(cmd, spec.Flags[0]); got != "from-env" {
+	if got := cmdcore.EffectiveValue(cmd, spec.Flags[0]); got != "from-env" {
 		t.Fatalf("effective = %q, want whitespace primary to fall through to env", got)
 	}
 	// 别名纯空白也回退；env 纯空白最终落到注册默认值。
@@ -294,7 +295,7 @@ func TestLeafTrimWhitespaceFallsThroughChain(t *testing.T) {
 	if err := cmd.Flags().Set("kind", "\t"); err != nil {
 		t.Fatal(err)
 	}
-	if got := leafEffectiveValue(cmd, spec.Flags[0]); got != "ALL" {
+	if got := cmdcore.EffectiveValue(cmd, spec.Flags[0]); got != "ALL" {
 		t.Fatalf("effective = %q, want whitespace chain to land on default", got)
 	}
 }

--- a/internal/helpers/leaf_test.go
+++ b/internal/helpers/leaf_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cmdcore"
 )
 
 func leafTestSpec() LeafSpec {
@@ -86,7 +88,7 @@ func TestLeafValidateRequiredPlainGroup(t *testing.T) {
 	if err := cmd.Flags().Set("users", "u1"); err != nil {
 		t.Fatal(err)
 	}
-	err := leafValidateRequired(cmd, leafTestSpec())
+	err := cmdcore.ValidateRequired(cmd, leafTestSpec().Flags)
 	if err == nil || !strings.Contains(err.Error(), "missing required flag(s): --content") {
 		t.Fatalf("leafValidateRequired() = %v, want missing --content", err)
 	}
@@ -104,7 +106,7 @@ func TestLeafValidateRequiredSatisfiedByAlias(t *testing.T) {
 	if err := cmd.Flags().Set("remark", "仅别名"); err != nil {
 		t.Fatal(err)
 	}
-	if err := leafValidateRequired(cmd, spec); err != nil {
+	if err := cmdcore.ValidateRequired(cmd, spec.Flags); err != nil {
 		t.Fatalf("leafValidateRequired() = %v, want nil (alias satisfies required)", err)
 	}
 }
@@ -118,7 +120,7 @@ func TestLeafValidateRequiredAliasAbsentStillFails(t *testing.T) {
 		},
 	}
 	cmd := NewLeafCommand(spec)
-	err := leafValidateRequired(cmd, spec)
+	err := cmdcore.ValidateRequired(cmd, spec.Flags)
 	if err == nil || !strings.Contains(err.Error(), "missing required flag(s): --content") {
 		t.Fatalf("leafValidateRequired() = %v, want missing --content", err)
 	}
@@ -136,7 +138,7 @@ func TestLeafValidateRequiredTrimWhitespaceOnlyFails(t *testing.T) {
 	if err := cmd.Flags().Set("content", "   "); err != nil {
 		t.Fatal(err)
 	}
-	err := leafValidateRequired(cmd, spec)
+	err := cmdcore.ValidateRequired(cmd, spec.Flags)
 	if err == nil || !strings.Contains(err.Error(), "missing required flag(s): --content") {
 		t.Fatalf("leafValidateRequired() = %v, want whitespace-only treated as missing", err)
 	}
@@ -144,7 +146,7 @@ func TestLeafValidateRequiredTrimWhitespaceOnlyFails(t *testing.T) {
 
 func TestLeafValidateRequiredEnvFallback(t *testing.T) {
 	cmd := NewLeafCommand(leafTestSpec())
-	err := leafValidateRequired(cmd, leafTestSpec())
+	err := cmdcore.ValidateRequired(cmd, leafTestSpec().Flags)
 	// 普通组（users/content）先报错，不触及 env 组。
 	if err == nil || !strings.Contains(err.Error(), "missing required flag(s): --users, --content") {
 		t.Fatalf("leafValidateRequired() = %v, want plain group first", err)
@@ -156,13 +158,13 @@ func TestLeafValidateRequiredEnvFallback(t *testing.T) {
 	if err := cmd.Flags().Set("content", "c"); err != nil {
 		t.Fatal(err)
 	}
-	err = leafValidateRequired(cmd, leafTestSpec())
+	err = cmdcore.ValidateRequired(cmd, leafTestSpec().Flags)
 	if err == nil || !strings.Contains(err.Error(), "DWS_LEAF_TEST_TOKEN") {
 		t.Fatalf("leafValidateRequired() = %v, want env hint", err)
 	}
 	// env 提供后通过。
 	t.Setenv("DWS_LEAF_TEST_TOKEN", "tok")
-	if err := leafValidateRequired(cmd, leafTestSpec()); err != nil {
+	if err := cmdcore.ValidateRequired(cmd, leafTestSpec().Flags); err != nil {
 		t.Fatalf("leafValidateRequired() = %v, want nil", err)
 	}
 }
@@ -182,7 +184,7 @@ func TestLeafArgs(t *testing.T) {
 	if err := cmd.Flags().Set("cursor", "10"); err != nil {
 		t.Fatal(err)
 	}
-	args, err := leafArgs(cmd, leafTestSpec())
+	args, err := cmdcore.BuildArgs(cmd, leafTestSpec().Flags)
 	if err != nil {
 		t.Fatalf("leafArgs() error = %v", err)
 	}
@@ -209,7 +211,7 @@ func TestLeafArgs(t *testing.T) {
 
 func TestLeafArgsOmitsEmptyAndNonPositive(t *testing.T) {
 	cmd := NewLeafCommand(leafTestSpec())
-	args, err := leafArgs(cmd, leafTestSpec())
+	args, err := cmdcore.BuildArgs(cmd, leafTestSpec().Flags)
 	if err != nil {
 		t.Fatalf("leafArgs() error = %v", err)
 	}
@@ -287,7 +289,7 @@ func TestLeafArgsTransformNilSkipsKey(t *testing.T) {
 	if err := cmd.Flags().Set("page", "abc"); err != nil {
 		t.Fatal(err)
 	}
-	args, err := leafArgs(cmd, spec)
+	args, err := cmdcore.BuildArgs(cmd, spec.Flags)
 	if err != nil {
 		t.Fatalf("leafArgs() error = %v", err)
 	}
@@ -306,7 +308,7 @@ func TestLeafArgsLeafIntOmitsZero(t *testing.T) {
 	}
 	cmd := NewLeafCommand(spec)
 	// 默认 0：不入参。
-	args, err := leafArgs(cmd, spec)
+	args, err := cmdcore.BuildArgs(cmd, spec.Flags)
 	if err != nil {
 		t.Fatalf("leafArgs() error = %v", err)
 	}
@@ -317,7 +319,7 @@ func TestLeafArgsLeafIntOmitsZero(t *testing.T) {
 	if err := cmd.Flags().Set("develop-type", "2"); err != nil {
 		t.Fatal(err)
 	}
-	args, err = leafArgs(cmd, spec)
+	args, err = cmdcore.BuildArgs(cmd, spec.Flags)
 	if err != nil {
 		t.Fatalf("leafArgs() error = %v", err)
 	}
@@ -394,7 +396,7 @@ func TestLeafArgsTrimsValue(t *testing.T) {
 	if err := cmd.Flags().Set("note", "  x  "); err != nil {
 		t.Fatal(err)
 	}
-	args, err := leafArgs(cmd, spec)
+	args, err := cmdcore.BuildArgs(cmd, spec.Flags)
 	if err != nil {
 		t.Fatalf("leafArgs() error = %v", err)
 	}


### PR DESCRIPTION
## Summary
Phase 1 of converging the three command-definition frameworks onto a single typed base (borrowing Lark's single typed-registry shape). Extracts LeafSpec's reusable primitives into a new dispatch-agnostic `internal/cmdcore` package and makes LeafSpec delegate to it. **Scope is limited to the leaf framework** — Shortcut delegation is deferred to Phase 2/3.

`internal/cmdcore` now owns: flag registration, the alias/env/default effective-value fallback chain, required validation, cross-flag constraint declaration checks + runtime enforcement, **Risk-driven write confirmation (`--dry-run` / `--yes` / root-injected global flags supported via a 3-level bool lookup)**, toolArgs assembly, and Agent Runtime Schema projection.

`internal/helpers/leaf.go` keeps only the LeafSpec shell (MCP dispatch fields) + `NewLeafCommand` orchestration. `LeafFlag`/`LeafFlagKind`/`LeafConstraint`/`LeafConstraintKind`/`LeafRisk` and their constants become **type aliases** to cmdcore, so all 27 devapp call sites compile unchanged. Dispatch (`callMCPTool`/`OnServer`/`Call`) stays in helpers.

## Zero behavior change — proof
- **`check-generated-drift` ok**: the schema catalog is byte-identical (840 tools, same registry/source hashes). This is the equivalence proof for a pure extraction.
- Leaf unit + risk + constraint tests pass unchanged (incl. `--dry-run`/`--yes` bypass tests).
- Changed-code coverage **100%** (224 statements across cmdcore + helpers).
- `go build ./...`, `go vet`, `gofmt` clean.

## Note on stacking
This branch is stacked on #827 (LeafSpec constraints + Risk), which the extraction lifts into cmdcore. Until #827 merges, this PR's diff includes #827's content; after #827 merges it reduces to the cmdcore extraction + leaf delegation.

## Test plan
- [x] `./scripts/policy/check-generated-drift.sh` — ok (catalog unchanged)
- [x] `go test ./internal/helpers/` — full suite green
- [x] `make coverage-gate-platform` — 100% changed-code coverage
- [x] `--dry-run` / `--yes` / read-vs-write confirmation preserved (risk bypass tests)