### PR TITLE
fix(skill): avoid duplicate Agent skill roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The verifier uses isolated directories and does not replace the `dws` on the cur
 The upgrade process follows a two-phase atomic flow to ensure consistency:
 
 1. **Prepare** — downloads the platform-specific binary and skill packages to a temporary directory, verifies SHA256 checksums, and extracts/validates all files. If any step fails, the upgrade aborts without modifying the existing installation.
-2. **Apply** — only after all preparations succeed, the binary is replaced and skill packages are installed to all detected agent directories (`~/.agents/skills/dws`, `~/.claude/skills/dws`, `~/.cursor/skills/dws`, etc.).
+2. **Apply** — only after all preparations succeed, the binary is replaced and skills are flattened into detected agent-specific roots (for example `~/.codex/skills/dingtalk-chat`). `~/.agents/skills` is used only when no specific Agent is detected; once a specific root is active, older DWS-managed generic copies are backed up and retired so the same Skill is not discovered twice.
 
 A backup of the current version is automatically created before each upgrade. Use `dws upgrade --rollback` to restore the previous version if needed.
 
@@ -405,7 +405,7 @@ After installing, AI tools like Claude Code / Cursor can operate DingTalk direct
 curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install-skills.sh | sh
 ```
 
-> `install.sh` installs under `$HOME/.agents/skills/` (global; multi layout is per-product siblings, mono is the `dws/` subdirectory); `install-skills.sh` installs under `./.agents/skills/` (current project).
+> Installers prefer detected agent-specific roots such as `$HOME/.codex/skills/`. They use `.agents/skills/` only as the generic fallback when no specific Agent is detected; multi layout is per-product siblings, while mono uses the `dws/` subdirectory.
 >
 > China users: prefix `DWS_GITEE_REPO` to use the Gitee mirror — see [China mirror](#china-mirror).
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -207,7 +207,7 @@ bash verify-all-channels.sh
 升级过程采用两阶段原子流程，确保一致性：
 
 1. **准备阶段** — 将平台对应的二进制文件和技能包下载到临时目录，校验 SHA256 校验和，解压并验证所有文件。任何步骤失败则立即中止，不会修改现有安装。
-2. **执行阶段** — 仅在所有准备工作成功后，替换二进制文件并将技能包安装到所有已检测到的 Agent 目录（`~/.agents/skills/dws`、`~/.claude/skills/dws`、`~/.cursor/skills/dws` 等）。
+2. **执行阶段** — 仅在所有准备工作成功后，替换二进制文件并将技能包平铺到已检测到的具体 Agent 目录（例如 `~/.codex/skills/dingtalk-chat`、`~/.claude/skills/dingtalk-chat`）。只有未检测到具体 Agent 时才使用 `~/.agents/skills`；检测到具体 Agent 后会备份迁走旧的 DWS 通用副本，避免同一 Skill 被重复发现。
 
 每次升级前自动备份当前版本，可通过 `dws upgrade --rollback` 随时回滚。
 
@@ -399,7 +399,7 @@ Schema 生成的叶子 safety/参数/选型文案由 Go 中的 ProductDecl / Con
 curl -fsSL https://raw.githubusercontent.com/DingTalk-Real-AI/dingtalk-workspace-cli/main/scripts/install-skills.sh | sh
 ```
 
