### PR TITLE
docs: seal v1.0.56 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.56] - 2026-08-04
+
+This stable release promotes the fully delivered `v1.0.56-beta.4` baseline.
+It includes PR #852's resilient multipart Drive download implementation,
+together with the v1.0.56 beta-line command, Schema, Skill, and runtime
+improvements already validated through the prerelease channel.
+
+### Added
+
+- **Resilient multipart Drive downloads** (#852) — `drive download` and
+  `drive download-version` support parallel chunk transfer, Range probing,
+  fingerprint-validated checkpoint resume, automatic 401/403 credential
+  refresh, and graceful interruption with checkpoint preservation.
+
 ## [1.0.56-beta.4] - 2026-08-04
 
 This beta adds PR #852 on top of v1.0.56-beta.3. It makes Drive downloads


### PR DESCRIPTION
Release seal for v1.0.56.\n\nPromotes the independently verified `v1.0.56-beta.4` baseline.\n\nFrozen scope:\n- #852: resilient multipart Drive downloads.\n\nValidation:\n- `git diff --check origin/main...HEAD`\n- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`