### PR TITLE
docs(chat): clarify image markdown guide

### DIFF
--- a/.changes/85387314-chat-image-guide.md
+++ b/.changes/85387314-chat-image-guide.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Chat message send help** - Clarifies Markdown image syntax for inline mixed text and images.

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -2799,6 +2799,8 @@ func newChatCommand() *cobra.Command {
 
 纯文本 / Markdown 消息（默认）：
   无需指定 --msg-type，直接传消息内容即可。推荐使用 --text flag 传递内容（尤其当内容含换行、引号等特殊字符时），也支持位置参数。可选 --title 作为消息标题。
+  图文混排时，公网图片 URL 需要写成 Markdown 图片语法：![图片标题](https://example.com/image.png)，才会以内联图片展示。
+  如果省略开头的 !，例如 [图片标题](https://example.com/image.png)，将按链接/URL 展示，不会渲染为图片。
 
 返回值与后续操作：
   发送后会返回 openTaskId。如需编辑或撤回刚发送的消息，使用
@@ -2816,6 +2818,8 @@ func newChatCommand() *cobra.Command {
   dws chat message send --user <userId> "请查收"
   dws chat message send --open-dingtalk-id <openDingTalkId> "请查收"
   dws chat message send --group <openconversation_id> --title "周报提醒" "请大家本周五前提交周报"
+  # 图文混排 Markdown：公网图片 URL 需要写成 ![图片标题](URL) 才会以内联图片展示
+  dws chat message send --group <openconversation_id> --text $'这是图文说明\n\n![这个是展示图片标题](https://down.dingtalk.com/media/lQLPM5jiBEiBNjswMLAKd_CTzm8eowpEWPT_7-cA_48_48.png)'
   # 发送本地图片或文件（图片会作为可下载的 file 附件发送）
   dws chat message send --group <openconversation_id> --msg-type file --file-path ./screenshot.png
   dws chat message send --group <openconversation_id> --msg-type file --file-path ./report.pdf

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -565,6 +565,7 @@ Flags:
 **重要：该接口会真实发送消息到目标会话，不可用于测试或试探性调用。调用前必须确认消息内容和接收对象无误。**
 
 --group 指定群聊 openConversationId 发群消息；--user 指定用户 userId 发单聊；--open-dingtalk-id 指定用户 openDingTalkId 发单聊。三者只能选其一，不能同时指定。纯文本/Markdown 单聊传 --user 时直接走 userId 发送能力，不需要先手动查询 openDingTalkId。推荐使用 --text flag 传递消息内容（也支持位置参数）。可选 --title 作为消息标题。
+图文混排 Markdown 中，公网图片 URL 需要写成 `![图片标题](https://example.com/image.png)` 才会以内联图片展示；省略开头的 `!` 时会按链接/URL 展示，不会渲染为图片。
 若用户只提供了数字群号而非 openConversationId，需先调用 `chat group get-by-group-id` 将群号转为 openConversationId，再传入 --group。
 --群聊时可选 --at-all @所有人，或 --at-open-dingtalk-ids 指定成员（仅群聊时生效）。
 --本地图片、文件、音频或视频统一用 --msg-type file --file-path；图片会作为可下载的文件附件发送。--msg-type image --media-id 仅用于上游已经提供有效 mediaId 的场景。
@@ -585,6 +586,8 @@ Example:
   dws chat message send --open-dingtalk-id <openDingTalkId> --text "请查收"
   dws chat message send --group <openconversation_id> "hello"
   dws chat message send --group <openconversation_id> --title "周报提醒" --text "请大家本周五前提交周报"
+  # 图文混排 Markdown：公网图片 URL 需要写成 ![图片标题](URL) 才会以内联图片展示
+  dws chat message send --group <openconversation_id> --text $'这是图文说明\n\n![这个是展示图片标题](https://down.dingtalk.com/media/lQLPM5jiBEiBNjswMLAKd_CTzm8eowpEWPT_7-cA_48_48.png)'
   # 幂等发送（24h 内相同 uuid 不重复投递）
   dws chat message send --group <openconversation_id> --text "hello" --uuid "unique-id-123"
   dws chat message send --group <openconversation_id> --at-all "<@all> 请大家注意"
@@ -624,6 +627,7 @@ Flags:
   - **换行符**：消息内容按 Markdown 渲染，换行有两层要求，缺一不可：
     1. 必须使用**真实换行符**（Unicode `U+000A`），而非字面量字符串 `\n`（反斜杠 + 字母 n）。程序或大模型构造参数时，须确保已正确反转义；否则全部内容会渲染在同一行
     2. Markdown 规范下**单个换行不产生换行效果**。需要换行时请使用：段落分隔（连续两个真实换行符 `\n\n`）、行尾两个空格 + 真实换行符（硬换行 `<br>`），或直接写 HTML 的 `<br>` 标签
+  - **图文混排**：公网图片 URL 需要写成 `![图片标题](https://example.com/image.png)` 才会以内联图片展示；如果省略开头的 `!`，例如 `[图片标题](https://example.com/image.png)`，将按链接/URL 展示，不会渲染为图片
   - 本地图片、文档、压缩包、音频和视频统一使用 `--msg-type file --file-path <本地路径>`；图片会成为可下载的 file 附件，不会内联渲染，也不会生成 mediaId
   - `--msg-type image --media-id` 仅接受上游已经提供的有效 mediaId；DWS CLI 不提供本地文件到 mediaId 的上传或转换能力
   - audio/video 仍是兼容的 file 语义别名，但本地文件的推荐路径保持为 `--msg-type file --file-path`

--- a/skills/multi/dingtalk-chat/references/chat/chat-message.md
+++ b/skills/multi/dingtalk-chat/references/chat/chat-message.md
@@ -33,6 +33,7 @@
 - 发送位置消息前必须确认纬度、经度、地址名称；地图缩略图需先通过旧媒体上传链路拿到 mediaId。
 - 分享联系人名片前必须确认联系人 `openDingTalkId`，不要把 userId 直接当 `--contact-id`。
 - 消息内容按 Markdown 渲染，换行必须是真实换行符；需要换行效果时用空行、行尾两个空格或 `<br>`。
+- 图文混排 Markdown 中，公网图片 URL 需要写成 `![图片标题](https://example.com/image.png)` 才会以内联图片展示；省略开头的 `!` 时会按链接/URL 展示，不会渲染为图片。
 - 建议发送时带 `--uuid`，失败重试复用同一个值。
 - Bot/Webhook 只支持文本/Markdown；Bot 多群使用 `+messages-send --groups/--groups-file` 的逐项
   ledger。不要把 user 文件/图片能力外推到 Bot。
@@ -54,6 +55,7 @@ dws chat message send --group <openConversationId> --text "hello"
 dws chat message send --user <userId> --text "请查收"
 dws chat message send --open-dingtalk-id <openDingTalkId> --text "请查收"
 dws chat message send --group <openConversationId> --title "周报提醒" --text "请大家本周五前提交周报" --uuid <uuid>
+dws chat message send --group <openConversationId> --text $'这是图文说明\n\n![这个是展示图片标题](https://down.dingtalk.com/media/lQLPM5jiBEiBNjswMLAKd_CTzm8eowpEWPT_7-cA_48_48.png)'
 
 # @ 群成员
 dws chat message send --group <openConversationId> --at-all "<@all> 请大家注意"


### PR DESCRIPTION
## Summary
- Add image markdown guidance to `dws chat message send --help` for mixed text/image messages.
- Sync the same guidance into mono and multi chat markdown references.
- Add a changeset for the help/docs wording update.

## Scope
- Only covers `dws chat message send --help` and related md guidance.
- Does not change shortcut, bot/robot, webhook, schema, generated command index, install, or release paths.
- Does not change runtime send logic, flags, parameters, or output contracts.

## Validation
- `go run ./cmd chat message send --help`
- `go test ./internal/helpers -run 'Test.*Chat.*Send|Test.*Help' -count=1`
- `go test ./internal/app -run 'TestRootHelp|TestCommandPathFallback' -count=1`
- `go test ./test/smoke -count=1`
- `scripts/policy/check-skill-commands.sh`
- `scripts/policy/check-mono-multi-skill-content.sh`
- `scripts/policy/check-command-surface.sh --strict`
- `scripts/policy/check-generated-drift.sh`
- `make build`
- `git diff --check origin/main...HEAD`

## Review Notes
- Please review wording consistency across help, mono skill docs, and multi skill docs.
- PR is Draft because GitHub user-attachments screenshot URL is not available yet.

## Screenshots / 验证截图
<img width="2664" height="528" alt="image" src="https://github.com/user-attachments/assets/92457b5c-b5c6-4930-98e5-c245d263c1cc" />
<img width="2006" height="1770" alt="image" src="https://github.com/user-attachments/assets/0778e255-0396-4feb-86a6-e173b7e94078" />

