### PR TITLE
feat(chat): expose streaming-card send receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ### Changed
 
+- **Streaming-card send receipt handoff** — `chat message send-card` and
+  `chat +messages-send-card` now document the returned `bizId` / `openTaskId`
+  split. The high-level shortcut projects both identifiers at the top level and
+  links `openTaskId` to the existing one-shot `query-send-status` command
+  without adding automatic polling.
 - **Minutes `permission apply --policy` type** — `--policy` is now declared as
   an `int` flag and its required check uses `Flags().Changed`, matching the
   numeric-parameter convention. `--help` reports `int` instead of `string`;

--- a/internal/app/chat_message_receipt_action_contract_test.go
+++ b/internal/app/chat_message_receipt_action_contract_test.go
@@ -45,6 +45,13 @@ func TestCrossPlatformCoverageChatMessageReceiptActionsBindToRunnableCommands(t 
 				"status":             "SUCCESS",
 			}, "task-ready"),
 		},
+		{
+			name: "streaming card awaiting status",
+			payload: chatmsg.ProjectStreamingCardReceipt(map[string]any{
+				"bizId":      "biz-card",
+				"openTaskId": "task-card",
+			}, "biz-card"),
+		},
 	}
 
 	root := NewRootCommand()

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -5724,6 +5724,9 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 群聊创建卡片时可通过 --at-open-dingtalk-ids @指定成员，或通过 --at-all @所有人。
 创建时无需传入卡片内容，后续通过 update-card 更新内容。
 
