### PR TITLE
docs(release): add v1.0.55-beta.8 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.55-beta.8] - 2026-07-30
+
+This beta revalidates the `v1.0.55-beta.7` product baseline through a complete
+guarded release delivery. It carries no new product-facing command behavior;
+the new version is required because the published beta.7 artifacts succeeded
+on GitHub, npm, and Homebrew, but its enabled optional Gitee mirror failed and
+left that Release run ineligible for stable promotion.
+
+### Changed
+
+- **Complete promotion evidence** — republishes the validated v1.0.55 command, Runtime Schema, Skill, authentication, and projection changes with the optional Gitee upload fallback disabled, so the release can produce one successful auditable delivery proof before stable promotion.
+
 ## [1.0.55] - 2026-07-29
 
 This release promotes the validated `v1.0.55-beta.7` baseline to stable. It


### PR DESCRIPTION
## Summary

- add the exact `1.0.55-beta.8` release section
- state explicitly that beta.8 revalidates the beta.7 product baseline without new product behavior
- record why a new beta is required for a complete stable-promotion delivery proof

## Release context

- beta plan: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/30506902999
- allocator result: `release_version=v1.0.55-beta.8`
- `ENABLE_GITEE_UPLOAD_FALLBACK=false` was verified before planning

Beta.7 published immutable GitHub assets, npm, and Homebrew, but its enabled
optional Gitee mirror failed. Current policy does not accept a channel repair
as beta-to-stable delivery proof, so beta.8 must complete one full Release run.

## Validation

- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`
- `./scripts/release/next-release-version.sh --channel beta --bump patch`
- `git diff --check origin/main...HEAD`

All checks pass, and this PR modifies only `CHANGELOG.md`.
