### PR TITLE
feat(chatmsg): extract interactive card body from cardContent tree

### DIFF
--- a/internal/shortcut/chatmsg/chatmsg.go
+++ b/internal/shortcut/chatmsg/chatmsg.go
@@ -223,10 +223,23 @@ func senderDisplayName(m map[string]any) string {
 
 // Text reads a message's textual content (tolerating common text keys and one
 // level of nesting) and runs it through CleanText.
+//
+// Interactive cards (msgtype=interactiveCard or action_card) nest their body in
+// cardContent[].children[].value (elementType TEXT).  When the MCP service
+// includes that field in the response this function extracts it.  Currently the
+// MCP service only returns the plain fallback text; the cardContent path is
+// present and ready for when the service-side schema is updated.
 func Text(m map[string]any) any {
 	for _, key := range []string{"text", "content", "msgContent", "message", "msg", "body", "plainText"} {
 		v, ok := m[key]
 		if !ok || v == nil {
+			// Fallback: check for interactive-card cardContent at the message
+			// level (alongside content/text) when the primary key is absent.
+			if key == "content" || key == "text" {
+				if extracted := extractInteractiveCardTextFromMap(m); extracted != "" {
+					return extracted
+				}
+			}
 			continue
 		}
 		switch t := v.(type) {
@@ -235,6 +248,10 @@ func Text(m map[string]any) any {
 				return CleanText(t)
 			}
 		case map[string]any:
+			// Interactive-card body: data.Content is a map with cardContent.
+			if extracted := extractInteractiveCardTextFromMap(t); extracted != "" {
+				return extracted
+			}
 			for _, inner := range []string{"text", "content", "richText", "title", "value"} {
 				if s, ok := t[inner].(string); ok && s != "" {
 					return CleanText(s)
@@ -242,7 +259,56 @@ func Text(m map[string]any) any {
 			}
 		}
 	}
+	// Last-resort: cardContent directly at the top level of the message map,
+	// without a wrapping content/text key.
+	if extracted := extractInteractiveCardTextFromMap(m); extracted != "" {
+		return extracted
+	}
 	return nil
+}
+
+// extractInteractiveCardTextFromMap extracts readable text from an
+// interactiveCard cardContent tree.  Shape (verified live from bot callbacks):
+// cardContent is an array of blocks, each with a "children" array of
+// {elementType:"TEXT", value:"..."} leaves; nested blocks recurse via their own
+// "children".
+func extractInteractiveCardTextFromMap(m map[string]any) string {
+	raw, ok := m["cardContent"]
+	if !ok || raw == nil {
+		return ""
+	}
+	leaves := cardContentLeaves(raw)
+	if len(leaves) == 0 {
+		return ""
+	}
+	return strings.Join(leaves, "")
+}
+
+// cardContentLeaves flattens an interactiveCard cardContent tree into its
+// ordered TEXT leaf values.
+func cardContentLeaves(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	var leaves []string
+	var walk func(items []any)
+	walk = func(items []any) {
+		for _, item := range items {
+			child, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if s, ok := child["value"].(string); ok && s != "" {
+				leaves = append(leaves, s)
+			}
+			if kids, ok := child["children"].([]any); ok {
+				walk(kids)
+			}
+		}
+	}
+	walk(arr)
+	return leaves
 }
 
 // CreateTime reads a message's create/send time under whichever candidate key is
@@ -1178,8 +1244,15 @@ func CleanText(s string) string {
 	}
 
 	// Fast path: no JSON delimiters at all — the overwhelming common case.
-	if !strings.ContainsAny(s, "{[") {
+	if !strings.ContainsAny(s, "{[\n") {
 		return s
+	}
+
+	// Interactive card: the whole body might be a single JSON blob whose
+	// top-level shape contains cardContent.  Try to parse and extract before
+	// the line-by-line rich-content heuristic.
+	if extracted := tryExtractInteractiveCardJSON(s); extracted != "" {
+		return extracted
 	}
 
 	lines := strings.Split(s, "\n")
@@ -1216,9 +1289,6 @@ func CleanText(s string) string {
 			out = append(out, extracted[i]...)
 			continue
 		}
-		// In card mode, drop only JSON shapes known to be card decoration.
-		// Unrecognised JSON may be user-authored message content and must remain
-		// verbatim even when another line contains a rich-content block.
 		if isJSON[i] && isDecoration[i] {
 			continue
 		}
@@ -1227,9 +1297,23 @@ func CleanText(s string) string {
 		}
 		out = append(out, line)
 	}
-	// anyExtracted is true here, so out always holds at least one non-empty
-	// extracted text — the joined result is never empty.
 	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// tryExtractInteractiveCardJSON parses a single-line JSON interactive-card body
+// (including the common `{"cardContent":[...]}` shape) and returns the
+// concatenated TEXT leaves.  Returns "" if the input is not a recognised
+// interactive card.
+func tryExtractInteractiveCardJSON(s string) string {
+	t := strings.TrimSpace(s)
+	if !strings.HasPrefix(t, "{") || !strings.Contains(t, "cardContent") {
+		return ""
+	}
+	var v map[string]any
+	if json.Unmarshal([]byte(t), &v) != nil {
+		return ""
+	}
+	return extractInteractiveCardTextFromMap(v)
 }
 
 // isKnownRichDecoration recognises the two decoration records emitted alongside

--- a/internal/shortcut/chatmsg/chatmsg.go
+++ b/internal/shortcut/chatmsg/chatmsg.go
@@ -259,11 +259,6 @@ func Text(m map[string]any) any {
 			}
 		}
 	}
-	// Last-resort: cardContent directly at the top level of the message map,
-	// without a wrapping content/text key.
-	if extracted := extractInteractiveCardTextFromMap(m); extracted != "" {
-		return extracted
-	}
 	return nil
 }
 

