### PR TITLE
ci: increase integration test timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,7 +483,7 @@ jobs:
             exit 0
           fi
           mapfile -t packages <<< "$package_output"
-          go test -v -race -count=1 -timeout=8m "${packages[@]}"
+          go test -v -race -count=1 -timeout=15m "${packages[@]}"
 
   test-race:
     name: "Test (race: ${{ matrix.shard }})"
@@ -523,7 +523,7 @@ jobs:
           test -n "$package_output"
           mapfile -t packages <<< "$package_output"
           test "${#packages[@]}" -gt 0
-          go test -v -race -count=1 -timeout=10m "${packages[@]}"
+          go test -v -race -count=1 -timeout=12m "${packages[@]}"
 
   test-release-scripts:
     name: Test (workflow and release contracts)

--- a/.github/workflows/multi-profile-e2e.yml
+++ b/.github/workflows/multi-profile-e2e.yml
@@ -51,5 +51,6 @@ jobs:
           path: |
             .tmp-bin/multi-profile-e2e.*/out
             .tmp-bin/multi-profile-e2e.log
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 3

--- a/scripts/dev/test-multi-profile-e2e.sh
+++ b/scripts/dev/test-multi-profile-e2e.sh
@@ -15,6 +15,7 @@ RUN_GO_TESTS=1
 VERBOSE=0
 KEEP_WORKDIR=0
 E2E_VERSION="${DWS_PACKAGE_VERSION:-v1.0.53-beta.3}"
+GO_TEST_TIMEOUT="${MULTI_PROFILE_GO_TEST_TIMEOUT:-10m}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -582,7 +583,7 @@ cd "$ROOT"
 
 if [[ "$RUN_GO_TESTS" -eq 1 ]]; then
   log "running multi-profile Go regressions"
-  go test -timeout 180s -count=1 ./internal/auth ./internal/app ./test/cli
+  go test -timeout "$GO_TEST_TIMEOUT" -count=1 ./internal/auth ./internal/app ./test/cli
 fi
 
 log "building dws"

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -523,6 +523,19 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 	if !strings.Contains(focusedJob, "timeout-minutes: 20") {
 		t.Error("focused test job must allow the scoped race suite up to 20 minutes")
 	}
+	if !strings.Contains(focusedJob, `go test -v -race -count=1 -timeout=15m "${packages[@]}"`) {
+		t.Error("focused race tests must retain enough package-level time for internal/app")
+	}
+
+	raceStart := focusedEnd
+	raceEnd := strings.Index(admission, "\n  test-release-scripts:\n")
+	if raceEnd <= raceStart {
+		t.Fatal("Code Admission workflow missing race test job boundaries")
+	}
+	raceJob := admission[raceStart:raceEnd]
+	if !strings.Contains(raceJob, `go test -v -race -count=1 -timeout=12m "${packages[@]}"`) {
+		t.Error("full race shards must retain enough package-level time for internal/app")
+	}
 
 	coverageStart := strings.Index(admission, "\n  coverage:\n")
 	coverageEnd := strings.Index(admission, "\n  policy:\n")
@@ -602,6 +615,17 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 	}
 	if strings.Contains(integration, "pull_request:") {
 		t.Error("complete Multi-profile E2E must not run as a pull-request admission context")
+	}
+	if !strings.Contains(integration, "include-hidden-files: true") {
+		t.Error("main integration must upload diagnostics stored below the hidden .tmp-bin directory")
+	}
+
+	integrationScript := readWorkflow("scripts/dev/test-multi-profile-e2e.sh")
+	if !strings.Contains(integrationScript, `GO_TEST_TIMEOUT="${MULTI_PROFILE_GO_TEST_TIMEOUT:-10m}"`) {
+		t.Error("multi-profile E2E must allow enough time for the complete internal/app regression suite")
+	}
+	if strings.Contains(integrationScript, "go test -timeout 180s") {
+		t.Error("multi-profile E2E must not retain the obsolete three-minute Go test budget")
 	}
 }
 


### PR DESCRIPTION
## 问题

当前 `internal/app` 测试规模已经超过既有 CI 预算，出现了两个可重复的包级超时：

- Main Integration `Multi-profile E2E`：`go test -timeout 180s`，连续两次在 `internal/app` 约 180 秒时失败。
- PR #831 `Test (changed packages)`：race 测试在 `internal/app` 约 480 秒时触发 `-timeout=8m`。

日志没有断言失败；超时瞬间显示的测试只是当时刚开始执行的测试，大量 `t.Parallel` 测试仍在等待。

## 修改

- Multi-profile E2E 的 Go 包级超时默认提高到 10 分钟，并允许通过 `MULTI_PROFILE_GO_TEST_TIMEOUT` 覆盖。
- scoped race 测试包级超时从 8 分钟提高到 15 分钟。
- full race shard 包级超时从 10 分钟提高到 12 分钟，以确保本 PR 的 full-suite 验证也有足够预算。
- 失败时允许上传隐藏目录 `.tmp-bin` 下的诊断产物。
- 增加工作流契约测试，防止超时预算和隐藏产物配置回退。

## 验证

- `go test ./test/scripts -run '^TestChangelogPRFastPathWorkflowContract$' -count=1`
- `bash -n scripts/dev/test-multi-profile-e2e.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/multi-profile-e2e.yml`
- 完整 `scripts/dev/test-multi-profile-e2e.sh` 通过；其中 `internal/app` 实际耗时 191.239 秒，证明旧 180 秒预算不足，后续完整 profile 链路全部通过。
- `git diff --check`

完整 `go test ./test/scripts` 另有一个与本次改动无关的本机 npm 配置 warning 基线问题：`npm warn Unknown user config "email"` 污染了完整性输出；聚焦的工作流契约测试通过。
