### PR TITLE
feat(chat): classify write idempotency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+### Changed
+
+- **Chat retry safety metadata** — formal Chat write commands now publish
+  explicit idempotency: commands with `--uuid` are retryable with the same key,
+  while writes without deduplication support are marked non-idempotent. Chat
+  Shortcuts are unchanged.
+
 ## [1.0.58-beta.4] - 2026-08-12
 
 ### Added

--- a/internal/app/schema_safety_contract_test.go
+++ b/internal/app/schema_safety_contract_test.go
@@ -25,11 +25,16 @@ func TestReviewedMutationSafetyReachesFinalSchema(t *testing.T) {
 	const declared = "contract_final"
 	wants := []finalSchemaSafetyWant{
 		{canonical: "aitable.form_field_hide", effect: "write", risk: "medium", confirmation: "not_required", idempotency: "idempotent", provenance: declared},
-		{canonical: "chat.dismiss_group", effect: "destructive", risk: "high", confirmation: "user_required", idempotency: "unknown", provenance: declared},
+		{canonical: "chat.dismiss_group", effect: "destructive", risk: "high", confirmation: "user_required", idempotency: "non_idempotent", provenance: declared},
+		{canonical: "chat.send_personal_message", effect: "write", risk: "medium", confirmation: "not_required", idempotency: "idempotent", provenance: declared},
+		{canonical: "chat.reply_personal_message", effect: "write", risk: "medium", confirmation: "not_required", idempotency: "idempotent", provenance: declared},
+		{canonical: "chat.forward_message", effect: "write", risk: "medium", confirmation: "not_required", idempotency: "idempotent", provenance: declared},
+		{canonical: "chat.combine_forward_messages", effect: "write", risk: "medium", confirmation: "not_required", idempotency: "idempotent", provenance: declared},
+		{canonical: "chat.share_group_invite_url", effect: "write", risk: "medium", confirmation: "user_required", idempotency: "idempotent", provenance: declared},
 		// Card update intentionally layers confirmation: the atomic typed command
 		// preserves its original contract, while the Agent-facing shortcut owns
 		// the outer confirmation boundary.
-		{canonical: "chat.update_streaming_card", effect: "write", risk: "medium", confirmation: "not_required", idempotency: "unknown", provenance: declared},
+		{canonical: "chat.update_streaming_card", effect: "write", risk: "medium", confirmation: "not_required", idempotency: "non_idempotent", provenance: declared},
 		{canonical: "chat.shortcut_messages_send", effect: "write", risk: "medium", confirmation: "user_required", idempotency: "unknown", provenance: declared},
 		{canonical: "chat.shortcut_messages_send_by_webhook", effect: "write", risk: "medium", confirmation: "user_required", idempotency: "unknown", provenance: declared},
 		{canonical: "chat.shortcut_messages_send_card", effect: "write", risk: "medium", confirmation: "user_required", idempotency: "unknown", provenance: declared},

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -2082,7 +2082,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatChmodCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "high",
-			Confirmation: "user_required", Idempotency: "unknown",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -2157,7 +2157,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatDataAuthCrossOrgCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "high",
-			Confirmation: "user_required", Idempotency: "unknown",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
 		},
 		Validate: func(cmd *cobra.Command, args []string) error {
 			_, err := buildChatCrossOrgDataAuthArgs(cmd)
@@ -2275,7 +2275,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatGroupCreateCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -2408,7 +2408,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatGroupMembersAddBotCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -2457,7 +2457,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatGroupRenameCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -2509,7 +2509,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatGroupMemberAddCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -2564,7 +2564,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatGroupMemberRemoveCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -3020,7 +3020,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatMessageSendCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -3047,6 +3047,7 @@ func newChatCommand() *cobra.Command {
 				{Name: "at-open-dingtalk-ids", Property: "atOpenDingTalkIds"},
 				{Name: "group", Property: "openConversationId"},
 				{Name: "open-dingtalk-id", Property: "receiverOpenDingTalkId"},
+				{Name: "uuid", Property: "uuid", Required: boolPtr(false)},
 			},
 		},
 	})
