### PR TITLE
docs: seal v1.0.57-beta.4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,49 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.57-beta.4] - 2026-08-06
+
+### Added
+
+- **Expanded open CLI workflows** (#887) — adds calendar event-instance
+  queries, Drive latest-file selection, Markdown diff, Mail calendar/export/
+  share-to-chat workflows, and Minutes hot-word, permission, and audio-memo
+  operations, with matching Schema and cross-platform coverage.
+
+### Changed
+
+- **Multi-skill framework alignment** (#887) — folds long-tail skills into
+  `dingtalk-misc`, renames the shared package to `dingtalk-shared`, removes
+  stale Preview guidance, and reorganizes shared recipes and routing for more
+  predictable Agent selection.
+- **Bounded Agent Schema delivery** (#887) — keeps compact and wire projections
+  focused on executable contract facts, retires stale MCP metadata candidates,
+  and teaches Agents to prefer `dws schema --compact` for bounded context.
+
 ### Deprecated
 
-- **`dws recovery` CLI** — keeps a visible Deprecated compatibility stub for
-  plan/execute/finalize that returns an explicit “不再支持” notice. The
-  `internal/recovery` package is removed; Skills must not teach this path.
-  Transport errors keep generic retry/auth guidance without pointing callers
-  at recovery.
+- **Recovery and discovery-cache compatibility surfaces** (#887) — keeps
+  visible Deprecated `dws recovery` and `dws cache` compatibility stubs while
+  retiring their former recovery engine and dynamic discovery-cache behavior.
+  Recovery plan/execute/finalize now return an explicit “不再支持” notice, and
+  Skills no longer teach either retired workflow.
+
+### Fixed
+
+- **Mail share-to-chat confirmation** (#887) — requires explicit confirmation
+  before the first remote write, while preserving the confirmed sign-retry
+  flow and covering both direct-success and retry responses.
 
 ## [1.0.57] - 2026-08-06
 
-This stable release promotes the fully delivered `v1.0.57-beta.3` baseline.
-It includes reviewed document shortcuts and chat reply mentions, together with
-the v1.0.57 beta-line command-contract, document, chat, OA, Wiki, compatibility,
-and CI reliability improvements validated through the prerelease channel.
+This stable release promotes the fully delivered `v1.0.57-beta.4` baseline.
+It includes the v1.0.57 beta-line command-contract, document, chat, OA, Wiki,
+and compatibility improvements, plus the multi-skill framework alignment and
+expanded calendar, Drive, Markdown, Mail, and Minutes workflows validated in
+the final prerelease.
 
-- **Promote v1.0.57-beta.3** — publishes the validated prerelease baseline as
-  the stable `v1.0.57` release without adding post-beta product changes.
+- **Promote v1.0.57-beta.4** — publishes the final validated prerelease
+  baseline as stable `v1.0.57` without adding post-beta product changes.
 
 ## [1.0.57-beta.3] - 2026-08-06
 


### PR DESCRIPTION
## 发布范围

- 候选版本：`v1.0.57-beta.4`
- 绑定 main：`f9ccff963fed72ab87f265e5bb4962a140889498`
- Cloud plan：https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/31084189590
- 纳入变更：#887

## CHANGELOG

- 增加 beta.4 的真实用户可见变更：开放版 CLI 能力补齐、multi-skill 框架对齐、Agent Schema 投影收敛、兼容入口退役和 Mail 写入确认修复。
- 将已经失效的 stable 文案从“晋级 beta.3、无 beta 后产品变化”修正为晋级最终 beta.4 基线。
- 清空已经归入 beta.4 的 Unreleased recovery 退役说明。

## 验证

- `git diff --check origin/main...HEAD`
- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`

Plan 仅计算候选版本，没有创建 tag 或发布产物。本 PR 必须在 Reviewer Router 完成后关闭 auto-merge，并由真人账号手动合并。
