### PR TITLE
docs(skills): dingtalk-drive SKILL 补充 --latest 域内路由

### DIFF
--- a/skills/multi/dingtalk-drive/SKILL.md
+++ b/skills/multi/dingtalk-drive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dingtalk-drive
-description: 钉钉文件管理（存储层）。Use when 用户说 钉盘/上传文件/下载文件/文件夹/查文件/找文件/全局搜索文件/复制/移动/重命名/删除/回收站/还原删除文件/权限管理/普通文件下载。任何文件类型都适用；文档内容编辑走 dingtalk-doc，知识库空间和空间内节点管理走 dingtalk-wiki。命令前缀：dws drive。
+description: 钉钉文件管理（存储层）。Use when 用户说 钉盘/上传文件/下载文件/文件夹/查文件/找文件/全局搜索文件/最新或最近修改的文件/复制/移动/重命名/删除/回收站/还原删除文件/权限管理/普通文件下载。任何文件类型都适用；文档内容编辑走 dingtalk-doc，知识库空间和空间内节点管理走 dingtalk-wiki。命令前缀：dws drive。
 metadata:
   cli_version: ">=0.2.14"
   category: product
@@ -38,6 +38,7 @@ metadata:
 | 用户说 | 命令 |
 |--------|------|
 | "看钉盘文件 / 文件夹列表" | `dws drive list [--folder <dentryUuid>]` |
+| "最新 / 最近修改的文件" | `dws drive list --latest <N>` |
 | "钉盘目录树" | `python scripts/drive_tree_list.py --depth 2` |
 | "查文件元数据" | `dws drive info --node <dentryUuid>` |
 | "搜文件 / 找文件" | `dws drive search --query "<关键词>"` |


### PR DESCRIPTION
为 #885 补充 skill 入口路由。

## 背景
真实 Agent e2e 测试（千问办公 / Qoder Work）发现：`--latest` 的路由指引只存在于 references 二级文档（drive.md / intent-guide.md），multi 模式入口 SKILL.md 零提及，导致 Agent 不下钻时退回 `drive search` 等既有路由。

## 改动（仅 2 行，multi/dingtalk-drive/SKILL.md）
1. frontmatter `Use when` 触发词列表加入「最新或最近修改的文件」
2. 意图表新增一行：`"最新 / 最近修改的文件" → dws drive list --latest <N>`（占位符风格与邻行一致）

未动 mono/SKILL.md 分域决策树（该节仅做产品域区分，不承载功能修饰词）。

## 验证
- make skill-command-integrity：ok
- make skill-context-budget：ok
- go test -tags skill_verify ./test/skill_static/... ./test/skill_e2e/...：ok（Layer A/B）