@@ -3220,7 +3221,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatMessageSendByBotCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -3289,7 +3290,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatMessageRecallByBotCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -3381,7 +3382,7 @@ func newChatCommand() *cobra.Command {
 	DeclareLeafMetadata(chatMessageSendByWebhookCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -3976,7 +3977,7 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 	DeclareLeafMetadata(chatMessageRecallCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -4074,7 +4075,7 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 	DeclareLeafMetadata(chatMessageEditCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -4881,7 +4882,7 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 	DeclareLeafMetadata(chatCategoryCreateCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "low",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -4936,7 +4937,7 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 	DeclareLeafMetadata(chatCategoryDeleteCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "destructive", Risk: "high",
-			Confirmation: "user_required", Idempotency: "unknown",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -5354,7 +5355,7 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 	DeclareLeafMetadata(chatMessageAddEmojiCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -5415,7 +5416,7 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 	DeclareLeafMetadata(chatMessageRemoveEmojiCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -5478,7 +5479,7 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 	DeclareLeafMetadata(chatMessageAddTextEmotionCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -5543,7 +5544,7 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 	DeclareLeafMetadata(chatMessageRemoveTextEmotionCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -5685,7 +5686,7 @@ chat message edit 或 chat message recall 的 --msg-id 和 --conversation-id。
 	DeclareLeafMetadata(chatMessageCreateTextEmotionCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -5770,7 +5771,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMessageSendCardCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -5872,7 +5873,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 			// preserves its original no-extra-confirmation contract. The
 			// Agent-facing +messages-update-card shortcut owns the higher-level
 			// confirmation boundary.
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6123,7 +6124,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupTransferOwnerCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6236,7 +6237,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMuteCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6291,7 +6292,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupQuitCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6347,7 +6348,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupUpdateIconCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6423,7 +6424,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupUpdateSettingsCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6519,7 +6520,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMessageReplyCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6546,6 +6547,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 				{Name: "at-all", Property: "atAll", Required: boolPtr(false), InterfaceType: "boolean"},
 				{Name: "at-open-dingtalk-ids", Property: "atOpenDingTalkIds", Required: boolPtr(false), InterfaceType: "array"},
 				{Name: "conversation-id", Property: "openConversationId"},
+				{Name: "uuid", Property: "uuid", Required: boolPtr(false)},
 			},
 		},
 	})
@@ -6593,7 +6595,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMessageForwardCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6619,6 +6621,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 				{Name: "dest-conversation-id", Property: "destOpenCid"},
 				{Name: "msg-id", Property: "srcOpenMessageId"},
 				{Name: "src-conversation-id", Property: "srcOpenCid"},
+				{Name: "uuid", Property: "uuid", Required: boolPtr(false)},
 			},
 		},
 	})
@@ -6657,7 +6660,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatSetTopCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6759,7 +6762,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupMuteCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6854,7 +6857,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupMuteMemberCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -6934,7 +6937,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupSetAdminCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7095,7 +7098,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupRoleAddCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7145,7 +7148,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupRoleUpdateCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7197,7 +7200,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupRoleRemoveCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7260,7 +7263,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupRoleSetUserCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7325,7 +7328,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupRoleRemoveUserCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7506,7 +7509,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupMembersRemoveBotCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7633,7 +7636,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupDismissCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "destructive", Risk: "high",
-			Confirmation: "user_required", Idempotency: "unknown",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7699,7 +7702,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatGroupSetHistoryCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7760,7 +7763,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMessageCombineForwardCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7786,6 +7789,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 				{Name: "dest-conversation-id", Property: "destOpenCid"},
 				{Name: "msg-ids", Property: "srcOpenMessageIds"},
 				{Name: "src-conversation-id", Property: "srcOpenCid"},
+				{Name: "uuid", Property: "uuid", Required: boolPtr(false)},
 			},
 		},
 	})
