### PR TITLE
docs: seal v1.0.56-beta.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,20 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.56-beta.3] - 2026-08-03
+
+This beta adds PRs #846 and #851 on top of v1.0.56-beta.2. It adds a
+service-provided Aitable workflow-editing reference command and makes local
+event-bus IPC reliable on shared filesystems by placing Unix sockets in a
+validated private runtime directory.
+
 ### Added
 
-- **Aitable workflow editing reference** — adds `dws aitable workflow edit-example`, a parameter-free read command that returns the service-provided workflow editing documentation and `workflow-dsl/v1` examples through `aitable/edit_workflow_example`.
+- **Aitable workflow editing reference** (#851) — adds `dws aitable workflow edit-example`, a parameter-free read command that returns the service-provided workflow editing documentation and `workflow-dsl/v1` examples through `aitable/edit_workflow_example`.
 
 ### Fixed
 
-- **Event bus sockets on shared filesystems** — Unix event buses now place their local IPC socket in a private per-user runtime directory (`XDG_RUNTIME_DIR` when available, otherwise a `0700` per-UID directory under the system temporary directory) while retaining locks, metadata, logs, and subscription state in the configured Workdir. Listener and dial paths validate directory ownership and permissions before use. This prevents `dws event consume` from failing with `bind: errno 524` when `~/.dws` is hosted on NFS, CSI, FUSE, or another filesystem that does not support Unix Domain Sockets without exposing the socket directly in a shared `/tmp` root. When `XDG_RUNTIME_DIR` is unavailable, the per-UID directory name is deterministic: ownership validation prevents endpoint hijacking, but another local user can pre-create the directory to deny service; multi-user deployments should provide a private `XDG_RUNTIME_DIR`.
+- **Event bus sockets on shared filesystems** (#846) — Unix event buses now place their local IPC socket in a private per-user runtime directory (`XDG_RUNTIME_DIR` when available, otherwise a `0700` per-UID directory under the system temporary directory) while retaining locks, metadata, logs, and subscription state in the configured Workdir. Listener and dial paths validate directory ownership and permissions before use. This prevents `dws event consume` from failing with `bind: errno 524` when `~/.dws` is hosted on NFS, CSI, FUSE, or another filesystem that does not support Unix Domain Sockets without exposing the socket directly in a shared `/tmp` root. When `XDG_RUNTIME_DIR` is unavailable, the per-UID directory name is deterministic: ownership validation prevents endpoint hijacking, but another local user can pre-create the directory to deny service; multi-user deployments should provide a private `XDG_RUNTIME_DIR`.
 
 ## [1.0.56-beta.2] - 2026-07-30
 


### PR DESCRIPTION
## Summary

- 为候选版本 `v1.0.56-beta.3` 创建唯一、精确且非空的 CHANGELOG 章节。
- 冻结自 `v1.0.56-beta.2` 以来进入 `main` 的产品范围：PR #846 与 PR #851。
- 明确排除 beta.2 发布后的 Formula-only 自动提交；本 PR 只修改 `CHANGELOG.md`。

## Release scope

| PR | Merge commit | CHANGELOG | 用户可见变化 |
|---|---|---|---|
| #851 | `8854e0d1` | Added | 新增 `dws aitable workflow edit-example` 只读命令，返回服务端工作流编辑文档及 `workflow-dsl/v1` 示例。 |
| #846 | `96bfae07` | Fixed | 将 Unix event bus socket 放入经过所有权和权限校验的私有运行时目录，修复 NFS、CSI、FUSE 等共享文件系统上的 `bind: errno 524`。 |

## Verification

- Cloud plan: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/30813908333
- Plan SHA: `96bfae079a8f8797bef1aff7a13c920a6664a64d`
- `git diff --check origin/main...HEAD` — passed
- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD` — passed (`release_sections=1`, `unreleased_changed=1`)
- Diff scope: exactly one in-place modification of `CHANGELOG.md`

## Release note

`plan` 只计算候选版本，尚未创建 tag、GitHub Release 或任何渠道产物。