### PR TITLE
fix(skills): drop stale EXPERIMENTAL banners and dead skill links

### DIFF
--- a/skills/multi/dingtalk-chat/SKILL.md
+++ b/skills/multi/dingtalk-chat/SKILL.md
@@ -128,7 +128,7 @@ metadata:
 ## 跨产品协作
 
 - 收件人是人名 → 先用 `dingtalk-contact` 或 `dingtalk-aisearch` 拿 `openDingTalkId` / `userId`
-- 要发图片/文件 → 先 `dt_media_upload` 上传 → `python scripts/extract_media_id.py "<URL>"` 提取 mediaId → 再用 `--media-id`
+- 要发图片/文件 → `dws chat message send --msg-type file|audio|video --file-path <path>`（已有 mediaId 的旧图片链路才用 `--msg-type image --media-id`）
 - 紧急升级（应用内/短信/电话）→ 切到 `dingtalk-misc`（`references/ding.md`）
 - 发邮件 → 切到 `dingtalk-mail`
 ## 局部意图与短流程

--- a/skills/multi/dingtalk-chat/references/chat/chat-workflows.md
+++ b/skills/multi/dingtalk-chat/references/chat/chat-workflows.md
@@ -168,7 +168,6 @@ dws chat text translate --query "你好世界" --to en_US --format json
 |------|------|------|
 | [chat_export_messages.py](../../scripts/chat_export_messages.py) | 导出群聊消息到 JSON 文件 | `python chat_export_messages.py --query "项目冲刺" --time "2026-03-10 00:00:00"` |
 | [chat_history_with_user.py](../../scripts/chat_history_with_user.py) | 查询与某人的单聊聊天记录 | `python chat_history_with_user.py --name "张三" --time "2026-03-10 00:00:00"` |
-| [extract_media_id.py](../../scripts/extract_media_id.py) | 旧链路：从 dt_media_upload URL 提取 mediaId | 新场景不要用，文件/音视频直接 `--msg-type file|audio|video --file-path` |
 
 ## 常见错误与回退
 

--- a/skills/multi/dingtalk-drive/references/drive.md
+++ b/skills/multi/dingtalk-drive/references/drive.md
@@ -780,5 +780,5 @@ dws drive copy --node <源文件dentryUuid> --folder <目标文件夹fileId> --f
 ## 相关产品
 
 - [doc](../../dingtalk-doc/references/doc.md) — 文档内容读写/知识库空间，不是文件存储
-- [markdown](../../dingtalk-misc/references/markdown.md) — `.md` 文件的内容读取（fetch），非文件管理
+- [markdown](../../dingtalk-markdown/references/markdown.md) — `.md` 文件的内容读取（fetch），非文件管理
 - [chat](../../dingtalk-chat/references/chat.md) — 上传文件到 drive 后可通过 Markdown 语法发送图片/文件消息

--- a/skills/multi/dingtalk-hrbrain/SKILL.md
+++ b/skills/multi/dingtalk-hrbrain/SKILL.md
@@ -12,11 +12,9 @@ metadata:
 
 # 钉钉 Hrbrain（组织大脑）Skill
 
-> 🧪 **EXPERIMENTAL · 试验版 / Preview** — multi 模式当前未达 stable 标准。全部 dingtalk-* skill 已通过 dispatch verifier，但接口、命名、跨 skill 引用后续可能调整；生产 / 共享环境请优先使用 mono 模式（`dws skill setup --mode mono`）。问题请提 issue 反馈。
+> **multi 为默认安装模式** — 全部 dingtalk-* skill 已通过 dispatch verifier。单 skill（mono）模式仍可用：`dws skill setup --mode mono`。问题请提 issue 反馈。
 
 > **PREREQUISITE:** Read the `dws-shared` skill first for auth, global flags, product routing, URL preflight, error codes, and safety rules. The `dws` binary must be on PATH.
-
-<!-- SAFETY_PREAMBLE_INJECT -->
 
 > ⚠️ **命令可用性以当前 dws 二进制为准**。服务发现已下线，本文档随内置 skill 发布；如果 `dws <cmd> --help` 不存在，说明当前版本未暴露该命令。若命令存在但调用失败，请按错误中的 endpoint 或 tool 提示确认静态端点目录和后端工具注册。实际调用前可用 `dws <cmd> --help` 或 `--dry-run` 验证。
 

--- a/skills/multi/dingtalk-markdown/SKILL.md
+++ b/skills/multi/dingtalk-markdown/SKILL.md
@@ -12,11 +12,9 @@ metadata:
 
 # 钉钉 Markdown 文件 Skill
 
-> 🧪 **EXPERIMENTAL · 试验版 / Preview** — multi 模式当前未达 stable 标准。全部 dingtalk-* skill 已通过 dispatch verifier，但接口、命名、跨 skill 引用后续可能调整；生产 / 共享环境请优先使用 mono 模式（`dws skill setup --mode mono`）。问题请提 issue 反馈。
+> **multi 为默认安装模式** — 全部 dingtalk-* skill 已通过 dispatch verifier。单 skill（mono）模式仍可用：`dws skill setup --mode mono`。问题请提 issue 反馈。
 
 > **PREREQUISITE:** Read the `dws-shared` skill first for auth, global flags, product routing, URL preflight, error codes, and safety rules. The `dws` binary must be on PATH.
-
-<!-- SAFETY_PREAMBLE_INJECT -->
 
 > ⚠️ **命令可用性以当前 dws 二进制为准**。服务发现已下线，本文档随内置 skill 发布；如果 `dws <cmd> --help` 不存在，说明当前版本未暴露该命令。若命令存在但调用失败，请按错误中的 endpoint 或 tool 提示确认静态端点目录和后端工具注册。实际调用前可用 `dws <cmd> --help` 或 `--dry-run` 验证。
 

