### PR TITLE
docs(release): complete v1.0.56-beta.2 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ loading without changing the public command or Runtime Schema surface.
 ### Fixed
 
 - **Stable PAT/routing identity** (#831) — restores the CLI-emitted open-source HTTP `claw-type` and PAT `hostControl.clawType` to the edition-fixed `openClaw` value. `DWS_AGENT_PRODUCT` no longer changes those wire values, and the client continues to derive PAT, authentication, routing, and Discovery behaviour from the existing independent signals.
+- **Portable generated Skill validation** (#835) — resolves the mono Skill name by scanning upward from the generated target, keeping `--check` independent of the repository checkout path and preventing false drift failures when an ancestor directory resembles a Skill name.
 
 ## [1.0.56-beta.1] - 2026-07-30
 


### PR DESCRIPTION
## Summary

- Add the portable generated Skill validation fix from #835 to the sealed v1.0.56-beta.2 notes.
- Keep the change strictly limited to the existing v1.0.56-beta.2 CHANGELOG section.

## Why this follow-up is required

The first sealing PR was merged by a workflow token, which did not recursively create the push Actions required on the exact sealed commit.

After approval, this PR must be merged manually rather than by GitHub-Actions auto-merge. The resulting push run supplies the exact sealed-commit Code Admission and Main Integration evidence required by Release.

## Verification

- ./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD — passed
- git diff --check — passed
- changed files: only CHANGELOG.md