### PR TITLE
fix(drive): verify upload and move readback

### DIFF
--- a/internal/shortcut/drive/catalog_operations.go
+++ b/internal/shortcut/drive/catalog_operations.go
@@ -489,6 +489,13 @@ var Upload = shortcut.Shortcut{
 		if remoteName := firstString(verified, "name", "fileName"); remoteName == "" || !strings.HasPrefix(remoteName, strings.TrimSuffix(name, filepath.Ext(name))) {
 			return driveResponseError("drive/commit_upload", "readback_mismatch", fmt.Sprintf("上传后读回名称 %q 与请求 %q 不一致", remoteName, name))
 		}
+		remoteSize, ok := firstInt64(verified, "fileSize", "size", "byteSize", "length")
+		if !ok {
+			return driveResponseError("drive/commit_upload", "readback_missing_size", "上传后读回缺少有效文件大小；无法证明远端文件完整")
+		}
+		if remoteSize != info.Size() {
+			return driveResponseError("drive/commit_upload", "readback_size_mismatch", fmt.Sprintf("上传后读回大小 %d 与本地文件大小 %d 不一致", remoteSize, info.Size()))
+		}
 		return rt.Output(map[string]any{"success": true, "nodeId": nodeID, "sizeBytes": info.Size(), "file": verified})
 	},
 }

--- a/internal/shortcut/drive/catalog_operations.go
+++ b/internal/shortcut/drive/catalog_operations.go
@@ -486,7 +486,14 @@ var Upload = shortcut.Shortcut{
 		if err != nil {
 			return err
 		}
-		if remoteName := firstString(verified, "name", "fileName"); remoteName == "" || !strings.HasPrefix(remoteName, strings.TrimSuffix(name, filepath.Ext(name))) {
+		remoteID := firstString(verified, "fileId", "dentryUuid", "nodeId", "id")
+		if remoteID == "" {
+			return driveResponseError("drive/commit_upload", "readback_missing_id", "上传后读回缺少文件 ID；无法证明读回的是已提交文件")
+		}
+		if remoteID != nodeID {
+			return driveResponseError("drive/commit_upload", "readback_id_mismatch", fmt.Sprintf("上传后读回文件 ID %q 与提交 ID %q 不一致", remoteID, nodeID))
+		}
+		if remoteName := firstString(verified, "name", "fileName"); !driveReadbackNameMatches(verified, name) {
 			return driveResponseError("drive/commit_upload", "readback_mismatch", fmt.Sprintf("上传后读回名称 %q 与请求 %q 不一致", remoteName, name))
 		}
 		remoteSize, ok := firstInt64(verified, "fileSize", "size", "byteSize", "length")

--- a/internal/shortcut/drive/common.go
+++ b/internal/shortcut/drive/common.go
@@ -218,6 +218,15 @@ func nestedString(data map[string]any, keys ...string) string {
 	return ""
 }
 
+func driveReadbackNameMatches(data map[string]any, requested string) bool {
+	remoteName := firstString(data, "name", "fileName")
+	if remoteName == requested {
+		return true
+	}
+	extension := strings.TrimLeft(firstString(data, "extension", "fileExtension", "ext"), ".")
+	return extension != "" && remoteName+"."+extension == requested
+}
+
 func firstInt64(data map[string]any, keys ...string) (int64, bool) {
 	for _, key := range keys {
 		value, present := data[key]
@@ -246,7 +255,6 @@ func firstInt64(data map[string]any, keys ...string) (int64, bool) {
 				return parsed, true
 			}
 		}
-		return 0, false
 	}
 	return 0, false
 }

--- a/internal/shortcut/drive/common.go
+++ b/internal/shortcut/drive/common.go
@@ -6,6 +6,8 @@ package drive
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd"
@@ -214,6 +216,39 @@ func nestedString(data map[string]any, keys ...string) string {
 		}
 	}
 	return ""