+发送成功会返回 bizId 和 openTaskId：使用 bizId 调用 update-card 更新内容；需要确认消息投递结果或取得
+openMessageId 时，执行 dws chat message query-send-status --open-task-id <openTaskId>。
+
 注意：send-card 必须和 update-card 搭配使用。发送卡片后，使用返回的 bizId 调用 update-card 更新内容，
 最后一次更新必须将 --flow-status 设为 3（finish），否则卡片会一直处于"生成中"的加载状态。
 flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成(FINISH)，4=执行中(EXECUTING)，5=错误(ERROR)。`,
@@ -5788,7 +5791,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 			},
 			Selection: contract.SelectionSpec{
 				AgentSummary: "创建并向群聊或单聊发送互动卡片；群聊创建时可 @成员或 @所有人",
-				UseWhen:      []string{"需要创建卡片且已准备接收会话或用户时；群聊创建可同时指定 @成员或 @所有人"},
+				UseWhen:      []string{"需要卡片式交互且已准备接收会话或用户时；群聊创建可同时指定 @成员或 @所有人；成功结果中的 bizId 用于更新卡片，openTaskId 可交给 chat message query-send-status 查询消息投递状态"},
 				AvoidWhen:    []string{"只发送普通文本时使用 send 或 send-by-bot"},
 				Examples:     []string{"dws chat message send-card --group <openConversationId>"},
 			},

--- a/internal/shortcut/chat/chat_message.go
+++ b/internal/shortcut/chat/chat_message.go
@@ -1452,7 +1452,7 @@ var MessagesSendCard = shortcut.Shortcut{
 	Command:     "+messages-send-card",
 	Product:     "im",
 	Description: "创建流式卡片，可在同一次调用中写入内容并结束；群聊创建时可 @成员或 @所有人",
-	Intent:      "当你要发送一张流式文本卡片时使用；群 openConversationId、单聊 userId、单聊 openDingTalkId 严格三选一，分别使用 --group、--receiver、--receiver-open-dingtalk-id。群聊可用 --at-open-dingtalk-ids 或 --at-all 在创建卡片时设置 @对象；同时传 --content 时，Runtime 会把创建响应中的 atTag 自动加在正文前，后续更新不重复传递 @参数。--receiver 始终按 userId 通过通讯录关键词搜索做精确匹配，即使值以 D/d 开头也不会猜成 openDingTalkId；已有 openDingTalkId 时必须用显式参数直传。userId 包括在 --dry-run 时也会先解析。只传目标时创建卡片并返回 bizId，供后续 messages-update-card 流式更新；同时传 --content 时会自动串联创建和更新，默认以 flowStatus=3 完成。当前只支持 streaming text，不支持 Card JSON 组件或 action callback。",
+	Intent:      "当你要发送一张流式文本卡片时使用；群 openConversationId、单聊 userId、单聊 openDingTalkId 严格三选一，分别使用 --group、--receiver、--receiver-open-dingtalk-id。群聊可用 --at-open-dingtalk-ids 或 --at-all 在创建卡片时设置 @对象；同时传 --content 时，Runtime 会把创建响应中的 atTag 自动加在正文前，后续更新不重复传递 @参数。--receiver 始终按 userId 通过通讯录关键词搜索做精确匹配，即使值以 D/d 开头也不会猜成 openDingTalkId；已有 openDingTalkId 时必须用显式参数直传。userId 包括在 --dry-run 时也会先解析。成功结果顶层返回 bizId 和 openTaskId：bizId 供 messages-update-card 流式更新，openTaskId 可交给 chat message query-send-status 查询消息投递状态；命令本身不轮询。只传目标时仅创建卡片；同时传 --content 时会自动串联创建和更新，默认以 flowStatus=3 完成。当前只支持 streaming text，不支持 Card JSON 组件或 action callback。",
 	Risk:        shortcut.RiskWrite,
 	Safety: contract.SafetySpec{
 		Effect: "write", Risk: "medium",
@@ -1474,7 +1474,7 @@ var MessagesSendCard = shortcut.Shortcut{
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "创建流式卡片，可在同一次调用中写入内容并结束；群聊创建时可 @成员或 @所有人",
-			UseWhen:      []string{"当你要发送一张流式文本卡片时使用；群 openConversationId、单聊 userId、单聊 openDingTalkId 严格三选一，分别使用 --group、--receiver、--receiver-open-dingtalk-id。群聊可用 --at-open-dingtalk-ids 或 --at-all 在创建卡片时设置 @对象；同时传 --content 时，Runtime 会把创建响应中的 atTag 自动加在正文前，后续更新不重复传递 @参数。--receiver 始终按 userId 通过通讯录关键词搜索做精确匹配，即使值以 D/d 开头也不会猜成 openDingTalkId；已有 openDingTalkId 时必须用显式参数直传。userId 包括在 --dry-run 时也会先解析。只传目标时创建卡片并返回 bizId，供后续 messages-update-card 流式更新；同时传 --content 时会自动串联创建和更新，默认以 flowStatus=3 完成。当前只支持 streaming text，不支持 Card JSON 组件或 action callback。"},
+			UseWhen:      []string{"当你要发送一张流式文本卡片时使用；群 openConversationId、单聊 userId、单聊 openDingTalkId 严格三选一，分别使用 --group、--receiver、--receiver-open-dingtalk-id。群聊可用 --at-open-dingtalk-ids 或 --at-all 在创建卡片时设置 @对象；同时传 --content 时，Runtime 会把创建响应中的 atTag 自动加在正文前，后续更新不重复传递 @参数。--receiver 始终按 userId 通过通讯录关键词搜索做精确匹配，即使值以 D/d 开头也不会猜成 openDingTalkId；已有 openDingTalkId 时必须用显式参数直传。userId 包括在 --dry-run 时也会先解析。成功结果顶层返回 bizId 和 openTaskId：bizId 供 messages-update-card 流式更新，openTaskId 可交给 chat message query-send-status 查询消息投递状态；命令本身不轮询。只传目标时仅创建卡片；同时传 --content 时会自动串联创建和更新，默认以 flowStatus=3 完成。当前只支持 streaming text，不支持 Card JSON 组件或 action callback。"},
 			AvoidWhen:    []string{"已有 bizId、只需要追加或更新现有卡片内容时使用 +messages-update-card"},
 			Examples: []string{
 				"dws chat +messages-send-card --group <openConversationId> --at-open-dingtalk-ids <openDingTalkId> --content \"任务已完成\"",
@@ -1493,7 +1493,7 @@ var MessagesSendCard = shortcut.Shortcut{
 		{Name: "receiver-open-dingtalk-id", Type: shortcut.FlagString, Desc: "单聊接收者 openDingTalkId（与 --group/--receiver 互斥）；显式直传且不做通讯录解析"},
 		{Name: "at-open-dingtalk-ids", Type: shortcut.FlagStringSlice, Desc: "群聊创建卡片时 @ 的 openDingTalkId 列表；仅随 create_and_send_card 发送；艾特参数仅支持群聊 --group"},
 		{Name: "at-all", Type: shortcut.FlagBool, Desc: "群聊创建卡片时 @ 所有人；仅随 create_and_send_card 发送；艾特参数仅支持群聊 --group"},
-		{Name: "content", Type: shortcut.FlagString, Desc: "创建后立即写入的卡片正文；群聊 @ 时 Runtime 自动前置 create 返回的 atTag；省略时仅创建并返回 bizId"},
+		{Name: "content", Type: shortcut.FlagString, Desc: "创建后立即写入的卡片正文；群聊 @ 时 Runtime 自动前置 create 返回的 atTag；省略时仅创建；成功结果返回 bizId 和 openTaskId"},
 		{Name: "flow-status", Type: shortcut.FlagInt, Default: "3", Desc: "自动更新状态：1处理中/2输入中/3完成/4执行中/5错误；--flow-status 必须在 1-5 之间，且显式指定时必须同时提供 --content"},
 	},
 	Constraints: []shortcut.Constraint{

--- a/internal/shortcut/chat/gap_fill_test.go
+++ b/internal/shortcut/chat/gap_fill_test.go
@@ -763,7 +763,7 @@ func TestCrossPlatformCoverageMessagesSendTextModesAndExecuteGuard(t *testing.T)
 
 func TestCrossPlatformCoverageMessagesSendCardOneCallLifecycle(t *testing.T) {
 	fake := &larkAlignmentCaller{responses: map[string]string{
-		"im/create_and_send_card":  `{"result":{"card":{"biz_id":"biz-1","atTag":"<a atId=D-one>甲</a> <a atId=D-two>乙</a> "}}}`,
+		"im/create_and_send_card":  `{"result":{"card":{"biz_id":"biz-1","openTaskId":"task-card-1","atTag":"<a atId=D-one>甲</a> <a atId=D-two>乙</a> "}}}`,
 		"im/update_streaming_card": `{"result":{"updated":true}}`,
 	}}
 	helpers.InitDeps(fake)
@@ -807,8 +807,12 @@ func TestCrossPlatformCoverageMessagesSendCardOneCallLifecycle(t *testing.T) {
 	if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
 		t.Fatal(err)
 	}
-	if payload["bizId"] != "biz-1" || payload["ok"] != true {
+	if payload["bizId"] != "biz-1" || payload["openTaskId"] != "task-card-1" || payload["ok"] != true {
 		t.Fatalf("card output = %#v", payload)
+	}
+	receipt, _ := payload["sendReceipt"].(map[string]any)
+	if receipt["openTaskId"] != "task-card-1" {
+		t.Fatalf("card sendReceipt = %#v", receipt)
 	}
 }
 

--- a/internal/shortcut/chatmsg/card_ref.go
+++ b/internal/shortcut/chatmsg/card_ref.go
@@ -10,14 +10,17 @@ import "strings"
 // high-level card shortcuts.
 const StreamingCardContractVersion = "im.streaming-card.v1"
 
-// ProjectStreamingCardReceipt publishes every server-returned identifier in a
-// single cardRef. referencePairAvailable means this response contained both
-// the update identifier and the visible message identifiers; it does not claim
-// that older messages can be resolved without server-side mapping support.
+// ProjectStreamingCardReceipt publishes the card update identifier and links
+// the asynchronous send receipt to the existing status-query workflow.
+// referencePairAvailable means this response contained both the update
+// identifier and the visible message identifiers; it does not claim that older
+// messages can be resolved without server-side mapping support.
 func ProjectStreamingCardReceipt(created map[string]any, bizID string) map[string]any {
 	bizID = strings.TrimSpace(bizID)
 	messageID := firstSendStatusString(created, "openMessageId", "messageId", "msgId")
 	conversationID := firstSendStatusString(created, "openConversationId", "conversationId", "openCid")
+	sendReceipt := ProjectMessageSendReceipt(created)
+	taskID, _ := sendReceipt["openTaskId"].(string)
 	cardRef := map[string]any{}
 	if bizID != "" {
 		cardRef["bizId"] = bizID
@@ -32,23 +35,40 @@ func ProjectStreamingCardReceipt(created map[string]any, bizID string) map[strin
 	payload := map[string]any{
 		"contractVersion":        StreamingCardContractVersion,
 		"ok":                     true,
+		"bizId":                  bizID,
 		"cardRef":                cardRef,
+		"sendReceipt":            sendReceipt,
 		"referencePairAvailable": pairAvailable,
 		"created":                created,
 		"nextActions":            []map[string]any{},
 	}
+	if taskID != "" {
+		payload["openTaskId"] = taskID
+	}
+	actions := make([]map[string]any, 0, 2)
 	if bizID != "" {
-		payload["nextActions"] = []map[string]any{{
+		actions = append(actions, map[string]any{
 			"cliPath": "chat +messages-update-card",
 			"arguments": map[string]any{
 				"biz-id": bizID,
 			},
 			"requiredArguments": []string{"content", "flow-status"},
 			"ready":             false,
-		}}
+		})
 	}
-	if !pairAvailable {
-		payload["capabilityGap"] = "服务端尚未同时返回 bizId、openMessageId 和 openConversationId；CLI 只能保留本次响应，不能据此承诺从历史消息反向恢复 bizId"
+	if !pairAvailable && taskID != "" {
+		actions = append(actions, map[string]any{
+			"cliPath": "chat message query-send-status",
+			"arguments": map[string]any{
+				"open-task-id": taskID,
+			},
+			"ready": true,
+			"when":  "需要确认卡片消息投递结果或取得真实消息 ID 时",
+		})
+	}
+	payload["nextActions"] = actions
+	if !pairAvailable && taskID == "" {
+		payload["capabilityGap"] = "服务端未返回 openTaskId，也未同时返回 openMessageId 和 openConversationId；CLI 无法衔接消息投递状态查询"
 	}
 	return payload
 }

--- a/internal/shortcut/chatmsg/card_ref_test.go
+++ b/internal/shortcut/chatmsg/card_ref_test.go
@@ -10,11 +10,13 @@ func TestCrossPlatformCoverageProjectStreamingCardReceipt(t *testing.T) {
 	complete := ProjectStreamingCardReceipt(map[string]any{
 		"result": map[string]any{
 			"bizId":              "biz-1",
+			"openTaskId":         "task-1",
 			"openMessageId":      "msg-1",
 			"openConversationId": "cid-1",
 		},
 	}, "biz-1")
-	if complete["contractVersion"] != StreamingCardContractVersion || complete["referencePairAvailable"] != true {
+	if complete["contractVersion"] != StreamingCardContractVersion || complete["referencePairAvailable"] != true ||
+		complete["bizId"] != "biz-1" || complete["openTaskId"] != "task-1" {
 		t.Fatalf("complete receipt = %#v", complete)
 	}
 	ref, _ := complete["cardRef"].(map[string]any)
@@ -25,9 +27,23 @@ func TestCrossPlatformCoverageProjectStreamingCardReceipt(t *testing.T) {
 		t.Fatalf("complete receipt has capability gap: %#v", complete)
 	}
 
-	partial := ProjectStreamingCardReceipt(map[string]any{"result": map[string]any{"bizId": "biz-2"}}, "biz-2")
-	if partial["referencePairAvailable"] != false || partial["capabilityGap"] == "" {
+	partial := ProjectStreamingCardReceipt(map[string]any{
+		"result": map[string]any{"bizId": "biz-2", "openTaskId": "task-2"},
+	}, "biz-2")
+	if partial["referencePairAvailable"] != false || partial["openTaskId"] != "task-2" {
 		t.Fatalf("partial receipt = %#v", partial)
+	}
+	if _, exists := partial["capabilityGap"]; exists {
+		t.Fatalf("queryable partial receipt has capability gap: %#v", partial)
+	}
+	actions, _ := partial["nextActions"].([]map[string]any)
+	if len(actions) != 2 || actions[1]["cliPath"] != "chat message query-send-status" {
+		t.Fatalf("partial nextActions = %#v", actions)
+	}
+
+	missingTask := ProjectStreamingCardReceipt(map[string]any{"result": map[string]any{"bizId": "biz-3"}}, "biz-3")
+	if missingTask["capabilityGap"] == "" {
+		t.Fatalf("missing-task receipt = %#v", missingTask)
 	}
 }
 

--- a/internal/shortcut/chatmsg/send_status.go
+++ b/internal/shortcut/chatmsg/send_status.go
@@ -138,7 +138,7 @@ func firstSendStatusString(value any, keys ...string) string {
 				return strings.TrimSpace(candidate)
 			}
 		}
-		for _, key := range []string{"result", "data", "response", "content", "message"} {
+		for _, key := range []string{"result", "data", "response", "content", "message", "card"} {
 			if candidate := firstSendStatusString(typed[key], keys...); candidate != "" {
 				return candidate
 			}

--- a/internal/shortcut/chatmsg/send_status_test.go
+++ b/internal/shortcut/chatmsg/send_status_test.go
@@ -85,7 +85,7 @@ func TestCrossPlatformCoverageFirstSendStatusStringTraversesArrays(t *testing.T)
 	value := []any{
 		nil,
 		map[string]any{"result": []any{
-			map[string]any{"openTaskId": "  task-from-array  "},
+			map[string]any{"card": map[string]any{"openTaskId": "  task-from-array  "}},
 		}},
 	}
 	if got := firstSendStatusString(value, "openTaskId"); got != "task-from-array" {

--- a/internal/shortcut/semantic_catalog.json
+++ b/internal/shortcut/semantic_catalog.json
@@ -550,7 +550,7 @@
     },
     "+messages-send-card": {
       "disposition": "semantic_adapter",
-      "semantic_delta": "既可只创建流式卡片，也可在一次调用中创建、提取 bizId、写入内容并设置流式状态；dry-run 输出两步执行计划，更新失败时保留已创建的 bizId。",
+      "semantic_delta": "既可只创建流式卡片，也可在一次调用中创建、提取 bizId、写入内容并设置流式状态；成功结果保留 bizId 与 openTaskId，并引导复用消息状态查询；dry-run 输出两步执行计划，更新失败时保留已创建的 bizId。",
       "risk": "write",
       "public": true,
       "reviewed": true

--- a/skills/mono/references/intent-guide.md
+++ b/skills/mono/references/intent-guide.md
@@ -296,6 +296,7 @@ dws chat +messages-send --as user --open-dingtalk-id <openDingTalkId> --msg-type
 - 单聊已有 userId 时使用 `--receiver <userId>`，CLI 始终通过通讯录关键词搜索并按 userId 精确匹配 openDingTalkId；即使 userId 以 D/d 开头也不会猜测类型，`--dry-run` 也会执行该解析。
 - 单聊已有 openDingTalkId 时必须显式使用 `--receiver-open-dingtalk-id <openDingTalkId>`，避免与 userId 混淆。
 - `--group`、`--receiver`、`--receiver-open-dingtalk-id` 严格三选一；传 `--content` 可在同一次调用中创建并结束卡片。
+- 成功结果中的 `bizId` 用于后续更新卡片；`openTaskId` 传给 `chat message query-send-status` 查询投递状态。发送命令本身不轮询。
 
 **用 `chat +messages-send --as bot` 的场景**：
 - "让机器人在群里发一条通知" — **机器人身份**发消息

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -2388,6 +2388,8 @@ dws chat message send --group <openConversationId> --msg-type image --media-id "
 
 群聊传 --group，单聊传 --receiver，二者互斥。群聊创建时可通过 --at-open-dingtalk-ids @指定成员，或通过 --at-all @所有人。
 
+发送成功会返回 `bizId` 和 `openTaskId`：`bizId` 用于 update-card；需要确认消息投递结果或取得 `openMessageId` 时，执行 `dws chat message query-send-status --open-task-id <openTaskId>`。发送命令本身不轮询。
+
 **注意：send-card 必须和 update-card 搭配使用。** 创建卡片时无需传入内容，后续通过 update-card 更新内容，最后一次更新必须将 --flow-status 设为 3（finish），否则卡片会一直处于"生成中"的加载状态。
 flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成(FINISH)，4=执行中(EXECUTING)，5=错误(ERROR)。
 ```