@@ -7828,7 +7832,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMessageForwardTopicCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7891,7 +7895,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMessageSetPinCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -7945,7 +7949,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMessageUnsetPinCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -8061,7 +8065,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMessageAddFavoriteCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -8110,7 +8114,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	DeclareLeafMetadata(chatMessageRemoveFavoriteCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -8422,7 +8426,7 @@ status 可选值:
 	DeclareLeafMetadata(chatGroupAuditJoinValidationCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -8717,7 +8721,7 @@ status 可选值:
 	DeclareLeafMetadata(chatClearMessagesCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "destructive", Risk: "high",
-			Confirmation: "user_required", Idempotency: "unknown",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -9016,7 +9020,7 @@ status 可选值:
 	DeclareLeafMetadata(chatGroupUpdateAliasCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "low",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -9073,7 +9077,7 @@ status 可选值:
 	DeclareLeafMetadata(chatHideCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "low",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -9133,7 +9137,7 @@ status 可选值:
 	DeclareLeafMetadata(chatMuteAtAllCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "low",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -9194,7 +9198,7 @@ status 可选值:
 	DeclareLeafMetadata(chatMuteRedEnvelopeCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "low",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -9325,7 +9329,7 @@ status 可选值:
 	DeclareLeafMetadata(chatGroupNoticeCreateCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -9571,7 +9575,7 @@ status 可选值:
 	DeclareLeafMetadata(chatGroupShareInviteCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "user_required", Idempotency: "unknown",
+			Confirmation: "user_required", Idempotency: "idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -9645,7 +9649,7 @@ status 可选值:
 	DeclareLeafMetadata(chatGroupUpgradeToExternalCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "destructive", Risk: "high",
-			Confirmation: "user_required", Idempotency: "unknown",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{
@@ -9713,7 +9717,7 @@ status 可选值:
 	DeclareLeafMetadata(chatCategoryCreateSmartCmd, LeafSpec{
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
-			Confirmation: "not_required", Idempotency: "unknown",
+			Confirmation: "not_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
 			Identity: contract.ToolIdentitySpec{

--- a/internal/helpers/chat_safety_catalog_test.go
+++ b/internal/helpers/chat_safety_catalog_test.go
@@ -7,8 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contractfinal"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func TestCrossPlatformCoverageChatCatalogSafetyMetadataIsExplicit(t *testing.T) {
@@ -16,6 +18,7 @@ func TestCrossPlatformCoverageChatCatalogSafetyMetadataIsExplicit(t *testing.T) 
 	root.AddCommand(newChatCommand())
 
 	checked := 0
+	writesChecked := 0
 	walkChatCatalogLeaves(root, func(cmd *cobra.Command) {
 		final, ok := contractfinal.RuntimeContractFinal(cmd)
 		if !ok || final.Identity == nil || final.Safety == nil {
@@ -39,10 +42,51 @@ func TestCrossPlatformCoverageChatCatalogSafetyMetadataIsExplicit(t *testing.T) 
 					canonical, *safety)
 			}
 		}
+		cliPath := strings.TrimSpace(final.Identity.PrimaryCLIPath)
+		if cliPath == "" {
+			cliPath = strings.TrimSpace(final.Identity.CLIPath)
+		}
+		if strings.HasPrefix(cliPath, "chat +") || (safety.Effect != "write" && safety.Effect != "destructive") {
+			return
+		}
+		writesChecked++
+		if safety.Idempotency == "unknown" {
+			t.Fatalf("formal chat write %s must declare retry safety, got idempotency=unknown", canonical)
+		}
+		if hasChatDeduplicationParameter(cmd, final.Parameters) && safety.Idempotency != "idempotent" {
+			t.Fatalf("formal chat write %s exposes a deduplication parameter but idempotency=%s, want idempotent", canonical, safety.Idempotency)
+		}
 	})
 	if checked == 0 {
 		t.Fatal("no chat Catalog leaves checked")
 	}
+	if writesChecked == 0 {
+		t.Fatal("no formal chat write Catalog leaves checked")
+	}
+}
+
+func hasChatDeduplicationParameter(cmd *cobra.Command, parameters []contract.ParamDecl) bool {
+	isDeduplicationName := func(name string) bool {
+		normalized := strings.NewReplacer("-", "", "_", "").Replace(strings.ToLower(strings.TrimSpace(name)))
+		switch normalized {
+		case "uuid", "clienttoken", "idempotencykey":
+			return true
+		default:
+			return false
+		}
+	}
+	for _, parameter := range parameters {
+		if isDeduplicationName(parameter.Name) || isDeduplicationName(parameter.Property) {
+			return true
+		}
+	}
+	found := false
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if isDeduplicationName(flag.Name) {
+			found = true
+		}
+	})
+	return found
 }
 
 func walkChatCatalogLeaves(cmd *cobra.Command, fn func(*cobra.Command)) {


### PR DESCRIPTION
## Summary

- What changed?
  - Classified every formal Chat write/destructive command with explicit retry semantics.
  - Marked the five commands exposing `--uuid` as `idempotent`; commands without reviewed deduplication support now publish `non_idempotent`.
  - Added a Chat contract gate that rejects future formal writes with `idempotency=unknown` and rejects deduplication parameters that are not marked idempotent.
  - Declared `uuid` explicitly for send, reply, forward, and combine-forward. Chat Shortcuts are intentionally unchanged.
- Why is this change needed?
  - Agents need to determine from Chat Schema/Help whether a failed write can be retried safely with the same deduplication key.
  - This removes the formal Chat write `unknown` gap and prevents future declaration omissions.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [x] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

Record the smallest targeted evidence that proves the changed behavior. Do not
repeat the entire CI suite locally only to fill this checklist: CI expands the
selected tier from documentation checks, through affected-package tests, to
the complete high-risk suite.

- [ ] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`):
  `.changes/<unique-name>.md`; ordinary PRs must not edit `CHANGELOG.md`.
  - Pending migration to the latest `main`, which introduced release fragments after this branch was created.
- [ ] Release-seal validation (otherwise `N/A`):
  `./scripts/policy/check-changelog-pr.sh --content-only "$(git merge-base HEAD origin/main)" HEAD`
  - Pending the same migration.
- [x] Targeted test/check commands and results:
  - `make build` — exit 0
  - `go test ./internal/helpers -run '^TestCrossPlatformCoverageChatCatalogSafetyMetadataIsExplicit$' -count=1` — exit 0
  - `go test ./internal/app -run '^TestReviewedMutationSafetyReachesFinalSchema$' -count=1` — exit 0
  - `make generate-schema` — exit 0; assembly determinism passed
  - `./scripts/policy/check-generated-drift.sh` — exit 0
  - `./scripts/policy/check-schema-catalog.sh` — exit 0; 27 products / 1096 tools
  - `./scripts/policy/check-command-surface.sh --strict` — exit 0
- [x] Behavior evidence (test name, CLI output shape, or before/after result):
  - Formal Chat writes: 23 `idempotent`, 53 `non_idempotent`, 0 `unknown`.
  - `chat message send` publishes `idempotency=idempotent`; safe retry requires the same `--uuid` and unchanged business arguments.
  - `chat group create` publishes `idempotency=non_idempotent` and must not be retried automatically after an ambiguous failure.
  - `chat +messages-send` remains `idempotency=unknown`, proving Shortcuts were not changed.
- [ ] Documentation links/content/rendering checked (documentation-only, otherwise
  `N/A`)
  - N/A.
- [x] Full local suite run because the change is high-risk (optional for other
  tiers; record command/result or `N/A`)
  - `GOWORK=off DWS_PACKAGE_VERSION=0.0.0-test go test ./...` — exit 0.
- [x] `./scripts/policy/check-generated-drift.sh`
  (when generator inputs or generated artifacts may change)
- [x] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed)
- [ ] `./scripts/release/verify-package-managers.sh`
  (after `make package`, if packaging or installer surfaces changed)
  - N/A: packaging and installer surfaces are unchanged.

## 指令 CI 集成测试截图（chat）

- 证据提交：`3edd6c565fb22b3a1580e9c3718e2c460fe64463`
- 结果：两条 current-head 定向测试均退出 0，覆盖 Chat 声明完整性和最终 Runtime Schema 投影；未执行钉钉业务命令。

![chat 指令 CI 集成测试截图：Chat idempotency 声明与最终 Schema 投影测试通过](https://raw.githubusercontent.com/Anonymity-0/Picgo/main/dws-pr-evidence/pr-965/3edd6c56/chat-idempotency-cli-tests.png)

chat 指令 CI 集成测试：**PASS**。

## Agent 测试报告截图（chat）

- 证据提交：`3edd6c565fb22b3a1580e9c3718e2c460fe64463`
- 用户任务：让 Agent 根据当前公开工具能力判断普通消息发送、群聊创建和快捷发送能否安全自动重试，只做能力检查。
- 结果：同一次 Qoder CLI 原生会话读取封存的 current-head DWS/Skill，只调用公开 Schema/Help；正确区分 `idempotent`、`non_idempotent`、`unknown`，钉钉写入次数为 0。

![chat Agent 测试报告截图：Qoder 根据 Chat idempotency 判断安全重试策略](https://raw.githubusercontent.com/Anonymity-0/Picgo/main/dws-pr-evidence/pr-965/3edd6c56/chat-idempotency-agent-report.png)

chat Agent 测试报告：**PASS**。

## Notes

- Evidence commit: `3edd6c565fb22b3a1580e9c3718e2c460fe64463`.
- No DingTalk business write was executed; Qoder used only the sealed current-head DWS/Skill and public Schema/Help.
- The only failing CI check is `Interface Integrity`: the merge-base compatibility policy rejects every intended `idempotency=unknown` refinement. A prerequisite policy change is required before this PR can become mergeable.
- No generated Catalog or Schema snapshot is committed.

The repository automatically requests one eligible peer reviewer, including
after a new head push when another review is needed. Once the latest push has
peer approval and all nine required checks are current and green, auto-merge
completes the PR; authors do not need to coordinate a separate routine merge.
