### PR TITLE
docs: seal v1.0.58-beta.6 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.58-beta.6] - 2026-08-13
+
+### Fixed
+
+- **npm package verification for multi-skill installs** (#991) — aligns the
+  release verifier with the installer’s concrete Agent skill-root selection,
+  preventing valid multi-skill package layouts from failing release delivery.
+
+### Changed
+
+- **Release-seal CI classification** (#987) — recognizes the reviewed
+  CHANGELOG-and-fragment archival shape while retaining release-contract and
+  lifecycle validation, reducing unrelated CI work for release-seal PRs.
+
 ## [1.0.58-beta.5] - 2026-08-13
 
 ### Added


### PR DESCRIPTION
## 发布封板

- 目标版本：`v1.0.58-beta.6`
- 冻结基线：`d52d16dba48028ee1b1324c9bf9bf67ac52680c7`
- 本 PR 仅更新 `CHANGELOG.md`，不包含产品代码。

## 纳入范围

- #991：修复多 Skill npm 包布局的发布校验，避免有效安装布局阻断交付。
- #987：为经过审查的 CHANGELOG 与 fragment 归档封板形态提供严格 CI 分类，同时保留发布契约和生命周期校验。

## 验证

- `git diff --check origin/main...HEAD`
- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`

## 风险与回滚

- 风险限于发布说明文本；如封板停止，可关闭 PR，未创建 tag 或发布产物。