-> `install.sh` 安装到 `$HOME/.agents/skills/`（全局，multi 为按产品平铺，mono 为 `dws/` 子目录）；`install-skills.sh` 安装到 `./.agents/skills/`（当前项目）。
+> 安装器优先使用检测到的具体 Agent 根目录（如 `$HOME/.codex/skills/`）；仅在未检测到具体 Agent 时回退到 `.agents/skills/`。multi 为按产品平铺，mono 为 `dws/` 子目录。
 >
 > 国内用户加 `DWS_GITEE_REPO` 走 Gitee 镜像，见 [国内加速安装](#国内加速安装)。
 
@@ -427,7 +427,7 @@ DWS_SKILL_SOURCE=/path/to/skills dws skill setup --mode multi
 | 参数 | 取值 | 说明 |
 |------|------|------|
 | `--mode` | `mono` \| `multi` | skill 布局，不指定则交互式询问 |
-| `--target` | `all` \| `claude` \| `cursor` \| `codex` \| `opencode` \| `qoder` | 安装目标，`all` 表示铺到所有检测到的 Agent home |
+| `--target` | `all` \| `claude` \| `cursor` \| `codex` \| `opencode` \| `qoder` | 安装目标；`all` 表示铺到检测到的具体 Agent home，仅在未检测到具体 Agent 时回退到 `~/.agents/skills` |
 | `--source` | 路径 | 本地源目录（覆盖内置 skills） |
 | `--yes` | — | 仅供脚本使用：跳过确认提示。删除操作仍会先备份到 `~/.dws/skill-backups/` |
 

--- a/build/npm/install.js
+++ b/build/npm/install.js
@@ -233,6 +233,10 @@ function installSkillsToHomes(skillRoot) {
   let attempted = 0;
   let failed = 0;
 
+  const specificAgentDirs = AGENT_DIRS.slice(1).filter((agentDir) =>
+    fs.existsSync(path.dirname(path.join(homeDir, agentDir))),
+  );
+
   const installToBase = (baseDir) => {
     const victims = [path.join(baseDir, "dws")];
     if (fs.existsSync(baseDir)) {
@@ -252,6 +256,9 @@ function installSkillsToHomes(skillRoot) {
   };
 
   AGENT_DIRS.forEach((agentDir, index) => {
+    if (index === 0 && specificAgentDirs.length > 0) {
+      return;
+    }
     const baseDir = path.join(homeDir, agentDir);
     const parentGate = path.dirname(baseDir);
     if (index > 0 && !fs.existsSync(parentGate)) {
@@ -264,6 +271,15 @@ function installSkillsToHomes(skillRoot) {
       failed += 1;
     }
   });
+
+  if (specificAgentDirs.length > 0 && installed > 0) {
+    try {
+      retireGenericSkillRoot(homeDir, managedNames);
+    } catch (err) {
+      console.warn(`⚠️  通用 Skill 副本迁移失败: ${err.message}`);
+      failed += 1;
+    }
+  }
 
   if (attempted === 0) {
     if (installToBase(path.join(homeDir, ".agents", "skills"))) {
@@ -327,6 +343,40 @@ function readManagedSkillNames(homeDir) {
 function isManagedMultiSkillDir(dir, managedNames) {
   const name = path.basename(dir);
   return LEGACY_OFFICIAL_MULTI_SKILLS.has(name) || managedNames.has(name);
+}
+
+function retireGenericSkillRoot(homeDir, managedNames) {
+  const baseDir = path.join(homeDir, ".agents", "skills");
+  const victims = [path.join(baseDir, "dws")];
+  if (fs.existsSync(baseDir)) {
+    for (const entry of fs.readdirSync(baseDir, { withFileTypes: true })) {
+      if (entry.isDirectory() && isManagedMultiSkillDir(path.join(baseDir, entry.name), managedNames)) {
+        victims.push(path.join(baseDir, entry.name));
+      }
+    }
+  }
+  const backups = [];
+  try {
+    for (const victim of victims) {
+      if (!backupAndRemoveSkillDir(homeDir, victim, backups)) {
+        throw new Error(`failed to back up Skill directory ${victim}`);
+      }
+    }
+  } catch (err) {
+    const restoreErrors = [];
+    for (let i = backups.length - 1; i >= 0; i -= 1) {
+      try {
+        fs.mkdirSync(path.dirname(backups[i].original), { recursive: true });
+        fs.renameSync(backups[i].backup, backups[i].original);
+      } catch (restoreErr) {
+        restoreErrors.push(`${backups[i].original}: ${restoreErr.message}`);
+      }
+    }
+    if (restoreErrors.length > 0) {
+      throw new Error(`${err.message}; generic-root rollback failed: ${restoreErrors.join("; ")}`);
+    }
+    throw err;
+  }
 }
 
 function skillDirectoryDigest(dir) {
@@ -577,6 +627,10 @@ function installMultiSkillsToHomes(multiRoot) {
   let attempted = 0;
   let failed = 0;
 
+  const specificAgentDirs = AGENT_DIRS.slice(1).filter((agentDir) =>
+    fs.existsSync(path.dirname(path.join(homeDir, agentDir))),
+  );
+
   const installToBase = (baseDir) => {
     fs.mkdirSync(baseDir, { recursive: true });
     const victims = [path.join(baseDir, "dws")];
@@ -604,6 +658,9 @@ function installMultiSkillsToHomes(multiRoot) {
   };
 
   AGENT_DIRS.forEach((agentDir, index) => {
+    if (index === 0 && specificAgentDirs.length > 0) {
+      return;
+    }
     const baseDir = path.join(homeDir, agentDir);
     const parentGate = path.dirname(baseDir);
     if (index > 0 && !fs.existsSync(parentGate)) {
@@ -616,6 +673,15 @@ function installMultiSkillsToHomes(multiRoot) {
       failed += 1;
     }
   });
+
+  if (specificAgentDirs.length > 0 && installed > 0) {
+    try {
+      retireGenericSkillRoot(homeDir, managedNames);
+    } catch (err) {
+      console.warn(`⚠️  通用 Skill 副本迁移失败: ${err.message}`);
+      failed += 1;
+    }
+  }
 
   if (attempted === 0) {
     if (installToBase(path.join(homeDir, ".agents", "skills"))) {

--- a/docs/rfc-skill-installation-and-upgrade.md
+++ b/docs/rfc-skill-installation-and-upgrade.md
@@ -142,6 +142,9 @@ Agent 仍只需以 `SKILL.md` 发现和加载 Skill；统一元数据位于 Agen
 
 升级器对每个 Agent 目标执行：
 
+- 先探测具体 Agent home；只在没有任何具体 Agent 时使用 `~/.agents/skills` 通用 fallback；
+- 具体 Agent 安装成功后，将 `~/.agents/skills` 中旧的 DWS 受管副本可恢复地迁入备份，避免 Codex 等同时扫描两个根目录时重复发现同名 Skill；
+
 1. 只读计算对面布局、过期受管 Skill 和同名官方 Skill；
 2. 在目标文件系统的 staging 中复制完整新集合；
 3. staging 全部成功后，才将旧集合移入备份目录；

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -681,9 +681,9 @@ func newRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine, 
 			if _, err := parseAgentProduct(os.Getenv(agentproduct.EnvName)); err != nil {
 				return err
 			}
-			if shouldRepairNestedSkillLayout(cmd) {
-				if err := repairNestedMultiSkillLayout(); err != nil {
-					fmt.Fprintf(cmd.ErrOrStderr(), "⚠️  检测到旧升级器留下的嵌套 Skill，但自动修复失败: %v；请运行 dws skill setup --mode multi --yes\n", err)
+			if shouldDetectNestedSkillLayout(cmd) {
+				if found, err := detectNestedMultiSkillLayout(); err == nil && found {
+					fmt.Fprintln(cmd.ErrOrStderr(), "⚠️  检测到旧升级器留下的嵌套 Skill；请运行 dws skill setup --mode multi 查看迁移计划并确认")
 				}
 			}
 

--- a/internal/app/root.go
+++ b/internal/app/root.go
@@ -681,6 +681,11 @@ func newRootCommandWithEngine(rootCtx context.Context, engine *pipeline.Engine, 
 			if _, err := parseAgentProduct(os.Getenv(agentproduct.EnvName)); err != nil {
 				return err
 			}
+			if shouldRepairNestedSkillLayout(cmd) {
+				if err := repairNestedMultiSkillLayout(); err != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "⚠️  检测到旧升级器留下的嵌套 Skill，但自动修复失败: %v；请运行 dws skill setup --mode multi --yes\n", err)
+				}
+			}
 
 			authpkg.SetRuntimeProfile(flags.Profile)
 			// Apply OAuth credential overrides from CLI flags (highest priority).

--- a/internal/app/skill_setup.go
+++ b/internal/app/skill_setup.go
@@ -961,25 +961,37 @@ func detectExistingAgentHomes(home, mode string) []string {
 }
 
 func genericSkillCleanupTarget(dests []string, managed map[string]bool) (*skillSetupTargetPlan, error) {
-	home, err := skillSetupUserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("无法解析 HOME 以计算通用 Skill 迁移: %w", err)
-	}
-	genericBase := filepath.Join(home, ".agents", "skills")
-	usesSpecificRoot := false
+	// Derive HOME from a concrete Agent destination instead of resolving it a
+	// second time. The destinations were already resolved from HOME by the
+	// caller, and a later/transient UserHomeDir failure must not turn an
+	// otherwise valid setup plan into an error. Direct/custom destinations that
+	// do not match a known concrete Agent root have no generic-root migration.
+	home := ""
 	for _, dest := range dests {
 		base := dest
 		if filepath.Base(dest) == "dws" {
 			base = filepath.Dir(dest)
 		}
-		if filepath.Clean(base) != filepath.Clean(genericBase) {
-			usesSpecificRoot = true
+		base = filepath.Clean(base)
+		for i, rel := range skillSetupAgentHomes {
+			if i == 0 {
+				continue
+			}
+			suffix := filepath.Clean(filepath.FromSlash(rel))
+			needle := string(filepath.Separator) + suffix
+			if strings.HasSuffix(base, needle) {
+				home = strings.TrimSuffix(base, needle)
+				break
+			}
+		}
+		if home != "" {
 			break
 		}
 	}
-	if !usesSpecificRoot {
+	if home == "" {
 		return nil, nil
 	}
+	genericBase := filepath.Join(home, ".agents", "skills")
 
 	target := &skillSetupTargetPlan{Destination: genericBase, CleanupOnly: true}
 	add := func(path, reason string) {

--- a/internal/app/skill_setup.go
+++ b/internal/app/skill_setup.go
@@ -92,6 +92,7 @@ type skillSetupBackup struct {
 type skillSetupTargetPlan struct {
 	Destination string
 	Backups     []skillSetupBackup
+	CleanupOnly bool
 }
 
 type skillSetupPlan struct {
@@ -147,7 +148,8 @@ multi 模式支持按产品挑选：
     备份失败时保留原目录并跳过该目标，绝不静默删除。
   · 所有将被移除的目录都会在确认前逐条列出。
 
-不带 --mode 时进入交互式询问；不带 --target 时铺到所有检测到的 Agent 目录。
+不带 --mode 时进入交互式询问；不带 --target 时铺到检测到的具体 Agent 目录；
+未检测到具体 Agent 时才回退到 ~/.agents/skills，避免同一 Agent 扫描两份 Skill。
 skill 源默认取二进制内嵌的版本（升级二进制即升级 skill）；--source / DWS_SKILL_SOURCE 可显式覆盖。`,
 		Example: `  dws skill setup --mode multi --target claude --dry-run
   dws skill setup --mode multi --target claude`,
@@ -940,18 +942,67 @@ func agentHomeForMode(base, mode string) string {
 }
 
 func detectExistingAgentHomes(home, mode string) []string {
-	var out []string
+	var specific []string
 	for i, rel := range skillSetupAgentHomes {
+		if i == 0 {
+			continue
+		}
 		base := filepath.Join(home, rel)
 		parent := filepath.Dir(base)
-		if i > 0 {
-			if _, err := skillSetupStat(parent); errors.Is(err, os.ErrNotExist) {
-				continue
-			}
+		if info, err := skillSetupStat(parent); err != nil || !info.IsDir() {
+			continue
 		}
-		out = append(out, agentHomeForMode(base, mode))
+		specific = append(specific, agentHomeForMode(base, mode))
 	}
-	return out
+	if len(specific) > 0 {
+		return specific
+	}
+	return []string{agentHomeForMode(filepath.Join(home, skillSetupAgentHomes[0]), mode)}
+}
+
+func genericSkillCleanupTarget(dests []string, managed map[string]bool) (*skillSetupTargetPlan, error) {
+	home, err := skillSetupUserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("无法解析 HOME 以计算通用 Skill 迁移: %w", err)
+	}
+	genericBase := filepath.Join(home, ".agents", "skills")
+	usesSpecificRoot := false
+	for _, dest := range dests {
+		base := dest
+		if filepath.Base(dest) == "dws" {
+			base = filepath.Dir(dest)
+		}
+		if filepath.Clean(base) != filepath.Clean(genericBase) {
+			usesSpecificRoot = true
+			break
+		}
+	}
+	if !usesSpecificRoot {
+		return nil, nil
+	}
+
+	target := &skillSetupTargetPlan{Destination: genericBase, CleanupOnly: true}
+	add := func(path, reason string) {
+		if info, statErr := skillSetupStat(path); statErr == nil && info.IsDir() {
+			target.Backups = append(target.Backups, skillSetupBackup{Path: path, Reason: reason})
+		}
+	}
+	add(filepath.Join(genericBase, "dws"), skillSetupBackupMutual)
+	entries, readErr := skillSetupReadDir(genericBase)
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("扫描通用 Skill 根目录失败 %s: %w", genericBase, readErr)
+	}
+	for _, entry := range entries {
+		path := filepath.Join(genericBase, entry.Name())
+		if entry.IsDir() && isManagedDWSMultiSkillDir(path, managed) {
+			target.Backups = append(target.Backups, skillSetupBackup{Path: path, Reason: skillSetupBackupStale})
+		}
+	}
+	if len(target.Backups) == 0 {
+		return nil, nil
+	}
+	sort.Slice(target.Backups, func(i, j int) bool { return target.Backups[i].Path < target.Backups[j].Path })
+	return target, nil
 }
 
 func buildSkillSetupPlan(mode, src string, dests, multiSkillNames []string, filtered bool) (*skillSetupPlan, error) {
@@ -1027,6 +1078,13 @@ func buildSkillSetupPlan(mode, src string, dests, multiSkillNames []string, filt
 		sort.Slice(target.Backups, func(i, j int) bool { return target.Backups[i].Path < target.Backups[j].Path })
 		plan.Targets = append(plan.Targets, target)
 	}
+	cleanupTarget, cleanupErr := genericSkillCleanupTarget(sortedDests, managedNames)
+	if cleanupErr != nil {
+		return nil, cleanupErr
+	}
+	if cleanupTarget != nil {
+		plan.Targets = append(plan.Targets, *cleanupTarget)
+	}
 	return plan, nil
 }
 
@@ -1079,7 +1137,11 @@ func renderSkillSetupPlan(out io.Writer, plan *skillSetupPlan) {
 	}
 	fmt.Fprintln(out, "  destinations:")
 	for _, target := range plan.Targets {
-		fmt.Fprintf(out, "    - %s\n", target.Destination)
+		if target.CleanupOnly {
+			fmt.Fprintf(out, "    - %s (仅迁移旧的通用 DWS 副本)\n", target.Destination)
+		} else {
+			fmt.Fprintf(out, "    - %s\n", target.Destination)
+		}
 	}
 	fmt.Fprintln(out, "  将备份并移除（先保存到 ~/.dws/skill-backups/）：")
 	count := 0
@@ -1676,6 +1738,21 @@ func executeSkillSetupPlan(plan *skillSetupPlan, out, errOut io.Writer) (install
 		perTarget = len(plan.MultiSkillNames)
 	}
 	for _, target := range plan.Targets {
+		if target.CleanupOnly {
+			if skipped > 0 {
+				continue
+			}
+			if homeErr != nil {
+				fmt.Fprintf(errOut, "  ✗ 无法解析 HOME，保留通用 Skill 副本 %s: %v\n", target.Destination, homeErr)
+				skipped++
+				continue
+			}
+			if _, cleanupErr := backupSkillSetupTarget(home, target.Backups, out); cleanupErr != nil {
+				fmt.Fprintf(errOut, "  ✗ 通用 Skill 副本迁移失败，已回滚 %s: %v\n", target.Destination, cleanupErr)
+				skipped++
+			}
+			continue
+		}
 		if len(target.Backups) > 0 && homeErr != nil {
 			if plan.Mode == skillSetupModeMono {
 				fmt.Fprintf(errOut, "  ✗ 无法解析 HOME，跳过刷新（保留原目录） %s: %v\n", target.Destination, homeErr)

--- a/internal/app/skill_setup_plan_test.go
+++ b/internal/app/skill_setup_plan_test.go
@@ -146,6 +146,29 @@ func TestCrossPlatformCoverageSkillSetupMonoPlanIncludesSameNameTarget(t *testin
 	}
 }
 
+func TestCrossPlatformCoverageSkillSetupGenericCleanupDerivesHomeFromConcreteTarget(t *testing.T) {
+	home := t.TempDir()
+	dest := filepath.Join(home, ".codex", "skills")
+	genericMono := filepath.Join(home, ".agents", "skills", "dws")
+	if err := os.MkdirAll(genericMono, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) {
+		return "", errors.New("transient HOME failure")
+	})
+
+	plan, err := buildSkillSetupPlan(skillSetupModeMulti, "source", []string{dest}, []string{"dingtalk-chat"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Targets) != 2 || !plan.Targets[1].CleanupOnly || plan.Targets[1].Destination != filepath.Dir(genericMono) {
+		t.Fatalf("generic cleanup target = %#v", plan.Targets)
+	}
+	if len(plan.Targets[1].Backups) != 1 || plan.Targets[1].Backups[0].Path != genericMono {
+		t.Fatalf("generic cleanup backups = %#v", plan.Targets[1].Backups)
+	}
+}
+
 func TestCrossPlatformCoverageSkillSetupPlanDeduplicatesAndFailsClosed(t *testing.T) {
 	dest := filepath.Join(t.TempDir(), "skills")
 	if err := os.MkdirAll(filepath.Join(dest, "dws"), 0o755); err != nil {

--- a/internal/app/skill_setup_plan_test.go
+++ b/internal/app/skill_setup_plan_test.go
@@ -167,6 +167,63 @@ func TestCrossPlatformCoverageSkillSetupGenericCleanupDerivesHomeFromConcreteTar
 	if len(plan.Targets[1].Backups) != 1 || plan.Targets[1].Backups[0].Path != genericMono {
 		t.Fatalf("generic cleanup backups = %#v", plan.Targets[1].Backups)
 	}
+	var preview bytes.Buffer
+	renderSkillSetupPlan(&preview, plan)
+	if !strings.Contains(preview.String(), "仅迁移旧的通用 DWS 副本") {
+		t.Fatalf("generic cleanup preview missing: %s", preview.String())
+	}
+
+	t.Run("managed multi and scan failure", func(t *testing.T) {
+		managedDir := filepath.Join(home, ".agents", "skills", "dingtalk-chat")
+		if err := os.MkdirAll(managedDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		target, targetErr := genericSkillCleanupTarget([]string{dest}, map[string]bool{"dingtalk-chat": true})
+		if targetErr != nil || target == nil || len(target.Backups) != 2 {
+			t.Fatalf("managed generic cleanup = %#v, %v", target, targetErr)
+		}
+		failure := errors.New("generic scan failure")
+		testseam.Swap(t, &skillSetupReadDir, func(string) ([]os.DirEntry, error) { return nil, failure })
+		if _, targetErr := genericSkillCleanupTarget([]string{dest}, nil); !errors.Is(targetErr, failure) {
+			t.Fatalf("generic scan error = %v", targetErr)
+		}
+		if _, planErr := buildSkillSetupPlan(skillSetupModeMulti, "source", []string{dest}, []string{"dingtalk-chat"}, true); !errors.Is(planErr, failure) {
+			t.Fatalf("generic cleanup plan error = %v", planErr)
+		}
+	})
+}
+
+func TestCrossPlatformCoverageSkillSetupCleanupOnlyExecutionBranches(t *testing.T) {
+	failure := errors.New("cleanup failure")
+	cleanup := skillSetupTargetPlan{Destination: "generic", CleanupOnly: true, Backups: []skillSetupBackup{{Path: "old"}}}
+
+	t.Run("prior skip suppresses cleanup", func(t *testing.T) {
+		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return t.TempDir(), nil })
+		plan := &skillSetupPlan{Mode: skillSetupModeMono, Source: "missing", Targets: []skillSetupTargetPlan{{Destination: "install"}, cleanup}}
+		installed, skipped, err := executeSkillSetupPlan(plan, io.Discard, io.Discard)
+		if err != nil || installed != 0 || skipped != 1 {
+			t.Fatalf("cleanup after skip = (%d, %d, %v)", installed, skipped, err)
+		}
+	})
+
+	t.Run("home failure keeps generic copy", func(t *testing.T) {
+		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return "", failure })
+		var stderr bytes.Buffer
+		_, skipped, err := executeSkillSetupPlan(&skillSetupPlan{Mode: skillSetupModeMono, Targets: []skillSetupTargetPlan{cleanup}}, io.Discard, &stderr)
+		if err != nil || skipped != 1 || !strings.Contains(stderr.String(), "保留通用 Skill 副本") {
+			t.Fatalf("cleanup HOME failure = (%d, %v, %q)", skipped, err, stderr.String())
+		}
+	})
+
+	t.Run("backup failure is reported", func(t *testing.T) {
+		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return t.TempDir(), nil })
+		testseam.Swap(t, &skillSetupBackupAndRemove, func(string, string) (string, error) { return "", failure })
+		var stderr bytes.Buffer
+		_, skipped, err := executeSkillSetupPlan(&skillSetupPlan{Mode: skillSetupModeMono, Targets: []skillSetupTargetPlan{cleanup}}, io.Discard, &stderr)
+		if err != nil || skipped != 1 || !strings.Contains(stderr.String(), "迁移失败") {
+			t.Fatalf("cleanup backup failure = (%d, %v, %q)", skipped, err, stderr.String())
+		}
+	})
 }
 
 func TestCrossPlatformCoverageSkillSetupPlanDeduplicatesAndFailsClosed(t *testing.T) {

--- a/internal/app/skill_setup_test.go
+++ b/internal/app/skill_setup_test.go
@@ -330,6 +330,24 @@ func TestResolveSkillSetupTargetsMultiOmitsDwsTail(t *testing.T) {
 	}
 }
 
+func TestCrossPlatformCoverageResolveSkillSetupTargetsPrefersSpecificAgentRoot(t *testing.T) {
+	home := t.TempDir()
+	testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
+	testseam.Swap(t, &skillSetupAgentHomes, []string{".agents/skills", ".codex/skills"})
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveSkillSetupTargets("all", skillSetupModeMulti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".codex", "skills")
+	if len(got) != 1 || filepath.Clean(got[0]) != filepath.Clean(want) {
+		t.Fatalf("targets = %v, want [%s]", got, want)
+	}
+}
+
 func TestCrossPlatformCoverageInstallSkillToHomesEndToEnd(t *testing.T) {
 	src := t.TempDir()
 	if err := os.WriteFile(filepath.Join(src, "SKILL.md"), []byte("# test"), 0o644); err != nil {

--- a/internal/app/skill_startup_repair.go
+++ b/internal/app/skill_startup_repair.go
@@ -4,56 +4,34 @@
 package app
 
 import (
-	"fmt"
 	"path/filepath"
 
-	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/upgrade"
 	"github.com/spf13/cobra"
 )
 
-var repairNestedSkillUpgrade = upgrade.UpgradeSkillLocationsWithOptions
-
-// repairNestedMultiSkillLayout closes the compatibility gap where an older
+// detectNestedMultiSkillLayout detects the compatibility gap where an older
 // running dws process replaces itself with a newer binary, but then installs
 // the new release bundle with its legacy mono copier. That produces the
-// impossible layout <agent>/dws/multi/<skill>/SKILL.md. The new binary cannot
-// change the already-running old process, so its next invocation repairs this
-// exact malformed layout from the bundle embedded in the new binary.
+// impossible layout <agent>/dws/multi/<skill>/SKILL.md.
 //
-// A legitimate mono install has no dws/multi product tree and is untouched.
-func repairNestedMultiSkillLayout() error {
+// Detection is deliberately read-only. Ordinary commands must not turn a
+// compatibility warning into an unconfirmed, cross-Agent Skill refresh.
+// A legitimate mono install has no dws/multi product tree and is ignored.
+func detectNestedMultiSkillLayout() (bool, error) {
 	home, err := skillSetupUserHomeDir()
 	if err != nil {
-		return err
+		return false, err
 	}
-	found := false
 	for _, rel := range skillSetupAgentHomes {
 		nested := filepath.Join(home, rel, "dws", "multi")
 		if isSkillSourceRoot(nested, skillSetupModeMulti) {
-			found = true
-			break
+			return true, nil
 		}
 	}
-	if !found {
-		return nil
-	}
-
-	source, cleanup, err := materializeEmbeddedSkillSource(skillSetupModeMulti)
-	if err != nil {
-		return fmt.Errorf("提取当前版本内嵌 multi Skill 失败: %w", err)
-	}
-	defer cleanup()
-	result, err := repairNestedSkillUpgrade(source, upgrade.SkillUpgradeOptions{Version: RawVersion()})
-	if err != nil {
-		return err
-	}
-	if failed := result.Failed(); len(failed) > 0 {
-		return fmt.Errorf("%d 个 Agent 目录修复失败", len(failed))
-	}
-	return nil
+	return false, nil
 }
 
-func shouldRepairNestedSkillLayout(cmd *cobra.Command) bool {
+func shouldDetectNestedSkillLayout(cmd *cobra.Command) bool {
 	if cmd == nil {
 		return true
 	}

--- a/internal/app/skill_startup_repair.go
+++ b/internal/app/skill_startup_repair.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0
+
+package app
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/upgrade"
+	"github.com/spf13/cobra"
+)
+
+var repairNestedSkillUpgrade = upgrade.UpgradeSkillLocationsWithOptions
+
+// repairNestedMultiSkillLayout closes the compatibility gap where an older
+// running dws process replaces itself with a newer binary, but then installs
+// the new release bundle with its legacy mono copier. That produces the
+// impossible layout <agent>/dws/multi/<skill>/SKILL.md. The new binary cannot
+// change the already-running old process, so its next invocation repairs this
+// exact malformed layout from the bundle embedded in the new binary.
+//
+// A legitimate mono install has no dws/multi product tree and is untouched.
+func repairNestedMultiSkillLayout() error {
+	home, err := skillSetupUserHomeDir()
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, rel := range skillSetupAgentHomes {
+		nested := filepath.Join(home, rel, "dws", "multi")
+		if isSkillSourceRoot(nested, skillSetupModeMulti) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+
+	source, cleanup, err := materializeEmbeddedSkillSource(skillSetupModeMulti)
+	if err != nil {
+		return fmt.Errorf("提取当前版本内嵌 multi Skill 失败: %w", err)
+	}
+	defer cleanup()
+	result, err := repairNestedSkillUpgrade(source, upgrade.SkillUpgradeOptions{Version: RawVersion()})
+	if err != nil {
+		return err
+	}
+	if failed := result.Failed(); len(failed) > 0 {
+		return fmt.Errorf("%d 个 Agent 目录修复失败", len(failed))
+	}
+	return nil
+}
+
+func shouldRepairNestedSkillLayout(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return true
+	}
+	if cmd.Name() == "upgrade" {
+		return false
+	}
+	return !(cmd.Name() == "setup" && cmd.Parent() != nil && cmd.Parent().Name() == "skill")
+}

--- a/internal/app/skill_startup_repair_test.go
+++ b/internal/app/skill_startup_repair_test.go
@@ -12,19 +12,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/skillstate"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
-	upgradepkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/upgrade"
 	"github.com/spf13/cobra"
 )
 
-func TestCrossPlatformCoverageStartupRepairsNestedUpgradeLayout(t *testing.T) {
+func TestCrossPlatformCoverageStartupDetectsNestedUpgradeLayoutWithoutMutation(t *testing.T) {
 	home := t.TempDir()
 	testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
-	upgradepkg.SwapUserHomeDirForTest(t, func() (string, error) { return home, nil })
 	testseam.Swap(t, &skillSetupAgentHomes, []string{".agents/skills", ".codex/skills"})
-	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 	nested := filepath.Join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat")
 	if err := os.MkdirAll(nested, 0o755); err != nil {
 		t.Fatal(err)
@@ -33,18 +29,20 @@ func TestCrossPlatformCoverageStartupRepairsNestedUpgradeLayout(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := repairNestedMultiSkillLayout(); err != nil {
-		t.Fatal(err)
+	found, err := detectNestedMultiSkillLayout()
+	if err != nil || !found {
+		t.Fatalf("detect nested layout = (%v, %v), want (true, nil)", found, err)
 	}
-	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "dingtalk-chat", "SKILL.md")); err != nil {
-		t.Fatalf("canonical Codex Skill missing: %v", err)
+	data, err := os.ReadFile(filepath.Join(nested, "SKILL.md"))
+	if err != nil || string(data) != "old nested" {
+		t.Fatalf("detection changed nested Skill: data=%q err=%v", data, err)
 	}
-	if _, err := os.Stat(filepath.Join(home, ".agents", "skills", "dws")); !os.IsNotExist(err) {
-		t.Fatalf("nested generic layout remains: %v", err)
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "dingtalk-chat")); !os.IsNotExist(err) {
+		t.Fatalf("detection unexpectedly installed a canonical Skill: %v", err)
 	}
 }
 
-func TestCrossPlatformCoverageStartupRepairIgnoresLegitimateMonoAndReportsFailure(t *testing.T) {
+func TestCrossPlatformCoverageStartupDetectionIgnoresMonoAndReportsReadFailure(t *testing.T) {
 	home := t.TempDir()
 	testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
 	testseam.Swap(t, &skillSetupAgentHomes, []string{".agents/skills"})
@@ -55,100 +53,79 @@ func TestCrossPlatformCoverageStartupRepairIgnoresLegitimateMonoAndReportsFailur
 	if err := os.WriteFile(filepath.Join(mono, "SKILL.md"), []byte("valid mono"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	called := false
-	testseam.Swap(t, &repairNestedSkillUpgrade, func(string, upgradepkg.SkillUpgradeOptions) (*upgradepkg.SkillUpgradeResult, error) {
-		called = true
-		return nil, errors.New("unexpected")
-	})
-	if err := repairNestedMultiSkillLayout(); err != nil || called {
-		t.Fatalf("valid mono repair = %v, called=%v", err, called)
+	found, err := detectNestedMultiSkillLayout()
+	if err != nil || found {
+		t.Fatalf("valid mono detection = (%v, %v), want (false, nil)", found, err)
 	}
 
-	nested := filepath.Join(mono, "multi", "dingtalk-chat")
-	if err := os.MkdirAll(nested, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte("nested"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := repairNestedMultiSkillLayout(); err == nil {
-		t.Fatal("repair failure was not surfaced")
+	failure := errors.New("HOME failure")
+	testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return "", failure })
+	found, err = detectNestedMultiSkillLayout()
+	if found || !errors.Is(err, failure) {
+		t.Fatalf("HOME failure detection = (%v, %v)", found, err)
 	}
 }
 
-func TestCrossPlatformCoverageStartupRepairSkipsExplicitSkillManagers(t *testing.T) {
+func TestCrossPlatformCoverageStartupDetectionSkipsExplicitSkillManagers(t *testing.T) {
 	upgradeCmd := &cobra.Command{Use: "upgrade"}
-	if shouldRepairNestedSkillLayout(upgradeCmd) {
+	if shouldDetectNestedSkillLayout(upgradeCmd) {
 		t.Fatal("upgrade must manage its own Skill lifecycle")
 	}
 	skillCmd := &cobra.Command{Use: "skill"}
 	setupCmd := &cobra.Command{Use: "setup"}
 	skillCmd.AddCommand(setupCmd)
-	if shouldRepairNestedSkillLayout(setupCmd) {
+	if shouldDetectNestedSkillLayout(setupCmd) {
 		t.Fatal("skill setup must manage its own Skill lifecycle")
 	}
-	if !shouldRepairNestedSkillLayout(&cobra.Command{Use: "version"}) || !shouldRepairNestedSkillLayout(nil) {
-		t.Fatal("ordinary commands must trigger repair detection")
+	if !shouldDetectNestedSkillLayout(&cobra.Command{Use: "version"}) || !shouldDetectNestedSkillLayout(nil) {
+		t.Fatal("ordinary commands must trigger read-only detection")
 	}
 }
 
-func TestCrossPlatformCoverageStartupRepairErrorBranchesAndRootWarning(t *testing.T) {
-	failure := errors.New("repair failure")
-	t.Run("HOME failure", func(t *testing.T) {
-		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return "", failure })
-		if err := repairNestedMultiSkillLayout(); !errors.Is(err, failure) {
-			t.Fatalf("HOME error = %v", err)
-		}
+func TestCrossPlatformCoverageStartupWarningIsReadOnlyAndDoesNotBypassConfirmation(t *testing.T) {
+	home := t.TempDir()
+	testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
+	testseam.Swap(t, &skillSetupAgentHomes, []string{".codex/skills"})
+	nested := filepath.Join(home, ".codex", "skills", "dws", "multi", "dingtalk-chat")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte("old nested"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Any accidental return to startup mutation must fail this test before it
+	// can touch the fixture.
+	testseam.Swap(t, &skillSetupCopyDir, func(string, string) error {
+		t.Fatal("ordinary command attempted to copy Skills")
+		return nil
+	})
+	testseam.Swap(t, &skillSetupBackupAndRemove, func(string, string) (string, error) {
+		t.Fatal("ordinary command attempted to back up or remove Skills")
+		return "", nil
+	})
+	testseam.Swap(t, &skillSetupWriteState, func(string, skillstate.State) error {
+		t.Fatal("ordinary command attempted to write Skill state")
+		return nil
 	})
 
-	t.Run("embedded extraction failure", func(t *testing.T) {
-		home := t.TempDir()
-		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
-		testseam.Swap(t, &skillSetupAgentHomes, []string{".agents/skills"})
-		nested := filepath.Join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat")
-		if err := os.MkdirAll(nested, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte("nested"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		testseam.Swap(t, &embeddedSkillStat, func(string) (os.FileInfo, error) { return nil, failure })
-		if err := repairNestedMultiSkillLayout(); !errors.Is(err, failure) {
-			t.Fatalf("embedded extraction error = %v", err)
-		}
-	})
-
-	t.Run("failed Agent result", func(t *testing.T) {
-		home := t.TempDir()
-		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
-		testseam.Swap(t, &skillSetupAgentHomes, []string{".agents/skills"})
-		nested := filepath.Join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat")
-		if err := os.MkdirAll(nested, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte("nested"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		testseam.Swap(t, &repairNestedSkillUpgrade, func(string, upgradepkg.SkillUpgradeOptions) (*upgradepkg.SkillUpgradeResult, error) {
-			return &upgradepkg.SkillUpgradeResult{Results: []upgradepkg.SkillDirResult{{Status: upgradepkg.SkillDirFailed, Err: failure}}}, nil
-		})
-		if err := repairNestedMultiSkillLayout(); err == nil {
-			t.Fatal("failed Agent repair succeeded")
-		}
-	})
-
-	t.Run("root warning", func(t *testing.T) {
-		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return "", failure })
-		root := newRootCommandWithEngine(context.Background(), nil, false, true)
-		cmd := &cobra.Command{Use: "version"}
-		cmd.SetContext(context.Background())
-		var stderr bytes.Buffer
-		cmd.SetErr(&stderr)
-		if err := root.PersistentPreRunE(cmd, nil); err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(stderr.String(), "自动修复失败") {
-			t.Fatalf("root repair warning missing: %q", stderr.String())
-		}
-	})
+	root := newRootCommandWithEngine(context.Background(), nil, false, true)
+	cmd := &cobra.Command{Use: "version"}
+	cmd.SetContext(context.Background())
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	if err := root.PersistentPreRunE(cmd, nil); err != nil {
+		t.Fatal(err)
+	}
+	warning := stderr.String()
+	if !strings.Contains(warning, "dws skill setup --mode multi") {
+		t.Fatalf("safe migration hint missing: %q", warning)
+	}
+	if strings.Contains(warning, "--yes") {
+		t.Fatalf("migration hint bypasses confirmation: %q", warning)
+	}
+	data, err := os.ReadFile(filepath.Join(nested, "SKILL.md"))
+	if err != nil || string(data) != "old nested" {
+		t.Fatalf("ordinary command changed nested Skill: data=%q err=%v", data, err)
+	}
 }

--- a/internal/app/skill_startup_repair_test.go
+++ b/internal/app/skill_startup_repair_test.go
@@ -4,9 +4,12 @@
 package app
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
@@ -87,4 +90,65 @@ func TestCrossPlatformCoverageStartupRepairSkipsExplicitSkillManagers(t *testing
 	if !shouldRepairNestedSkillLayout(&cobra.Command{Use: "version"}) || !shouldRepairNestedSkillLayout(nil) {
 		t.Fatal("ordinary commands must trigger repair detection")
 	}
+}
+
+func TestCrossPlatformCoverageStartupRepairErrorBranchesAndRootWarning(t *testing.T) {
+	failure := errors.New("repair failure")
+	t.Run("HOME failure", func(t *testing.T) {
+		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return "", failure })
+		if err := repairNestedMultiSkillLayout(); !errors.Is(err, failure) {
+			t.Fatalf("HOME error = %v", err)
+		}
+	})
+
+	t.Run("embedded extraction failure", func(t *testing.T) {
+		home := t.TempDir()
+		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
+		testseam.Swap(t, &skillSetupAgentHomes, []string{".agents/skills"})
+		nested := filepath.Join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte("nested"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		testseam.Swap(t, &embeddedSkillStat, func(string) (os.FileInfo, error) { return nil, failure })
+		if err := repairNestedMultiSkillLayout(); !errors.Is(err, failure) {
+			t.Fatalf("embedded extraction error = %v", err)
+		}
+	})
+
+	t.Run("failed Agent result", func(t *testing.T) {
+		home := t.TempDir()
+		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
+		testseam.Swap(t, &skillSetupAgentHomes, []string{".agents/skills"})
+		nested := filepath.Join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte("nested"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		testseam.Swap(t, &repairNestedSkillUpgrade, func(string, upgradepkg.SkillUpgradeOptions) (*upgradepkg.SkillUpgradeResult, error) {
+			return &upgradepkg.SkillUpgradeResult{Results: []upgradepkg.SkillDirResult{{Status: upgradepkg.SkillDirFailed, Err: failure}}}, nil
+		})
+		if err := repairNestedMultiSkillLayout(); err == nil {
+			t.Fatal("failed Agent repair succeeded")
+		}
+	})
+
+	t.Run("root warning", func(t *testing.T) {
+		testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return "", failure })
+		root := newRootCommandWithEngine(context.Background(), nil, false, true)
+		cmd := &cobra.Command{Use: "version"}
+		cmd.SetContext(context.Background())
+		var stderr bytes.Buffer
+		cmd.SetErr(&stderr)
+		if err := root.PersistentPreRunE(cmd, nil); err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(stderr.String(), "自动修复失败") {
+			t.Fatalf("root repair warning missing: %q", stderr.String())
+		}
+	})
 }

--- a/internal/app/skill_startup_repair_test.go
+++ b/internal/app/skill_startup_repair_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0
+
+package app
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
+	upgradepkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/upgrade"
+	"github.com/spf13/cobra"
+)
+
+func TestCrossPlatformCoverageStartupRepairsNestedUpgradeLayout(t *testing.T) {
+	home := t.TempDir()
+	testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
+	upgradepkg.SwapUserHomeDirForTest(t, func() (string, error) { return home, nil })
+	testseam.Swap(t, &skillSetupAgentHomes, []string{".agents/skills", ".codex/skills"})
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte("old nested"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repairNestedMultiSkillLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "dingtalk-chat", "SKILL.md")); err != nil {
+		t.Fatalf("canonical Codex Skill missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".agents", "skills", "dws")); !os.IsNotExist(err) {
+		t.Fatalf("nested generic layout remains: %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageStartupRepairIgnoresLegitimateMonoAndReportsFailure(t *testing.T) {
+	home := t.TempDir()
+	testseam.Swap(t, &skillSetupUserHomeDir, func() (string, error) { return home, nil })
+	testseam.Swap(t, &skillSetupAgentHomes, []string{".agents/skills"})
+	mono := filepath.Join(home, ".agents", "skills", "dws")
+	if err := os.MkdirAll(mono, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mono, "SKILL.md"), []byte("valid mono"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	testseam.Swap(t, &repairNestedSkillUpgrade, func(string, upgradepkg.SkillUpgradeOptions) (*upgradepkg.SkillUpgradeResult, error) {
+		called = true
+		return nil, errors.New("unexpected")
+	})
+	if err := repairNestedMultiSkillLayout(); err != nil || called {
+		t.Fatalf("valid mono repair = %v, called=%v", err, called)
+	}
+
+	nested := filepath.Join(mono, "multi", "dingtalk-chat")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "SKILL.md"), []byte("nested"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := repairNestedMultiSkillLayout(); err == nil {
+		t.Fatal("repair failure was not surfaced")
+	}
+}
+
+func TestCrossPlatformCoverageStartupRepairSkipsExplicitSkillManagers(t *testing.T) {
+	upgradeCmd := &cobra.Command{Use: "upgrade"}
+	if shouldRepairNestedSkillLayout(upgradeCmd) {
+		t.Fatal("upgrade must manage its own Skill lifecycle")
+	}
+	skillCmd := &cobra.Command{Use: "skill"}
+	setupCmd := &cobra.Command{Use: "setup"}
+	skillCmd.AddCommand(setupCmd)
+	if shouldRepairNestedSkillLayout(setupCmd) {
+		t.Fatal("skill setup must manage its own Skill lifecycle")
+	}
+	if !shouldRepairNestedSkillLayout(&cobra.Command{Use: "version"}) || !shouldRepairNestedSkillLayout(nil) {
+		t.Fatal("ordinary commands must trigger repair detection")
+	}
+}

--- a/internal/upgrade/coverage_edges_test.go
+++ b/internal/upgrade/coverage_edges_test.go
@@ -264,7 +264,7 @@ func TestCrossPlatformCoverageUpgradePathsAndSkillsEdges(t *testing.T) {
 	}
 	knownSkillDirs = []string{".agents/skills", ".real/skills", ".missing/skills", ".present/skills"}
 	result, err := UpgradeSkillLocations(source)
-	if err != nil || len(result.Succeeded()) != 2 || len(result.Failed()) != 0 {
+	if err != nil || len(result.Succeeded()) != 1 || len(result.Failed()) != 0 {
 		t.Fatalf("skill upgrade = %#v, %v", result, err)
 	}
 	knownSkillDirs = []string{".real/skills"}

--- a/internal/upgrade/paths.go
+++ b/internal/upgrade/paths.go
@@ -35,8 +35,10 @@ const (
 //   - test/scripts/package_script_test.go                   expectedPackagedSkillTargets
 //   - scripts/release/verify-package-managers.sh            HOME_AGENT_PARENTS / HOME_SKILL_TARGETS
 //
-// The first entry (.agents/skills) is always updated; subsequent entries are
-// only updated when their parent directory already exists.
+// The first entry (.agents/skills) is a generic fallback. It is used only
+// when no concrete Agent home is detected; otherwise publishing there would
+// duplicate every Skill for Agents (including Codex) that scan both roots.
+// Subsequent entries are updated when their parent directory already exists.
 var knownSkillDirs = []string{
 	".agents/skills",
 	".claude/skills",
@@ -201,9 +203,9 @@ func (r *SkillUpgradeResult) Failed() []SkillDirResult {
 // `dws skill setup --mode mono` flow.
 //
 // Strategy (matches npm install.js installSkillsToHomes):
-//   - ~/.agents/skills/ is ALWAYS updated (primary install location)
-//   - Other agent dirs (claude, cursor, ...) are updated only when the parent
-//     directory exists (e.g. ~/.claude/ exists => user has Claude)
+//   - Concrete agent dirs (claude, cursor, codex, ...) are updated when their
+//     parent directory exists (e.g. ~/.codex/ exists => user has Codex)
+//   - ~/.agents/skills/ is used only when no concrete Agent is detected
 //   - ~/.real/ and other blacklisted paths are NEVER touched
 //   - If no location was updated at all, fall back to ~/.agents/skills/
 //
@@ -514,23 +516,57 @@ func publishMultiUpgradeTarget(homeDir, destBase, multiRoot string, skills []str
 	return publishStagedSkillSet(homeDir, staged, victims)
 }
 
+func hasDetectedSpecificSkillRoot(homeDir string) bool {
+	for _, agentDir := range knownSkillDirs {
+		if isGenericSkillRoot(agentDir) || isBlacklisted(agentDir) {
+			continue
+		}
+		parentGate := filepath.Dir(filepath.Join(homeDir, agentDir))
+		if info, err := upgradeStat(parentGate); err == nil && info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+func isGenericSkillRoot(agentDir string) bool {
+	return filepath.Clean(agentDir) == filepath.Clean(".agents/skills")
+}
+
+func retireGenericSkillRoot(homeDir string, managed map[string]bool) error {
+	base := filepath.Join(homeDir, ".agents", "skills")
+	victims, err := managedMultiSkillVictims(base, managed)
+	if err != nil {
+		return err
+	}
+	victims = append(victims, filepath.Join(base, "dws"))
+	if _, err := backupSkillSet(homeDir, victims); err != nil {
+		return fmt.Errorf("迁移通用 Skill 根目录失败: %w", err)
+	}
+	return nil
+}
+
 // upgradeMonoSkillLocations is the legacy mono behavior: one dws/ directory
 // per agent home.
 func upgradeMonoSkillLocations(homeDir, skillSrc string) (*SkillUpgradeResult, error) {
 	result := &SkillUpgradeResult{}
 	managedNames := readManagedSkillNames(homeDir)
+	hasSpecificRoot := hasDetectedSpecificSkillRoot(homeDir)
 
-	for i, agentDir := range knownSkillDirs {
+	for _, agentDir := range knownSkillDirs {
 		destDir := filepath.Join(homeDir, agentDir, "dws")
 
 		if isBlacklisted(agentDir) {
 			result.Results = append(result.Results, SkillDirResult{Dir: destDir, Status: SkillDirBlacklisted})
 			continue
 		}
+		if isGenericSkillRoot(agentDir) && hasSpecificRoot {
+			continue
+		}
 
-		if i > 0 {
+		if !isGenericSkillRoot(agentDir) {
 			parentGate := filepath.Dir(filepath.Join(homeDir, agentDir))
-			if _, err := os.Stat(parentGate); os.IsNotExist(err) {
+			if _, err := upgradeStat(parentGate); os.IsNotExist(err) {
 				result.Results = append(result.Results, SkillDirResult{Dir: destDir, Status: SkillDirSkipped})
 				continue
 			}
@@ -542,12 +578,20 @@ func upgradeMonoSkillLocations(homeDir, skillSrc string) (*SkillUpgradeResult, e
 		}
 		result.Results = append(result.Results, SkillDirResult{Dir: destDir, Status: SkillDirOK})
 	}
+	if hasSpecificRoot && len(result.Succeeded()) > 0 {
+		genericBase := filepath.Join(homeDir, ".agents", "skills")
+		if err := retireGenericSkillRoot(homeDir, managedNames); err != nil {
+			result.Results = append(result.Results, SkillDirResult{Dir: genericBase, Status: SkillDirFailed, Err: err})
+		} else {
+			result.Results = append(result.Results, SkillDirResult{Dir: genericBase, Status: SkillDirSkipped})
+		}
+	}
 
 	// Fallback: if nothing succeeded, force the primary location. The multi
 	// leftovers under the primary base are the usual reason the primary
 	// install failed, so clean them first — failing loud like the multi
 	// fallback — instead of letting mono and multi co-exist marked OK.
-	if len(result.Succeeded()) == 0 {
+	if len(result.Succeeded()) == 0 && !hasSpecificRoot {
 		destBase := filepath.Join(homeDir, ".agents", "skills")
 		dest := filepath.Join(destBase, "dws")
 		if err := publishMonoUpgradeTarget(homeDir, destBase, skillSrc, managedNames); err != nil {
@@ -588,18 +632,22 @@ func upgradeMultiSkillLocations(homeDir, multiRoot string, skills []string) (*Sk
 
 	result := &SkillUpgradeResult{}
 	managedNames := readManagedSkillNames(homeDir)
+	hasSpecificRoot := hasDetectedSpecificSkillRoot(homeDir)
 
-	for i, agentDir := range knownSkillDirs {
+	for _, agentDir := range knownSkillDirs {
 		destBase := filepath.Join(homeDir, agentDir)
 
 		if isBlacklisted(agentDir) {
 			result.Results = append(result.Results, SkillDirResult{Dir: destBase, Status: SkillDirBlacklisted})
 			continue
 		}
+		if isGenericSkillRoot(agentDir) && hasSpecificRoot {
+			continue
+		}
 
-		if i > 0 {
+		if !isGenericSkillRoot(agentDir) {
 			parentGate := filepath.Dir(destBase)
-			if _, err := os.Stat(parentGate); os.IsNotExist(err) {
+			if _, err := upgradeStat(parentGate); os.IsNotExist(err) {
 				result.Results = append(result.Results, SkillDirResult{Dir: destBase, Status: SkillDirSkipped})
 				continue
 			}
@@ -611,9 +659,17 @@ func upgradeMultiSkillLocations(homeDir, multiRoot string, skills []string) (*Sk
 		}
 		result.Results = append(result.Results, SkillDirResult{Dir: destBase, Status: SkillDirOK})
 	}
+	if hasSpecificRoot && len(result.Succeeded()) > 0 {
+		genericBase := filepath.Join(homeDir, ".agents", "skills")
+		if err := retireGenericSkillRoot(homeDir, managedNames); err != nil {
+			result.Results = append(result.Results, SkillDirResult{Dir: genericBase, Status: SkillDirFailed, Err: err})
+		} else {
+			result.Results = append(result.Results, SkillDirResult{Dir: genericBase, Status: SkillDirSkipped})
+		}
+	}
 
 	// Fallback: if nothing succeeded, force the primary location
-	if len(result.Succeeded()) == 0 {
+	if len(result.Succeeded()) == 0 && !hasSpecificRoot {
 		destBase := filepath.Join(homeDir, ".agents", "skills")
 		if err := publishMultiUpgradeTarget(homeDir, destBase, multiRoot, skills, skillSet, managedNames); err != nil {
 			return result, fmt.Errorf("所有技能目录安装失败，回退到主目录也失败: %w", err)

--- a/internal/upgrade/paths_multi_test.go
+++ b/internal/upgrade/paths_multi_test.go
@@ -124,7 +124,8 @@ func TestCrossPlatformCoverageBundleSkillNamesLayouts(t *testing.T) {
 func TestCrossPlatformCoverageUpgradeSkillLocationsMulti(t *testing.T) {
 	home := withFakeHome(t)
 
-	// .agents always installs; .claude installs (parent exists); .cursor skipped.
+	// A concrete Agent root wins over the generic .agents fallback; .claude
+	// installs and .cursor is skipped.
 	agentsBase := filepath.Join(home, ".agents", "skills")
 	claudeBase := filepath.Join(home, ".claude", "skills")
 	for _, base := range []string{agentsBase, claudeBase} {
@@ -164,7 +165,7 @@ func TestCrossPlatformCoverageUpgradeSkillLocationsMulti(t *testing.T) {
 		t.Fatalf("expected 0 failures, got %v", failed)
 	}
 
-	for _, base := range []string{agentsBase, claudeBase} {
+	for _, base := range []string{claudeBase} {
 		if _, err := os.Stat(filepath.Join(base, "dws")); !os.IsNotExist(err) {
 			t.Errorf("mono leftover still present: %s", filepath.Join(base, "dws"))
 		}
@@ -192,14 +193,17 @@ func TestCrossPlatformCoverageUpgradeSkillLocationsMulti(t *testing.T) {
 
 	// Succeeded entries report the agent home base in multi mode.
 	succeeded := result.Succeeded()
-	if len(succeeded) != 2 {
-		t.Fatalf("Succeeded() len = %d, want 2 (%v)", len(succeeded), result.Results)
+	if len(succeeded) != 1 {
+		t.Fatalf("Succeeded() len = %d, want 1 (%v)", len(succeeded), result.Results)
 	}
-	wantDirs := map[string]bool{agentsBase: true, claudeBase: true}
+	wantDirs := map[string]bool{claudeBase: true}
 	for _, d := range succeeded {
 		if !wantDirs[d.Dir] {
 			t.Errorf("unexpected succeeded dir %q", d.Dir)
 		}
+	}
+	if _, err := os.Stat(filepath.Join(agentsBase, "dws")); !os.IsNotExist(err) {
+		t.Fatalf("generic mono duplicate still visible: %v", err)
 	}
 
 	// Multi cache refreshed under the fake home.
@@ -209,6 +213,45 @@ func TestCrossPlatformCoverageUpgradeSkillLocationsMulti(t *testing.T) {
 	// Mono sibling tree refreshed the mono cache too.
 	if _, err := os.Stat(filepath.Join(home, ".dws", "skills", "mono", "SKILL.md")); err != nil {
 		t.Errorf("mono cache not refreshed from sibling mono tree: %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageUpgradeUsesAgentSpecificRootWithoutGenericDuplicate(t *testing.T) {
+	home := withFakeHome(t)
+	testseam.Swap(t, &knownSkillDirs, []string{".agents/skills", ".codex/skills"})
+
+	genericBase := filepath.Join(home, ".agents", "skills")
+	codexBase := filepath.Join(home, ".codex", "skills")
+	for _, base := range []string{genericBase, codexBase} {
+		if err := os.MkdirAll(base, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	legacyNested := filepath.Join(genericBase, "dws", "multi", "dingtalk-chat")
+	if err := os.MkdirAll(legacyNested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyNested, "SKILL.md"), []byte("old nested"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	multiRoot := writeMultiBundle(t, t.TempDir(), "dingtalk-chat", "dingtalk-shared")
+	result, err := UpgradeSkillLocationsWithOptions(multiRoot, SkillUpgradeOptions{Version: "1.2.3"})
+	if err != nil || len(result.Failed()) != 0 {
+		t.Fatalf("UpgradeSkillLocationsWithOptions() = %#v, %v", result, err)
+	}
+
+	want := filepath.Join(codexBase, "dingtalk-chat", "SKILL.md")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("canonical Codex Skill missing at %s: %v", want, err)
+	}
+	for _, duplicate := range []string{
+		filepath.Join(genericBase, "dingtalk-chat", "SKILL.md"),
+		filepath.Join(genericBase, "dws", "multi", "dingtalk-chat", "SKILL.md"),
+	} {
+		if _, err := os.Stat(duplicate); !os.IsNotExist(err) {
+			t.Fatalf("generic duplicate still visible at %s: %v", duplicate, err)
+		}
 	}
 }
 
@@ -508,7 +551,7 @@ func TestCrossPlatformCoverageUpgradeSkillLocationsMonoReadDirErrorFailsHome(t *
 	if len(failed) != 1 {
 		t.Fatalf("Failed() len = %d, want 1 (%v)", len(failed), result.Results)
 	}
-	wantDir := filepath.Join(agentsBase, "dws")
+	wantDir := agentsBase
 	if failed[0].Dir != wantDir || failed[0].Err == nil {
 		t.Fatalf("failed entry = %#v, want dir %q with non-nil err", failed[0], wantDir)
 	}
@@ -931,8 +974,8 @@ func TestCrossPlatformCoverageMultiUpgradeBackupAndFallbackEdges(t *testing.T) {
 		t.Fatalf("blacklisted home must never be touched, stat err=%v", err)
 	}
 
-	// Per-skill backup failure fails the home; a second home still succeeds so
-	// the fallback never runs.
+	// A detected concrete Agent root wins over .agents. A failure while retiring
+	// the old generic copy is surfaced after the concrete root succeeds.
 	home2 := t.TempDir()
 	testseam.Swap(t, &upgradeUserHomeDir, func() (string, error) { return home2, nil })
 	knownSkillDirs = []string{".agents/skills", ".claude/skills"}
@@ -956,12 +999,13 @@ func TestCrossPlatformCoverageMultiUpgradeBackupAndFallbackEdges(t *testing.T) {
 	}
 	testseam.Swap(t, &upgradeRename, os.Rename)
 
-	// Per-skill copy failure fails the home the same way.
+	// Per-skill copy failure on the concrete home fails that home; with no
+	// successful concrete target, the generic copy is left untouched.
 	home3 := t.TempDir()
 	testseam.Swap(t, &upgradeUserHomeDir, func() (string, error) { return home3, nil })
 	os.MkdirAll(filepath.Join(home3, ".claude"), 0o755)
 	testseam.Swap(t, &upgradeCopyDir, func(src, dst string) error {
-		if strings.Contains(dst, ".agents") {
+		if strings.Contains(dst, ".claude") {
 			return errors.New("copy denied")
 		}
 		return copyDir(src, dst)

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -408,6 +408,28 @@ multi_tree_has_skills() {
   return 1
 }
 
+# Move DWS-owned copies out of the generic root once a concrete Agent root is
+# active. This prevents Agents such as Codex from discovering duplicates.
+retire_generic_skill_root() {
+  _rgs_root="$1"
+  _rgs_base="$_rgs_root/.agents/skills"
+  _rgs_stage="$(mktemp -d "${TMPDIR:-/tmp}/dws-retire-generic.XXXXXX")" || return 1
+  _rgs_backups="$_rgs_stage/backups"
+  : > "$_rgs_backups" || { rm -rf "$_rgs_stage"; return 1; }
+  for _rgs_victim in "$_rgs_base/dws" "$_rgs_base"/*; do
+    [ -d "$_rgs_victim" ] || continue
+    if [ "$(basename "$_rgs_victim")" != "dws" ] && ! is_managed_multi_skill_dir "$_rgs_victim"; then
+      continue
+    fi
+    if ! backup_and_record_skill_dir "$_rgs_victim" "$_rgs_backups"; then
+      restore_multi_skill_set /dev/null "$_rgs_backups" || true
+      rm -rf "$_rgs_stage"
+      return 1
+    fi
+  done
+  rm -rf "$_rgs_stage"
+}
+
 # Same semantics as build/npm/install.js installMultiSkillsToHomes (root = DWS_SKILLS_ROOT or PWD).
 install_multi_skills_to_root() {
   multi_src="$1"
@@ -416,6 +438,15 @@ install_multi_skills_to_root() {
   attempted=0
   failed=0
   idx=0
+  specific_agents=0
+  for specific_dir in \
+    ".claude/skills" ".cursor/skills" ".qoder/skills" ".qoderwork/skills" \
+    ".gemini/skills" ".codex/skills" ".github/skills" ".windsurf/skills" \
+    ".augment/skills" ".cline/skills" ".amp/skills" ".kiro/skills" \
+    ".trae/skills" ".openclaw/skills" ".hermes/skills"
+  do
+    [ -e "$root/$(dirname "$specific_dir")" ] && specific_agents=$((specific_agents + 1))
+  done
   for agent_dir in \
     ".agents/skills" \
     ".claude/skills" \
@@ -434,6 +465,10 @@ install_multi_skills_to_root() {
     ".openclaw/skills" \
     ".hermes/skills"
   do
+    if [ "$idx" -eq 0 ] && [ "$specific_agents" -gt 0 ]; then
+      idx=$((idx + 1))
+      continue
+    fi
     base_dir="$root/$agent_dir"
     parent_gate="$(dirname "$base_dir")"
     if [ "$idx" -gt 0 ] && [ ! -e "$parent_gate" ]; then
@@ -449,6 +484,9 @@ install_multi_skills_to_root() {
     fi
     idx=$((idx + 1))
   done
+  if [ "$specific_agents" -gt 0 ] && [ "$installed" -gt 0 ]; then
+    retire_generic_skill_root "$root" || failed=$((failed + 1))
+  fi
   if [ "$attempted" -eq 0 ] && _install_multi_to_base "$multi_src" "$root/.agents/skills" "$root" ".agents/skills"; then
     installed=$((installed + 1))
   fi
@@ -618,6 +656,15 @@ install_skills_to_root() {
   attempted=0
   failed=0
   idx=0
+  specific_agents=0
+  for specific_dir in \
+    ".claude/skills" ".cursor/skills" ".qoder/skills" ".qoderwork/skills" \
+    ".gemini/skills" ".codex/skills" ".github/skills" ".windsurf/skills" \
+    ".augment/skills" ".cline/skills" ".amp/skills" ".kiro/skills" \
+    ".trae/skills" ".openclaw/skills" ".hermes/skills"
+  do
+    [ -e "$root/$(dirname "$specific_dir")" ] && specific_agents=$((specific_agents + 1))
+  done
   for agent_dir in \
     ".agents/skills" \
     ".claude/skills" \
@@ -636,6 +683,10 @@ install_skills_to_root() {
     ".openclaw/skills" \
     ".hermes/skills"
   do
+    if [ "$idx" -eq 0 ] && [ "$specific_agents" -gt 0 ]; then
+      idx=$((idx + 1))
+      continue
+    fi
     base_dir="$root/$agent_dir"
     parent_gate="$(dirname "$base_dir")"
     if [ "$idx" -gt 0 ] && [ ! -e "$parent_gate" ]; then
@@ -655,6 +706,9 @@ install_skills_to_root() {
     fi
     idx=$((idx + 1))
   done
+  if [ "$specific_agents" -gt 0 ] && [ "$installed" -gt 0 ]; then
+    retire_generic_skill_root "$root" || failed=$((failed + 1))
+  fi
   if [ "$attempted" -eq 0 ]; then
     if [ "$root" = "$HOME" ]; then
       flabel="~/.agents/skills/$SKILL_NAME"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -457,6 +457,38 @@ function Restore-MultiSkillSet {
     return $ok
 }
 
+function Move-GenericSkillRootToBackup {
+    param([string]$Root)
+
+    $baseDir = Join-Path $Root ".agents\skills"
+    $victims = [System.Collections.Generic.List[string]]::new()
+    $victims.Add((Join-Path $baseDir $SkillName))
+    foreach ($existing in Get-ChildItem -Path $baseDir -Directory -ErrorAction SilentlyContinue) {
+        if (Test-ManagedMultiSkillDir -Dir $existing.FullName) {
+            $victims.Add($existing.FullName)
+        }
+    }
+    $backups = @()
+    try {
+        $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+        foreach ($victim in $victims) {
+            if (!$seen.Add($victim)) { continue }
+            $backupPath = ""
+            if (!(Backup-SkillDir -Dir $victim -BackupPath ([ref]$backupPath))) {
+                throw "通用 Skill 副本备份失败: $victim"
+            }
+            if ($backupPath) {
+                $backups += [pscustomobject]@{ Original = $victim; Backup = $backupPath }
+            }
+        }
+        return $true
+    } catch {
+        Restore-MultiSkillSet -Published @() -Backups $backups | Out-Null
+        Write-Say "⚠️  通用 Skill 副本迁移失败，已回滚: $_"
+        return $false
+    }
+}
+
 function Copy-SkillToDir {
     param([string]$SkillSrc, [string]$Dest, [string]$Label)
 
@@ -780,7 +812,11 @@ function Install-SkillsToHomes {
     $installed = 0
     $attempted = 0
     $failed = 0
+	$specificAgents = @($AgentDirs | Select-Object -Skip 1 | Where-Object {
+		Test-Path (Split-Path (Join-Path $Root $_) -Parent)
+	})
     for ($i = 0; $i -lt $AgentDirs.Count; $i++) {
+		if ($i -eq 0 -and $specificAgents.Count -gt 0) { continue }
         $agentDir = $AgentDirs[$i]
         $baseDir = Join-Path $Root $agentDir
         $parentGate = Split-Path $baseDir -Parent
@@ -800,6 +836,9 @@ function Install-SkillsToHomes {
             $failed++
         }
     }
+	if ($specificAgents.Count -gt 0 -and $installed -gt 0) {
+		if (!(Move-GenericSkillRootToBackup -Root $Root)) { $failed++ }
+	}
     if ($attempted -eq 0) {
         $fallback = Join-Path (Join-Path $Root ".agents\skills") $SkillName
         if ($Root -eq $HOME) {
@@ -851,7 +890,11 @@ function Install-MultiSkillsToHomes {
     $installed = 0
     $attempted = 0
     $failed = 0
+	$specificAgents = @($AgentDirs | Select-Object -Skip 1 | Where-Object {
+		Test-Path (Split-Path (Join-Path $Root $_) -Parent)
+	})
     for ($i = 0; $i -lt $AgentDirs.Count; $i++) {
+		if ($i -eq 0 -and $specificAgents.Count -gt 0) { continue }
         $agentDir = $AgentDirs[$i]
         $baseDir = Join-Path $Root $agentDir
         $parentGate = Split-Path $baseDir -Parent
@@ -866,6 +909,9 @@ function Install-MultiSkillsToHomes {
             $failed++
         }
     }
+	if ($specificAgents.Count -gt 0 -and $installed -gt 0) {
+		if (!(Move-GenericSkillRootToBackup -Root $Root)) { $failed++ }
+	}
     if ($attempted -eq 0) {
         if (Install-MultiToBase -MultiSrc $MultiSrc -BaseDir (Join-Path $Root ".agents\skills") -Root $Root -AgentDir ".agents\skills") {
             $installed++

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -643,6 +643,29 @@ _install_mono_to_base() {
   say "✅ Skills → ${_mono_label} (${_mono_count} files)"
 }
 
+# Move DWS-owned copies out of the generic root once a concrete Agent root is
+# active. This prevents Agents such as Codex from discovering the same Skill
+# through both ~/.agents/skills and ~/.codex/skills.
+retire_generic_skill_root() {
+  _rgs_root="$1"
+  _rgs_base="$_rgs_root/.agents/skills"
+  _rgs_stage="$(mktemp -d "${TMPDIR:-/tmp}/dws-retire-generic.XXXXXX")" || return 1
+  _rgs_backups="$_rgs_stage/backups"
+  : > "$_rgs_backups" || { rm -rf "$_rgs_stage"; return 1; }
+  for _rgs_victim in "$_rgs_base/dws" "$_rgs_base"/*; do
+    [ -d "$_rgs_victim" ] || continue
+    if [ "$(basename "$_rgs_victim")" != "dws" ] && ! is_managed_multi_skill_dir "$_rgs_victim"; then
+      continue
+    fi
+    if ! backup_and_record_skill_dir "$_rgs_victim" "$_rgs_backups"; then
+      restore_multi_skill_set /dev/null "$_rgs_backups" || true
+      rm -rf "$_rgs_stage"
+      return 1
+    fi
+  done
+  rm -rf "$_rgs_stage"
+}
+
 # Install skill tree into all agent homes (same rules as build/npm/install.js installSkillsToHomes).
 # Installing mono removes proven DWS-managed multi leftovers for mutual exclusion,
 # mirroring `dws skill setup --mode mono`.
@@ -653,6 +676,15 @@ install_skills_to_homes() {
   attempted=0
   failed=0
   idx=0
+  specific_agents=0
+  for specific_dir in \
+    ".claude/skills" ".cursor/skills" ".qoder/skills" ".qoderwork/skills" \
+    ".gemini/skills" ".codex/skills" ".github/skills" ".windsurf/skills" \
+    ".augment/skills" ".cline/skills" ".amp/skills" ".kiro/skills" \
+    ".trae/skills" ".openclaw/skills" ".hermes/skills"
+  do
+    [ -e "$root/$(dirname "$specific_dir")" ] && specific_agents=$((specific_agents + 1))
+  done
   for agent_dir in \
     ".agents/skills" \
     ".claude/skills" \
@@ -671,6 +703,10 @@ install_skills_to_homes() {
     ".openclaw/skills" \
     ".hermes/skills"
   do
+    if [ "$idx" -eq 0 ] && [ "$specific_agents" -gt 0 ]; then
+      idx=$((idx + 1))
+      continue
+    fi
     base_dir="$root/$agent_dir"
     parent_gate="$(dirname "$base_dir")"
     if [ "$idx" -gt 0 ] && [ ! -e "$parent_gate" ]; then
@@ -693,6 +729,9 @@ install_skills_to_homes() {
     fi
     idx=$((idx + 1))
   done
+  if [ "$specific_agents" -gt 0 ] && [ "$installed" -gt 0 ]; then
+    retire_generic_skill_root "$root" || failed=$((failed + 1))
+  fi
   if [ "$attempted" -eq 0 ]; then
     case "$root" in
       "$HOME")
@@ -746,6 +785,15 @@ install_multi_skills_to_homes() {
   attempted=0
   failed=0
   idx=0
+  specific_agents=0
+  for specific_dir in \
+    ".claude/skills" ".cursor/skills" ".qoder/skills" ".qoderwork/skills" \
+    ".gemini/skills" ".codex/skills" ".github/skills" ".windsurf/skills" \
+    ".augment/skills" ".cline/skills" ".amp/skills" ".kiro/skills" \
+    ".trae/skills" ".openclaw/skills" ".hermes/skills"
+  do
+    [ -e "$root/$(dirname "$specific_dir")" ] && specific_agents=$((specific_agents + 1))
+  done
   for agent_dir in \
     ".agents/skills" \
     ".claude/skills" \
@@ -764,6 +812,10 @@ install_multi_skills_to_homes() {
     ".openclaw/skills" \
     ".hermes/skills"
   do
+    if [ "$idx" -eq 0 ] && [ "$specific_agents" -gt 0 ]; then
+      idx=$((idx + 1))
+      continue
+    fi
     base_dir="$root/$agent_dir"
     parent_gate="$(dirname "$base_dir")"
     if [ "$idx" -gt 0 ] && [ ! -e "$parent_gate" ]; then
@@ -779,6 +831,9 @@ install_multi_skills_to_homes() {
     fi
     idx=$((idx + 1))
   done
+  if [ "$specific_agents" -gt 0 ] && [ "$installed" -gt 0 ]; then
+    retire_generic_skill_root "$root" || failed=$((failed + 1))
+  fi
   if [ "$attempted" -eq 0 ] && _install_multi_to_base "$multi_src" "$root/.agents/skills" "$root" ".agents/skills"; then
     installed=$((installed + 1))
   fi

--- a/test/scripts/install_js_smoke.mjs
+++ b/test/scripts/install_js_smoke.mjs
@@ -193,6 +193,38 @@ scenario("multi install lays out sibling skills and caches", () => {
   }
 });
 
+scenario("Codex uses its canonical root without a generic duplicate", () => {
+  const { tmp, pkg, home } = stagePkg({
+    "mono/SKILL.md": "# mono fixture\n",
+    "multi/dingtalk-chat/SKILL.md": "# dingtalk-chat\n",
+    "multi/dws-shared/SKILL.md": "# dws-shared\n",
+  });
+  try {
+    writeFile(path.join(home, ".codex", "config.toml"), "model = \"test\"\n");
+    writeFile(
+      path.join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat", "SKILL.md"),
+      "old nested duplicate\n",
+    );
+
+    const res = runInstall(pkg, home, "multi");
+    assert.equal(res.status, 0, `exit=${res.status}\nstdout=${res.stdout}\nstderr=${res.stderr}`);
+    assert.ok(
+      fs.existsSync(path.join(home, ".codex", "skills", "dingtalk-chat", "SKILL.md")),
+      "Codex canonical Skill installed",
+    );
+    assert.ok(
+      !fs.existsSync(path.join(home, ".agents", "skills", "dingtalk-chat", "SKILL.md")),
+      "generic flat duplicate not installed",
+    );
+    assert.ok(
+      !fs.existsSync(path.join(home, ".agents", "skills", "dws")),
+      "legacy nested duplicate retired",
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 scenario("empty multi/ tree falls back to mono and keeps the old multi cache", () => {
   const { tmp, pkg, home } = stagePkg({
     "SKILL.md": "# mono root copy\n",

--- a/test/scripts/install_script_test.go
+++ b/test/scripts/install_script_test.go
@@ -1245,6 +1245,105 @@ install_multi_skills_to_root "$DWS_TEST_MULTI" "$DWS_TEST_ROOT"
 	assertSkillProvenance(t, home, filepath.Join(base, "dingtalk-test"), "dingtalk-test", "install-skills.sh")
 }
 
+func TestInstallerShellPrefersCodexRootWithoutGenericDuplicate(t *testing.T) {
+	for _, scriptName := range []string{"install.sh", "install-skills.sh"} {
+		t.Run(scriptName, func(t *testing.T) {
+			scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", scriptName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(scriptPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cut := strings.LastIndex(string(data), "\nmain\n")
+			if cut < 0 {
+				t.Fatalf("%s final main invocation not found", scriptName)
+			}
+			library := filepath.Join(t.TempDir(), scriptName+"-lib.sh")
+			mustWriteFile(t, library, data[:cut], 0o755)
+
+			home := t.TempDir()
+			source := filepath.Join(t.TempDir(), "multi")
+			mustWriteFile(t, filepath.Join(home, ".codex", "config.toml"), []byte("model=test\n"), 0o644)
+			mustWriteFile(t, filepath.Join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat", "SKILL.md"), []byte("old nested\n"), 0o644)
+			mustWriteFile(t, filepath.Join(source, "dingtalk-chat", "SKILL.md"), []byte("new chat\n"), 0o644)
+
+			installCall := `install_multi_skills_to_homes "$DWS_TEST_SOURCE"`
+			if scriptName == "install-skills.sh" {
+				installCall = `install_multi_skills_to_root "$DWS_TEST_SOURCE" "$HOME"`
+			}
+			cmd := exec.Command("sh", "-c", `. "$DWS_TEST_LIBRARY"
+`+installCall+`
+`)
+			cmd.Env = append(os.Environ(), "HOME="+home, "DWS_TEST_LIBRARY="+library, "DWS_TEST_SOURCE="+source)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("%s Codex-root harness failed: %v\n%s", scriptName, err, output)
+			}
+			if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "dingtalk-chat", "SKILL.md")); err != nil {
+				t.Fatalf("%s canonical Codex Skill missing: %v", scriptName, err)
+			}
+			for _, duplicate := range []string{
+				filepath.Join(home, ".agents", "skills", "dingtalk-chat", "SKILL.md"),
+				filepath.Join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat", "SKILL.md"),
+			} {
+				if _, err := os.Stat(duplicate); !os.IsNotExist(err) {
+					t.Fatalf("%s generic duplicate remains at %s: %v", scriptName, duplicate, err)
+				}
+			}
+		})
+	}
+}
+
+func TestInstallPowerShellPrefersCodexRootWithoutGenericDuplicate(t *testing.T) {
+	pwsh, err := exec.LookPath("pwsh")
+	if err != nil {
+		if runtime.GOOS == "windows" {
+			pwsh, err = exec.LookPath("powershell")
+		}
+		if err != nil {
+			t.Skip("PowerShell is not available")
+		}
+	}
+	scriptPath, err := filepath.Abs(filepath.Join("..", "..", "scripts", "install.ps1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(scriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cut := strings.LastIndex(string(data), "# ── Main")
+	if cut < 0 {
+		t.Fatal("install.ps1 main section not found")
+	}
+	prefix := strings.ReplaceAll(string(data[:cut]), "$HOME", "$env:DWS_TEST_HOME")
+	prefix += `
+if (!(Install-MultiSkillsToHomes -MultiSrc $env:DWS_TEST_MULTI -Root $env:DWS_TEST_HOME)) { exit 2 }
+exit 0
+`
+	harnessPath := filepath.Join(t.TempDir(), "install-codex-root.ps1")
+	mustWriteFile(t, harnessPath, []byte(prefix), 0o644)
+
+	home := t.TempDir()
+	multi := filepath.Join(t.TempDir(), "multi")
+	mustWriteFile(t, filepath.Join(home, ".codex", "config.toml"), []byte("model=test\n"), 0o644)
+	mustWriteFile(t, filepath.Join(home, ".agents", "skills", "dws", "multi", "dingtalk-chat", "SKILL.md"), []byte("old nested\n"), 0o644)
+	mustWriteFile(t, filepath.Join(multi, "dingtalk-chat", "SKILL.md"), []byte("new chat\n"), 0o644)
+
+	cmd := exec.Command(pwsh, "-NoProfile", "-NonInteractive", "-File", harnessPath)
+	cmd.Env = append(os.Environ(), "DWS_TEST_HOME="+home, "DWS_TEST_MULTI="+multi)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("PowerShell Codex-root harness failed: %v\n%s", err, output)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "skills", "dingtalk-chat", "SKILL.md")); err != nil {
+		t.Fatalf("PowerShell canonical Codex Skill missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".agents", "skills", "dws")); !os.IsNotExist(err) {
+		t.Fatalf("PowerShell generic duplicate remains: %v", err)
+	}
+}
+
 func TestInstallPowerShellBackupFailureWritesNoMultiSkills(t *testing.T) {
 	pwsh, err := exec.LookPath("pwsh")
 	if err != nil {

--- a/test/scripts/install_script_test.go
+++ b/test/scripts/install_script_test.go
@@ -15,11 +15,6 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/skillstate"
 )
 
-var expectedHomeSkillTargets = []string{
-	".agents/skills/dws",
-	".cursor/skills/dws",
-}
-
 func assertSkillProvenance(t *testing.T, home, skillDir, name, source string) {
 	t.Helper()
 	state, readable, err := skillstate.Read(home)
@@ -187,11 +182,13 @@ func TestInstallScriptSourceModeInstallsSkillsIntoAgentsDir(t *testing.T) {
 		t.Fatalf("install.sh error = %v\noutput:\n%s", err, string(output))
 	}
 
-	for _, rel := range expectedHomeSkillTargets {
-		skillPath := filepath.Join(fixture.fakeHome, filepath.FromSlash(rel), "SKILL.md")
-		if _, err := os.Stat(skillPath); err != nil {
-			t.Fatalf("Stat(%s) error = %v\noutput:\n%s", skillPath, err, string(output))
-		}
+	skillPath := filepath.Join(fixture.fakeHome, ".cursor", "skills", "dws", "SKILL.md")
+	if _, err := os.Stat(skillPath); err != nil {
+		t.Fatalf("Stat(%s) error = %v\noutput:\n%s", skillPath, err, string(output))
+	}
+	genericPath := filepath.Join(fixture.fakeHome, ".agents", "skills", "dws")
+	if _, err := os.Stat(genericPath); !os.IsNotExist(err) {
+		t.Fatalf("generic Skill root must not duplicate detected Cursor: Stat(%s) = %v\noutput:\n%s", genericPath, err, string(output))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Prefer detected Agent-specific Skill roots; use `~/.agents/skills` only as the fallback when no concrete Agent exists.
- Back up and retire DWS-owned generic copies after a concrete target succeeds, so Codex sees only `~/.codex/skills/dingtalk-chat/SKILL.md` instead of both that path and `~/.agents/skills/dws/multi/...`.
- Detect the exact malformed nested layout left by an older running upgrade process, but keep ordinary commands read-only. The warning directs users to the explicit, plan-confirmed `dws skill setup --mode multi` migration without a confirmation-bypass flag.
- Keep Go upgrade/setup, npm postinstall, POSIX installers, and PowerShell on the same target-selection and recoverable-cleanup contract.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

- [x] Exact in-place `CHANGELOG.md`-only check (otherwise `N/A`): N/A
- [x] Targeted test/check commands and results:
  - `DWS_PACKAGE_VERSION=0.0.0-test go test -count=1 ./internal/app ./internal/upgrade ./internal/skillstate ./test/scripts` — passed
  - `node test/scripts/install_js_smoke.mjs` — 13/13 scenarios passed
  - `sh -n scripts/install.sh && sh -n scripts/install-skills.sh` — passed
  - changed-code coverage gate — 100.0000% (150/150 executable statements)
- [x] Safety behavior evidence:
  - ordinary command with legacy nested layout performs read-only detection; copy, backup/remove, and state-write seams remain unused
  - warning contains `dws skill setup --mode multi` and does not contain `--yes`
  - declined/non-interactive unconfirmed setup performs zero mutation
  - confirmed setup executes the exact backup/install plan
- [x] Isolated beta.4 upgrade simulation:
  - real v1.0.58-beta.4 metadata/assets downloaded from an isolated local release endpoint
  - checksum verification, archive extraction, and Skill publication completed twice
  - both runs installed `~/.codex/skills/dingtalk-chat/SKILL.md` with no generic nested duplicate
  - legacy nested fixture remained unchanged after an ordinary command and migrated only after explicit setup confirmation
- [x] Full local suite: `DWS_PACKAGE_VERSION=0.0.0-test go test -count=1 ./...` — passed
- [x] `git diff --check` — passed

## Notes

- User/market Skills are never selected by a `dingtalk-*` prefix. Generic-root retirement remains limited to centralized ownership metadata and the frozen exact legacy official list.
- A legitimate mono layout is not migrated by startup detection.
- The explicit setup flow remains the authority for migration because it previews exact paths and obtains confirmation before writes.
