### PR TITLE
feat(chat): support mentions in message replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and compatibility and CI reliability fixes.
 
 ### Changed
 
+- **Chat reply mentions** — `dws chat message reply` can @ specified group members with `--at-open-dingtalk-ids` or @ everyone with `--at-all`, forwarding the existing `send_personal_message` mention fields and normalizing current-user `<@id>` / `<@all>` placeholders.
 - **Pinned MCP metadata retired** — deletes `internal/cli/schema_mcp_metadata.json` and removes its embed/loader/fallback role from Schema assembly. Catalog now assembles from Contract/ParamDecl/Interface + Cobra only; `make fetch-mcp-metadata` remains an optional diagnostic dump under `artifacts/` and refuses the retired pin path. Policy bans the pin from reappearing.
 - **MCP service review retired** — deletes `schema_mcp_service_review.json` and removes its policy jq / outputguard / test disposition gate (`notify` → `out_of_surface`, snapshot hash pin). No replacement ledger.
 - **Hints retired; ContractDecl is the leaf Schema source** (#830) — `schema_hints/`, Manual/Schema hint overlays, and `schema_agent_metadata/` delivery are removed. Selection, safety, parameters, and interface facts declare on ProductDecl / leaf `Contract` (`corecmd.ContractDecl` + `contract.ParamDecl` / `Safety`). Authoring renamed `SchemaDecl` → `ContractDecl`; nested fields reuse `contract.*` directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ and compatibility and CI reliability fixes.
 
 ### Changed
 
-- **Chat reply mentions** — `dws chat message reply` can @ specified group members with `--at-open-dingtalk-ids` or @ everyone with `--at-all`, forwarding the existing `send_personal_message` mention fields and normalizing current-user `<@id>` / `<@all>` placeholders.
+- **Chat reply mentions** — `dws chat message reply` can @ specified group members with `--at-open-dingtalk-ids` or @ everyone with `--at-all`, forwarding the existing `send_personal_message` mention fields and automatically adding missing current-user `<@id>` / `<@all>` placeholders.
 - **Pinned MCP metadata retired** — deletes `internal/cli/schema_mcp_metadata.json` and removes its embed/loader/fallback role from Schema assembly. Catalog now assembles from Contract/ParamDecl/Interface + Cobra only; `make fetch-mcp-metadata` remains an optional diagnostic dump under `artifacts/` and refuses the retired pin path. Policy bans the pin from reappearing.
 - **MCP service review retired** — deletes `schema_mcp_service_review.json` and removes its policy jq / outputguard / test disposition gate (`notify` → `out_of_surface`, snapshot hash pin). No replacement ledger.
 - **Hints retired; ContractDecl is the leaf Schema source** (#830) — `schema_hints/`, Manual/Schema hint overlays, and `schema_agent_metadata/` delivery are removed. Selection, safety, parameters, and interface facts declare on ProductDecl / leaf `Contract` (`corecmd.ContractDecl` + `contract.ParamDecl` / `Safety`). Authoring renamed `SchemaDecl` → `ContractDecl`; nested fields reuse `contract.*` directly.

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -424,6 +424,30 @@ func applyCurrentUserGroupMentions(params map[string]any, text, rawOpenIDs strin
 	return text
 }
 
+func addMissingCurrentUserMentionPlaceholders(text, rawOpenIDs string) string {
+	if rawOpenIDs == "" {
+		return text
+	}
+	missing := make([]string, 0)
+	probeText := text
+	for _, id := range parseCSVValues(rawOpenIDs) {
+		placeholder := "<@" + id + ">"
+		if strings.Contains(probeText, placeholder) {
+			continue
+		}
+		missing = append(missing, placeholder)
+		probeText += placeholder
+	}
+	if len(missing) == 0 {
+		return text
+	}
+	prefix := strings.Join(missing, " ")
+	if strings.HasPrefix(text, "<@all> ") {
+		return "<@all> " + prefix + " " + strings.TrimPrefix(text, "<@all> ")
+	}
+	return prefix + " " + text
+}
+
 func containsMessageMention(text, placeholder string) bool {
 	if strings.HasPrefix(placeholder, "<") {
 		return strings.Contains(text, placeholder)
@@ -5382,14 +5406,14 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	chatMessageReplyCmd := &cobra.Command{
 		Use:   "reply",
 		Short: "引用回复消息（支持单聊/群聊）",
-		Long: `以当前用户身份引用某条消息并回复。需要指定会话 ID、被引用消息 ID、原消息发送者 openDingTalkId，以及回复内容。群聊回复可通过 --at-open-dingtalk-ids @指定成员，或通过 --at-all @所有人；正文中的裸 @openDingTalkId 会自动规范化为 <@openDingTalkId>，缺少 <@all> 时会自动补齐。
+		Long: `以当前用户身份引用某条消息并回复。需要指定会话 ID、被引用消息 ID、原消息发送者 openDingTalkId，以及回复内容。群聊回复可通过 --at-open-dingtalk-ids @指定成员，或通过 --at-all @所有人；正文中的裸 @openDingTalkId 会自动规范化为 <@openDingTalkId>，缺少对应成员或 <@all> 占位符时会自动补齐。
 
 如何获取 openConversationId（如果上层已有则直接使用，不必再查）：
   - 群聊：dws chat search --query "群名"
   - 单聊：dws chat conversation-info --open-dingtalk-id <openDingTalkId>
           （人员信息可通过 dws contact user search --keyword "姓名" --format json 获取）`,
 		Example: `  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "收到，马上处理"
-  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "<@mentionedOpenDingTalkId> 请看一下" --at-open-dingtalk-ids <mentionedOpenDingTalkId>`,
+  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "请看一下" --at-open-dingtalk-ids <mentionedOpenDingTalkId>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateRequiredFlags(cmd, "conversation-id", "ref-msg-id", "ref-sender", "text"); err != nil {
 				return err
@@ -5413,12 +5437,14 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 				"clawType":           clawType,
 			}
 			atAll, _ := cmd.Flags().GetBool("at-all")
+			atOpenIDs := mustGetFlag(cmd, "at-open-dingtalk-ids")
 			replyText := applyCurrentUserGroupMentions(
 				toolArgs,
 				mustGetFlag(cmd, "text"),
-				mustGetFlag(cmd, "at-open-dingtalk-ids"),
+				atOpenIDs,
 				atAll,
 			)
+			replyText = addMissingCurrentUserMentionPlaceholders(replyText, atOpenIDs)
 			replyContent := map[string]string{
 				"referenceOpenMessageId":   mustGetFlag(cmd, "ref-msg-id"),
 				"srcMsgSendOpenDingTalkId": refSender,
@@ -5477,7 +5503,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	chatMessageReplyCmd.Flags().String("uuid", "", "幂等键（可选）")
 	chatMessageReplyCmd.Flags().Bool("ai-tag", true, "消息是否带 AI 发送角标（默认 true）")
 	chatMessageReplyCmd.Flags().Bool("at-all", false, "@所有人（仅群聊时生效；正文缺少 <@all> 时自动补齐）")
-	chatMessageReplyCmd.Flags().String("at-open-dingtalk-ids", "", "@指定成员的 openDingTalkId 列表，逗号分隔（仅群聊时生效；正文中的裸 @id 自动规范化为 <@id>）")
+	chatMessageReplyCmd.Flags().String("at-open-dingtalk-ids", "", "@指定成员的 openDingTalkId 列表，逗号分隔（仅群聊时生效；正文缺少对应 <@id> 时自动补齐，裸 @id 自动规范化）")
 	cli.AttachRuntimeSchema(chatMessageReplyCmd, "chat", "reply_personal_message", "hardcoded:chat")
 
 	// ── message forward: 转发单条消息 ────────────────────────

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -404,6 +404,26 @@ func NormalizeMessageMentions(text string, ids []string, atAll, wrapAngle bool) 
 	return text
 }
 
+// applyCurrentUserGroupMentions keeps the body placeholders and
+// send_personal_message mention arguments aligned for send and reply.
+func applyCurrentUserGroupMentions(params map[string]any, text, rawOpenIDs string, atAll bool) string {
+	var atOpenIDs []string
+	if rawOpenIDs != "" {
+		atOpenIDs = strings.Split(rawOpenIDs, ",")
+	}
+	if atAll && !strings.Contains(text, "<@all>") {
+		text = "<@all> " + text
+	}
+	text = normalizeAtPlaceholders(text, atOpenIDs, true)
+	if atAll {
+		params["atAll"] = true
+	}
+	if len(atOpenIDs) > 0 {
+		params["atOpenDingTalkIds"] = atOpenIDs
+	}
+	return text
+}
+
 func containsMessageMention(text, placeholder string) bool {
 	if strings.HasPrefix(placeholder, "<") {
 		return strings.Contains(text, placeholder)
@@ -2037,29 +2057,15 @@ func newChatCommand() *cobra.Command {
 			if groupID != "" {
 				atAll, _ := cmd.Flags().GetBool("at-all")
 				atOpenIdsStr, _ := cmd.Flags().GetString("at-open-dingtalk-ids")
-				var atOpenIds []string
-				if atOpenIdsStr != "" {
-					atOpenIds = strings.Split(atOpenIdsStr, ",")
-				}
-				if atAll && !strings.Contains(text, "<@all>") {
-					text = "<@all> " + text
-				}
-				// 用户身份发消息要求 @ 占位符为 <@openDingTalkId>；模型若写成裸 @id 自动补全，已有 <@id> 不变
-				text = normalizeAtPlaceholders(text, atOpenIds, true)
 				// 群聊统一走 openDingTalkId @ 人接口。
-				contentJSON, _ := marshalJSONRaw(map[string]string{"title": title, "text": text})
 				newParams := map[string]any{
 					"openConversationId": groupID,
 					"msgType":            "markdown",
-					"content":            string(contentJSON),
 					"clawType":           clawType,
 				}
-				if atAll {
-					newParams["atAll"] = true
-				}
-				if len(atOpenIds) > 0 {
-					newParams["atOpenDingTalkIds"] = atOpenIds
-				}
+				text = applyCurrentUserGroupMentions(newParams, text, atOpenIdsStr, atAll)
+				contentJSON, _ := marshalJSONRaw(map[string]string{"title": title, "text": text})
+				newParams["content"] = string(contentJSON)
 				if msgUuid != "" {
 					newParams["uuid"] = msgUuid
 				}
@@ -5376,13 +5382,14 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	chatMessageReplyCmd := &cobra.Command{
 		Use:   "reply",
 		Short: "引用回复消息（支持单聊/群聊）",
-		Long: `以当前用户身份引用某条消息并回复。需要指定会话 ID、被引用消息 ID、原消息发送者 openDingTalkId，以及回复内容。
+		Long: `以当前用户身份引用某条消息并回复。需要指定会话 ID、被引用消息 ID、原消息发送者 openDingTalkId，以及回复内容。群聊回复可通过 --at-open-dingtalk-ids @指定成员，或通过 --at-all @所有人；正文中的裸 @openDingTalkId 会自动规范化为 <@openDingTalkId>，缺少 <@all> 时会自动补齐。
 
 如何获取 openConversationId（如果上层已有则直接使用，不必再查）：
   - 群聊：dws chat search --query "群名"
   - 单聊：dws chat conversation-info --open-dingtalk-id <openDingTalkId>
           （人员信息可通过 dws contact user search --keyword "姓名" --format json 获取）`,
-		Example: `  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "收到，马上处理"`,
+		Example: `  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "收到，马上处理"
+  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "<@mentionedOpenDingTalkId> 请看一下" --at-open-dingtalk-ids <mentionedOpenDingTalkId>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateRequiredFlags(cmd, "conversation-id", "ref-msg-id", "ref-sender", "text"); err != nil {
 				return err
@@ -5395,13 +5402,6 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 				}
 				refSender = resolved
 			}
-			replyContent := map[string]string{
-				"referenceOpenMessageId":   mustGetFlag(cmd, "ref-msg-id"),
-				"srcMsgSendOpenDingTalkId": refSender,
-				"replyMsgType":             "text",
-				"content":                  mustGetFlag(cmd, "text"),
-			}
-			contentJSON, _ := marshalJSONRaw(replyContent)
 			clawType := ""
 			aiTag, _ := cmd.Flags().GetBool("ai-tag")
 			if aiTag {
@@ -5410,9 +5410,23 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 			toolArgs := map[string]any{
 				"openConversationId": mustGetFlag(cmd, "conversation-id"),
 				"msgType":            "reply",
-				"content":            string(contentJSON),
 				"clawType":           clawType,
 			}
+			atAll, _ := cmd.Flags().GetBool("at-all")
+			replyText := applyCurrentUserGroupMentions(
+				toolArgs,
+				mustGetFlag(cmd, "text"),
+				mustGetFlag(cmd, "at-open-dingtalk-ids"),
+				atAll,
+			)
+			replyContent := map[string]string{
+				"referenceOpenMessageId":   mustGetFlag(cmd, "ref-msg-id"),
+				"srcMsgSendOpenDingTalkId": refSender,
+				"replyMsgType":             "text",
+				"content":                  replyText,
+			}
+			contentJSON, _ := marshalJSONRaw(replyContent)
+			toolArgs["content"] = string(contentJSON)
 			if v, _ := cmd.Flags().GetString("uuid"); v != "" {
 				toolArgs["uuid"] = v
 			}
@@ -5446,6 +5460,8 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 			},
 			Parameters: []contract.ParamDecl{
 				{Name: "ai-tag", Property: "clawType", InterfaceType: "string"},
+				{Name: "at-all", Property: "atAll", Required: boolPtr(false), InterfaceType: "boolean"},
+				{Name: "at-open-dingtalk-ids", Property: "atOpenDingTalkIds", Required: boolPtr(false), InterfaceType: "array"},
 				{Name: "conversation-id", Property: "openConversationId"},
 			},
 		},
@@ -5460,6 +5476,8 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	_ = chatMessageReplyCmd.MarkFlagRequired("text")
 	chatMessageReplyCmd.Flags().String("uuid", "", "幂等键（可选）")
 	chatMessageReplyCmd.Flags().Bool("ai-tag", true, "消息是否带 AI 发送角标（默认 true）")
+	chatMessageReplyCmd.Flags().Bool("at-all", false, "@所有人（仅群聊时生效；正文缺少 <@all> 时自动补齐）")
+	chatMessageReplyCmd.Flags().String("at-open-dingtalk-ids", "", "@指定成员的 openDingTalkId 列表，逗号分隔（仅群聊时生效；正文中的裸 @id 自动规范化为 <@id>）")
 	cli.AttachRuntimeSchema(chatMessageReplyCmd, "chat", "reply_personal_message", "hardcoded:chat")
 
 	// ── message forward: 转发单条消息 ────────────────────────

--- a/internal/helpers/chat_message_search_test.go
+++ b/internal/helpers/chat_message_search_test.go
@@ -309,6 +309,17 @@ func TestCrossPlatformCoverageChatCurrentUserSendAndReplyMentions(t *testing.T) 
 			wantOpenIDs:  []string{"D-target", "D-second"},
 		},
 		{
+			name: "send keeps missing member placeholders unchanged",
+			args: []string{
+				"message", "send", "--group", "cid",
+				"--text", "DWS 发消息自测",
+				"--at-open-dingtalk-ids", "D-target",
+			},
+			contentField: "text",
+			wantContent:  "DWS 发消息自测",
+			wantOpenIDs:  []string{"D-target"},
+		},
+		{
 			name: "reply",
 			args: []string{
 				"message", "reply",
@@ -323,6 +334,36 @@ func TestCrossPlatformCoverageChatCurrentUserSendAndReplyMentions(t *testing.T) 
 			wantContent:  "<@all> 收到 <@D-target> 和 <@D-second>",
 			wantAtAll:    true,
 			wantOpenIDs:  []string{"D-target", "D-second"},
+		},
+		{
+			name: "reply adds missing member placeholders",
+			args: []string{
+				"message", "reply",
+				"--conversation-id", "cid",
+				"--ref-msg-id", "mid",
+				"--ref-sender", "D-sender",
+				"--text", "DWS 回复艾特前津（非主用）自测",
+				"--at-open-dingtalk-ids", "D-target,D-second,D-target",
+			},
+			contentField: "content",
+			wantContent:  "<@D-target> <@D-second> DWS 回复艾特前津（非主用）自测",
+			wantOpenIDs:  []string{"D-target", "D-second", "D-target"},
+		},
+		{
+			name: "reply adds missing member placeholders after at-all",
+			args: []string{
+				"message", "reply",
+				"--conversation-id", "cid",
+				"--ref-msg-id", "mid",
+				"--ref-sender", "D-sender",
+				"--text", "请大家确认",
+				"--at-open-dingtalk-ids", "D-target",
+				"--at-all",
+			},
+			contentField: "content",
+			wantContent:  "<@all> <@D-target> 请大家确认",
+			wantAtAll:    true,
+			wantOpenIDs:  []string{"D-target"},
 		},
 		{
 			name: "reply at-all preserves alliance word",

--- a/internal/helpers/chat_message_search_test.go
+++ b/internal/helpers/chat_message_search_test.go
@@ -15,6 +15,7 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"reflect"
@@ -280,6 +281,109 @@ func TestChatSendAndReplyDisableAITagWithEmptyClawType(t *testing.T) {
 			got, present := caller.calls[0].args["clawType"]
 			if !present || got != "" {
 				t.Fatalf("clawType = %#v, present = %v; want present empty string", got, present)
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageChatCurrentUserSendAndReplyMentions(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		contentField string
+		wantContent  string
+		wantAtAll    bool
+		wantOpenIDs  []string
+	}{
+		{
+			name: "send",
+			args: []string{
+				"message", "send", "--group", "cid",
+				"--text", "收到 @D-target 和 <@D-second>",
+				"--at-open-dingtalk-ids", "D-target,D-second",
+				"--at-all",
+			},
+			contentField: "text",
+			wantContent:  "<@all> 收到 <@D-target> 和 <@D-second>",
+			wantAtAll:    true,
+			wantOpenIDs:  []string{"D-target", "D-second"},
+		},
+		{
+			name: "reply",
+			args: []string{
+				"message", "reply",
+				"--conversation-id", "cid",
+				"--ref-msg-id", "mid",
+				"--ref-sender", "D-sender",
+				"--text", "收到 @D-target 和 <@D-second>",
+				"--at-open-dingtalk-ids", "D-target,D-second",
+				"--at-all",
+			},
+			contentField: "content",
+			wantContent:  "<@all> 收到 <@D-target> 和 <@D-second>",
+			wantAtAll:    true,
+			wantOpenIDs:  []string{"D-target", "D-second"},
+		},
+		{
+			name: "reply at-all preserves alliance word",
+			args: []string{
+				"message", "reply",
+				"--conversation-id", "cid",
+				"--ref-msg-id", "mid",
+				"--ref-sender", "D-sender",
+				"--text", "联系 @alliance",
+				"--at-all",
+			},
+			contentField: "content",
+			wantContent:  "<@all> 联系 @alliance",
+			wantAtAll:    true,
+		},
+		{
+			name: "reply without at flags preserves alliance word",
+			args: []string{
+				"message", "reply",
+				"--conversation-id", "cid",
+				"--ref-msg-id", "mid",
+				"--ref-sender", "D-sender",
+				"--text", "联系 @alliance",
+			},
+			contentField: "content",
+			wantContent:  "联系 @alliance",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &chatChangedContractCaller{}
+			if err := executeChatChangedContract(t, caller, tc.args...); err != nil {
+				t.Fatal(err)
+			}
+			if len(caller.calls) != 1 || caller.calls[0].toolName != "send_personal_message" {
+				t.Fatalf("calls = %#v", caller.calls)
+			}
+			args := caller.calls[0].args
+			gotAtAll, hasAtAll := args["atAll"]
+			if tc.wantAtAll {
+				if !hasAtAll || gotAtAll != true {
+					t.Fatalf("atAll = %#v, present = %v; want true", gotAtAll, hasAtAll)
+				}
+			} else if hasAtAll {
+				t.Fatalf("atAll = %#v; want absent", gotAtAll)
+			}
+			gotOpenIDs, hasOpenIDs := args["atOpenDingTalkIds"]
+			if len(tc.wantOpenIDs) > 0 {
+				if !hasOpenIDs || !reflect.DeepEqual(gotOpenIDs, tc.wantOpenIDs) {
+					t.Fatalf("atOpenDingTalkIds = %#v, present = %v; want %#v", gotOpenIDs, hasOpenIDs, tc.wantOpenIDs)
+				}
+			} else if hasOpenIDs {
+				t.Fatalf("atOpenDingTalkIds = %#v; want absent", gotOpenIDs)
+			}
+			var content map[string]string
+			if err := json.Unmarshal([]byte(args["content"].(string)), &content); err != nil {
+				t.Fatal(err)
+			}
+			if got := content[tc.contentField]; got != tc.wantContent {
+				t.Fatalf("content[%q] = %q; want %q", tc.contentField, got, tc.wantContent)
 			}
 		})
 	}

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -1245,8 +1245,11 @@ Usage:
   dws chat message reply [flags]
 Example:
   dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "收到，马上处理"
+  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "<@mentionedOpenDingTalkId> 请看一下" --at-open-dingtalk-ids <mentionedOpenDingTalkId>
   # 被引用消息的 openMessageId、发送者 openDingTalkId 通过 dws chat message list 获取
 Flags:
+      --at-all                   @所有人（仅群聊时生效；正文缺少 <@all> 时自动补齐）
+      --at-open-dingtalk-ids string  @指定成员的 openDingTalkId 列表，逗号分隔（仅群聊时生效）
       --conversation-id string   会话 openConversationId (必填，支持单聊/群聊)
       --ref-msg-id string        被引用的消息 openMessageId (必填)
       --ref-sender string        被引用消息的发送者 openDingTalkId (必填)
@@ -1256,6 +1259,7 @@ Flags:
 
 注意:
   - 以当前用户身份引用回复，语义同 chat message send；目前回复类型仅支持 text
+  - 群聊 @指定成员时，正文中的裸 @openDingTalkId 会规范化为 <@openDingTalkId>；--at-all 会自动补齐 <@all>
 ```
 
 #### 转发单条消息 — 将一条消息从源会话转发到目标会话（源/目标均支持单聊/群聊）

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -1245,11 +1245,11 @@ Usage:
   dws chat message reply [flags]
 Example:
   dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "收到，马上处理"
-  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "<@mentionedOpenDingTalkId> 请看一下" --at-open-dingtalk-ids <mentionedOpenDingTalkId>
+  dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <openDingTalkId> --text "请看一下" --at-open-dingtalk-ids <mentionedOpenDingTalkId>
   # 被引用消息的 openMessageId、发送者 openDingTalkId 通过 dws chat message list 获取
 Flags:
       --at-all                   @所有人（仅群聊时生效；正文缺少 <@all> 时自动补齐）
-      --at-open-dingtalk-ids string  @指定成员的 openDingTalkId 列表，逗号分隔（仅群聊时生效）
+      --at-open-dingtalk-ids string  @指定成员的 openDingTalkId 列表，逗号分隔（仅群聊时生效；正文缺少对应 <@id> 时自动补齐）
       --conversation-id string   会话 openConversationId (必填，支持单聊/群聊)
       --ref-msg-id string        被引用的消息 openMessageId (必填)
       --ref-sender string        被引用消息的发送者 openDingTalkId (必填)
@@ -1259,7 +1259,7 @@ Flags:
 
 注意:
   - 以当前用户身份引用回复，语义同 chat message send；目前回复类型仅支持 text
-  - 群聊 @指定成员时，正文中的裸 @openDingTalkId 会规范化为 <@openDingTalkId>；--at-all 会自动补齐 <@all>
+  - 群聊 @指定成员时，正文缺少对应 <@openDingTalkId> 会自动补齐，已有裸 @openDingTalkId 会规范化；--at-all 会自动补齐 <@all>
 ```
 
 #### 转发单条消息 — 将一条消息从源会话转发到目标会话（源/目标均支持单聊/群聊）

--- a/skills/multi/dingtalk-chat/references/chat/chat-message.md
+++ b/skills/multi/dingtalk-chat/references/chat/chat-message.md
@@ -185,10 +185,10 @@ dws chat message edit --group <openConversationId> --msg-id <openMessageId> --co
 | `message combine-forward` | 多条消息合并为一条转发 | `--src-conversation-id` `--msg-ids` `--dest-conversation-id`，可选 `--uuid` |
 | `message forward-topic` | 转发话题消息 | `--src-msg-id` `--src-conversation-id` `--src-thread-id` `--dest-conversation-id` |
 
-群聊引用回复的 @ 规则与当前用户发消息一致：`--at-open-dingtalk-ids` 会传 `atOpenDingTalkIds`，正文中的裸 `@openDingTalkId` 自动规范化为 `<@openDingTalkId>`；`--at-all` 会传 `atAll=true`，正文缺少 `<@all>` 时自动补齐。
+群聊引用回复使用 `--at-open-dingtalk-ids` 传 `atOpenDingTalkIds`；正文缺少对应 `<@openDingTalkId>` 时自动补齐，已有裸 `@openDingTalkId` 会规范化。`--at-all` 会传 `atAll=true`，正文缺少 `<@all>` 时自动补齐。
 
 ```bash
-dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <senderOpenDingTalkId> --text "<@mentionedOpenDingTalkId> 请看一下" --at-open-dingtalk-ids <mentionedOpenDingTalkId>
+dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <senderOpenDingTalkId> --text "请看一下" --at-open-dingtalk-ids <mentionedOpenDingTalkId>
 dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <senderOpenDingTalkId> --text "请大家确认" --at-all
 ```
 

--- a/skills/multi/dingtalk-chat/references/chat/chat-message.md
+++ b/skills/multi/dingtalk-chat/references/chat/chat-message.md
@@ -180,10 +180,17 @@ dws chat message edit --group <openConversationId> --msg-id <openMessageId> --co
 
 | 命令 | 用途 | 必填参数 |
 |------|------|----------|
-| `message reply` | 引用回复，单聊/群聊均可 | `--conversation-id` `--ref-msg-id` `--ref-sender` `--text` |
+| `message reply` | 引用回复，单聊/群聊均可；群聊可 @指定成员或 @所有人 | `--conversation-id` `--ref-msg-id` `--ref-sender` `--text`；可选 `--at-open-dingtalk-ids` `--at-all` |
 | `message forward` | 转发单条消息，源/目标均支持单聊/群聊 | `--src-conversation-id` `--msg-id` `--dest-conversation-id` |
 | `message combine-forward` | 多条消息合并为一条转发 | `--src-conversation-id` `--msg-ids` `--dest-conversation-id`，可选 `--uuid` |
 | `message forward-topic` | 转发话题消息 | `--src-msg-id` `--src-conversation-id` `--src-thread-id` `--dest-conversation-id` |
+
+群聊引用回复的 @ 规则与当前用户发消息一致：`--at-open-dingtalk-ids` 会传 `atOpenDingTalkIds`，正文中的裸 `@openDingTalkId` 自动规范化为 `<@openDingTalkId>`；`--at-all` 会传 `atAll=true`，正文缺少 `<@all>` 时自动补齐。
+
+```bash
+dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <senderOpenDingTalkId> --text "<@mentionedOpenDingTalkId> 请看一下" --at-open-dingtalk-ids <mentionedOpenDingTalkId>
+dws chat message reply --conversation-id <openConversationId> --ref-msg-id <openMessageId> --ref-sender <senderOpenDingTalkId> --text "请大家确认" --at-all
+```
 
 ### 话题与卡片
 


### PR DESCRIPTION
## Summary

- What changed? `dws chat message reply` now accepts `--at-open-dingtalk-ids` and `--at-all`, forwards the existing `send_personal_message` mention fields, and adds any missing reply-body `<@id>` / `<@all>` placeholders. Existing current-user send behavior remains unchanged.
- Why is this change needed? Agents can now quote-reply in group chats while mentioning selected members or everyone without having to construct message placeholders manually.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [x] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

Record the smallest targeted evidence that proves the changed behavior. Do not
repeat the entire CI suite locally only to fill this checklist: CI expands the
selected tier from documentation checks, through affected-package tests, to
the complete high-risk suite.

- [x] Exact in-place `CHANGELOG.md`-only check (otherwise `N/A`): N/A — this is an implementation PR.
- [x] Targeted test/check commands and results:
  - `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/helpers -run '^TestCrossPlatformCoverageChatCurrentUserSendAndReplyMentions$' -count=1` — passed.
  - `go test ./internal/helpers -run TestCrossPlatformCoverageDriveStarCommands -count=1` — passed as the requested drive baseline smoke regression.
  - `make build` — passed.
  - `git diff --check` — passed.
- [x] Behavior evidence (test name, CLI output shape, or before/after result):
  - `TestCrossPlatformCoverageChatCurrentUserSendAndReplyMentions` covers selected-member mentions, `--at-all`, combined flags, missing placeholders, duplicate member IDs, the `@alliance` regression, and no-mention preservation.
  - The focused `chat` and `drive` command tests passed on PR head `545ee17316d7`.
  - A direct pre-production `dws chat message reply` invocation returned `success=true` and an `openTaskId`; all identifiers are redacted below.
  - Pre-production Agent self-tests successfully quote-replied with one selected member and with `@所有人`, then retrieved the sent messages and confirmed the reference and mention rendering.

## 指令 CI 集成测试截图（chat）

![chat 指令 CI 集成测试截图：定向测试通过](https://github.com/Anonymity-0/dingtalk-workspace-cli/releases/download/pr881-test-evidence/pr881-chat-ci.png)

![chat 指令 CI 集成测试截图：真实 CLI 调用成功](https://github.com/Anonymity-0/dingtalk-workspace-cli/releases/download/pr881-test-evidence/pr881-chat-cli-live.png)

chat 指令 CI 集成测试：**PASS**。定向回归测试和预发真实 CLI 调用均通过，真实调用返回 `success=true`；标识符均已脱敏。

## Agent 测试报告截图（chat）

![chat Agent 测试报告截图：引用回复并艾特指定成员](https://github.com/Anonymity-0/dingtalk-workspace-cli/releases/download/pr881-test-evidence/pr881-chat-agent-member.png)

![chat Agent 测试报告截图：引用回复并艾特所有人](https://github.com/Anonymity-0/dingtalk-workspace-cli/releases/download/pr881-test-evidence/pr881-chat-agent-all.png)

chat Agent 测试报告：**PASS**。Agent 分别完成引用回复并艾特指定成员、引用回复并艾特所有人，且回拉消息确认引用关系与艾特渲染正确。

- [x] Documentation links/content/rendering checked (documentation-only, otherwise `N/A`) — N/A; CLI and bundled Skill references were reviewed against the implemented flags.
- [x] Full local suite run because the change is high-risk (optional for other tiers; record command/result or `N/A`) — N/A for Standard risk.
- [x] `./scripts/policy/check-generated-drift.sh` — passed.
  (when generator inputs or generated artifacts may change)
- [x] `./scripts/policy/check-command-surface.sh --strict` — passed after rebase.
  (if command surface changed)
- [x] `./scripts/release/verify-package-managers.sh` — N/A; packaging and installer surfaces are unchanged.
  (after `make package`, if packaging or installer surfaces changed)

Additional Schema evidence: `./scripts/policy/check-schema-catalog.sh` passed with 27 products and 908 tools.

## Notes

- Mention placeholder insertion is intentionally reply-only. The shared current-user argument mapping is reused, while existing `message send` body behavior is preserved for compatibility.
- Test identities, conversation IDs, message IDs, task IDs, and the pre-production endpoint are omitted from the branch and PR text.

The repository automatically requests one eligible peer reviewer, including
after a new head push when another review is needed. Once the latest push has
peer approval and all nine required checks are current and green, auto-merge
completes the PR; authors do not need to coordinate a separate routine merge.