--- a/internal/shortcut/chatmsg/chatmsg_test.go
+++ b/internal/shortcut/chatmsg/chatmsg_test.go
@@ -662,9 +662,10 @@ func TestCrossPlatformCoverageSearchMessageItemsFlattensConversationGroups(t *te
 	}
 }
 
-func TestInteractiveCardTextExtraction(t *testing.T) {
+func TestCrossPlatformCoverageInteractiveCardTextExtraction(t *testing.T) {
 	// Verified live shape from bot callbacks.
 	cardContent := []any{
+		"invalid-node",
 		map[string]any{
 			"children": []any{
 				map[string]any{"elementType": "TEXT", "value": "@监控机器人 "},
@@ -721,6 +722,20 @@ func TestInteractiveCardTextExtraction(t *testing.T) {
 		}
 	})
 
+	t.Run("empty cardContent returns empty", func(t *testing.T) {
+		got := extractInteractiveCardTextFromMap(map[string]any{"cardContent": []any{}})
+		if got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("non-array cardContent returns empty", func(t *testing.T) {
+		got := extractInteractiveCardTextFromMap(map[string]any{"cardContent": "invalid"})
+		if got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+
 	t.Run("CleanText with JSON cardContent", func(t *testing.T) {
 		input := `{"cardContent":[{"children":[{"elementType":"TEXT","value":"Alert: "},{"elementType":"TEXT","value":"CPU high"}]}]}`
 		got := CleanText(input)
@@ -731,6 +746,14 @@ func TestInteractiveCardTextExtraction(t *testing.T) {
 
 	t.Run("CleanText plain text unchanged", func(t *testing.T) {
 		input := "pod_status_no_running_wbprod"
+		got := CleanText(input)
+		if got != input {
+			t.Fatalf("CleanText() = %q, want unchanged", got)
+		}
+	})
+
+	t.Run("CleanText malformed card JSON unchanged", func(t *testing.T) {
+		input := `{"cardContent":`
 		got := CleanText(input)
 		if got != input {
 			t.Fatalf("CleanText() = %q, want unchanged", got)

--- a/internal/shortcut/chatmsg/chatmsg_test.go
+++ b/internal/shortcut/chatmsg/chatmsg_test.go
@@ -697,7 +697,7 @@ func TestInteractiveCardTextExtraction(t *testing.T) {
 
 	t.Run("cardContent at message top level", func(t *testing.T) {
 		msg := map[string]any{
-			"messageId": "msg-1",
+			"messageId":   "msg-1",
 			"cardContent": cardContent,
 		}
 		got := Text(msg)

--- a/internal/shortcut/chatmsg/chatmsg_test.go
+++ b/internal/shortcut/chatmsg/chatmsg_test.go
@@ -661,3 +661,79 @@ func TestCrossPlatformCoverageSearchMessageItemsFlattensConversationGroups(t *te
 		t.Fatal("non-map result was accepted")
 	}
 }
+
+func TestInteractiveCardTextExtraction(t *testing.T) {
+	// Verified live shape from bot callbacks.
+	cardContent := []any{
+		map[string]any{
+			"children": []any{
+				map[string]any{"elementType": "TEXT", "value": "@监控机器人 "},
+				map[string]any{"elementType": "TEXT", "value": "pod_status_no_running_wbprod"},
+			},
+		},
+		map[string]any{
+			"children": []any{
+				map[string]any{"elementType": "TEXT", "value": "详情: "},
+				map[string]any{
+					"children": []any{
+						map[string]any{"elementType": "TEXT", "value": "集群: prod-cluster"},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("content map with cardContent", func(t *testing.T) {
+		msg := map[string]any{
+			"content": map[string]any{
+				"cardContent": cardContent,
+			},
+		}
+		got := Text(msg)
+		if got != "@监控机器人 pod_status_no_running_wbprod详情: 集群: prod-cluster" {
+			t.Fatalf("Text() = %q", got)
+		}
+	})
+
+	t.Run("cardContent at message top level", func(t *testing.T) {
+		msg := map[string]any{
+			"messageId": "msg-1",
+			"cardContent": cardContent,
+		}
+		got := Text(msg)
+		if got != "@监控机器人 pod_status_no_running_wbprod详情: 集群: prod-cluster" {
+			t.Fatalf("Text() = %q", got)
+		}
+	})
+
+	t.Run("no cardContent falls through plain text", func(t *testing.T) {
+		msg := map[string]any{"content": "plain text message"}
+		got := Text(msg)
+		if got != "plain text message" {
+			t.Fatalf("Text() = %q", got)
+		}
+	})
+
+	t.Run("nil cardContent returns nil", func(t *testing.T) {
+		got := extractInteractiveCardTextFromMap(map[string]any{"cardContent": nil})
+		if got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("CleanText with JSON cardContent", func(t *testing.T) {
+		input := `{"cardContent":[{"children":[{"elementType":"TEXT","value":"Alert: "},{"elementType":"TEXT","value":"CPU high"}]}]}`
+		got := CleanText(input)
+		if got != "Alert: CPU high" {
+			t.Fatalf("CleanText() = %q", got)
+		}
+	})
+
+	t.Run("CleanText plain text unchanged", func(t *testing.T) {
+		input := "pod_status_no_running_wbprod"
+		got := CleanText(input)
+		if got != input {
+			t.Fatalf("CleanText() = %q, want unchanged", got)
+		}
+	})
+}


### PR DESCRIPTION
Interactive card messages (msgtype=interactiveCard) sent by ARMS, SLS and other monitoring bots currently lose their rich body at the MCP service layer.  The CLI only receives the plain fallback text (e.g. 'pod_status_no_running_wbprod') while the actual alert details, links and structured content remain invisible to Agents and human operators.

This commit adds interactive-card-aware text extraction to the shared message projection layer (chatmsg), reusing the  tree shape already documented and consumed by the bot connector (connect_media.go:extractInteractiveCardText).

Changes:
- Text(): when  is a map containing , recursively walk  and join TEXT leaf values
- CleanText(): handle the case where  is a single-line JSON string with  at the top level
- Fallback: check for  at the message root (alongside other keys) when no / key is present

New functions:
- extractInteractiveCardTextFromMap(m) -> string
- cardContentLeaves(v) -> []string
- tryExtractInteractiveCardJSON(s) -> string

The existing rich-content and encrypted-message handling is untouched. When cardContent is absent the extraction returns empty, so plain-text messages pass through unchanged.

This is forward-compatible: the MCP service currently strips cardContent and only returns the fallback text.  Once the MCP schema is updated to include the raw cardContent field, the projection path is ready and tested.

Tests: 6 new cases covering content-map, message-root, nil guard, CleanText JSON and plain-text regression.

## Summary

- What changed?
- Why is this change needed?

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

Record the smallest targeted evidence that proves the changed behavior. Do not
repeat the entire CI suite locally only to fill this checklist: CI expands the
selected tier from documentation checks, through affected-package tests, to
the complete high-risk suite.

- [ ] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`):
  `.changes/<unique-name>.md`; ordinary PRs must not edit `CHANGELOG.md`.
- [ ] Release-seal validation (otherwise `N/A`):
  `./scripts/policy/check-changelog-pr.sh --content-only "$(git merge-base HEAD origin/main)" HEAD`
- [ ] Targeted test/check commands and results:
- [ ] Behavior evidence (test name, CLI output shape, or before/after result):
- [ ] Documentation links/content/rendering checked (documentation-only, otherwise
  `N/A`)
- [ ] Full local suite run because the change is high-risk (optional for other
  tiers; record command/result or `N/A`)
- [ ] `./scripts/policy/check-generated-drift.sh`
  (when generator inputs or generated artifacts may change)
- [ ] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed)
- [ ] `./scripts/release/verify-package-managers.sh`
  (after `make package`, if packaging or installer surfaces changed)

## Notes

- Any risks, follow-up work, or intentional scope cuts

The repository automatically requests one eligible peer reviewer, including
after a new head push when another review is needed. Once the latest push has
peer approval and all nine required checks are current and green, auto-merge
completes the PR; authors do not need to coordinate a separate routine merge.
