### PR TITLE
fix: allow hidden canonical requiredness transfer to #85349380

### DIFF
--- a/internal/interfacesnapshot/migrations.go
+++ b/internal/interfacesnapshot/migrations.go
@@ -325,9 +325,12 @@ func (m FlagMigration) validate() error {
 		return fmt.Errorf("canonical flag must remain visible")
 	}
 	// Requiredness belongs to the one logical parameter. The hidden legacy
-	// spelling must not remain independently required, while the canonical
-	// spelling inherits the exact before-state contract. If the canonical flag
-	// already existed, a rename receipt cannot authorize changing it either.
+	// spelling must not remain independently required, while the visible
+	// canonical spelling inherits the legacy contract. A pre-existing visible
+	// canonical flag cannot change requiredness. The only permitted transfer is
+	// from a required legacy Primary to an already registered hidden optional
+	// canonical alias; making that alias visible without the transfer would make
+	// a previously invalid invocation valid and weaken the logical contract.
 	if m.Legacy.After.Required {
 		return fmt.Errorf("legacy compatibility alias must not remain independently required after migration")
 	}
@@ -336,7 +339,9 @@ func (m FlagMigration) validate() error {
 			"flag requiredness must be preserved from legacy before to canonical after",
 		)
 	}
-	if m.Canonical.Before.Present && m.Canonical.Before.Required != m.Canonical.After.Required {
+	if m.Canonical.Before.Present &&
+		m.Canonical.Before.Required != m.Canonical.After.Required &&
+		!m.transfersRequirednessToHiddenCanonical() {
 		return fmt.Errorf("canonical flag requiredness must remain unchanged when already present")
 	}
 	if m.Legacy.After.AliasOf != m.Canonical.Name {
@@ -375,6 +380,14 @@ func (m FlagMigration) validate() error {
 		return fmt.Errorf("legacy flag scope must remain unchanged")
 	}
 	return nil
+}
+
+func (m FlagMigration) transfersRequirednessToHiddenCanonical() bool {
+	return m.Legacy.Before.Required &&
+		m.Canonical.Before.Present &&
+		m.Canonical.Before.Hidden &&
+		!m.Canonical.Before.Required &&
+		m.Canonical.After.Required
 }
 
 func (s FlagMigrationState) validate(label string) error {
@@ -688,6 +701,10 @@ func flagMigrationAuthorizesChange(
 		if !migration.Canonical.Before.Present &&
 			migration.Canonical.After.Required &&
 			change.Kind == "required_flag_added" {
+			return true
+		}
+		if migration.transfersRequirednessToHiddenCanonical() &&
+			change.Kind == "flag_became_required" {
 			return true
 		}
 	}

--- a/internal/interfacesnapshot/migrations_coverage_test.go
+++ b/internal/interfacesnapshot/migrations_coverage_test.go
@@ -792,6 +792,35 @@ func TestCrossPlatformCoverageCompareAllWithFlagMigrationsInheritedAndOptionalCa
 			t.Fatalf("existing optional canonical migration = (%#v, %v), want compatible", report, err)
 		}
 	})
