### PR TITLE
OVO-2: fix(chat): build streaming-card mention tags in CLI

### DIFF
--- a/.changes/card-mention-client-placeholder.md
+++ b/.changes/card-mention-client-placeholder.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- `dws chat +messages-send-card` 由 CLI 根据 `openDingTalkId` 生成卡片艾特占位标签，不再依赖 `create_and_send_card` 返回 `atTag`。

--- a/internal/shortcut/chat/chat_message.go
+++ b/internal/shortcut/chat/chat_message.go
@@ -1453,7 +1453,7 @@ var MessagesSendCard = shortcut.Shortcut{
 	Command:     "+messages-send-card",
 	Product:     "im",
 	Description: "创建流式卡片，可在同一次调用中写入内容并结束；群聊创建时可 @成员或 @所有人",
-	Intent:      "当你要发送一张流式文本卡片时使用；群 openConversationId、单聊 userId、单聊 openDingTalkId 严格三选一，分别使用 --group、--receiver、--receiver-open-dingtalk-id。群聊可用 --at-open-dingtalk-ids 或 --at-all 在创建卡片时设置 @对象；同时传 --content 时，Runtime 会把创建响应中的 atTag 自动加在正文前，后续更新不重复传递 @参数。--receiver 始终按 userId 通过通讯录关键词搜索做精确匹配，即使值以 D/d 开头也不会猜成 openDingTalkId；已有 openDingTalkId 时必须用显式参数直传。userId 包括在 --dry-run 时也会先解析。只传目标时创建卡片并返回 bizId，供后续 messages-update-card 流式更新；同时传 --content 时会自动串联创建和更新，默认以 flowStatus=3 完成。当前只支持 streaming text，不支持 Card JSON 组件或 action callback。",
+	Intent:      "当你要发送一张流式文本卡片时使用；群 openConversationId、单聊 userId、单聊 openDingTalkId 严格三选一，分别使用 --group、--receiver、--receiver-open-dingtalk-id。群聊可用 --at-open-dingtalk-ids 或 --at-all 在创建卡片时设置 @对象；同时传 --content 时，Runtime 会用 openDingTalkId 作为显示占位自行生成艾特标签并加在正文前，后续更新不重复传递 @参数，也不依赖创建响应返回 atTag。--receiver 始终按 userId 通过通讯录关键词搜索做精确匹配，即使值以 D/d 开头也不会猜成 openDingTalkId；已有 openDingTalkId 时必须用显式参数直传。userId 包括在 --dry-run 时也会先解析。只传目标时创建卡片并返回 bizId，供后续 messages-update-card 流式更新；同时传 --content 时会自动串联创建和更新，默认以 flowStatus=3 完成。当前只支持 streaming text，不支持 Card JSON 组件或 action callback。",
 	Risk:        shortcut.RiskWrite,
 	Safety: contract.SafetySpec{
 		Effect: "write", Risk: "medium",
@@ -1471,11 +1471,11 @@ var MessagesSendCard = shortcut.Shortcut{
 		Interface: &contract.InterfaceSpec{
 			Mode:         "composite",
 			Availability: "available",
-			Reason:       "Reviewed card lifecycle adapter: it can resolve a userId through contact search with exact matching, call create_and_send_card alone, or compose creation with update_streaming_card after extracting the returned bizId and atTag.",
+			Reason:       "Reviewed card lifecycle adapter: it can resolve a userId through contact search with exact matching, call create_and_send_card alone, or compose creation with update_streaming_card after extracting the returned bizId and generating mention tags from the requested openDingTalkIds.",
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "创建流式卡片，可在同一次调用中写入内容并结束；群聊创建时可 @成员或 @所有人",
-			UseWhen:      []string{"当你要发送一张流式文本卡片时使用；群 openConversationId、单聊 userId、单聊 openDingTalkId 严格三选一，分别使用 --group、--receiver、--receiver-open-dingtalk-id。群聊可用 --at-open-dingtalk-ids 或 --at-all 在创建卡片时设置 @对象；同时传 --content 时，Runtime 会把创建响应中的 atTag 自动加在正文前，后续更新不重复传递 @参数。--receiver 始终按 userId 通过通讯录关键词搜索做精确匹配，即使值以 D/d 开头也不会猜成 openDingTalkId；已有 openDingTalkId 时必须用显式参数直传。userId 包括在 --dry-run 时也会先解析。只传目标时创建卡片并返回 bizId，供后续 messages-update-card 流式更新；同时传 --content 时会自动串联创建和更新，默认以 flowStatus=3 完成。当前只支持 streaming text，不支持 Card JSON 组件或 action callback。"},
+			UseWhen:      []string{"当你要发送一张流式文本卡片时使用；群 openConversationId、单聊 userId、单聊 openDingTalkId 严格三选一，分别使用 --group、--receiver、--receiver-open-dingtalk-id。群聊可用 --at-open-dingtalk-ids 或 --at-all 在创建卡片时设置 @对象；同时传 --content 时，Runtime 会用 openDingTalkId 作为显示占位自行生成艾特标签并加在正文前，后续更新不重复传递 @参数，也不依赖创建响应返回 atTag。--receiver 始终按 userId 通过通讯录关键词搜索做精确匹配，即使值以 D/d 开头也不会猜成 openDingTalkId；已有 openDingTalkId 时必须用显式参数直传。userId 包括在 --dry-run 时也会先解析。只传目标时创建卡片并返回 bizId，供后续 messages-update-card 流式更新；同时传 --content 时会自动串联创建和更新，默认以 flowStatus=3 完成。当前只支持 streaming text，不支持 Card JSON 组件或 action callback。"},
 			AvoidWhen:    []string{"已有 bizId、只需要追加或更新现有卡片内容时使用 +messages-update-card"},
 			Examples: []string{
 				"dws chat +messages-send-card --group <openConversationId> --at-open-dingtalk-ids <openDingTalkId> --content \"任务已完成\"",
@@ -1494,7 +1494,7 @@ var MessagesSendCard = shortcut.Shortcut{
 		{Name: "receiver-open-dingtalk-id", Type: shortcut.FlagString, Desc: "单聊接收者 openDingTalkId（与 --group/--receiver 互斥）；显式直传且不做通讯录解析"},
 		{Name: "at-open-dingtalk-ids", Type: shortcut.FlagStringSlice, Desc: "群聊创建卡片时 @ 的 openDingTalkId 列表；仅随 create_and_send_card 发送；艾特参数仅支持群聊 --group"},
 		{Name: "at-all", Type: shortcut.FlagBool, Desc: "群聊创建卡片时 @ 所有人；仅随 create_and_send_card 发送；艾特参数仅支持群聊 --group"},
-		{Name: "content", Type: shortcut.FlagString, Desc: "创建后立即写入的卡片正文；群聊 @ 时 Runtime 自动前置 create 返回的 atTag；省略时仅创建并返回 bizId"},
+		{Name: "content", Type: shortcut.FlagString, Desc: "创建后立即写入的卡片正文；群聊 @ 时 Runtime 用 openDingTalkId 显示占位自动生成并前置艾特标签；省略时仅创建并返回 bizId"},
 		{Name: "flow-status", Type: shortcut.FlagInt, Default: "3", Desc: "自动更新状态：1处理中/2输入中/3完成/4执行中/5错误；--flow-status 必须在 1-5 之间，且显式指定时必须同时提供 --content"},
 	},
 	Constraints: []shortcut.Constraint{
@@ -1531,18 +1531,19 @@ var MessagesSendCard = shortcut.Shortcut{
 		receiver := rt.Str("receiver")
 		receiverOpenID := rt.Str("receiver-open-dingtalk-id")
 		params := map[string]any{}
-		mentionsRequested := false
+		mentionTags := ""
 		switch {
 		case group != "":
 			params["openConversationId"] = group
-			if atOpenIDs := uniqueShortcutStrings(rt.StrSlice("at-open-dingtalk-ids")); len(atOpenIDs) > 0 {
+			atOpenIDs := uniqueShortcutStrings(rt.StrSlice("at-open-dingtalk-ids"))
+			if len(atOpenIDs) > 0 {
 				params["atOpenDingTalkIds"] = atOpenIDs
-				mentionsRequested = true
 			}
-			if rt.Bool("at-all") {
+			atAll := rt.Bool("at-all")
+			if atAll {
 				params["atAll"] = true
-				mentionsRequested = true
 			}
+			mentionTags = buildCardMentionPlaceholderTags(atOpenIDs, atAll)
 		case receiver != "":
 			openID, err := resolveUserOpenDingTalkID(rt, receiver)
 			if err != nil {
@@ -1579,10 +1580,6 @@ var MessagesSendCard = shortcut.Shortcut{
 		}
 		status := rt.Int("flow-status")
 		if rt.DryRun() {
-			plannedContent := content
-			if mentionsRequested {
-				plannedContent = "<atTag from create_and_send_card>" + content
-			}
 			return rt.Output(map[string]any{
 				"contractVersion": currentCardWorkflowContract.Version,
 				"dry_run":         true,
@@ -1599,7 +1596,7 @@ var MessagesSendCard = shortcut.Shortcut{
 						"tool": "update_streaming_card",
 						"arguments": map[string]any{
 							"bizId":      "<from create_and_send_card>",
-							"msgContent": plannedContent,
+							"msgContent": mentionTags + content,
 							"flowStatus": status,
 						},
 					},
@@ -1614,13 +1611,9 @@ var MessagesSendCard = shortcut.Shortcut{
 		if bizID == "" {
 			return fmt.Errorf("卡片已创建但下层未返回 bizId，无法自动更新；请检查 create_and_send_card 响应")
 		}
-		atTag := findCardAtTag(created)
-		if mentionsRequested && atTag == "" {
-			return fmt.Errorf("卡片已创建（bizId=%s），但下层未返回 atTag，无法保证请求的 @ 生效；未执行自动更新", bizID)
-		}
 		updated, err := rt.CallMCPWriteData("im", "update_streaming_card", map[string]any{
 			"bizId":      bizID,
-			"msgContent": atTag + content,
+			"msgContent": mentionTags + content,
 			"flowStatus": status,
 		})
 		if err != nil {
@@ -1641,8 +1634,19 @@ func findCardBizID(value any) string {
 	return strings.TrimSpace(findCardResponseString(value, []string{"bizId", "bizID", "biz_id"}))
 }
 
-func findCardAtTag(value any) string {
-	return findCardResponseString(value, []string{"atTag"})
+func buildCardMentionPlaceholderTags(atOpenDingTalkIDs []string, atAll bool) string {
+	var tags strings.Builder
+	for _, openID := range uniqueShortcutStrings(atOpenDingTalkIDs) {
+		tags.WriteString("<a atId=")
+		tags.WriteString(openID)
+		tags.WriteString(">")
+		tags.WriteString(openID)
+		tags.WriteString("</a> ")
+	}
+	if atAll {
+		tags.WriteString("<a atId=10>所有人</a> ")
+	}
+	return tags.String()
 }
 
 func findCardResponseString(value any, directKeys []string) string {

--- a/internal/shortcut/chat/gap_fill_test.go
+++ b/internal/shortcut/chat/gap_fill_test.go
@@ -763,6 +763,7 @@ func TestCrossPlatformCoverageMessagesSendTextModesAndExecuteGuard(t *testing.T)
 
 func TestCrossPlatformCoverageMessagesSendCardOneCallLifecycle(t *testing.T) {
 	fake := &larkAlignmentCaller{responses: map[string]string{
+		// Legacy servers may still return atTag. Runtime intentionally ignores it.
 		"im/create_and_send_card":  `{"result":{"card":{"biz_id":"biz-1","atTag":"<a atId=D-one>甲</a> <a atId=D-two>乙</a> "}}}`,
 		"im/update_streaming_card": `{"result":{"updated":true}}`,
 	}}
@@ -799,7 +800,7 @@ func TestCrossPlatformCoverageMessagesSendCardOneCallLifecycle(t *testing.T) {
 		t.Fatalf("card update leaked atAll: %#v", fake.calls[1].args)
 	}
 	if fake.calls[1].args["bizId"] != "biz-1" ||
-		fake.calls[1].args["msgContent"] != "<a atId=D-one>甲</a> <a atId=D-two>乙</a> 完成" ||
+		fake.calls[1].args["msgContent"] != "<a atId=D-one>D-one</a> <a atId=D-two>D-two</a> <a atId=10>所有人</a> 完成" ||
 		fake.calls[1].args["flowStatus"] != 3 {
 		t.Fatalf("card update args = %#v", fake.calls[1].args)
 	}
@@ -833,9 +834,10 @@ func TestCrossPlatformCoverageMessagesSendCardKeepsContentWithoutAtTag(t *testin
 	}
 }
 
-func TestCrossPlatformCoverageMessagesSendCardRejectsMissingRequestedAtTag(t *testing.T) {
+func TestCrossPlatformCoverageMessagesSendCardDoesNotRequireServerAtTag(t *testing.T) {
 	fake := &larkAlignmentCaller{responses: map[string]string{
-		"im/create_and_send_card": `{"result":{"bizId":"biz-missing-at-tag"}}`,
+		"im/create_and_send_card":  `{"result":{"bizId":"biz-without-at-tag"}}`,
+		"im/update_streaming_card": `{"result":{"updated":true}}`,
 	}}
 	helpers.InitDeps(fake)
 	root := newPlatformCoverageRoot()
@@ -846,12 +848,14 @@ func TestCrossPlatformCoverageMessagesSendCardRejectsMissingRequestedAtTag(t *te
 		"--content", "正文",
 		"--yes",
 	})
-	err := root.Execute()
-	if err == nil || !strings.Contains(err.Error(), "biz-missing-at-tag") || !strings.Contains(err.Error(), "atTag") {
-		t.Fatalf("error = %v, want recoverable missing-atTag error containing bizId", err)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
 	}
-	if len(fake.calls) != 1 || fake.calls[0].tool != "create_and_send_card" {
-		t.Fatalf("card calls = %#v, want create only", fake.calls)
+	if len(fake.calls) != 2 || fake.calls[1].tool != "update_streaming_card" {
+		t.Fatalf("card calls = %#v, want create then update", fake.calls)
+	}
+	if got := fake.calls[1].args["msgContent"]; got != "<a atId=D-mentioned>D-mentioned</a> 正文" {
+		t.Fatalf("card update content = %#v", got)
 	}
 }
 
@@ -999,7 +1003,7 @@ func TestCrossPlatformCoverageMessagesSendCardDryRunAndFailureBoundaries(t *test
 		if _, exists := updateArguments["atAll"]; exists {
 			t.Fatalf("card update dry-run leaked atAll: %#v", updateArguments)
 		}
-		if updateArguments["msgContent"] != "<atTag from create_and_send_card>处理中" {
+		if updateArguments["msgContent"] != "<a atId=D-mentioned>D-mentioned</a> <a atId=10>所有人</a> 处理中" {
 			t.Fatalf("card update dry-run content = %#v", updateArguments["msgContent"])
 		}
 	})
@@ -1249,20 +1253,19 @@ func TestCrossPlatformCoverageFindCardBizIDResponseShapes(t *testing.T) {
 	}
 }
 
-func TestCrossPlatformCoverageFindCardAtTagResponseShapes(t *testing.T) {
+func TestCrossPlatformCoverageBuildCardMentionPlaceholderTags(t *testing.T) {
 	for _, tc := range []struct {
-		value any
+		ids   []string
+		atAll bool
 		want  string
 	}{
-		{map[string]any{"atTag": "<a atId=D-direct>甲</a> "}, "<a atId=D-direct>甲</a> "},
-		{map[string]any{"result": map[string]any{"atTag": "<a atId=D-nested>乙</a> "}}, "<a atId=D-nested>乙</a> "},
-		{`{"result":{"card":{"atTag":"<a atId=D-json>丙</a> "}}}`, "<a atId=D-json>丙</a> "},
-		{map[string]any{"atTag": "  "}, ""},
-		{map[string]any{"atTag": 42}, ""},
-		{map[string]any{"result": map[string]any{"created": true}}, ""},
+		{ids: []string{"D-one", "D-two", "D-one"}, atAll: true, want: "<a atId=D-one>D-one</a> <a atId=D-two>D-two</a> <a atId=10>所有人</a> "},
+		{ids: []string{"", " D-one "}, want: "<a atId=D-one>D-one</a> "},
+		{atAll: true, want: "<a atId=10>所有人</a> "},
+		{},
 	} {
-		if got := findCardAtTag(tc.value); got != tc.want {
-			t.Errorf("findCardAtTag(%#v) = %q, want %q", tc.value, got, tc.want)
+		if got := buildCardMentionPlaceholderTags(tc.ids, tc.atAll); got != tc.want {
+			t.Errorf("buildCardMentionPlaceholderTags(%#v, %v) = %q, want %q", tc.ids, tc.atAll, got, tc.want)
 		}
 	}
 }

--- a/skills/mono/references/intent-guide.md
+++ b/skills/mono/references/intent-guide.md
@@ -296,6 +296,7 @@ dws chat +messages-send --as user --open-dingtalk-id <openDingTalkId> --msg-type
 - 单聊已有 userId 时使用 `--receiver <userId>`，CLI 始终通过通讯录关键词搜索并按 userId 精确匹配 openDingTalkId；即使 userId 以 D/d 开头也不会猜测类型，`--dry-run` 也会执行该解析。
 - 单聊已有 openDingTalkId 时必须显式使用 `--receiver-open-dingtalk-id <openDingTalkId>`，避免与 userId 混淆。
 - `--group`、`--receiver`、`--receiver-open-dingtalk-id` 严格三选一；传 `--content` 可在同一次调用中创建并结束卡片。
+- 群聊艾特由 Runtime 用 openDingTalkId 显示占位生成标签，不依赖创建响应返回 `atTag`；调用方不要手写占位符。
 
 **用 `chat +messages-send --as bot` 的场景**：
 - "让机器人在群里发一条通知" — **机器人身份**发消息

--- a/skills/multi/dingtalk-chat/SKILL.md
+++ b/skills/multi/dingtalk-chat/SKILL.md
@@ -75,7 +75,7 @@ metadata:
 - `+messages-send`：文件、Bot、Webhook、复杂 @ 或幂等控制。user 已知 ID 可直接传，也可用 `--user-query` / `--chat-query` 运行同一只读解析链；Bot 多群使用 `--groups/--groups-file`，返回 `im.batch-write.v1`；bot/webhook 只使用下层真实支持的文本/Markdown 能力。
 - 文件直接传 `+messages-send --file <相对路径>`；不要先独立上传并提取 mediaId。
 - Webhook 使用 `+messages-send --as webhook --webhook-token <token>`；不要退回原子 Webhook 命令。
-- 流式卡片用 `+messages-send-card`；群聊@传 ID/`--at-all`，Runtime 把 create 返回前缀加到 `--content`；禁写占位符；仅 text。
+- 流式卡片用 `+messages-send-card`；群聊@传 ID/`--at-all`，Runtime 用 openDingTalkId 显示占位生成标签并加到 `--content`，不依赖 create 返回 `atTag`；禁手写占位符；仅 text。
 
 ## 关键结果语义
 

--- a/skills/multi/dingtalk-chat/references/card/create.md
+++ b/skills/multi/dingtalk-chat/references/card/create.md
@@ -8,9 +8,9 @@ Runtime 会唯一解析为 openDingTalkId；已有 openDingTalkId 时传
 - 同时传 `--content`：Runtime 串行执行 create → 从返回提取 `bizId` → update；默认
   `--flow-status 3`。
 - 群聊可传 `--at-open-dingtalk-ids` 或 `--at-all`；艾特对象只进入初始
-  `create_and_send_card`。同一次调用带 `--content` 时，Runtime 将 create 返回的
-  `atTag` 自动加在正文前，再调用 `update_streaming_card`；调用方不要拼 ID
-  或艾特占位符。
+  `create_and_send_card`。同一次调用带 `--content` 时，Runtime 用 openDingTalkId
+  作为显示占位生成艾特标签并加在正文前，再调用 `update_streaming_card`；不依赖
+  create 返回 `atTag`，调用方不要手写 ID 或艾特占位符。
 - `--dry-run` 仍执行只读 userId 解析，只输出两步计划，不执行写入。
 
 自动更新结果不确定时，不要再次更新或重复创建；保留返回结果并告知用户。若结果中已经

--- a/skills/multi/dingtalk-chat/references/chat/chat-message.md
+++ b/skills/multi/dingtalk-chat/references/chat/chat-message.md
@@ -300,7 +300,8 @@ dws chat +messages-update-card --biz-id <bizId> --content "最终内容" --flow-
 
 `flow-status`：1=处理中，2=输入中，3=完成，4=执行中，5=错误，Runtime 拒绝范围外值。
 群聊还可传 `--at-all`；两种艾特参数只随创建请求发送。send-card 同时带正文时，
-Runtime 会把创建响应的 `atTag` 自动放在正文前；不要自行写 ID 或占位符。
+Runtime 会用 openDingTalkId 作为显示占位生成艾特标签并放在正文前，不依赖创建响应
+返回 `atTag`；不要自行写 ID 或占位符。
 当前只支持 streaming text；不支持 Card JSON 组件或 action callback。精确边界见
 [card references](../card/schema.md)。
 


### PR DESCRIPTION
## Summary

- Build streaming-card mention tags in `chat +messages-send-card` from the requested `openDingTalkId` values, using each ID as its visible placeholder.
- Preserve the existing `create_and_send_card` mention arguments, but stop consuming the optional server `atTag` response before `update_streaming_card`.
- Keep the historical `<a atId=10>所有人</a>` tag for `--at-all`, and update Help/Schema declarations, Chat Skill guidance, tests, and the release fragment.
- This is needed so production and pre-production behave consistently while the server-side `atTag` response is removed and nickname rendering moves downstream.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [x] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

Record the smallest targeted evidence that proves the changed behavior. Do not
repeat the entire CI suite locally only to fill this checklist: CI expands the
selected tier from documentation checks, through affected-package tests, to
the complete high-risk suite.

- [x] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`):
  `.changes/card-mention-client-placeholder.md`
- [ ] Release-seal validation (otherwise `N/A`): N/A — ordinary implementation PR.
- [x] Targeted test/check commands and results:
  - `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/shortcut/chat -run '^TestCrossPlatformCoverage(MessagesSendCard|BuildCardMentionPlaceholderTags)' -count=1` — passed.
  - `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/shortcut/chat -count=1` — passed with local loopback enabled for the existing `httptest` case.
  - `make build` — passed.
  - `make generate-schema` — passed with no generated diff.
  - `make skill-context-budget` — passed (`chat_bytes=10257`, max `10500`).
  - `./scripts/policy/check-generated-drift.sh` — passed.
  - `./scripts/policy/check-schema-catalog.sh` — passed.
  - `./scripts/policy/check-release-fragments.sh upstream/main HEAD` — passed.
- [x] Behavior evidence (test name, CLI output shape, or before/after result): current-head `--dry-run` emits `msgContent` as `<a atId=D-one>D-one</a> <a atId=D-two>D-two</a> <a atId=10>所有人</a> 正文`; tests also prove a missing server `atTag` continues to the update and a legacy returned `atTag` is ignored.
- [ ] Documentation links/content/rendering checked (documentation-only, otherwise
  `N/A`): N/A — Help and both Chat Skill forms were checked through focused policy/build commands.
- [ ] Full local suite run because the change is high-risk (optional for other
  tiers; record command/result or `N/A`): N/A — Standard tier; focused package tests and CI expansion are used.
- [x] `./scripts/policy/check-generated-drift.sh`
  (when generator inputs or generated artifacts may change)
- [ ] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed): N/A — no path, flag, alias, or parameter mapping changed.
- [ ] `./scripts/release/verify-package-managers.sh`
  (after `make package`, if packaging or installer surfaces changed): N/A — no packaging or installer changes.

## Notes

- `create_and_send_card` and `update_streaming_card` remain the two required writes; this change removes only the intermediate server-response dependency on `atTag`.
- The atomic `chat message send-card` command remains create-only and is unchanged.
- No server repository changes are included.
- Keep this PR Draft until the author explicitly approves promotion to Ready.

The repository automatically requests one eligible peer reviewer, including
after a new head push when another review is needed. Once the latest push has
peer approval and all nine required checks are current and green, auto-merge
completes the PR; authors do not need to coordinate a separate routine merge.
