### PR TITLE
docs: seal v1.0.57-beta.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.57-beta.2] - 2026-08-05
+
+### Fixed
+
+- **Stable Chat command compatibility** (#876) — restores the hidden migration
+  entries for `chat send`, `chat history`, and their `im` aliases, preserving
+  the v1.0.56 command surface while directing callers to the supported
+  `chat message send/list` commands. Legacy flags now reach the same migration
+  hints instead of failing during flag parsing.
+- **Drive download cancellation-test stability** (#876) — replaces a
+  timing-sensitive worker-cancellation coverage test with a deterministic seam,
+  reducing flaky CI without changing download behavior.
+
 ### Fixed
 
 - **Stable Chat command compatibility** — restores the hidden migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,6 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
   timing-sensitive worker-cancellation coverage test with a deterministic seam,
   reducing flaky CI without changing download behavior.
 
-### Fixed
-
-- **Stable Chat command compatibility** — restores the hidden migration
-  entries for `chat send`, `chat history`, and their `im` aliases that PR #860
-  removed, preserving the v1.0.56 command surface while directing callers to
-  the supported `chat message send/list` commands.
-
 ## [1.0.57-beta.1] - 2026-08-05
 
 This beta starts the v1.0.57 line on top of v1.0.56. It packages the unified


### PR DESCRIPTION
## Release seal

- Candidate: `v1.0.57-beta.2`
- Frozen source: `db50be868bf296989c02b6214984bb0159436c3f`
- Scope: #876 — restores stable `chat send` / `chat history` compatibility (including `im` aliases and legacy flags), and makes Drive worker-cancellation coverage deterministic.
- Validation: `git diff --check origin/main...HEAD`; `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`.

After Reviewer routing completes, auto-merge will be disabled before the single peer approval.