### PR TITLE
fix(release): accept successful sealed run reruns

### DIFF
--- a/scripts/release/verify-release-workflow-delivery.sh
+++ b/scripts/release/verify-release-workflow-delivery.sh
@@ -150,16 +150,16 @@ print("\t".join([
 verify_cloud_delivery() {
   cloud_identity="$1"
   cloud_run_id="$(printf '%s\n' "$cloud_identity" | cut -f1)"
-  cloud_run_attempt="$(printf '%s\n' "$cloud_identity" | cut -f2)"
+  sealed_run_attempt="$(printf '%s\n' "$cloud_identity" | cut -f2)"
   cloud_actor="$(printf '%s\n' "$cloud_identity" | cut -f3)"
   cloud_actor_id="$(printf '%s\n' "$cloud_identity" | cut -f4)"
   cloud_workflow_sha="$(printf '%s\n' "$cloud_identity" | cut -f5)"
-  [ -n "$cloud_run_id" ] && [ -n "$cloud_run_attempt" ] &&
+  [ -n "$cloud_run_id" ] && [ -n "$sealed_run_attempt" ] &&
     [ -n "$cloud_actor" ] && [ -n "$cloud_actor_id" ] &&
     [ -n "$cloud_workflow_sha" ] || return 1
 
   cloud_run_state="$(
-    github_get "repos/$REPOSITORY/actions/runs/$cloud_run_id/attempts/$cloud_run_attempt" \
+    github_get "repos/$REPOSITORY/actions/runs/$cloud_run_id" \
       | python3 -c 'import json,sys
 r=json.load(sys.stdin)
 print("\t".join(str(value) for value in (
@@ -176,6 +176,9 @@ print("\t".join(str(value) for value in (
     r.get("actor", {}).get("id", ""),
 )))'
   )" || return 1
+  cloud_run_attempt="$(printf '%s\n' "$cloud_run_state" | cut -f2)"
+  printf '%s\n' "$cloud_run_attempt" | grep -Eq '^[1-9][0-9]*$' || return 1
+  [ "$cloud_run_attempt" -ge "$sealed_run_attempt" ] || return 1
   expected_cloud_core="$(printf '%s\t%s\t%s\t.github/workflows/release.yml\tworkflow_dispatch\tcompleted\tsuccess\tmain\t%s' \
     "$cloud_run_id" "$cloud_run_attempt" "$REPOSITORY" "$cloud_workflow_sha")"
   [ "$(printf '%s\n' "$cloud_run_state" | cut -f1-9)" = "$expected_cloud_core" ] ||

--- a/test/scripts/release_script_test.go
+++ b/test/scripts/release_script_test.go
@@ -845,7 +845,7 @@ print(json.dumps({
 }))
 PY
     ;;
-  */actions/runs/42/attempts/1/jobs*)
+  */actions/runs/42/attempts/*/jobs*)
     python3 - <<'PY'
 import json
 import os
@@ -891,13 +891,13 @@ for name in required:
 print(json.dumps({"jobs": jobs}))
 PY
     ;;
-  */actions/runs/42/attempts/1)
+  */actions/runs/42|*/actions/runs/42/attempts/1)
     python3 - <<'PY'
 import json
 import os
 print(json.dumps({
     "id": 42,
-    "run_attempt": 1,
+    "run_attempt": int(os.environ.get("RUN_ATTEMPT", "1")),
     "repository": {"full_name": "owner/repo"},
     "path": ".github/workflows/release.yml",
     "event": "workflow_dispatch",
@@ -942,6 +942,10 @@ esac
 
 	if output, err := run(); err != nil || !strings.Contains(output, "cloud release run 42") {
 		t.Fatalf("tag-bound cloud delivery was rejected: err=%v\noutput:\n%s", err, output)
+	}
+	if output, err := run("RUN_ATTEMPT=2"); err != nil ||
+		!strings.Contains(output, "cloud release run 42") {
+		t.Fatalf("successful rerun of tag-bound cloud delivery was rejected: err=%v\noutput:\n%s", err, output)
 	}
 	if output, err := runWithArgs(
 		[]string{"--channel-repair", "oss", tag, commit},


### PR DESCRIPTION
## 背景

v1.0.57-beta.4 的不可变 tag 绑定 Release run 31085002482 attempt 1；该 attempt 因 GitHub 默认分支 API 短暂一致性延迟失败，随后同一 run 的 attempt 2 完整成功。stable 严格交付门禁仍只读取 tag 中的原 attempt，因此拒绝晋级。

## 修复

- tag 继续绑定同一个 Release run、提交、actor 与封签元数据。
- 交付验收读取该 run 的最新 attempt，并要求其编号不早于封签 attempt、状态 completed、结论 success。
- 继续校验完整发布 job graph、精确 head SHA 与封签步骤。
- 增加封签 attempt 1、成功重跑 attempt 2 的回归测试。

## 验证

- go test ./test/scripts -run ReleaseWorkflowDelivery|ReleaseWorkflow -count=1
- 对真实 v1.0.57-beta.4 运行交付 verifier，成功识别 cloud release run 31085002482。

此 PR 必须人工合并；请勿启用 auto-merge。