### PR TITLE
ci: keep release seals out of auto-merge

### DIFF
--- a/.github/workflows/reviewer-router.yml
+++ b/.github/workflows/reviewer-router.yml
@@ -61,6 +61,9 @@ jobs:
             }
             const author = pullRequest.user.login.toLowerCase();
             const headSha = pullRequest.head.sha;
+            const isReleaseSeal = /^docs: seal v[^\s]+ changelog$/i.test(
+              pullRequest.title,
+            );
             const latestPusher =
               context.payload.action === 'synchronize'
                 ? context.payload.sender?.login?.toLowerCase()
@@ -214,6 +217,12 @@ jobs:
             }
 
             async function enableAutoMerge() {
+              if (isReleaseSeal) {
+                core.info(
+                  `PR #${pullNumber} is a release seal; auto-merge stays disabled for its required human merge.`,
+                );
+                return;
+              }
               try {
                 const currentPull = await getReadyEventPull('auto-merge enable');
                 if (!currentPull) {


### PR DESCRIPTION
Prevents Reviewer Router from enabling native auto-merge for release-seal PR titles (`docs: seal v* changelog`), while preserving reviewer routing. This restores the required human merge gate for beta and stable seals.