### PR TITLE
Retire MCP pin candidates from Schema parameter assembly

### DIFF
--- a/internal/cli/contract_final_assembly_test.go
+++ b/internal/cli/contract_final_assembly_test.go
@@ -24,39 +24,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func TestCrossPlatformCoverageRuntimeToolSpecFromContractFinalMCPMetadataLookup(t *testing.T) {
-	cmd := &cobra.Command{Use: "reply"}
-	t.Cleanup(func() { contractfinal.ClearRuntimeContractFinalForTest(cmd) })
-	cmd.Flags().String("text", "", "text")
-	runtimeannotate.AnnotateRuntimeFlag(cmd, "text", "text", "string", false)
-	contractfinal.RegisterRuntimeContractFinal(cmd, contract.ContractFinalPayload{
-		Identity: &contract.ToolIdentitySpec{
-			ProductID: "chat", Name: "reply_personal_message", CanonicalPath: "chat.reply_personal_message",
-			CLIPath: "chat reply", PrimaryCLIPath: "chat reply",
-		},
-		Interface: &contract.InterfaceSpec{
-			Mode:         contract.InterfaceModeMCP,
-			Availability: contract.InterfaceAvailable,
-			Ref:          &contract.InterfaceRefSpec{ProductID: "chat", RPCName: "send_personal_message"},
-		},
-	})
-
-	entry := runtimeSchemaEntry{
-		ProductID: "chat", ToolName: "reply_personal_message", Command: cmd,
-		CLIPath: "chat reply", PrimaryCLIPath: "chat reply",
-	}
-	metadata := runtimeSchemaMetadataSources{
-		MCP: embeddedMCPMetadata{Tools: map[string]embeddedMCPToolMetadata{
-			"chat.send_personal_message": {Parameters: map[string]embeddedMCPParamMeta{
-				"text": {Type: "string"},
-			}},
-		}},
-	}
-	if _, err := runtimeToolSpecFromContractFinal(entry, mustFinal(t, cmd), metadata); err != nil {
-		t.Fatalf("runtimeToolSpecFromContractFinal with MCP metadata = %v", err)
-	}
-}
-
 func TestCrossPlatformCoverageRuntimeToolSpecFromContractFinalPassThrough(t *testing.T) {
 	cmd := &cobra.Command{Use: "create", Short: "s", Long: "l"}
 	t.Cleanup(func() { contractfinal.ClearRuntimeContractFinalForTest(cmd) })
@@ -318,7 +285,7 @@ func TestCrossPlatformCoverageRuntimeToolSpecFromContractFinalSafetyAnnotationFa
 func TestCrossPlatformCoverageRuntimeToolSpecFromContractFinalParameterResolutionError(t *testing.T) {
 	oldParameters := resolveRuntimeParameters
 	t.Cleanup(func() { resolveRuntimeParameters = oldParameters })
-	resolveRuntimeParameters = func(*cobra.Command, string, map[string]embeddedMCPParamMeta, RuntimeSchemaConstraints) ([]ParameterSpec, error) {
+	resolveRuntimeParameters = func(*cobra.Command, string, RuntimeSchemaConstraints) ([]ParameterSpec, error) {
 		return nil, errors.New("parameters failed")
 	}
 	entry := runtimeSchemaEntry{

--- a/internal/cli/runtime_schema.go
+++ b/internal/cli/runtime_schema.go
@@ -89,9 +89,9 @@ func RegisterRuntimeSchemaConstraints(canonicalPath string, constraints RuntimeS
 }
 
 // emptyPinnedMCPMetadata returns the retired pin shape with no tools.
-// schema_mcp_metadata.json is deleted; production assembly does not embed or
-// load a pinned MCP snapshot. Test fixtures may still inject non-empty maps
-// through schemaRegistryForTestWithMetadata.
+// schema_mcp_metadata.json is deleted; Schema parameter assembly never loads
+// or ranks MCP pin candidates. Optional Interface-registry validators may
+// still pass this empty shape when they only need ContractFinal self-checks.
 func emptyPinnedMCPMetadata() embeddedMCPMetadata {
 	return embeddedMCPMetadata{Tools: map[string]embeddedMCPToolMetadata{}}
 }
@@ -217,62 +217,6 @@ func collectRuntimeSchemaEntriesFromBound(bound BoundCommandRegistry) ([]runtime
 	return entries, nil
 }
 
-func pinnedMCPMetadataForEntryFrom(entry runtimeSchemaEntry, agentMetadata agentMetadata, mcpMetadata embeddedMCPMetadata) (embeddedMCPToolMetadata, bool) {
-	// Optional test/diagnostic lookup only. Production mcpMetadata is empty;
-	// Contract/ParamDecl own interface facts. When a non-empty fixture is
-	// injected, ContractFinal Interface.Ref remaps CLI canonical names onto
-	// fixture keys (e.g. reply_personal_message → chat.send_personal_message).
-	if len(mcpMetadata.Tools) == 0 {
-		return embeddedMCPToolMetadata{}, false
-	}
-	if entry.Command != nil {
-		if final, ok := RuntimeContractFinal(entry.Command); ok && final.Interface != nil && final.Interface.Ref != nil {
-			if metadata, found := mcpMetadataForInterfaceRef(mcpMetadata, final.Interface.Ref.ProductID, final.Interface.Ref.RPCName); found {
-				return metadata, true
-			}
-		}
-	}
-	paths := []string{
-		entry.PrimaryCLIPath,
-		entry.CLIPath,
-		entry.ProductID + "." + entry.ToolName,
-	}
-	paths = append(paths, entry.Aliases...)
-	if toolMetadata, ok := lookupAgentToolMetadataFrom(agentMetadata, paths...); ok && toolMetadata.InterfaceRef != nil {
-		if metadata, found := mcpMetadataForInterfaceRef(mcpMetadata, toolMetadata.InterfaceRef.ProductID, toolMetadata.InterfaceRef.RPCName); found {
-			return metadata, true
-		}
-	}
-	for _, key := range []string{
-		entry.SourceProductID + "." + entry.ToolName,
-		entry.ProductID + "." + entry.ToolName,
-	} {
-		key = strings.Trim(key, ".")
-		if key == "" {
-			continue
-		}
-		if meta, ok := mcpMetadata.Tools[key]; ok {
-			return meta, true
-		}
-	}
-	return embeddedMCPToolMetadata{}, false
-}
-
-func mcpMetadataForInterfaceRef(mcpMetadata embeddedMCPMetadata, productID, rpcName string) (embeddedMCPToolMetadata, bool) {
-	productID = strings.TrimSpace(productID)
-	rpcName = strings.TrimSpace(rpcName)
-	key := strings.Trim(productID+"."+rpcName, ".")
-	if key == "" {
-		return embeddedMCPToolMetadata{}, false
-	}
-	metadata, exists := mcpMetadata.Tools[key]
-	if !exists {
-		return embeddedMCPToolMetadata{}, false
-	}
-	metadata.InterfaceRef = &embeddedMCPInterfaceRef{ProductID: productID, RPCName: rpcName}
-	return metadata, true
-}
-
 func runtimeSchemaAnnotations(cmd *cobra.Command) (productID, toolName, source string) {
 	if cmd == nil || cmd.Annotations == nil {
 		return "", "", ""
@@ -322,7 +266,6 @@ const (
 	runtimeSchemaRankDefault          = 0
 	runtimeSchemaRankDerived          = 50
 	runtimeSchemaRankInference        = 100
-	runtimeSchemaRankMCP              = 400
 	runtimeSchemaRankCobraHelp        = 450
 	runtimeSchemaRankCobraDefault     = 600
 	runtimeSchemaRankCobraContract    = 610
@@ -332,7 +275,7 @@ const (
 	runtimeSchemaRankVersionedBinding = 650
 	// ParamDecl.Property (dws.schema.property) outranks residual versioned
 	// binding candidates (active bindings JSON is empty after Phase 2).
-	// Mapping exclusions stay highest so an explicit "no MCP property" review
+	// Mapping exclusions stay highest so an explicit "no RPC property" review
 	// cannot be overridden by a leaf ParamDecl that still carries a Property.
 	runtimeSchemaRankParamDeclProperty = 655
 	runtimeSchemaRankMappingExclusion  = 660
@@ -340,7 +283,6 @@ const (
 	runtimeSchemaPrecedenceDefault          = "default"
 	runtimeSchemaPrecedenceDerived          = "derived_resolution"
 	runtimeSchemaPrecedenceInference        = "inference"
-	runtimeSchemaPrecedenceMCP              = "mcp_metadata"
 	runtimeSchemaPrecedenceCobraHelp        = "cobra_help"
 	runtimeSchemaPrecedenceCobra            = "cobra_contract"
 	runtimeSchemaPrecedenceNativeAnnotation = "native_annotation"
@@ -533,8 +475,6 @@ func runtimeSchemaSourcePriority(source string) (int, string) {
 			return runtimeSchemaRankCobraDefault, runtimeSchemaPrecedenceCobra
 		}
 		return runtimeSchemaRankCobraContract, runtimeSchemaPrecedenceCobra
-	case "mcp_metadata", "pinned_mcp_metadata":
-		return runtimeSchemaRankMCP, runtimeSchemaPrecedenceMCP
 	case "cobra_help":
 		return runtimeSchemaRankCobraHelp, runtimeSchemaPrecedenceCobraHelp
 	case "flag_name_inference", "usage_required_inference", "usage_format_inference":
@@ -575,9 +515,9 @@ func runtimeSchemaParameterMappingKey(canonicalPath, flagName string) string {
 
 // runtimeSchemaParameterMappingCandidates resolves the two reviewed,
 // versioned property-mapping inputs. An exclusion is an explicit statement
-// that the CLI parameter is not a direct MCP property: it therefore supplies
-// a present empty candidate (rather than allowing name inference to survive)
-// and keeps the review reason in provenance.
+// that the CLI parameter is not a direct RPC/interface property: it therefore
+// supplies a present empty candidate (rather than allowing name inference to
+// survive) and keeps the review reason in provenance.
 func runtimeSchemaParameterMappingCandidates(snapshot schemaParameterBindingSnapshot, canonicalPath, flagName string) (runtimeSchemaFieldCandidate, runtimeSchemaFieldCandidate, error) {
 	binding := strings.TrimSpace(snapshot.Bindings[strings.TrimSpace(canonicalPath)][strings.TrimSpace(flagName)])
 	bindingCandidate := runtimeSchemaStringCandidate(binding, "versioned_parameter_binding")
@@ -605,34 +545,24 @@ func runtimeSchemaParameterMappingCandidates(snapshot schemaParameterBindingSnap
 type runtimeParameterFieldContext struct {
 	flag        *pflag.Flag
 	metadata    RuntimeSchemaParameterMetadata
-	pinnedParam embeddedMCPParamMeta
-	hasPinned   bool
 	paramType   string
 	constraints RuntimeSchemaConstraints
 	property    string
 }
 
 func (c runtimeParameterFieldContext) interfaceTypeCandidates() []runtimeSchemaFieldCandidate {
-	candidates := []runtimeSchemaFieldCandidate{
+	return []runtimeSchemaFieldCandidate{
 		runtimeSchemaStringCandidate(firstFlagAnnotation(c.flag, runtimeSchemaFlagTypeAnnotation), "native_annotation"),
-	}
-	if c.hasPinned {
-		candidates = append(candidates, runtimeSchemaStringCandidate(c.pinnedParam.Type, "mcp_metadata"))
-	}
-	return append(candidates,
 		runtimeSchemaStringCandidateAtRank(c.paramType, "cobra_flag_type", runtimeSchemaRankInference, "fallback"),
-	)
+	}
 }
 
 func (c runtimeParameterFieldContext) descriptionCandidates() []runtimeSchemaFieldCandidate {
-	candidates := []runtimeSchemaFieldCandidate{
+	return []runtimeSchemaFieldCandidate{
 		runtimeSchemaStringCandidate(firstFlagAnnotation(c.flag, runtimeSchemaFlagDescriptionAnnotation), "native_annotation"),
 		runtimeSchemaStringCandidate(c.flag.Usage, "cobra_usage"),
+		runtimeSchemaCandidate("", true, "default"),
 	}
-	if c.hasPinned {
-		candidates = append(candidates, runtimeSchemaStringCandidate(c.pinnedParam.Description, "mcp_metadata"))
-	}
-	return append(candidates, runtimeSchemaCandidate("", true, "default"))
 }
 
 func (c runtimeParameterFieldContext) requiredCandidates() []runtimeSchemaFieldCandidate {
@@ -649,7 +579,7 @@ func (c runtimeParameterFieldContext) requiredCandidates() []runtimeSchemaFieldC
 			break
 		}
 	}
-	candidates := []runtimeSchemaFieldCandidate{
+	return []runtimeSchemaFieldCandidate{
 		constraintRequired,
 		runtimeSchemaCandidate(true, typedRequired, "typed_parameter_metadata"),
 		runtimeSchemaAnnotatedBoolCandidate(c.flag, runtimeSchemaFlagMetadataRequiredAnnotation, "typed_parameter_metadata"),
@@ -657,50 +587,36 @@ func (c runtimeParameterFieldContext) requiredCandidates() []runtimeSchemaFieldC
 		runtimeSchemaCandidate(true, runtimeFlagCobraHardRequired(c.flag), "cobra_hard_required"),
 		runtimeSchemaCandidate(false, cobraDefaultOptional, "cobra_nonzero_default"),
 		runtimeSchemaCandidate(usageRequired, usageRequired, "usage_required_inference"),
+		runtimeSchemaCandidate(false, true, "default"),
 	}
-	if c.hasPinned && c.pinnedParam.Required != nil {
-		candidates = append(candidates, runtimeSchemaCandidate(*c.pinnedParam.Required, true, "mcp_metadata"))
-	}
-	return append(candidates, runtimeSchemaCandidate(false, true, "default"))
 }
 
 func (c runtimeParameterFieldContext) requiredWhenCandidates() []runtimeSchemaFieldCandidate {
-	candidates := []runtimeSchemaFieldCandidate{
+	return []runtimeSchemaFieldCandidate{
 		runtimeSchemaStringCandidate(c.metadata.RequiredWhen[c.flag.Name], "typed_parameter_metadata"),
 		runtimeSchemaStringCandidate(firstFlagAnnotation(c.flag, runtimeSchemaFlagMetadataRequiredWhenAnnotation), "typed_parameter_metadata"),
 		runtimeSchemaStringCandidate(firstFlagAnnotation(c.flag, runtimeSchemaFlagRequiredWhenAnnotation), "native_annotation"),
+		runtimeSchemaCandidate("", true, "default"),
 	}
-	if c.hasPinned {
-		candidates = append(candidates, runtimeSchemaStringCandidate(c.pinnedParam.RequiredWhen, "mcp_metadata"))
-	}
-	return append(candidates, runtimeSchemaCandidate("", true, "default"))
 }
 
 func (c runtimeParameterFieldContext) formatCandidates() []runtimeSchemaFieldCandidate {
-	candidates := []runtimeSchemaFieldCandidate{
+	return []runtimeSchemaFieldCandidate{
 		runtimeSchemaStringCandidate(c.metadata.Formats[c.flag.Name], "typed_parameter_metadata"),
 		runtimeSchemaStringCandidate(firstFlagAnnotation(c.flag, runtimeSchemaFlagMetadataFormatAnnotation), "typed_parameter_metadata"),
 		runtimeSchemaStringCandidate(firstFlagAnnotation(c.flag, "x-cli-format"), "native_annotation"),
-	}
-	if c.hasPinned {
-		candidates = append(candidates, runtimeSchemaStringCandidate(c.pinnedParam.Format, "mcp_metadata"))
-	}
-	return append(candidates,
 		runtimeSchemaStringCandidate(inferredRuntimeFlagFormat(c.flag), "usage_format_inference"),
 		runtimeSchemaCandidate("", true, "default"),
-	)
+	}
 }
 
 func (c runtimeParameterFieldContext) enumCandidates() []runtimeSchemaFieldCandidate {
-	candidates := []runtimeSchemaFieldCandidate{
+	return []runtimeSchemaFieldCandidate{
 		runtimeSchemaEnumCandidate(c.metadata.Enums[c.flag.Name], "typed_parameter_metadata"),
 		runtimeSchemaEnumCandidate(runtimeFlagEnumAnnotation(c.flag, runtimeSchemaFlagMetadataEnumAnnotation), "typed_parameter_metadata"),
 		runtimeSchemaEnumCandidate(runtimeFlagEnum(c.flag), "native_annotation"),
+		runtimeSchemaCandidate([]string{}, true, "default"),
 	}
-	if c.hasPinned {
-		candidates = append(candidates, runtimeSchemaEnumCandidate(c.pinnedParam.Enum, "mcp_metadata"))
-	}
-	return append(candidates, runtimeSchemaCandidate([]string{}, true, "default"))
 }
 
 func (c runtimeParameterFieldContext) exampleCandidates() []runtimeSchemaFieldCandidate {
@@ -717,7 +633,8 @@ func (c runtimeParameterFieldContext) exampleCandidates() []runtimeSchemaFieldCa
 // source may intentionally raise or lower type/mapping/description semantics.
 // required is different: Cobra MarkFlagRequired is a hard floor that no
 // lower-priority source may demote (see resolveRequiredProjection).
-func runtimeCommandParameterSpecs(cmd *cobra.Command, canonicalPath string, pinnedParams map[string]embeddedMCPParamMeta, constraints RuntimeSchemaConstraints) ([]ParameterSpec, error) {
+// MCP pin / mcp_metadata is not a candidate source.
+func runtimeCommandParameterSpecs(cmd *cobra.Command, canonicalPath string, constraints RuntimeSchemaConstraints) ([]ParameterSpec, error) {
 	if cmd == nil {
 		return nil, nil
 	}
@@ -758,18 +675,10 @@ func runtimeCommandParameterSpecs(cmd *cobra.Command, canonicalPath string, pinn
 			return
 		}
 		property, _ := propertyWinner.Value.(string)
-		// pinnedParams remains for test fixtures that inject MCP-shaped maps;
-		// production assembly always passes an empty map (pin retired).
-		pinnedParam, hasPinnedParam := embeddedMCPParamMeta{}, false
-		if len(pinnedParams) > 0 && strings.TrimSpace(property) != "" {
-			pinnedParam, hasPinnedParam = lookupPinnedMCPParam(pinnedParams, property, flag.Name)
-		}
 		paramType := runtimeFlagCLIType(flag)
 		fieldCtx := runtimeParameterFieldContext{
 			flag:        flag,
 			metadata:    metadata,
-			pinnedParam: pinnedParam,
-			hasPinned:   hasPinnedParam,
 			paramType:   paramType,
 			constraints: constraints,
 			property:    property,
@@ -794,10 +703,6 @@ func runtimeCommandParameterSpecs(cmd *cobra.Command, canonicalPath string, pinn
 			return
 		}
 		description, _ := descriptionWinner.Value.(string)
-		interfaceDescription := ""
-		if hasPinnedParam {
-			interfaceDescription = strings.TrimSpace(pinnedParam.Description)
-		}
 
 		// Required uses field-level safe merge: higher sources may raise required, but
 		// Cobra MarkFlagRequired cannot be projected away as optional.
@@ -838,9 +743,6 @@ func runtimeCommandParameterSpecs(cmd *cobra.Command, canonicalPath string, pinn
 				runtimeSchemaCandidate(true, true, "cobra_hard_required"),
 			)
 		}
-		if interfaceDescription != "" && interfaceDescription != description {
-			parameter.InterfaceDescription = interfaceDescription
-		}
 		if interfaceType != "" && interfaceType != paramType {
 			parameter.InterfaceType = interfaceType
 			fieldProvenance["interface_type"] = runtimeSchemaFieldProvenance(interfaceTypeWinner)
@@ -854,12 +756,6 @@ func runtimeCommandParameterSpecs(cmd *cobra.Command, canonicalPath string, pinn
 		fieldProvenance["required_when"] = runtimeSchemaFieldProvenance(requiredWhenWinner)
 		if def := runtimeFlagDefault(flag); def != "" {
 			parameter.Default = runtimeSchemaJSONString(def)
-		}
-		if hasPinnedParam {
-			interfaceDefault := strings.TrimSpace(pinnedParam.Default)
-			if interfaceDefault != "" && interfaceDefault != runtimeFlagDefault(flag) {
-				parameter.InterfaceDefault = runtimeSchemaJSONString(interfaceDefault)
-			}
 		}
 		formatWinner, ok := resolveField("format", fieldCtx.formatCandidates())
 		if !ok {
@@ -989,19 +885,6 @@ func normalizeRuntimeSchemaConstraints(constraints RuntimeSchemaConstraints) Run
 
 func runtimeSchemaConstraintsEmpty(constraints RuntimeSchemaConstraints) bool {
 	return runtimeannotate.ConstraintsEmpty(constraints)
-}
-
-func lookupPinnedMCPParam(params map[string]embeddedMCPParamMeta, property, flagName string) (embeddedMCPParamMeta, bool) {
-	if len(params) == 0 {
-		return embeddedMCPParamMeta{}, false
-	}
-	if meta, ok := params[property]; ok {
-		return meta, true
-	}
-	if meta, ok := params[flagName]; ok {
-		return meta, true
-	}
-	return embeddedMCPParamMeta{}, false
 }
 
 func isGenericPayloadFlag(flag *pflag.Flag) bool {

--- a/internal/cli/runtime_schema_coverage_more_test.go
+++ b/internal/cli/runtime_schema_coverage_more_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
-	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contractfinal"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/runtimeannotate"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
 	"github.com/spf13/cobra"
@@ -63,39 +62,6 @@ func TestCrossPlatformCoverageCollectRuntimeSchemaEntriesErrorsAndOrdering(t *te
 }
 
 func TestCrossPlatformCoverageRuntimeSchemaMetadataLookupEdges(t *testing.T) {
-	if _, ok := pinnedMCPMetadataForEntryFrom(runtimeSchemaEntry{}, agentMetadata{}, embeddedMCPMetadata{Tools: map[string]embeddedMCPToolMetadata{}}); ok {
-		t.Fatal("empty lookup unexpectedly matched")
-	}
-
-	leaf := &cobra.Command{Use: "reply"}
-	contractfinal.RegisterRuntimeContractFinal(leaf, contract.ContractFinalPayload{
-		Identity: &contract.ToolIdentitySpec{
-			ProductID: "sample", Name: "run", CanonicalPath: "sample.run",
-			CLIPath: "sample run", PrimaryCLIPath: "sample run",
-		},
-
-		Interface: &contract.InterfaceSpec{
-			Mode:         contract.InterfaceModeMCP,
-			Availability: contract.InterfaceAvailable,
-			Ref:          &contract.InterfaceRefSpec{ProductID: "chat", RPCName: "send_personal_message"},
-		},
-	})
-	t.Cleanup(func() { ClearRuntimeContractFinalForTest(leaf) })
-	mcp := embeddedMCPMetadata{Tools: map[string]embeddedMCPToolMetadata{
-		"chat.send_personal_message": {
-			Parameters: map[string]embeddedMCPParamMeta{
-				"clawType": {Type: "string"},
-			},
-		},
-	}}
-	got, ok := pinnedMCPMetadataForEntryFrom(runtimeSchemaEntry{Command: leaf, ProductID: "chat", ToolName: "reply_personal_message"}, agentMetadata{}, mcp)
-	if !ok || got.Parameters["clawType"].Type != "string" {
-		t.Fatalf("ContractFinal Interface.Ref MCP remap = %#v ok=%v", got, ok)
-	}
-	if got.InterfaceRef == nil || got.InterfaceRef.RPCName != "send_personal_message" {
-		t.Fatalf("InterfaceRef = %#v", got.InterfaceRef)
-	}
-
 	for _, test := range []struct {
 		value any
 		want  int
@@ -155,13 +121,13 @@ func TestCrossPlatformCoverageRuntimeCommandParameterErrorEdges(t *testing.T) {
 	cmd.Flags().String("value", "", "value")
 	flag := cmd.Flags().Lookup("value")
 
-	if specs, err := runtimeCommandParameterSpecs(nil, "sample.run", nil, RuntimeSchemaConstraints{}); err != nil || specs != nil {
+	if specs, err := runtimeCommandParameterSpecs(nil, "sample.run", RuntimeSchemaConstraints{}); err != nil || specs != nil {
 		t.Fatalf("nil command specs = %#v, err = %v", specs, err)
 	}
 	testseam.Swap(t, &schemaParameterBindingData, func() (schemaParameterBindingSnapshot, error) {
 		return schemaParameterBindingSnapshot{}, errors.New("load failed")
 	})
-	if _, err := runtimeCommandParameterSpecs(cmd, "sample.run", nil, RuntimeSchemaConstraints{}); err == nil || !strings.Contains(err.Error(), "load failed") {
+	if _, err := runtimeCommandParameterSpecs(cmd, "sample.run", RuntimeSchemaConstraints{}); err == nil || !strings.Contains(err.Error(), "load failed") {
 		t.Fatalf("binding load error = %v", err)
 	}
 	testseam.Swap(t, &schemaParameterBindingData, func() (schemaParameterBindingSnapshot, error) {
@@ -179,7 +145,7 @@ func TestCrossPlatformCoverageRuntimeCommandParameterErrorEdges(t *testing.T) {
 			MappingExclusions: map[string]string{"sample.run --value": " "},
 		}, nil
 	})
-	if _, err := runtimeCommandParameterSpecs(cmd, "sample.run", nil, RuntimeSchemaConstraints{}); err == nil || !strings.Contains(err.Error(), "mapping exclusion") {
+	if _, err := runtimeCommandParameterSpecs(cmd, "sample.run", RuntimeSchemaConstraints{}); err == nil || !strings.Contains(err.Error(), "mapping exclusion") {
 		t.Fatalf("mapping exclusion error = %v", err)
 	}
 	testseam.Swap(t, &schemaParameterBindingData, func() (schemaParameterBindingSnapshot, error) {
@@ -194,22 +160,22 @@ func TestCrossPlatformCoverageRuntimeCommandParameterErrorEdges(t *testing.T) {
 			}
 			return resolveRuntimeSchemaCandidate(field, candidates...)
 		})
-		if _, err := runtimeCommandParameterSpecs(cmd, "sample.run", nil, RuntimeSchemaConstraints{}); err == nil || !strings.Contains(err.Error(), target) {
+		if _, err := runtimeCommandParameterSpecs(cmd, "sample.run", RuntimeSchemaConstraints{}); err == nil || !strings.Contains(err.Error(), target) {
 			t.Fatalf("%s resolution error = %v", target, err)
 		}
 	}
 	resolveRuntimeSchemaField = realResolver
 
-	if specs, err := runtimeCommandParameterSpecs(&cobra.Command{Use: "empty"}, "sample.empty", nil, RuntimeSchemaConstraints{}); err != nil || specs != nil {
+	if specs, err := runtimeCommandParameterSpecs(&cobra.Command{Use: "empty"}, "sample.empty", RuntimeSchemaConstraints{}); err != nil || specs != nil {
 		t.Fatalf("empty specs = %#v, err = %v", specs, err)
 	}
-	if payload, err := runtimeCommandParameters(nil, "", nil, RuntimeSchemaConstraints{}); err != nil || payload != nil {
+	if payload, err := runtimeCommandParameters(nil, "", RuntimeSchemaConstraints{}); err != nil || payload != nil {
 		t.Fatalf("empty payload = %#v, err = %v", payload, err)
 	}
-	testseam.Swap(t, &runtimeCommandParameterSpecsForPayload, func(*cobra.Command, string, map[string]embeddedMCPParamMeta, RuntimeSchemaConstraints) ([]ParameterSpec, error) {
+	testseam.Swap(t, &runtimeCommandParameterSpecsForPayload, func(*cobra.Command, string, RuntimeSchemaConstraints) ([]ParameterSpec, error) {
 		return []ParameterSpec{{Name: "bad", Example: json.RawMessage("{")}}, nil
 	})
-	if _, err := runtimeCommandParameters(cmd, "sample.run", nil, RuntimeSchemaConstraints{}); err == nil || !strings.Contains(err.Error(), "serialize Schema parameter") {
+	if _, err := runtimeCommandParameters(cmd, "sample.run", RuntimeSchemaConstraints{}); err == nil || !strings.Contains(err.Error(), "serialize Schema parameter") {
 		t.Fatalf("payload serialization error = %v", err)
 	}
 
@@ -218,32 +184,21 @@ func TestCrossPlatformCoverageRuntimeCommandParameterErrorEdges(t *testing.T) {
 		t.Fatalf("required annotation = %v/%v", required, present)
 	}
 
-	// Fixture MCP-shaped maps still participate when explicitly injected.
+	// Binding snapshot still supplies reviewed property mappings without MCP pin.
 	testseam.Swap(t, &schemaParameterBindingData, func() (schemaParameterBindingSnapshot, error) {
 		return schemaParameterBindingSnapshot{
 			Bindings: map[string]map[string]string{"sample.run": {"value": "clawType"}},
 		}, nil
 	})
-	requiredTrue := true
-	specs, err := runtimeCommandParameterSpecs(cmd, "sample.run", map[string]embeddedMCPParamMeta{
-		"clawType": {
-			Type:        "string",
-			Description: "fixture description",
-			Required:    &requiredTrue,
-			Default:     "fixture-default",
-		},
-	}, RuntimeSchemaConstraints{})
+	specs, err := runtimeCommandParameterSpecs(cmd, "sample.run", RuntimeSchemaConstraints{})
 	if err != nil {
-		t.Fatalf("fixture pinned parameter specs error = %v", err)
+		t.Fatalf("parameter specs error = %v", err)
 	}
-	if len(specs) != 1 || specs[0].Property != "clawType" || specs[0].InterfaceDescription != "fixture description" {
-		t.Fatalf("fixture pinned parameter specs = %#v", specs)
+	if len(specs) != 1 || specs[0].Property != "clawType" {
+		t.Fatalf("parameter specs = %#v", specs)
 	}
-	if len(specs[0].InterfaceDefault) == 0 {
-		t.Fatalf("fixture interface_default missing: %#v", specs[0])
-	}
-	if prov := specs[0].FieldProvenance["required"]; prov.Source == "" {
-		t.Fatalf("fixture required provenance missing: %#v", specs[0].FieldProvenance)
+	if prov := specs[0].FieldProvenance["property"]; prov.Source == "" {
+		t.Fatalf("property provenance missing: %#v", specs[0].FieldProvenance)
 	}
 }
 
@@ -272,9 +227,6 @@ func TestCrossPlatformCoverageRuntimeSchemaPureHelperEdges(t *testing.T) {
 	}).RequireOneOf
 	if !reflect.DeepEqual(groups, [][]string{{"one"}}) {
 		t.Fatalf("normalized groups = %#v", groups)
-	}
-	if meta, ok := lookupPinnedMCPParam(map[string]embeddedMCPParamMeta{"flag": {Type: "string"}}, "property", "flag"); !ok || meta.Type != "string" {
-		t.Fatalf("flag fallback metadata = %#v/%v", meta, ok)
 	}
 	if isGenericPayloadFlag(nil) {
 		t.Fatal("nil flag cannot be a generic payload")

--- a/internal/cli/schema_agent_metadata.go
+++ b/internal/cli/schema_agent_metadata.go
@@ -189,25 +189,6 @@ func cloneFieldCandidates(source []contract.FieldCandidateProvenance) []contract
 	return out
 }
 
-func lookupAgentToolMetadataFrom(source agentMetadata, paths ...string) (agentToolMetadata, bool) {
-	seen := map[string]bool{}
-	for _, path := range paths {
-		for _, candidate := range []string{
-			strings.TrimSpace(path),
-			strings.Join(splitSchemaPathTokens(path), " "),
-		} {
-			if candidate == "" || seen[candidate] {
-				continue
-			}
-			seen[candidate] = true
-			if metadata, ok := source.Tools[candidate]; ok {
-				return metadata, true
-			}
-		}
-	}
-	return agentToolMetadata{}, false
-}
-
 // agentMetadataSummaryFromProducts publishes Catalog-level Agent coverage from
 // the assembled Schema surface (ContractFinal / ProductDecl). This keeps
 // runtime delivery and CI dumps hash-aligned without requiring build-time

--- a/internal/cli/schema_agent_metadata_test.go
+++ b/internal/cli/schema_agent_metadata_test.go
@@ -20,7 +20,6 @@ import (
 	"testing/fstest"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
-	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contractfinal"
 	"github.com/spf13/cobra"
 )
 
@@ -94,9 +93,8 @@ func TestRuntimeSchemaIncludesAgentMetadata(t *testing.T) {
 	// longer participates in assembly.
 	root := buildRuntimeSchemaTestRoot()
 	declareRuntimeSchemaTestRootDoc(t, root, nil)
-	mcpFixture := embeddedMCPMetadata{Tools: map[string]embeddedMCPToolMetadata{}}
 
-	leaf, err := runtimeSchemaPayloadForTestWithMetadata(root, []string{"doc.create_document"}, emptyAgentMetadata(), mcpFixture)
+	leaf, err := runtimeSchemaPayloadForTest(root, []string{"doc.create_document"})
 	if err != nil {
 		t.Fatalf("runtimeSchemaPayloadForTest(leaf): %v", err)
 	}
@@ -110,7 +108,7 @@ func TestRuntimeSchemaIncludesAgentMetadata(t *testing.T) {
 		t.Fatalf("leaf examples = %#v", leaf["examples"])
 	}
 
-	catalog, err := runtimeSchemaPayloadForTestWithMetadata(root, nil, emptyAgentMetadata(), mcpFixture)
+	catalog, err := runtimeSchemaPayloadForTest(root, nil)
 	if err != nil {
 		t.Fatalf("runtimeSchemaPayloadForTest(catalog): %v", err)
 	}
@@ -136,7 +134,7 @@ func TestRuntimeSchemaIncludesAgentMetadata(t *testing.T) {
 		t.Fatalf("product summary must not include examples: %#v", tools[0])
 	}
 
-	registry, err := schemaRegistryForTestWithMetadata(root, emptyAgentMetadata(), mcpFixture)
+	registry, err := schemaRegistryForTest(root)
 	if err != nil {
 		t.Fatalf("schemaRegistryForTest(): %v", err)
 	}
@@ -162,7 +160,7 @@ func TestRuntimeSchemaAllPayloadContainsFullLeafParameters(t *testing.T) {
 	// exercises the production assembly path.
 	root := buildRuntimeSchemaTestRoot()
 	declareRuntimeSchemaTestRootDoc(t, root, nil)
-	registry, err := schemaRegistryForTestWithMetadata(root, emptyAgentMetadata(), embeddedMCPMetadata{})
+	registry, err := schemaRegistryForTest(root)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,9 +201,8 @@ func schemaTestInt(value any) int {
 }
 
 func TestRuntimeSchemaUsesVersionedInterfaceRef(t *testing.T) {
-	// interface_ref declares on the leaf ContractFinal; the injected MCP
-	// fixture participates through the gated fixture lookup (remapped via the
-	// declared Interface.Ref).
+	// interface_ref declares on the leaf ContractFinal; MCP pin is not a
+	// parameter candidate source.
 	root := buildRuntimeSchemaTestRoot()
 	declareRuntimeSchemaTestRootDoc(t, root, func(payload *contract.ContractFinalPayload) {
 		payload.Interface = &contract.InterfaceSpec{
@@ -215,17 +212,8 @@ func TestRuntimeSchemaUsesVersionedInterfaceRef(t *testing.T) {
 			Ref:          &contract.InterfaceRefSpec{ProductID: "documents", RPCName: "create_doc_v2"},
 		}
 	})
-	mcpFixture := embeddedMCPMetadata{
-		Tools: map[string]embeddedMCPToolMetadata{
-			"documents.create_doc_v2": {
-				Parameters: map[string]embeddedMCPParamMeta{
-					"title": {Description: "MCP document title"},
-				},
-			},
-		},
-	}
 
-	payload, err := runtimeSchemaPayloadForTestWithMetadata(root, []string{"doc.create_document"}, emptyAgentMetadata(), mcpFixture)
+	payload, err := runtimeSchemaPayloadForTest(root, []string{"doc.create_document"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -233,110 +221,9 @@ func TestRuntimeSchemaUsesVersionedInterfaceRef(t *testing.T) {
 	if ref["product_id"] != "documents" || ref["rpc_name"] != "create_doc_v2" {
 		t.Fatalf("interface_ref = %#v", payload["interface_ref"])
 	}
-	parameters, _ := payload["parameters"].(map[string]any)
-	title, _ := parameters["title"].(map[string]any)
-	if title["interface_description"] != "MCP document title" {
-		t.Fatalf("title metadata = %#v", title)
+	if payload["interface_mode"] != contract.InterfaceModeMCP {
+		t.Fatalf("interface_mode = %#v", payload["interface_mode"])
 	}
-}
-
-func TestMCPRequiredParticipatesInSourcePrecedence(t *testing.T) {
-	required := true
-	mcpFixture := embeddedMCPMetadata{
-		Tools: map[string]embeddedMCPToolMetadata{
-			"sample.list_items": {
-				Parameters: map[string]embeddedMCPParamMeta{
-					"limit": {Required: &required},
-				},
-			},
-		},
-	}
-
-	root := &cobra.Command{Use: "dws"}
-	list := &cobra.Command{Use: "list", Run: func(*cobra.Command, []string) {}}
-	list.Flags().Int("limit", 0, "optional page size")
-	AttachRuntimeSchema(list, "sample", "list_items", "test")
-	sample := &cobra.Command{Use: "sample"}
-	sample.AddCommand(list)
-	root.AddCommand(sample)
-	declareSampleListItemsLeaf(t, list)
-
-	payload, err := runtimeSchemaPayloadForTestWithMetadata(root, []string{"sample.list_items"}, emptyAgentMetadata(), mcpFixture)
-	if err != nil {
-		t.Fatal(err)
-	}
-	parameters, _ := payload["parameters"].(map[string]any)
-	limit, _ := parameters["limit"].(map[string]any)
-	if limit["required"] != true {
-		t.Fatalf("MCP required candidate did not win over the default: %#v", limit)
-	}
-}
-
-func TestMCPDefaultDoesNotOverrideCLIDefault(t *testing.T) {
-	mcpFixture := embeddedMCPMetadata{
-		Tools: map[string]embeddedMCPToolMetadata{
-			"sample.list_items": {
-				Parameters: map[string]embeddedMCPParamMeta{
-					"limit": {Default: "50"},
-				},
-			},
-		},
-	}
-
-	root := &cobra.Command{Use: "dws"}
-	list := &cobra.Command{Use: "list", Run: func(*cobra.Command, []string) {}}
-	list.Flags().Int("limit", 10, "optional page size")
-	AttachRuntimeSchema(list, "sample", "list_items", "test")
-	sample := &cobra.Command{Use: "sample"}
-	sample.AddCommand(list)
-	root.AddCommand(sample)
-	declareSampleListItemsLeaf(t, list)
-
-	payload, err := runtimeSchemaPayloadForTestWithMetadata(root, []string{"sample.list_items"}, emptyAgentMetadata(), mcpFixture)
-	if err != nil {
-		t.Fatal(err)
-	}
-	parameters, _ := payload["parameters"].(map[string]any)
-	limit, _ := parameters["limit"].(map[string]any)
-	if limit["default"] != "10" || limit["interface_default"] != "50" {
-		t.Fatalf("CLI and interface defaults were not separated: %#v", limit)
-	}
-}
-
-// declareSampleListItemsLeaf registers the ContractFinal / ProductDecl
-// declarations for the synthetic sample.list_items leaf so MCP fixture tests
-// assemble through the production path.
-func declareSampleListItemsLeaf(t *testing.T, list *cobra.Command) {
-	t.Helper()
-	contractfinal.RegisterRuntimeContractFinal(list, contract.ContractFinalPayload{
-		Identity: &contract.ToolIdentitySpec{
-			ProductID: "sample", Name: "list_items", CanonicalPath: "sample.list_items",
-			CLIPath: "sample list", PrimaryCLIPath: "sample list",
-		},
-		Title:       "List items",
-		Description: "List sample items",
-		Safety: &contract.SafetySpec{
-			Effect: "read", Risk: "low", Confirmation: "not_required", Idempotency: "idempotent",
-		},
-		Interface: &contract.InterfaceSpec{
-			Mode: "local", Availability: "available", Reason: "test local leaf",
-		},
-		Selection: &contract.SelectionSpec{
-			AgentSummary: "List sample items",
-			UseWhen:      []string{"list sample items"},
-			AvoidWhen:    []string{"not listing"},
-		},
-	})
-	t.Cleanup(func() { contractfinal.ClearRuntimeContractFinalForTest(list) })
-	contract.RegisterProductDecl(contract.ProductDecl{
-		ID: "sample",
-		Selection: contract.ProductSelectionDecl{
-			AgentSummary: "Sample product",
-			UseWhen:      []string{"sample routing"},
-			AvoidWhen:    []string{"not sample"},
-		},
-	})
-	t.Cleanup(func() { contract.ClearProductDeclForTest("sample") })
 }
 
 func findSchemaProduct(products []map[string]any, id string) map[string]any {

--- a/internal/cli/schema_catalog_test.go
+++ b/internal/cli/schema_catalog_test.go
@@ -1304,7 +1304,7 @@ func TestDeliveryCatalogContactParamDeclsMatchMergeBaseContract(t *testing.T) {
 			}
 			if want.interfaceType != "" {
 				prov := schemaMap(param["field_provenance"])["interface_type"]
-				if src, _ := prov["source"].(string); src != "native_annotation" && src != "mcp_metadata" {
+				if src, _ := prov["source"].(string); src != "native_annotation" {
 					t.Fatalf("%s --%s interface_type source = %#v", tc.path, flagName, prov)
 				}
 			}

--- a/internal/cli/schema_orphan_helpers_test.go
+++ b/internal/cli/schema_orphan_helpers_test.go
@@ -137,8 +137,8 @@ func schemaToolSpecFromPayload(payload map[string]any) (ToolSpec, error) {
 
 // runtimeCommandParameters is the compatibility wire adapter used only by
 // tests; resolution happens in runtimeCommandParameterSpecs.
-func runtimeCommandParameters(cmd *cobra.Command, canonicalPath string, pinnedParams map[string]embeddedMCPParamMeta, constraints RuntimeSchemaConstraints) (map[string]any, error) {
-	specs, err := runtimeCommandParameterSpecsForPayload(cmd, canonicalPath, pinnedParams, constraints)
+func runtimeCommandParameters(cmd *cobra.Command, canonicalPath string, constraints RuntimeSchemaConstraints) (map[string]any, error) {
+	specs, err := runtimeCommandParameterSpecsForPayload(cmd, canonicalPath, constraints)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/schema_overall_gap_coverage_test.go
+++ b/internal/cli/schema_overall_gap_coverage_test.go
@@ -969,16 +969,16 @@ func TestOverallCoverageGapDeliveryCompletenessAndDryRun(t *testing.T) {
 func TestOverallCoverageGapRuntimeParamsAndAgentMetadata(t *testing.T) {
 	prevSpecs := runtimeCommandParameterSpecsForPayload
 	t.Cleanup(func() { runtimeCommandParameterSpecsForPayload = prevSpecs })
-	runtimeCommandParameterSpecsForPayload = func(*cobra.Command, string, map[string]embeddedMCPParamMeta, RuntimeSchemaConstraints) ([]ParameterSpec, error) {
+	runtimeCommandParameterSpecsForPayload = func(*cobra.Command, string, RuntimeSchemaConstraints) ([]ParameterSpec, error) {
 		return nil, fmt.Errorf("specs boom")
 	}
-	if _, err := runtimeCommandParameters(&cobra.Command{Use: "run"}, "sample.run", nil, RuntimeSchemaConstraints{}); err == nil {
+	if _, err := runtimeCommandParameters(&cobra.Command{Use: "run"}, "sample.run", RuntimeSchemaConstraints{}); err == nil {
 		t.Fatal("parameter specs error must surface")
 	}
-	runtimeCommandParameterSpecsForPayload = func(*cobra.Command, string, map[string]embeddedMCPParamMeta, RuntimeSchemaConstraints) ([]ParameterSpec, error) {
+	runtimeCommandParameterSpecsForPayload = func(*cobra.Command, string, RuntimeSchemaConstraints) ([]ParameterSpec, error) {
 		return []ParameterSpec{{Name: "ok", Type: "string"}}, nil
 	}
-	payload, err := runtimeCommandParameters(&cobra.Command{Use: "run"}, "sample.run", nil, RuntimeSchemaConstraints{})
+	payload, err := runtimeCommandParameters(&cobra.Command{Use: "run"}, "sample.run", RuntimeSchemaConstraints{})
 	if err != nil || payload["ok"] == nil {
 		t.Fatalf("parameter payload = %#v err=%v", payload, err)
 	}
@@ -1070,24 +1070,6 @@ func TestOverallCoverageGapRuntimeParamsAndAgentMetadata(t *testing.T) {
 }
 
 func TestCrossPlatformCoverageOverallRegressionRecovery(t *testing.T) {
-	if _, ok := lookupPinnedMCPParam(nil, "property", "flag"); ok {
-		t.Fatal("nil pinned params must miss")
-	}
-	if _, ok := lookupPinnedMCPParam(map[string]embeddedMCPParamMeta{}, "property", "flag"); ok {
-		t.Fatal("empty pinned params must miss")
-	}
-	if _, ok := lookupPinnedMCPParam(map[string]embeddedMCPParamMeta{"other": {Type: "string"}}, "property", "flag"); ok {
-		t.Fatal("unmatched pinned params must miss")
-	}
-	if _, ok := pinnedMCPMetadataForEntryFrom(runtimeSchemaEntry{}, agentMetadata{}, embeddedMCPMetadata{}); ok {
-		t.Fatal("empty MCP metadata must not match")
-	}
-	if _, ok := pinnedMCPMetadataForEntryFrom(runtimeSchemaEntry{}, agentMetadata{}, embeddedMCPMetadata{
-		Tools: map[string]embeddedMCPToolMetadata{"other.key": {}},
-	}); ok {
-		t.Fatal("missing MCP metadata keys must not match")
-	}
-
 	left := runtimeSchemaStringCandidateAtPriority("same", true, "z-source", 5, "p")
 	right := runtimeSchemaStringCandidateAtPriority("same", true, "a-source", 5, "p")
 	winner, err := resolveRuntimeSchemaCandidate("source-order", left, right)

--- a/internal/cli/schema_parameter_mapping_completeness_test.go
+++ b/internal/cli/schema_parameter_mapping_completeness_test.go
@@ -410,7 +410,7 @@ func TestRuntimeCommandParameterSpecsPreserveReviewedEmptyPropertyProvenance(t *
 	cmd := &cobra.Command{Use: "query"}
 	cmd.Flags().Bool("all", false, "fetch every page")
 
-	parameters, err := runtimeCommandParameterSpecs(cmd, "aitable.query_records", nil, RuntimeSchemaConstraints{})
+	parameters, err := runtimeCommandParameterSpecs(cmd, "aitable.query_records", RuntimeSchemaConstraints{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/schema_registry_test_helpers_test.go
+++ b/internal/cli/schema_registry_test_helpers_test.go
@@ -70,18 +70,6 @@ func schemaRegistryForTest(root *cobra.Command) (SchemaRegistry, error) {
 	return AssembleSchemaRegistryFromBound(bound)
 }
 
-func schemaRegistryForTestWithMetadata(root *cobra.Command, agent agentMetadata, mcp embeddedMCPMetadata) (SchemaRegistry, error) {
-	bound, err := boundTestCommandRegistry(root)
-	if err != nil {
-		return SchemaRegistry{}, err
-	}
-	// Production-shaped assembly: leaves must carry ContractFinal and products
-	// a ProductDecl (see declareRuntimeSchemaTestRootDoc). Injected MCP/agent
-	// fixtures participate only through the gated fixture lookup in
-	// runtimeToolSpecFromContractFinal; production passes an empty pin.
-	return assembleSchemaRegistryFromBound(bound, runtimeSchemaMetadataSources{Agent: agent, MCP: mcp})
-}
-
 // declareRuntimeSchemaTestRootDoc registers the ContractFinal / ProductDecl
 // declarations for the synthetic doc.create_document tree built by
 // buildRuntimeSchemaTestRoot, so production-shaped assembly can resolve it.
@@ -146,18 +134,6 @@ func loadedSchemaCatalogForTestRegistry(registry SchemaRegistry) (loadedSchemaCa
 
 func runtimeSchemaPayloadForTest(root *cobra.Command, args []string) (map[string]any, error) {
 	registry, err := schemaRegistryForTest(root)
-	if err != nil {
-		return nil, err
-	}
-	loaded, err := loadedSchemaCatalogForTestRegistry(registry)
-	if err != nil {
-		return nil, err
-	}
-	return schemaPayloadFromLoadedCatalog(loaded, args)
-}
-
-func runtimeSchemaPayloadForTestWithMetadata(root *cobra.Command, args []string, agent agentMetadata, mcp embeddedMCPMetadata) (map[string]any, error) {
-	registry, err := schemaRegistryForTestWithMetadata(root, agent, mcp)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/schema_runtime_registry.go
+++ b/internal/cli/schema_runtime_registry.go
@@ -15,8 +15,10 @@ import (
 )
 
 type runtimeSchemaMetadataSources struct {
+	// Agent remains only for historical test seams that still construct this
+	// struct; production assembly does not overlay Agent or MCP pin onto
+	// parameters or tool text.
 	Agent agentMetadata
-	MCP   embeddedMCPMetadata
 }
 
 var (
@@ -62,10 +64,9 @@ func (resolved ResolvedSchemaBuild) CommandCount() int {
 }
 
 func pinnedRuntimeSchemaMetadataSources() runtimeSchemaMetadataSources {
-	return runtimeSchemaMetadataSources{
-		Agent: runtimeAgentMetadata(),
-		MCP:   emptyPinnedMCPMetadata(),
-	}
+	// Production pin and Agent inject are both retired; assembly is Contract /
+	// ParamDecl / Cobra only.
+	return runtimeSchemaMetadataSources{}
 }
 
 // ResolveSchemaBuild is the only assembly path from executable Cobra commands
@@ -123,7 +124,7 @@ func AssembleSchemaRegistryFromBound(bound BoundCommandRegistry) (SchemaRegistry
 
 // assembleSchemaRegistryFromBound resolves every entry through the
 // ContractFinal / ProductDecl production path. Missing declarations fail
-// closed; retired skill/MCP/agent-inject overlays are never reopened.
+// closed; retired skill/MCP-pin/agent-inject overlays are never reopened.
 func assembleSchemaRegistryFromBound(bound BoundCommandRegistry, metadata runtimeSchemaMetadataSources) (SchemaRegistry, error) {
 	entries, err := assembleCollectEntries(bound)
 	if err != nil {
@@ -197,18 +198,12 @@ func assembleProductSelection(entry runtimeSchemaEntry) (contract.SelectionSpec,
 
 // runtimeToolSpecFromContractFinal pass-throughs Contract-authored Schema fields.
 // Declared values are the final data source; hints/registry text does not merge.
-// Production MCP pin is empty, so assembly skips MCP-metadata lookups entirely;
-// interface_type / interface_* facts come from ParamDecl / native annotations.
-// Tests may still inject a non-empty MCP fixture map, which participates through
-// pinnedMCPMetadataForEntryFrom.
+// MCP pin is retired: interface_type / interface_* facts come from ParamDecl /
+// native annotations only.
 func runtimeToolSpecFromContractFinal(entry runtimeSchemaEntry, final contract.ContractFinalPayload, metadata runtimeSchemaMetadataSources) (ToolSpec, error) {
+	_ = metadata // reserved for historical assemble seams; no overlay sources remain
 	canonicalPath := entry.ProductID + "." + entry.ToolName
 	constraints := runtimeCommandConstraints(entry.Command)
-	var pinnedParams map[string]embeddedMCPParamMeta
-	if len(metadata.MCP.Tools) > 0 {
-		pinnedMeta, _ := pinnedMCPMetadataForEntryFrom(entry, metadata.Agent, metadata.MCP)
-		pinnedParams = pinnedMeta.Parameters
-	}
 	// Apply parameter declarations from the contract.ContractFinalPayload before the
 	// resolver reads them. The decls were put there by AttachContract at
 	// DeclareLeafMetadata time; now that all flags exist on the fully-built
@@ -216,7 +211,7 @@ func runtimeToolSpecFromContractFinal(entry runtimeSchemaEntry, final contract.C
 	if err := ApplyParamDecls(entry.Command, final.Parameters); err != nil {
 		return ToolSpec{}, fmt.Errorf("apply Contract Schema ParamDecls for %s: %w", canonicalPath, err)
 	}
-	parameters, err := resolveRuntimeParameters(entry.Command, canonicalPath, pinnedParams, constraints)
+	parameters, err := resolveRuntimeParameters(entry.Command, canonicalPath, constraints)
 	if err != nil {
 		return ToolSpec{}, fmt.Errorf("resolve Contract Schema parameters for %s: %w", canonicalPath, err)
 	}

--- a/internal/cli/schema_source_root_coverage_test.go
+++ b/internal/cli/schema_source_root_coverage_test.go
@@ -278,23 +278,10 @@ func TestCrossPlatformCoverageRenderSafetyAnnotationSuccess(t *testing.T) {
 }
 
 func TestCrossPlatformCoverageMCPMetadataInterfaceRefEdges(t *testing.T) {
-	if _, ok := mcpMetadataForInterfaceRef(embeddedMCPMetadata{}, " ", " "); ok {
-		t.Fatal("blank interface ref must miss")
-	}
-	if _, ok := mcpMetadataForInterfaceRef(embeddedMCPMetadata{Tools: map[string]embeddedMCPToolMetadata{}}, "chat", "missing"); ok {
-		t.Fatal("missing MCP tool must miss")
-	}
-	agent := agentMetadata{Tools: map[string]agentToolMetadata{
-		"chat reply": {InterfaceRef: &embeddedMCPInterfaceRef{ProductID: "chat", RPCName: "send_personal_message"}},
-	}}
-	mcp := embeddedMCPMetadata{Tools: map[string]embeddedMCPToolMetadata{
-		"chat.send_personal_message": {Parameters: map[string]embeddedMCPParamMeta{"clawType": {Type: "string"}}},
-	}}
-	got, ok := pinnedMCPMetadataForEntryFrom(runtimeSchemaEntry{
-		PrimaryCLIPath: "chat reply", ProductID: "chat", ToolName: "reply_personal_message",
-	}, agent, mcp)
-	if !ok || got.Parameters["clawType"].Type != "string" {
-		t.Fatalf("agent InterfaceRef remap = %#v ok=%v", got, ok)
+	// MCP pin lookup helpers are retired; keep this named coverage slot as a
+	// no-op marker so CrossPlatformCoverage* selection stays stable.
+	if got := emptyPinnedMCPMetadata(); got.Tools == nil || len(got.Tools) != 0 {
+		t.Fatalf("empty pinned metadata = %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove retired MCP pin / mcp_metadata candidate paths from Schema parameter assembly
- Keep interface_mode=mcp and empty pin types used for interface/diagnostics
- Leave the field-precedence tournament and usage_required_inference alone

## Test plan
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/cli -count=1`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/app -run 'Schema|MCP|Param|Catalog|ContractFinal|Homolog' -count=1`
- [ ] CI green on the PR

Made with [Cursor](https://cursor.com)