@@ -2451,7 +2453,7 @@ Flags:
 | `chat message create-text-emotion` | `emotionId` | add-text-emotion 的 --emotion-id |
 | `chat category list` | `categoryId` | category list-conversations 的 --category-id |
 | `chat group get-by-group-id` | `openConversationId` | 同 chat search，将群号转为 openConversationId |
-| `chat message send-card` | `bizId` | update-card 的 --biz-id |
+| `chat message send-card` | `bizId` + `openTaskId` | bizId 用于 update-card 的 --biz-id；openTaskId 用于 query-send-status 的 --open-task-id |
 | `chat message list` | `openMessageId` | message reply 的 --ref-msg-id、message forward 的 --msg-id |
 | `chat search` | `openConversationId` | set-top 的 --conversation-id、group-mute / group-mute-member 的 --group |
 

--- a/skills/multi/dingtalk-chat/SKILL.md
+++ b/skills/multi/dingtalk-chat/SKILL.md
@@ -75,7 +75,7 @@ metadata:
 - `+messages-send`：文件、Bot、Webhook、复杂 @ 或幂等控制。user 已知 ID 可直接传，也可用 `--user-query` / `--chat-query` 运行同一只读解析链；Bot 多群使用 `--groups/--groups-file`，返回 `im.batch-write.v1`；bot/webhook 只使用下层真实支持的文本/Markdown 能力。
 - 文件直接传 `+messages-send --file <相对路径>`；不要先独立上传并提取 mediaId。
 - Webhook 使用 `+messages-send --as webhook --webhook-token <token>`；不要退回原子 Webhook 命令。
