### PR TITLE
docs(release): promote v1.0.55-beta.8 baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ left that Release run ineligible for stable promotion.
 
 - **Complete promotion evidence** — republishes the validated v1.0.55 command, Runtime Schema, Skill, authentication, and projection changes with the optional Gitee upload fallback disabled, so the release can produce one successful auditable delivery proof before stable promotion.
 
-## [1.0.55] - 2026-07-29
+## [1.0.55] - 2026-07-30
 
-This release promotes the validated `v1.0.55-beta.7` baseline to stable. It
+This release promotes the validated `v1.0.55-beta.8` baseline to stable. It
 expands the public Workspace command surface and personal event consumption,
 makes the full built-in shortcut catalog available to Agents, and hardens
 multi-account routing, authentication compatibility, command safety, and


### PR DESCRIPTION
## 变更

- 将稳定版 `v1.0.55` 的发布日期更新为 2026-07-30
- 将稳定推广基线从 `v1.0.55-beta.7` 更新为已完整交付的 `v1.0.55-beta.8`

## 依据

- beta8 Release workflow 已成功完成最终 delivery gate
- GitHub Release 已公开且不可变，发布资产完整
- npm `beta` dist-tag 已指向 `1.0.55-beta.8`
- Homebrew beta formula 已指向 `v1.0.55-beta.8`
- 可选 Gitee 镜像已配置为 deferred，不参与交付门禁

## 验证

- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`
- `./scripts/policy/open-source-audit.sh`
- `./scripts/policy/check-open-source-assets.sh`
- `./scripts/release/next-release-version.sh --channel stable --bump patch`
- `git diff --check origin/main...HEAD`

稳定分配结果：

```text
release_version=v1.0.55
from_beta=v1.0.55-beta.8
channel=stable
base=v1.0.54
```