+}
+
+func firstInt64(data map[string]any, keys ...string) (int64, bool) {
+	for _, key := range keys {
+		value, present := data[key]
+		if !present {
+			continue
+		}
+		switch typed := value.(type) {
+		case int:
+			return int64(typed), true
+		case int32:
+			return int64(typed), true
+		case int64:
+			return typed, true
+		case float64:
+			if !math.IsNaN(typed) && !math.IsInf(typed, 0) && typed == math.Trunc(typed) && typed >= math.MinInt64 && typed < math.MaxInt64 {
+				return int64(typed), true
+			}
+		case json.Number:
+			parsed, err := strconv.ParseInt(typed.String(), 10, 64)
+			if err == nil {
+				return parsed, true
+			}
+		case string:
+			parsed, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
+			if err == nil {
+				return parsed, true
+			}
+		}
+		return 0, false
+	}
+	return 0, false
 }
 
 func driveResponseError(operation, reason, message string) error {

--- a/internal/shortcut/drive/drive.go
+++ b/internal/shortcut/drive/drive.go
@@ -20,6 +20,7 @@
 package drive
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd"
@@ -545,6 +546,24 @@ var Move = shortcut.Shortcut{
 		verified, err = requireDriveObject(verified, "doc/get_document_info")
 		if err != nil {
 			return err
+		}
+		if rt.Changed("folder") {
+			remoteFolder := firstString(verified, "folderId", "targetFolderId", "parentId")
+			if remoteFolder == "" {
+				return driveResponseError("doc/move_document", "readback_missing_folder", "移动后读回缺少目标文件夹 ID；无法证明移动已到达请求位置")
+			}
+			if remoteFolder != rt.Str("folder") {
+				return driveResponseError("doc/move_document", "readback_folder_mismatch", fmt.Sprintf("移动后读回文件夹 %q 与请求 %q 不一致", remoteFolder, rt.Str("folder")))
+			}
+		}
+		if rt.Changed("workspace") {
+			remoteWorkspace := firstString(verified, "workspaceId", "spaceId")
+			if remoteWorkspace == "" {
+				return driveResponseError("doc/move_document", "readback_missing_workspace", "移动后读回缺少目标知识库 ID；无法证明移动已到达请求位置")
+			}
+			if remoteWorkspace != rt.Str("workspace") {
+				return driveResponseError("doc/move_document", "readback_workspace_mismatch", fmt.Sprintf("移动后读回知识库 %q 与请求 %q 不一致", remoteWorkspace, rt.Str("workspace")))
+			}
 		}
 		return rt.Output(map[string]any{"success": true, "nodeId": rt.Str("node"), "file": verified})
 	},

--- a/internal/shortcut/drive/drive.go
+++ b/internal/shortcut/drive/drive.go
@@ -547,6 +547,13 @@ var Move = shortcut.Shortcut{
 		if err != nil {
 			return err
 		}
+		remoteID := firstString(verified, "nodeId", "fileId", "dentryUuid", "id")
+		if remoteID == "" {
+			return driveResponseError("doc/move_document", "readback_missing_id", "移动后读回缺少节点 ID；无法证明读回的是已移动节点")
+		}
+		if remoteID != rt.Str("node") {
+			return driveResponseError("doc/move_document", "readback_id_mismatch", fmt.Sprintf("移动后读回节点 %q 与请求节点 %q 不一致", remoteID, rt.Str("node")))
+		}
 		if rt.Changed("folder") {
 			remoteFolder := firstString(verified, "folderId", "targetFolderId", "parentId")
 			if remoteFolder == "" {

--- a/internal/shortcut/drive/drive_shortcuts_test.go
+++ b/internal/shortcut/drive/drive_shortcuts_test.go
@@ -178,16 +178,20 @@ func TestCrossPlatformCoverageDriveDownloadAndUploadRequireArtifactsAndReadback(
 		t.Fatal("upload path escape was accepted")
 	}
 	for _, tc := range []struct {
-		name     string
-		readback string
-		want     string
+		name        string
+		committedID string
+		readback    string
+		want        string
 	}{
-		{"missing remote size", `{"success":true,"result":{"fileId":"uploaded-2","name":"input.bin"}}`, "缺少有效文件大小"},
-		{"mismatched remote size", `{"success":true,"result":{"fileId":"uploaded-3","name":"input.bin","fileSize":17}}`, "与本地文件大小 18 不一致"},
+		{"missing remote id", "uploaded-2", `{"success":true,"result":{"name":"input.bin","fileSize":18}}`, "缺少文件 ID"},
+		{"mismatched remote id", "uploaded-3", `{"success":true,"result":{"fileId":"other","name":"input.bin","fileSize":18}}`, "与提交 ID"},
+		{"prefix-only remote name", "uploaded-4", `{"success":true,"result":{"fileId":"uploaded-4","name":"input.bin-old","fileSize":18}}`, "读回名称"},
+		{"missing remote size", "uploaded-5", `{"success":true,"result":{"fileId":"uploaded-5","name":"input.bin"}}`, "缺少有效文件大小"},
+		{"mismatched remote size", "uploaded-6", `{"success":true,"result":{"fileId":"uploaded-6","name":"input.bin","fileSize":17}}`, "与本地文件大小 18 不一致"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			testseam.Swap(t, &uploadDriveFile, func(context.Context, helpers.DriveUploadRequest) (map[string]any, error) {
-				return map[string]any{"success": true, "result": map[string]any{"fileId": strings.TrimSuffix(tc.name, " remote size")}}, nil
+				return map[string]any{"success": true, "result": map[string]any{"fileId": tc.committedID}}, nil
 			})
 			caller := &driveCoverageCaller{responses: map[string][]string{"get_file_info": {tc.readback}}}
 			err := runDriveCoverage(t, Upload, caller, "--file", "input.bin", "--yes")
@@ -196,6 +200,17 @@ func TestCrossPlatformCoverageDriveDownloadAndUploadRequireArtifactsAndReadback(
 			}
 		})
 	}
+	t.Run("split remote extension", func(t *testing.T) {
+		testseam.Swap(t, &uploadDriveFile, func(context.Context, helpers.DriveUploadRequest) (map[string]any, error) {
+			return map[string]any{"success": true, "result": map[string]any{"fileId": "uploaded-7"}}, nil
+		})
+		caller := &driveCoverageCaller{responses: map[string][]string{
+			"get_file_info": {`{"success":true,"result":{"fileId":"uploaded-7","name":"input","extension":"bin","fileSize":18}}`},
+		}}
+		if err := runDriveCoverage(t, Upload, caller, "--file", "input.bin", "--yes"); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	testseam.Swap(t, &driveDownload, func(_ context.Context, _ string, options localio.DownloadOptions) (localio.DownloadResult, error) {
 		if options.Output != "downloads/file.bin" || options.Headers["x-token"] != "secret" {
@@ -268,6 +283,9 @@ func TestCrossPlatformCoverageDriveFirstInt64(t *testing.T) {
 	}
 	if got, ok := firstInt64(map[string]any{}, "size"); ok || got != 0 {
 		t.Fatalf("missing firstInt64 = (%d, %t), want (0, false)", got, ok)
+	}
+	if got, ok := firstInt64(map[string]any{"fileSize": nil, "size": "7"}, "fileSize", "size"); !ok || got != 7 {
+		t.Fatalf("fallback firstInt64 = (%d, %t), want (7, true)", got, ok)
 	}
 }
 
@@ -512,6 +530,8 @@ func TestCrossPlatformCoverageDriveCreateRestoreCopyMoveRename(t *testing.T) {
 		readback string
 		want     string
 	}{
+		{"missing node id", `{"success":true,"result":{"folderId":"target","workspaceId":"space"}}`, "缺少节点 ID"},
+		{"wrong node id", `{"success":true,"result":{"nodeId":"other","folderId":"target","workspaceId":"space"}}`, "与请求节点 \"n1\" 不一致"},
 		{"missing folder", `{"success":true,"result":{"nodeId":"n1","workspaceId":"space"}}`, "缺少目标文件夹 ID"},
 		{"wrong folder", `{"success":true,"result":{"nodeId":"n1","folderId":"other","workspaceId":"space"}}`, "与请求 \"target\" 不一致"},
 		{"missing workspace", `{"success":true,"result":{"nodeId":"n1","folderId":"target"}}`, "缺少目标知识库 ID"},

--- a/internal/shortcut/drive/drive_shortcuts_test.go
+++ b/internal/shortcut/drive/drive_shortcuts_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -176,6 +177,25 @@ func TestCrossPlatformCoverageDriveDownloadAndUploadRequireArtifactsAndReadback(
 	if _, _, err := resolveDriveUploadInput("../escape.bin"); err == nil {
 		t.Fatal("upload path escape was accepted")
 	}
+	for _, tc := range []struct {
+		name     string
+		readback string
+		want     string
+	}{
+		{"missing remote size", `{"success":true,"result":{"fileId":"uploaded-2","name":"input.bin"}}`, "缺少有效文件大小"},
+		{"mismatched remote size", `{"success":true,"result":{"fileId":"uploaded-3","name":"input.bin","fileSize":17}}`, "与本地文件大小 18 不一致"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testseam.Swap(t, &uploadDriveFile, func(context.Context, helpers.DriveUploadRequest) (map[string]any, error) {
+				return map[string]any{"success": true, "result": map[string]any{"fileId": strings.TrimSuffix(tc.name, " remote size")}}, nil
+			})
+			caller := &driveCoverageCaller{responses: map[string][]string{"get_file_info": {tc.readback}}}
+			err := runDriveCoverage(t, Upload, caller, "--file", "input.bin", "--yes")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
 
 	testseam.Swap(t, &driveDownload, func(_ context.Context, _ string, options localio.DownloadOptions) (localio.DownloadResult, error) {
 		if options.Output != "downloads/file.bin" || options.Headers["x-token"] != "secret" {
@@ -215,6 +235,39 @@ func TestCrossPlatformCoverageDriveCopyPreservesSchemaProperties(t *testing.T) {
 		if got[name] != property {
 			t.Errorf("copy parameter %q property = %q, want %q", name, got[name], property)
 		}
+	}
+}
+
+func TestCrossPlatformCoverageDriveFirstInt64(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value any
+		want  int64
+		ok    bool
+	}{
+		{"int", int(1), 1, true},
+		{"int32", int32(2), 2, true},
+		{"int64", int64(3), 3, true},
+		{"float", float64(4), 4, true},
+		{"json number", json.Number("5"), 5, true},
+		{"string", " 6 ", 6, true},
+		{"fraction", 1.5, 0, false},
+		{"nan", math.NaN(), 0, false},
+		{"infinity", math.Inf(1), 0, false},
+		{"overflow", float64(math.MaxInt64), 0, false},
+		{"bad json number", json.Number("bad"), 0, false},
+		{"bad string", "bad", 0, false},
+		{"unsupported", true, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := firstInt64(map[string]any{"size": tc.value}, "missing", "size")
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("firstInt64(%#v) = (%d, %t), want (%d, %t)", tc.value, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+	if got, ok := firstInt64(map[string]any{}, "size"); ok || got != 0 {
+		t.Fatalf("missing firstInt64 = (%d, %t), want (0, false)", got, ok)
 	}
 }
 
@@ -449,10 +502,31 @@ func TestCrossPlatformCoverageDriveCreateRestoreCopyMoveRename(t *testing.T) {
 
 	move := &driveCoverageCaller{responses: map[string][]string{
 		"move_document":     {`{"success":true}`},
-		"get_document_info": {`{"success":true,"result":{"nodeId":"n1"}}`},
+		"get_document_info": {`{"success":true,"result":{"nodeId":"n1","folderId":"target","workspaceId":"space"}}`},
 	}}
 	if err := runDriveCoverage(t, Move, move, "--node", "n1", "--folder", "target", "--workspace", "space", "--yes"); err != nil {
 		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name     string
+		readback string
+		want     string
+	}{
+		{"missing folder", `{"success":true,"result":{"nodeId":"n1","workspaceId":"space"}}`, "缺少目标文件夹 ID"},
+		{"wrong folder", `{"success":true,"result":{"nodeId":"n1","folderId":"other","workspaceId":"space"}}`, "与请求 \"target\" 不一致"},
+		{"missing workspace", `{"success":true,"result":{"nodeId":"n1","folderId":"target"}}`, "缺少目标知识库 ID"},
+		{"wrong workspace", `{"success":true,"result":{"nodeId":"n1","folderId":"target","workspaceId":"other"}}`, "与请求 \"space\" 不一致"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &driveCoverageCaller{responses: map[string][]string{
+				"move_document":     {`{"success":true}`},
+				"get_document_info": {tc.readback},
+			}}
+			err := runDriveCoverage(t, Move, caller, "--node", "n1", "--folder", "target", "--workspace", "space", "--yes")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 
 	rename := &driveCoverageCaller{responses: map[string][]string{


### PR DESCRIPTION
## Summary

- fail closed when `drive +upload` readback omits the remote size or it differs from the local file
- bind upload readback to the exact committed node and requested name; reject prefix-only name matches
- bind move readback to the requested node before verifying every requested folder/workspace target
- accept actual numeric response forms and valid compatibility aliases without coercing fractions, invalid numbers, or overflow
- rebase onto current `main`

Follow-up to the two P2 findings in #959, plus self-review hardening against wrong-object readback.

## Previous behavior: trigger and impact

### Upload

The old success path was triggered after `commit_upload` returned success and `get_file_info` returned any non-empty object whose name merely started with the requested basename. It did not require the readback node ID to equal the committed ID and did not compare remote size with the local file.

Consequences:

- a stale or wrong object such as requested `report.pdf` versus returned `report-old.pdf` could pass the prefix check;
- an overwritten object that still exposed old metadata could be reported as the new upload;
- a truncated remote object could return `success=true` because `sizeBytes` came from the local file rather than remote metadata.

The command could therefore report success for an unproven remote artifact.

### Move

The old success path was triggered when `move_document` returned success and `get_document_info` returned any non-empty object. It did not require the readback node to equal the requested node and did not compare the requested folder/workspace with the readback position.

Consequences:

- an ignored target, delayed move, wrong-object readback, or move to the wrong folder/workspace could still be reported as success;
- callers could continue from a location that the server never reached.

## Risk tier

- [x] Standard: ordinary implementation change with a stable package graph

## Verification on current `main`

- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./... -count=1`
- [x] `make build`
- [x] `make generate-schema`
- [x] `./scripts/policy/check-generated-drift.sh`
- [x] `./scripts/policy/check-schema-catalog.sh`
- [x] changed-code coverage: **51/51 statements (100%)**
- [x] `make authoritative-interface-integrity BASE_REF=origin/main STABLE_REF=v1.0.57`: compatible, blocking=0
- [x] `make schema-compatibility BASE_REF=origin/main STABLE_REF=v1.0.57`: passed

## Reproducible real-data E2E (PII removed)

Prerequisites: build this branch as `./dws`, complete `./dws auth login`, and run from the repository so `go.mod` is an existing non-empty relative file. Replace all `<...>` placeholders only with IDs returned by the immediately preceding command. Use a unique `<PREFIX>` such as `drive-e2e-YYYYMMDD-HHMMSS`.

### 1. Prepare two isolated folders

```sh
./dws drive +create-folder --name "<PREFIX>-a" --format json
# Save the returned fileId as <FOLDER_A>.

./dws drive +create-folder --name "<PREFIX>-b" --format json
# Save the returned fileId as <FOLDER_B>.
```

Expected after each command: exit 0, `success=true`, and a non-empty `fileId` from the readback object.

### 2. Prepare one online document in folder A

```sh
./dws doc +create \
  --name "<PREFIX>-doc" \
  --content "drive readback e2e" \
  --folder "<FOLDER_A>" \
  --format json
# Save the returned nodeId as <DOC_ID>.
```

Expected: exit 0 and a non-empty `<DOC_ID>`.

### 3. Upload and verify exact remote metadata

```sh
wc -c < go.mod

./dws drive +upload \
  --file go.mod \
  --file-name "<PREFIX>.mod" \
  --folder "<FOLDER_A>" \
  --yes \
  --format json
# Save nodeId/fileId as <UPLOAD_ID>.
```

Expected: exit 0; returned `file.fileId` equals `<UPLOAD_ID>`; returned name represents exactly `<PREFIX>.mod` (either one name field or name plus extension); `file.fileSize` and `sizeBytes` both equal the `wc -c` value. Missing/mismatched ID, name, or size must return non-zero instead of an empty/false success.

### 4. Move to folder B and back to A

```sh
./dws drive +move \
  --node "<DOC_ID>" \
  --folder "<FOLDER_B>" \
  --yes \
  --format json

./dws drive +move \
  --node "<DOC_ID>" \
  --folder "<FOLDER_A>" \
  --yes \
  --format json
```

Expected for each command: exit 0; returned `nodeId` equals `<DOC_ID>`; readback `file.nodeId` equals `<DOC_ID>`; readback `file.folderId` equals the folder requested for that step. When testing a knowledge-space fixture, additionally pass `--workspace <WORKSPACE_ID>` and require readback `workspaceId` to match.

### 5. Clean up and prove no active fixture remains

```sh
./dws drive +delete --node "<UPLOAD_ID>" --yes --format json
./dws drive +delete --node "<DOC_ID>" --yes --format json
./dws drive +delete --node "<FOLDER_B>" --yes --format json
./dws drive +delete --node "<FOLDER_A>" --yes --format json

./dws drive +search --query "<PREFIX>" --limit 20 --format json
```

Expected: every delete exits 0 with terminal success evidence; final search returns an explicit collection with `count=0`. The latest run passed upload exact readback, move A→B→A, and cleanup-zero checks. No account identifiers, real resource IDs, URLs, tokens, absolute paths, or business content are included here.

## Self-review note

A possible `folder/workspace` at-least-one constraint was tested but intentionally not shipped: adding it changes the existing public Schema constraint and fails backwards compatibility. This patch does not hide the check in runtime-only validation because that would violate CLI/Schema homology.

## Notes

This change does not alter command paths, flags, Schema, or safety metadata. Missing or mismatched terminal evidence is treated as failure; it is never projected as an empty successful result.