+
+	t.Run("requiredness transfers to an existing hidden canonical alias", func(t *testing.T) {
+		pending := coverageManifest(FlagMigrationPending)
+		pending.Migrations[0].Canonical.Before = FlagMigrationState{
+			Present: true,
+			Type:    "string",
+			Hidden:  true,
+			Scope:   "local",
+		}
+		consumed := pending
+		consumed.Migrations = append([]FlagMigration(nil), pending.Migrations...)
+		consumed.Migrations[0].State = FlagMigrationConsumed
+		before := coverageMigrationSnapshot(pending.Migrations[0], false, false)
+		after := coverageMigrationSnapshot(pending.Migrations[0], true, false)
+
+		ordinary := Compare(after, before, "merge-base")
+		if !hasFlagChange(ordinary.Blocking, "flag_became_required", pending.Migrations[0].Command, pending.Migrations[0].Canonical.Name) {
+			t.Fatalf("fixture did not transfer canonical requiredness: %#v", ordinary.Blocking)
+		}
+		report, err := CompareAllWithFlagMigrations(
+			after,
+			map[string]Snapshot{"merge-base": before, "stable": before},
+			pending,
+			consumed,
+		)
+		if err != nil || !report.Compatible {
+			t.Fatalf("hidden canonical requiredness transfer = (%#v, %v), want compatible", report, err)
+		}
+	})
 }
 
 func TestCrossPlatformCoverageOptionalFlagMigrationLifecycleRemainsHostile(t *testing.T) {

--- a/scripts/policy/schema-compat/main.go
+++ b/scripts/policy/schema-compat/main.go
@@ -1239,7 +1239,7 @@ func normalizeSchemaFlagMigrations(
 		}
 		delete(normalizedTool.Parameters, migration.Legacy.Name)
 		if canonicalExisted {
-			if err := validateRenamedSchemaParameter(migration, oldCanonical, newCanonical); err != nil {
+			if err := validateCanonicalSchemaParameter(migration, oldCanonical, newCanonical); err != nil {
 				return schemaContract{}, err
 			}
 			normalizedCanonical := normalizedTool.Parameters[migration.Canonical.Name]
@@ -1306,6 +1306,34 @@ func schemaToolsByPrimaryPath(contract schemaContract, primaryPath string) []sch
 		return matches[i].toolID < matches[j].toolID
 	})
 	return matches
+}
+
+func validateCanonicalSchemaParameter(
+	migration interfacesnapshot.FlagMigration,
+	oldParameter parameterSchema,
+	newParameter parameterSchema,
+) error {
+	if err := validateRenamedSchemaParameter(migration, oldParameter, newParameter); err == nil {
+		return nil
+	}
+	// Match the interface receipt's one narrow requiredness transfer: a
+	// required legacy Primary may promote an already registered hidden optional
+	// canonical alias. Schema has no hidden bit, so the validated interface
+	// before-state is the authority for that fact; every non-requiredness field
+	// must still remain exact.
+	if !migration.Legacy.Before.Required ||
+		!migration.Canonical.Before.Present ||
+		!migration.Canonical.Before.Hidden ||
+		migration.Canonical.Before.Required ||
+		!migration.Canonical.After.Required ||
+		oldParameter.Required || oldParameter.CLIRequired ||
+		!newParameter.Required || !newParameter.CLIRequired {
+		return validateRenamedSchemaParameter(migration, oldParameter, newParameter)
+	}
+	relaxedOld := oldParameter
+	relaxedOld.Required = true
+	relaxedOld.CLIRequired = true
+	return validateRenamedSchemaParameter(migration, relaxedOld, newParameter)
 }
 
 func validateRenamedSchemaParameter(

--- a/scripts/policy/schema-compat/main_test.go
+++ b/scripts/policy/schema-compat/main_test.go
@@ -1442,6 +1442,39 @@ func TestCrossPlatformCoverageSchemaFlagMigrationAdapterBranches(t *testing.T) {
 	if err := validateRenamedSchemaParameter(schemaFlagMigrationAuthorizations()[0], optional, parameterSchema{CLIRequired: true}); err == nil || !strings.Contains(err.Error(), "changed cli_required") {
 		t.Fatalf("direct cli_required promotion error = %v", err)
 	}
+
+	hiddenTransfer := schemaFlagMigrationAuthorizations()[0]
+	hiddenTransfer.Legacy.Before.Required = true
+	hiddenTransfer.Canonical.Before = interfacesnapshot.FlagMigrationState{
+		Present: true,
+		Type:    "string",
+		Hidden:  true,
+		Scope:   "local",
+	}
+	hiddenTransfer.Canonical.After.Required = true
+	if err := validateCanonicalSchemaParameter(
+		hiddenTransfer,
+		optional,
+		parameterSchema{Required: true, CLIRequired: true},
+	); err != nil {
+		t.Fatalf("hidden canonical requiredness transfer error = %v", err)
+	}
+	if err := validateCanonicalSchemaParameter(
+		hiddenTransfer,
+		optional,
+		parameterSchema{Type: `"integer"`, Required: true, CLIRequired: true},
+	); err == nil || !strings.Contains(err.Error(), "non-migration field") {
+		t.Fatalf("hidden canonical semantic drift error = %v", err)
+	}
+	visibleTransfer := hiddenTransfer
+	visibleTransfer.Canonical.Before.Hidden = false
+	if err := validateCanonicalSchemaParameter(
+		visibleTransfer,
+		optional,
+		parameterSchema{Required: true, CLIRequired: true},
+	); err == nil || !strings.Contains(err.Error(), "changed requiredness") {
+		t.Fatalf("visible canonical requiredness promotion error = %v", err)
+	}
 }
 
 func TestCrossPlatformCoverageSchemaFlagMigrationRejectsPartialAndUnrelatedChanges(t *testing.T) {


### PR DESCRIPTION
## Summary

- Allow one narrowly scoped Primary rename case: a required visible legacy flag transfers requiredness to an already registered hidden optional canonical alias.
- Keep all other type, scope, shorthand, no-opt, and Schema fields exact.
- Add hostile coverage so visible canonical flags and unrelated semantic drift remain rejected.
- Preserve the base-owned approval boundary; this PR changes no product command surface and adds no approval receipts.

## Risk tier

- [ ] Documentation-only
- [ ] Standard
- [x] High-risk: interface and Schema compatibility governance

## Why

`main` already contains 34 reviewed IM-ID pending receipts. One receipt (`dws chat message list-topic-replies`) uses this hidden-alias pattern, but the governance merged in #966 rejects the existing record before #968 can be evaluated.

## Verification

- [x] `go test ./internal/interfacesnapshot ./scripts/policy/schema-compat -count=1`: PASS
- [x] `gofmt` and `go vet`: PASS
- [x] Product command/Schema surface is unchanged.
- [x] Migration ledger is unchanged from `main`.
- [ ] Full repository staticcheck: blocked by pre-existing unrelated findings on `main`; no new finding is in the four changed files.
- [x] Release fragment: N/A (governance-only, no user-visible command change)

## Dependencies

- Must merge before #968 and #969.
- Aone requirement: #85349380.