-- 流式卡片用 `+messages-send-card`；群聊@传 ID/`--at-all`，Runtime 把 create 返回前缀加到 `--content`；禁写占位符；仅 text。
+- 流式卡片用 `+messages-send-card`；群聊@传 ID/`--at-all`，Runtime 把 create 返回前缀加到 `--content`；禁写占位符；仅 text。成功结果中的 `bizId` 用于更新卡片，`openTaskId` 交给 `chat message query-send-status` 查询投递状态；发送命令本身不轮询。
 
 ## 关键结果语义
 

--- a/skills/multi/dingtalk-chat/references/card/create.md
+++ b/skills/multi/dingtalk-chat/references/card/create.md
@@ -4,7 +4,9 @@
 Runtime 会唯一解析为 openDingTalkId；已有 openDingTalkId 时传
 `--receiver-open-dingtalk-id`。三种目标严格三选一。
 
-- 只传目标：创建卡片并从真实结果取得 `bizId`，供后续更新。
+- 只传目标：创建卡片并从真实结果取得 `bizId` 和 `openTaskId`。`bizId` 供后续更新；
+  `openTaskId` 可传给 `dws chat message query-send-status --open-task-id <openTaskId>`
+  查询消息投递状态。发送命令本身不轮询。
 - 同时传 `--content`：Runtime 串行执行 create → 从返回提取 `bizId` → update；默认
   `--flow-status 3`。
 - 群聊可传 `--at-open-dingtalk-ids` 或 `--at-all`；艾特对象只进入初始
