### PR TITLE
chore: prepare safe v1.0.57 Formula recovery

### DIFF
--- a/Formula/dingtalk-workspace-cli.rb
+++ b/Formula/dingtalk-workspace-cli.rb
@@ -1,3 +1,4 @@
+# Recovery marker: Release run 31089100536 will restore the verified generated Formula.
 class DingtalkWorkspaceCli < Formula
   desc "Automate DingTalk workspace tasks from the terminal"
   homepage "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli"


### PR DESCRIPTION
## 背景

`v1.0.57` Release run 31089100536 已经封存 annotated tag、不可变 GitHub Release 和 stable Homebrew Formula，但 Formula-only 校验发现其父提交 `ebfba82ebce19fd4555d62520022f20b021bc15b` 没有精确 SHA 的九项 Code Admission，因此 npm 与后续渠道未执行。

该父提交来自 #867，由 `app/github-actions` native auto-merge 合并；PR head 检查成功，但 merge SHA 没有 push CI。

## 改动

- 只在 `Formula/dingtalk-workspace-cli.rb` 增加一行无功能影响的临时恢复标记。
- 不改变版本、下载 URL、资产 SHA256 或安装逻辑。
- 原 Release run 的 failed jobs 重跑时，会用已封存 `v1.0.57` 资产重新生成 byte-exact Formula，自动移除该标记并创建新的 Formula-only commit。

## 安全恢复步骤

1. 本 PR 必须关闭 auto-merge，并由真人账号手动 merge。
2. 必须等待本 PR 的精确 merge SHA 九项 Code Admission 全部成功。
3. 之后只重跑 Release run 31089100536 的 failed jobs。
4. 重跑必须完成 Formula-only sealing、npm `1.0.57` / `latest` 交付和最终 Release delivery gate。

不要手工创建 Checks、手工发布 npm、移动 tag 或创建新的 CHANGELOG PR。

## 验证

- `git diff --check`
- `ruby -c Formula/dingtalk-workspace-cli.rb`
- `GOCACHE=/private/tmp/dws-v1.0.57-recovery-gocache go test ./test/scripts -run 'Test.*Homebrew.*Formula' -count=1`