--- a/skills/multi/dingtalk-pat/SKILL.md
+++ b/skills/multi/dingtalk-pat/SKILL.md
@@ -12,11 +12,9 @@ metadata:
 
 # PAT 行为授权 Skill
 
-> 🧪 **EXPERIMENTAL · 试验版 / Preview** — multi 模式当前未达 stable 标准。全部 dingtalk-* skill 已通过 dispatch verifier，但接口、命名、跨 skill 引用后续可能调整；生产 / 共享环境请优先使用 mono 模式（`dws skill setup --mode mono`）。问题请提 issue 反馈。
+> **multi 为默认安装模式** — 全部 dingtalk-* skill 已通过 dispatch verifier。单 skill（mono）模式仍可用：`dws skill setup --mode mono`。问题请提 issue 反馈。
 
 > **PREREQUISITE:** Read the `dws-shared` skill first for auth, global flags, product routing, Schema discovery, error handling, and safety rules. The `dws` binary must be on PATH.
-
-<!-- SAFETY_PREAMBLE_INJECT -->
 
 > 命令参考：[pat.md](references/pat.md)。
 

--- a/skills/multi/dingtalk-profile/SKILL.md
+++ b/skills/multi/dingtalk-profile/SKILL.md
@@ -12,11 +12,9 @@ metadata:
 
 # 钉钉多组织 / profile Skill
 
-> 🧪 **EXPERIMENTAL · 试验版 / Preview** — multi 模式当前未达 stable 标准；接口、命名、跨 skill 引用后续可能调整。生产 / 共享环境请优先使用 mono 模式（`dws skill setup --mode mono`）。
+> **multi 为默认安装模式** — 全部 dingtalk-* skill 已通过 dispatch verifier。单 skill（mono）模式仍可用：`dws skill setup --mode mono`。问题请提 issue 反馈。
 
 > **PREREQUISITE:** Read the `dws-shared` skill first for auth, global flags, product routing, URL preflight, error codes, and safety rules. The `dws` binary must be on PATH.
-
-<!-- SAFETY_PREAMBLE_INJECT -->
 
 dws 可同时登录多个钉钉账号，同一组织也可保留多个账号。一个 profile = 一个 `corpId + userId` 身份；当前 profile 决定本次命令注入哪个身份。
 

--- a/skills/multi/dingtalk-skill/SKILL.md
+++ b/skills/multi/dingtalk-skill/SKILL.md
@@ -12,13 +12,11 @@ metadata:
 
 # DWS 技能管理 Skill
 
-> 🧪 **EXPERIMENTAL · 试验版 / Preview** — multi 模式当前未达 stable 标准。全部 dingtalk-* skill 已通过 dispatch verifier，但接口、命名、跨 skill 引用后续可能调整；生产 / 共享环境请优先使用 mono 模式（`dws skill setup --mode mono`）。问题请提 issue 反馈。
+> **multi 为默认安装模式** — 全部 dingtalk-* skill 已通过 dispatch verifier。单 skill（mono）模式仍可用：`dws skill setup --mode mono`。问题请提 issue 反馈。
 
 ## 前置条件
 
 > **`use_skill(dws-shared)`** — 认证、全局参数、错误码与安全规则。执行网络请求前先读；本地 `skill setup` 可直接使用本 skill。
-
-<!-- SAFETY_PREAMBLE_INJECT -->
 
 > 详细命令：[skill.md](references/skill.md)。
 

--- a/skills/multi/dws-shared/references/routing.md
+++ b/skills/multi/dws-shared/references/routing.md
@@ -19,7 +19,7 @@
 | 知识库/钉盘空间、空间节点和成员管理 | [`dingtalk-wiki`](../../dingtalk-wiki/SKILL.md) |
 | 姓名模糊找人、负责人、上下级、工号、手机号语义线索、企业知识和行为记录搜索 | [`dingtalk-aisearch`](../../dingtalk-aisearch/SKILL.md) |
 | 完整手机号精确反查，或已有 userId 后查人员详情、部门和角色 | [`dingtalk-contact`](../../dingtalk-contact/SKILL.md) |
-| Markdown / `.md` 内容读取、创建、覆盖、局部修改或版本差异比较 | [`dingtalk-misc`](../../dingtalk-misc/SKILL.md) → [`markdown.md`](../../dingtalk-misc/references/markdown.md) |
+| Markdown / `.md` 内容读取、创建、覆盖、局部修改或版本差异比较 | [`dingtalk-markdown`](../../dingtalk-markdown/SKILL.md) |
 | 审批、考勤、会议、电子表格、日志、DING、直播、宜搭、开放平台等长尾产品 | [`dingtalk-misc`](../../dingtalk-misc/SKILL.md) |
 
 选择 `dingtalk-misc` 后，先读取其 `SKILL.md` 产品索引，再只读取命中产品的单个


### PR DESCRIPTION
## Summary
- Update remaining multi skill EXPERIMENTAL banners to multi-default wording (profile/hrbrain/markdown/pat/skill)
- Retarget dead routing/drive links to dingtalk-markdown
- Replace chat extract_media_id.py dead guidance with --msg-type/--file-path
- Remove retired SAFETY_PREAMBLE_INJECT markers
- Note residual: README/skill_setup still EXPERIMENTAL until skill-mode migration

## Test plan
- [ ] Spot-check updated SKILL.md / reference docs for banner and link wording
- [ ] Confirm no remaining dead dingtalk-markdown-diff / extract_media_id references in touched skills
- [ ] Confirm SAFETY_PREAMBLE_INJECT markers are gone from skill docs


Made with [Cursor](https://cursor.com)