@@ -21,5 +23,6 @@ Runtime 会唯一解析为 openDingTalkId；已有 openDingTalkId 时传
 
 ```bash
 dws chat +messages-send-card --group <openConversationId> --at-open-dingtalk-ids <mentionedOpenDingTalkId> --content "请确认"
+dws chat message query-send-status --open-task-id <上一步返回的openTaskId>
 dws chat +messages-send-card --group <openConversationId> --at-all --content "请大家确认"
 ```


### PR DESCRIPTION
## Summary

- What changed? The streaming-card send shortcut now exposes the create receipt at its top level (`bizId`, `openTaskId`, `sendReceipt`, and follow-up actions). The update verifier also accepts the pre-production acknowledgement shape `{"success": true}` while preserving failures and contradictory evidence.
- Why is this change needed? Agents need the returned `openTaskId` to make the existing one-shot delivery-status query, while continuing to use `bizId` for card updates. Pre-production currently acknowledges a successful update without `updated` or `affected` fields, which previously caused the shortcut to report an unverified write and could lead an Agent to retry an update that had already succeeded.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [x] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

Record the smallest targeted evidence that proves the changed behavior. Do not
repeat the entire CI suite locally only to fill this checklist: CI expands the
selected tier from documentation checks, through affected-package tests, to
the complete high-risk suite.

