### PR TITLE
ci: shard helper changes through full suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
                 filename === '.github/actionlint.yaml' ||
                 filename.startsWith('scripts/') ||
                 filename.startsWith('verify/') ||
+                filename.startsWith('internal/helpers/') ||
                 filename.startsWith('internal/generator/') ||
                 filename.startsWith('internal/cli/schema') ||
                 filename.startsWith('internal/interfacesnapshot/') ||

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -578,6 +578,36 @@ if (!isInterfaceSensitive("internal/corecmd/corecmd.go")) {
 	}
 }
 
+func TestHighRiskClassificationShardsHelperChanges(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("Abs(repo root) error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("ReadFile(ci.yml) error = %v", err)
+	}
+	workflow := string(data)
+	start := strings.Index(workflow, "            const isDocsOnly =")
+	end := strings.Index(workflow, "            const classifyFiles =")
+	if start < 0 || end <= start {
+		t.Fatal("Code Admission workflow missing high-risk classifier boundaries")
+	}
+	classifier := strings.TrimSpace(workflow[start:end])
+	probe := classifier + `
+if (!isHighRisk("internal/helpers/minutes.go")) {
+  throw new Error("helper changes must use the sharded full suite");
+}
+if (isHighRisk("internal/helpersx/minutes.go")) {
+  throw new Error("helper high-risk classification must respect the path boundary");
+}
+`
+	cmd := exec.Command("node", "-e", probe)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("high-risk classifier rejected helper sharding contract: %v\n%s", err, output)
+	}
+}
+
 func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 	root, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {


### PR DESCRIPTION
## 修改内容

- 将 `internal/helpers/` 纳入 Code Admission 的高风险分类。
- helpers 代码变化改走现有的六路 full-suite race 分片，不再把全部反向依赖集中到单个 focused job。
- 增加分类合同测试，覆盖 helpers 正例及 `internal/helpersx/` 路径边界反例。

## 原因

PR #932 修改 `internal/helpers/aitable.go` 后，`Test (changed packages)` 将 helpers 的大量反向依赖集中在一个 Runner 中执行。该 job 在执行约 19 分 53 秒后撞上 20 分钟上限；其中 Schema Catalog 生成测试单包耗时约 628 秒。随后汇总 `Test` 因 focused shard 被取消而失败。

失败运行：https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/31449288342/job/93650264517

## 影响

普通 helpers 修改会执行完整但并行的测试分片，降低单个 Runner 因高扇出反向依赖超时的概率，同时保留全量 race 覆盖。

## 验证

- `go test ./test/scripts -run '^(TestHighRiskClassificationShardsHelperChanges|TestInterfaceSensitiveClassificationCoversCoreCommandFramework|TestChangelogPRFastPathWorkflowContract)$' -count=1`
- `go test ./test/scripts -count=1`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