- [x] Exact in-place `CHANGELOG.md`-only check (otherwise `N/A`):
  `N/A` — implementation and contract behavior changed.
- [x] Targeted test/check commands and results:
  - `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/shortcut/chat ./internal/shortcut/chatmsg ./internal/helpers ./internal/app -count=1` — passed from isolated source at `4c307ba45bcf5f3d85242635b33709cb45f90c00`.
  - `TestCrossPlatformCoverageVerifyStreamingCardUpdate`, `TestCrossPlatformCoverageNativeMessageUpdateCardVerifiesWrite`, and `TestCrossPlatformCoverageMessagesSendCardOneCallLifecycle` — passed, exit code 0.
  - `make build`, `make generate-schema`, Skill content/budget/integrity checks, and changed-code coverage gate — passed; changed-code coverage was `100.0000%` for 32 executable statements.
- [x] Behavior evidence (test name, CLI output shape, or before/after result):
  - Unit tests cover nested create-receipt extraction, top-level `bizId`/`openTaskId`, the `{"success": true}` update acknowledgement, false/conflicting evidence, and the one-call lifecycle.
  - In a fully isolated current-head environment, Qoder CLI 1.1.19 received only a natural-language request, activated the DWS Skill, selected `chat +messages-send-card`, requested confirmation, sent one real card to the approved pre-production test group, then called `chat +messages-query-send-status` exactly once.
  - DWS audit counts after setup: `create_and_send_card=1`, `update_streaming_card=1`, `query_message_send_status=1`, retries `0`; all three succeeded. The shortcut returned `created.success=true`, `updated.success=true` with `updated.result={}`, and a non-empty top-level `openTaskId`; the status query returned `success=true`, `sendStatus=SUCCESS`, and `readyForMessageActions=true`.

  ![Current-head focused tests — verifier and success acknowledgement](https://raw.githubusercontent.com/Anonymity-0/Picgo/main/dws-pr-evidence/pr-949/4c307ba4/focused-tests-top.png)

  ![Current-head focused tests — native update and one-call lifecycle](https://raw.githubusercontent.com/Anonymity-0/Picgo/main/dws-pr-evidence/pr-949/4c307ba4/focused-tests-bottom.png)

  ![Qoder natural-language pre-production Agent test](https://raw.githubusercontent.com/Anonymity-0/Picgo/main/dws-pr-evidence/pr-949/4c307ba4/qoder-agent-preprod.png)
- [x] Documentation links/content/rendering checked (documentation-only, otherwise
  `N/A`) — `N/A`; affected Skill/Help content was covered by content, budget, integrity, and Schema checks.
- [x] Full local suite run because the change is high-risk (optional for other
  tiers; record command/result or `N/A`) — `N/A` (Standard); affected packages and policy checks passed.
- [x] `./scripts/policy/check-generated-drift.sh`
  (when generator inputs or generated artifacts may change) — passed.
- [x] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed) — passed.
- [x] `./scripts/release/verify-package-managers.sh`
  (after `make package`, if packaging or installer surfaces changed) — `N/A`.

## Notes

- The send command itself does not poll. It returns `openTaskId` and guides the Agent to the existing one-shot status-query command when delivery confirmation is needed.
- The pre-production evidence used a separate DWS runtime, config directory, login, Qoder config, and Agent workspace. It did not switch or overwrite the shared DWS entry, did not use Computer Use, and did not call MCP directly.
- Public screenshots redact group, task, message, card, machine, and local-path identifiers while preserving the natural request, command paths, operation sequence, success acknowledgement, `SUCCESS` result, and commit attribution.
- Any risks, follow-up work, or intentional scope cuts: no package graph, endpoint, authentication, configuration, lock, or release-path changes.

The repository automatically requests one eligible peer reviewer, including
after a new head push when another review is needed. Once the latest push has
peer approval and all nine required checks are current and green, auto-merge
completes the PR; authors do not need to coordinate a separate routine merge.
