### PR TITLE
fix(corecmd,shortcut): make a source-loaded payload authoritative (follow-up to #1017)

### DIFF
--- a/docs/rfc-command-framework-convergence.md
+++ b/docs/rfc-command-framework-convergence.md
@@ -707,8 +707,10 @@ Flags: []shortcut.Flag{
 
 - 声明即全部能力：required/enum/约束/Validate 校验的已是解析后的真实内容，`Execute`/`Invoke` 无需任何额外代码。
 - `Usage`/`Desc` 必须写明支持 `@路径`/`-`；框架不自动改写 help 文案，今日也不向 Schema 投影（新增投影字段须先过 homology 评审，避免 catalog drift）。
-- `user_required` 确认的写命令若声明 `InputStdin`：stdin 在校验阶段被消费，交互确认将 fail-closed 为 `confirmation_required`，此类调用必须显式 `--yes`（或 `--dry-run`）。
+- `user_required` 确认的写命令若声明 `InputStdin`：stdin 在校验阶段被消费，交互确认随后读到 EOF 并 fail-closed 为 `confirmation_required`（已有回归测试钉住），此类调用必须显式 `--yes`（或 `--dry-run`）。**`ConfirmFirst` + `InputStdin` 在构造期直接 panic**：该顺序下确认发生在解析之前，提示会把管道里的 payload 当成答复——首行是 `yes` 的 payload 足以授权一次破坏性操作，而 flag 本身反而拿到空值（数据被当作控制通道）。需要 guard-first 语义时改用默认顺序并要求 `--yes`。
 - **声明前先确认取值空间不会被前缀吃掉**：声明 `InputFile` 后，任何以 `@` 开头的合法值都会被当成文件路径（本产品尤其常见的是 at 提及类取值，如 `--at-user @zhangsan` 会报读取文件失败），用户只能改用 `@@` 转义；声明 `InputStdin` 后字面值 `-` 不可达（与 curl 等约定一致）。若该 flag 的正常取值可能命中这两种形态，就不要声明对应来源。
+- **空载荷原样抵达（端到端）**：从 `@文件`/stdin 解析出的取值被标记为「来源已解析」，该权威贯穿整条流水线——`rawValue` 原样返回（即使为空，不回退到别名/环境/`Default`）；约束判定把它算作「已提供」（`at_least_one`/`exactly_one` 不会因载荷为空而误判未提供）；`BuildArgs` 的 `ArgDefault` 不再二次替换它。因此「用空文件清空某字段」在声明了 `Default`/`ArgDefault` 时也成立。内联的空值仍按既有语义回退。三个例外：必填 flag 遇空载荷照常报「不能为空」；`OmitEmpty` 丢弃空载荷；声明了 `Transform` 时空载荷经 `emptyTransformResult` 收敛后该键被跳过——后两者是作者显式声明的载荷规则（省略/转换），不是把值静默换成别的东西。若空载荷必须作为 `""` 抵达后端，就不要在同一 flag 上声明 `OmitEmpty`/`Transform`。
+- **Shortcut 路径已对齐同一不变量**（`Input` 的主要落地面）：`RuntimeContext.Str` 对已解析的 payload 原样返回（不再 `TrimSpace`，避免破坏校验和/结尾换行等字节精确内容），内联取值仍保持历史的无条件 trim，故既有命令行为不变；`StrFirst` 遇到显式提供的 payload 立即采用（即使为空），不会回退到别名；`rt.InputResolvedFromSource(name)` 为类型化访问器，供领域 guard 跳过形态启发式。
 - 声明在构造期校验（fail-closed panic）：仅限 `KindString`；源值必须是 `file`/`stdin` 且不重复。
 
 **今日实现与目标形态的差异**（迁移到本节目标 `FlagSpec` 时收敛）：
@@ -718,6 +720,7 @@ Flags: []shortcut.Flag{
 | 源类型 | `[]string` 常量 | 类型化 `InputSource` |
 | 路径边界 | 直接本地文件 IO | 复用 §5.5.2 本地文件 effect 边界 |
 | Schema 投影 | 无（靠作者在 Usage 声明） | 声明即最终源，随 Catalog 透传 |
+| 「来源已解析」标记 | 运行时 cobra flag 注解（非 `dws.schema.*`，每次调用先重置），经 `corecmd.InputResolvedFromSource(cmd, name)` / `Ctx.InputResolvedFromSource(name)` / `rt.InputResolvedFromSource(name)` 读取；同时让空载荷在回退链中保持权威。**成立前提**：一个命令对象同一时刻只有一次执行在飞（今日 CLI 与测试均满足；`dws mcp` 只是连接信息管理命令，不是并发派发器） | 由 §5.4 的类型化 `ResolvedValues` / `ValueMeta` 携带来源，不再借用 flag 注解存运行时状态——这也是引入进程内并发派发时必须先完成的前置 |
 
 核心 FlagSpec 故意没有：
 

--- a/internal/corecmd/corecmd.go
+++ b/internal/corecmd/corecmd.go
@@ -352,6 +352,13 @@ func (c *Ctx) StrSlice(name string) []string {
 // Changed reports whether the user explicitly passed the flag.
 func (c *Ctx) Changed(name string) bool { return c.cmd.Flags().Changed(name) }
 
+// InputResolvedFromSource reports whether the flag's value was loaded from
+// @file or stdin rather than typed inline. Guards applying shape heuristics to
+// inline values must skip resolved ones; see the package-level function.
+func (c *Ctx) InputResolvedFromSource(name string) bool {
+	return InputResolvedFromSource(c.cmd, name)
+}
+
 // DryRun reports the effective global --dry-run.
 func (c *Ctx) DryRun() bool { return BoolFlag(c.cmd, "dry-run") }
 
@@ -374,7 +381,7 @@ func New(spec Spec) *cobra.Command {
 	validateDispatchDecl(spec)
 	validateSafetySpec(spec)
 	validateContractDecl(spec)
-	validateInputSpecs(spec.Use, spec.Flags)
+	validateInputSpecs(spec)
 	// Help prose inherits the declaration when not authored separately:
 	// Selection.Examples (already contract-validated against the real flags)
 	// double as the --help Example block, keeping one authored source.
@@ -939,7 +946,9 @@ func BuildArgs(cmd *cobra.Command, flags []FlagSpec) (map[string]any, error) {
 			continue
 		}
 		effective := EffectiveValue(cmd, flag)
-		if effective == "" && flag.ArgDefault != "" {
+		// ArgDefault must not re-substitute an authoritative source-loaded
+		// payload; rawValue deliberately returned it verbatim, empty included.
+		if effective == "" && flag.ArgDefault != "" && !inputResolvedAny(cmd, flag) {
 			effective = flag.ArgDefault
 		}
 		if effective == "" && flag.OmitEmpty {
@@ -1005,13 +1014,19 @@ func EffectiveValue(cmd *cobra.Command, flag FlagSpec) string {
 // explicitly provided (Changed) and non-empty; the registration default is
 // demoted to a chain tail and no longer shadows aliases/env. When Trim is set,
 // candidates are judged empty after trimming, so whitespace-only and empty fall
-// through to the next fallback level.
+// through to the next fallback level. Exception: a value loaded from @file /
+// stdin (FlagSpec.Input) is authoritative and returned verbatim even when
+// empty — the user pointed at that source explicitly, so substituting an
+// alias/env/Default value would ship something they did not ask for.
 func rawValue(cmd *cobra.Command, flag FlagSpec) string {
 	usable := func(v string) bool {
 		if flag.Trim {
 			v = strings.TrimSpace(v)
 		}
 		return v != ""
+	}
+	if cmd.Flags().Changed(flag.Name) && InputResolvedFromSource(cmd, flag.Name) {
+		return flagString(cmd, flag.Kind, flag.Name)
 	}
 	if cmd.Flags().Changed(flag.Name) {
 		if v := flagString(cmd, flag.Kind, flag.Name); usable(v) {
@@ -1021,6 +1036,9 @@ func rawValue(cmd *cobra.Command, flag FlagSpec) string {
 	for _, alias := range flag.Aliases {
 		if !cmd.Flags().Changed(alias) {
 			continue
+		}
+		if InputResolvedFromSource(cmd, alias) {
+			return flagString(cmd, flag.Kind, alias)
 		}
 		if v := flagString(cmd, flag.Kind, alias); usable(v) {
 			return v
@@ -1101,6 +1119,12 @@ func ValidateConstraintDecls(use string, flags []FlagSpec, constraints []Constra
 // counts Changed on any declared name (booleans have no env fallback
 // semantics).
 func constraintProvided(cmd *cobra.Command, flag FlagSpec) bool {
+	// An explicitly supplied source-loaded payload counts as provided even when
+	// empty: the user did point at a file/stdin, and rawValue already treats
+	// that value as authoritative.
+	if inputResolvedAny(cmd, flag) {
+		return true
+	}
 	switch flag.Kind {
 	case KindBool:
 		return flagNameProvided(cmd, flag)

--- a/internal/corecmd/input.go
+++ b/internal/corecmd/input.go
@@ -40,32 +40,105 @@ const (
 // cannot corrupt the first CSV cell or break JSON parsing downstream.
 const utf8BOM = "\ufeff"
 
+// inputResolvedAnnotation marks a flag whose value was loaded from @file or
+// stdin during this invocation. The key deliberately avoids the dws.schema.*
+// prefix: it is per-invocation runtime state, not a published Schema fact, and
+// schema assembly only reads dws.schema.* keys.
+const inputResolvedAnnotation = "dws.runtime.input_resolved"
+
+// markInputResolved records that name's value came from an external source.
+func markInputResolved(cmd *cobra.Command, name string) {
+	_ = cmd.Flags().SetAnnotation(name, inputResolvedAnnotation, []string{"true"})
+}
+
+// resetInputResolved clears the markers a previous run left behind. The marker
+// is mutable state on the shared cobra command object, which is correct because
+// a command object has at most one invocation in flight; reset covers
+// sequential reuse (a test or wrapper executing the same object twice), where an
+// earlier @file call would otherwise keep making a later inline value look
+// source-loaded and authoritative. A future in-process concurrent dispatcher
+// must carry this provenance in per-invocation state instead of the annotation.
+func resetInputResolved(cmd *cobra.Command, flags []FlagSpec) {
+	for _, flag := range flags {
+		if len(flag.Input) == 0 {
+			continue
+		}
+		for _, name := range append([]string{flag.Name}, flag.Aliases...) {
+			// SetAnnotation only errors for an unregistered flag; RegisterFlags
+			// registers the main name and every declared alias.
+			_ = cmd.Flags().SetAnnotation(name, inputResolvedAnnotation, nil)
+		}
+	}
+}
+
+// InputResolvedFromSource reports whether the named flag's value was loaded
+// from @file or stdin rather than typed inline. A domain guard that applies
+// shape heuristics to inline values ("this looks like a path — did you forget
+// the @?") must skip resolved values: their content was already read from the
+// right place and may legitimately look like anything, including a path.
+// Without this bit such a guard re-rejects correct @file / stdin invocations,
+// because by the time Validate runs both arrive as plain text.
+func InputResolvedFromSource(cmd *cobra.Command, name string) bool {
+	if cmd == nil {
+		return false
+	}
+	flag := cmd.Flags().Lookup(name)
+	return flag != nil && len(flag.Annotations[inputResolvedAnnotation]) > 0
+}
+
+// inputResolvedAny reports whether any declared name of the flag carried a
+// source-loaded payload this invocation. Later pipeline stages (constraint
+// provision, args assembly) consult it so the "a source-loaded payload is
+// authoritative" rule holds end to end and not only inside rawValue.
+func inputResolvedAny(cmd *cobra.Command, flag FlagSpec) bool {
+	if len(flag.Input) == 0 {
+		return false
+	}
+	for _, name := range append([]string{flag.Name}, flag.Aliases...) {
+		if cmd.Flags().Changed(name) && InputResolvedFromSource(cmd, name) {
+			return true
+		}
+	}
+	return false
+}
+
 // validateInputSpecs rejects malformed Input declarations at build time. Like
 // the other declaration checks this panics: a bad Input spec is a programming
 // error every test and startup path should trip immediately.
-func validateInputSpecs(use string, flags []FlagSpec) {
-	for _, flag := range flags {
+func validateInputSpecs(spec Spec) {
+	for _, flag := range spec.Flags {
 		if len(flag.Input) == 0 {
 			continue
 		}
 		if flag.Kind != KindString {
 			panic(fmt.Sprintf(
 				"command %q flag %q: Input is only supported on KindString flags",
-				use, flag.Name))
+				spec.Use, flag.Name))
 		}
 		seen := map[string]bool{}
 		for _, source := range flag.Input {
 			if source != InputFile && source != InputStdin {
 				panic(fmt.Sprintf(
 					"command %q flag %q: unknown Input source %q (allowed: %s, %s)",
-					use, flag.Name, source, InputFile, InputStdin))
+					spec.Use, flag.Name, source, InputFile, InputStdin))
 			}
 			if seen[source] {
 				panic(fmt.Sprintf(
 					"command %q flag %q: duplicate Input source %q",
-					use, flag.Name, source))
+					spec.Use, flag.Name, source))
 			}
 			seen[source] = true
+		}
+		// ConfirmFirst confirms before resolution, so the prompt would read the
+		// piped payload as its answer: a payload whose first line is "yes"
+		// authorizes the operation while the flag itself ends up empty — data
+		// acting as a control channel. The default ordering is safe because
+		// resolution consumes stdin first and the prompt then fails closed with
+		// confirmation_required.
+		if spec.ConfirmFirst && inputSupports(flag, InputStdin) {
+			panic(fmt.Sprintf(
+				"command %q flag %q: ConfirmFirst cannot be combined with Input %q: the confirmation prompt would consume the piped payload and a payload starting with \"yes\" would authorize the operation; drop ConfirmFirst and require --yes instead",
+				spec.Use, flag.Name, InputStdin))
 		}
 	}
 }
@@ -112,14 +185,17 @@ func explicitInputFlagName(cmd *cobra.Command, flag FlagSpec) string {
 //   - "@@value" escapes to the literal "@value" and is not source-resolved.
 //
 // Resolution runs once per invocation inside runDeclaredPreflight. It
-// rewrites the cobra flag value in place (Set keeps Changed=true), so
-// fallback-chain readers (EffectiveValue/BuildArgs) observe the content.
+// rewrites the cobra flag value in place (Set keeps Changed=true) and marks the
+// flag as source-resolved, so fallback-chain readers (EffectiveValue/BuildArgs)
+// observe the content verbatim — including an empty payload, which stays
+// authoritative instead of falling back to an alias/env/Default value.
 //
 // Interaction with confirmation: stdin is consumed here, before the Safety
 // prompt of a user_required write would read it; such an interactive prompt
 // then sees EOF and fails closed with confirmation_required. Write commands
 // declaring InputStdin must be invoked with --yes (or --dry-run).
 func resolveInputFlags(cmd *cobra.Command, flags []FlagSpec) error {
+	resetInputResolved(cmd, flags)
 	stdinConsumed := false
 	for _, flag := range flags {
 		if len(flag.Input) == 0 {
@@ -157,6 +233,7 @@ func resolveInputFlags(cmd *cobra.Command, flags []FlagSpec) error {
 			}
 			// Setting a registered string flag cannot fail.
 			_ = cmd.Flags().Set(name, strings.TrimPrefix(string(data), utf8BOM))
+			markInputResolved(cmd, name)
 
 		case strings.HasPrefix(raw, "@@"):
 			// Escape: strip the first @, keep the rest as a literal inline value.
@@ -185,6 +262,7 @@ func resolveInputFlags(cmd *cobra.Command, flags []FlagSpec) error {
 					fmt.Sprintf("参数 --%s 读取文件 %q 失败：%v", flag.Name, path, err), opts...)
 			}
 			_ = cmd.Flags().Set(name, strings.TrimPrefix(string(data), utf8BOM))
+			markInputResolved(cmd, name)
 		}
 	}
 	return nil

--- a/internal/corecmd/input_test.go
+++ b/internal/corecmd/input_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
 )
 
 // newInputCommand builds a Spec whose Invoke captures toolArgs, so tests can
@@ -110,6 +112,276 @@ func TestCrossPlatformCoverageResolveInputFlagsBOMStripped(t *testing.T) {
 	if got["content"] != "{\"a\":1}" {
 		t.Fatalf("toolArgs[content] = %q", got["content"])
 	}
+}
+
+// A payload loaded from a source is authoritative: an empty file must reach
+// toolArgs verbatim rather than being replaced by the declared Default, because
+// the user pointed at that file explicitly (e.g. clearing a field).
+func TestCrossPlatformCoverageResolveInputFlagsEmptyPayloadIsAuthoritative(t *testing.T) {
+	var got map[string]any
+	cmd := newInputCommand([]FlagSpec{
+		{Name: "content", Usage: "C", Bind: "content", Default: "FALLBACK", Input: []string{InputFile}},
+	}, &got)
+	path := writeInputFile(t, "")
+
+	if err := runInputCommand(t, cmd, "--content", "@"+path); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got["content"] != "" {
+		t.Fatalf("toolArgs[content] = %q, want the empty payload", got["content"])
+	}
+}
+
+// Same authority through a declared alias.
+func TestCrossPlatformCoverageResolveInputFlagsEmptyPayloadViaAlias(t *testing.T) {
+	var got map[string]any
+	cmd := newInputCommand([]FlagSpec{
+		{Name: "content", Usage: "C", Bind: "content", Default: "FALLBACK",
+			Aliases: []string{"body"}, Input: []string{InputFile}},
+	}, &got)
+	path := writeInputFile(t, "")
+
+	if err := runInputCommand(t, cmd, "--body", "@"+path); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got["content"] != "" {
+		t.Fatalf("toolArgs[content] = %q, want the empty payload", got["content"])
+	}
+}
+
+// The resolved-source bit is true only for genuinely source-loaded values, so a
+// domain guard can skip shape heuristics without re-rejecting correct @file use.
+func TestCrossPlatformCoverageInputResolvedFromSourceReportsProvenance(t *testing.T) {
+	path := writeInputFile(t, "payload")
+	cases := []struct {
+		name     string
+		value    string
+		resolved bool
+	}{
+		{"file", "@" + path, true},
+		{"inline", "plain", false},
+		{"escaped", "@@plain", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var seen, seenViaCtx bool
+			cmd := New(Spec{
+				Use: "t", Short: "t",
+				Flags: []FlagSpec{{Name: "content", Usage: "C", Bind: "content", Input: []string{InputFile}}},
+				Invoke: func(c *Ctx, toolArgs map[string]any) error {
+					seen = InputResolvedFromSource(c.Command(), "content")
+					seenViaCtx = c.InputResolvedFromSource("content")
+					return nil
+				},
+			})
+			if err := runInputCommand(t, cmd, "--content", tc.value); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if seen != tc.resolved || seenViaCtx != tc.resolved {
+				t.Fatalf("resolved = %v (ctx %v), want %v", seen, seenViaCtx, tc.resolved)
+			}
+		})
+	}
+	if InputResolvedFromSource(nil, "content") {
+		t.Fatal("nil command must not report a resolved flag")
+	}
+}
+
+// A command object can be executed more than once (a test or wrapper reusing
+// it), so a marker from an earlier @file call must not make a later inline
+// value authoritative.
+func TestCrossPlatformCoverageInputResolvedMarkerIsPerInvocation(t *testing.T) {
+	var got map[string]any
+	cmd := newInputCommand([]FlagSpec{
+		{Name: "content", Usage: "C", Bind: "content", Default: "FALLBACK",
+			Aliases: []string{"body"}, Input: []string{InputFile}},
+	}, &got)
+	path := writeInputFile(t, "")
+
+	if err := runInputCommand(t, cmd, "--content", "@"+path); err != nil {
+		t.Fatalf("first execute: %v", err)
+	}
+	if got["content"] != "" {
+		t.Fatalf("first invocation toolArgs[content] = %q", got["content"])
+	}
+
+	// Reuse the same command with an inline empty value: no source was read, so
+	// the declared Default applies again.
+	if err := runInputCommand(t, cmd, "--content", ""); err != nil {
+		t.Fatalf("second execute: %v", err)
+	}
+	if got["content"] != "FALLBACK" {
+		t.Fatalf("second invocation toolArgs[content] = %q, want the Default", got["content"])
+	}
+	if InputResolvedFromSource(cmd, "content") {
+		t.Fatal("marker leaked into the second invocation")
+	}
+}
+
+// The authoritative rule must hold at constraint provision too: pointing at a
+// file is supplying the flag, so at_least_one is satisfied even by an empty
+// payload, while an inline empty value still fails it.
+func TestCrossPlatformCoverageInputResolvedSatisfiesConstraint(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		return New(Spec{
+			Use: "t", Short: "t",
+			Flags: []FlagSpec{
+				{Name: "content", Usage: "C", Bind: "content", Input: []string{InputFile}},
+				{Name: "url", Usage: "U", Bind: "url"},
+			},
+			Constraints: []Constraint{{Kind: AtLeastOne, Flags: []string{"content", "url"}}},
+			Invoke:      func(c *Ctx, toolArgs map[string]any) error { return nil },
+		})
+	}
+	path := writeInputFile(t, "")
+
+	if err := runInputCommand(t, newCmd(), "--content", "@"+path); err != nil {
+		t.Fatalf("empty payload must satisfy at_least_one, got %v", err)
+	}
+	err := runInputCommand(t, newCmd(), "--content", "")
+	if err == nil || !strings.Contains(err.Error(), "请至少指定") {
+		t.Fatalf("inline empty must still fail at_least_one, got %v", err)
+	}
+}
+
+// ArgDefault must not re-substitute an authoritative payload one stage after
+// rawValue returned it verbatim.
+func TestCrossPlatformCoverageInputResolvedBeatsArgDefault(t *testing.T) {
+	path := writeInputFile(t, "")
+	cases := []struct{ name, token string }{
+		{"main", "--content"},
+		{"alias", "--body"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got map[string]any
+			cmd := newInputCommand([]FlagSpec{
+				{Name: "content", Usage: "C", Bind: "content", ArgDefault: "ARGDEF",
+					Aliases: []string{"body"}, Input: []string{InputFile}},
+			}, &got)
+
+			if err := runInputCommand(t, cmd, tc.token, "@"+path); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if got["content"] != "" {
+				t.Fatalf("toolArgs[content] = %q, want the empty payload", got["content"])
+			}
+		})
+	}
+
+	// Without a source, ArgDefault still applies.
+	var got map[string]any
+	cmd := newInputCommand([]FlagSpec{
+		{Name: "content", Usage: "C", Bind: "content", ArgDefault: "ARGDEF", Input: []string{InputFile}},
+	}, &got)
+	if err := runInputCommand(t, cmd, "--content", ""); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got["content"] != "ARGDEF" {
+		t.Fatalf("toolArgs[content] = %q, want ArgDefault", got["content"])
+	}
+}
+
+// The corecmd path delivers a payload byte-exact when no Trim is declared, and
+// a declared Transform collapses an empty payload so its key is skipped — the
+// documented author-declared exception to "an empty payload reaches the args".
+func TestCrossPlatformCoverageInputPayloadBoundaries(t *testing.T) {
+	t.Run("verbatim", func(t *testing.T) {
+		var got map[string]any
+		cmd := newInputCommand([]FlagSpec{
+			{Name: "content", Usage: "C", Bind: "content", Input: []string{InputFile}},
+		}, &got)
+		path := writeInputFile(t, "  body  \n")
+
+		if err := runInputCommand(t, cmd, "--content", "@"+path); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if got["content"] != "  body  \n" {
+			t.Fatalf("toolArgs[content] = %q, want the payload byte-exact", got["content"])
+		}
+	})
+
+	t.Run("transform drops empty payload", func(t *testing.T) {
+		var got map[string]any
+		cmd := newInputCommand([]FlagSpec{
+			{Name: "content", Usage: "C", Bind: "content", Input: []string{InputFile},
+				Transform: func(raw string) (any, error) { return raw, nil }},
+		}, &got)
+		path := writeInputFile(t, "")
+
+		if err := runInputCommand(t, cmd, "--content", "@"+path); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if _, present := got["content"]; present {
+			t.Fatalf("toolArgs kept a collapsed Transform result: %#v", got)
+		}
+	})
+}
+
+// A user_required write declaring InputStdin must fail closed without --yes:
+// resolution consumed stdin, so the confirmation prompt sees EOF. Pinned
+// because this is a safety guarantee, not merely a convenience.
+func TestCrossPlatformCoverageInputStdinWriteFailsClosedWithoutYes(t *testing.T) {
+	newWriteCmd := func(executed *bool, got *map[string]any) *cobra.Command {
+		cmd := New(Spec{
+			Use: "t", Short: "t",
+			Safety: contract.SafetySpec{Effect: "write", Risk: "medium",
+				Confirmation: "user_required", Idempotency: "unknown"},
+			Flags: []FlagSpec{{Name: "content", Usage: "C", Bind: "content", Input: []string{InputStdin}}},
+			Invoke: func(c *Ctx, toolArgs map[string]any) error {
+				*executed = true
+				*got = toolArgs
+				return nil
+			},
+		})
+		cmd.PersistentFlags().Bool("yes", false, "")
+		cmd.PersistentFlags().Bool("dry-run", false, "")
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetIn(strings.NewReader("payload body"))
+		return cmd
+	}
+
+	var executed bool
+	var got map[string]any
+	err := runInputCommand(t, newWriteCmd(&executed, &got), "--content", "-")
+	if executed {
+		t.Fatal("write executed without confirmation")
+	}
+	if err == nil || !strings.Contains(err.Error(), "需要用户确认") {
+		t.Fatalf("expected confirmation_required, got %v", err)
+	}
+
+	executed, got = false, nil
+	if err := runInputCommand(t, newWriteCmd(&executed, &got), "--content", "-", "--yes"); err != nil {
+		t.Fatalf("execute with --yes: %v", err)
+	}
+	if !executed || got["content"] != "payload body" {
+		t.Fatalf("executed=%v toolArgs=%#v", executed, got)
+	}
+}
+
+// ConfirmFirst confirms before resolution, so the prompt would read the piped
+// payload as its answer and a payload starting with "yes" would authorize the
+// operation. The combination must be unrepresentable, not merely discouraged.
+func TestCrossPlatformCoverageConfirmFirstWithInputStdinPanics(t *testing.T) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected panic")
+		}
+		if msg, ok := recovered.(string); !ok || !strings.Contains(msg, "ConfirmFirst cannot be combined") {
+			t.Fatalf("unexpected panic %v", recovered)
+		}
+	}()
+	New(Spec{
+		Use: "t", Short: "t",
+		Safety: contract.SafetySpec{Effect: "destructive", Risk: "high",
+			Confirmation: "user_required", Idempotency: "unknown"},
+		ConfirmFirst: true,
+		Flags:        []FlagSpec{{Name: "content", Usage: "C", Bind: "content", Input: []string{InputStdin}}},
+		Invoke:       func(c *Ctx, toolArgs map[string]any) error { return nil },
+	})
 }
 
 // Required must be satisfied by the resolved payload, proving resolution runs

--- a/internal/shortcut/runner.go
+++ b/internal/shortcut/runner.go
@@ -48,16 +48,35 @@ func AIMessageTagFlag() Flag {
 // accessors below).
 func (rt *RuntimeContext) Command() *cobra.Command { return rt.cmd }
 
-// Str returns the trimmed string value of a flag, or "" if unset.
+// Str returns the trimmed string value of a flag, or "" if unset. A value
+// loaded from @file / stdin (FlagSpec.Input) is returned verbatim instead:
+// trimming a payload would corrupt byte-exact content such as a trailing
+// newline covered by a checksum. Inline values keep the historical trim.
 func (rt *RuntimeContext) Str(name string) string {
 	v, _ := rt.cmd.Flags().GetString(name)
+	if corecmd.InputResolvedFromSource(rt.cmd, name) {
+		return v
+	}
 	return strings.TrimSpace(v)
 }
 
+// InputResolvedFromSource reports whether the flag's value was loaded from
+// @file or stdin rather than typed inline. A guard applying shape heuristics to
+// inline values ("this looks like a path — did you forget the @?") must skip
+// resolved values, whose content may legitimately look like anything.
+func (rt *RuntimeContext) InputResolvedFromSource(name string) bool {
+	return corecmd.InputResolvedFromSource(rt.cmd, name)
+}
+
 // StrFirst returns the first non-empty string value across a primary flag and
-// its aliases.
+// its aliases. A source-loaded payload wins immediately even when empty: the
+// user pointed at that source explicitly, so falling through to an alias would
+// ship a value they did not ask for.
 func (rt *RuntimeContext) StrFirst(names ...string) string {
 	for _, name := range names {
+		if rt.InputResolvedFromSource(name) {
+			return rt.Str(name)
+		}
 		if v := rt.Str(name); v != "" {
 			return v
 		}

--- a/internal/shortcut/runner_input_test.go
+++ b/internal/shortcut/runner_input_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shortcut
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// runInputShortcut mounts a shortcut declaring an Input flag and runs it, so the
+// framework's @file resolution happens exactly as in production. It reports what
+// Execute observed through the typed accessors.
+func runInputShortcut(t *testing.T, args []string, flags []Flag, read func(rt *RuntimeContext)) {
+	t.Helper()
+	s := Shortcut{
+		Service: "doc",
+		Command: "+input-probe",
+		Flags:   flags,
+		Execute: func(rt *RuntimeContext) error {
+			read(rt)
+			return nil
+		},
+	}
+	cmd := mount(s)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute %v: %v", args, err)
+	}
+}
+
+func writeShortcutPayload(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "payload.md")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	return path
+}
+
+// A source-loaded payload must reach Execute byte-exact: RuntimeContext.Str
+// trims every inline value, and trimming a payload would silently drop content
+// a caller may depend on (a trailing newline covered by a checksum).
+func TestCrossPlatformCoverageRuntimeStrKeepsPayloadVerbatim(t *testing.T) {
+	flags := []Flag{{Name: "markdown", Desc: "内容（支持 @文件路径）", Input: []string{"file"}}}
+	path := writeShortcutPayload(t, "  body  \n")
+
+	var got string
+	var resolved bool
+	runInputShortcut(t, []string{"--markdown", "@" + path}, flags, func(rt *RuntimeContext) {
+		got = rt.Str("markdown")
+		resolved = rt.InputResolvedFromSource("markdown")
+	})
+	if got != "  body  \n" {
+		t.Fatalf("Str() = %q, want the payload byte-exact", got)
+	}
+	if !resolved {
+		t.Fatal("InputResolvedFromSource() = false for an @file value")
+	}
+}
+
+// An inline value keeps the historical unconditional trim, so the 376 existing
+// shortcut commands are unaffected by the payload exemption.
+func TestCrossPlatformCoverageRuntimeStrTrimsInlineValue(t *testing.T) {
+	flags := []Flag{{Name: "markdown", Desc: "内容（支持 @文件路径）", Input: []string{"file"}}}
+
+	var got string
+	var resolved bool
+	runInputShortcut(t, []string{"--markdown", "  x  "}, flags, func(rt *RuntimeContext) {
+		got = rt.Str("markdown")
+		resolved = rt.InputResolvedFromSource("markdown")
+	})
+	if got != "x" {
+		t.Fatalf("Str() = %q, want the trimmed inline value", got)
+	}
+	if resolved {
+		t.Fatal("InputResolvedFromSource() = true for an inline value")
+	}
+}
+
+// StrFirst must stop at an explicitly supplied payload even when it is empty;
+// falling through to the alias would ship a value the caller did not ask for.
+func TestCrossPlatformCoverageRuntimeStrFirstHonoursEmptyPayload(t *testing.T) {
+	flags := []Flag{
+		{Name: "markdown", Desc: "内容（支持 @文件路径）", Input: []string{"file"}},
+		{Name: "text", Desc: "备选内容"},
+	}
+	path := writeShortcutPayload(t, "")
+
+	var got string
+	runInputShortcut(t, []string{"--markdown", "@" + path, "--text", "ALIAS"}, flags, func(rt *RuntimeContext) {
+		got = rt.StrFirst("markdown", "text")
+	})
+	if got != "" {
+		t.Fatalf("StrFirst() = %q, want the empty payload to win", got)
+	}
+}
+
+// Without a source the existing first-non-empty behaviour is unchanged.
+func TestCrossPlatformCoverageRuntimeStrFirstFallsBackWithoutPayload(t *testing.T) {
+	flags := []Flag{
+		{Name: "markdown", Desc: "内容（支持 @文件路径）", Input: []string{"file"}},
+		{Name: "text", Desc: "备选内容"},
+	}
+
+	var got string
+	runInputShortcut(t, []string{"--text", "ALIAS"}, flags, func(rt *RuntimeContext) {
+		got = rt.StrFirst("markdown", "text")
+	})
+	if got != "ALIAS" {
+		t.Fatalf("StrFirst() = %q, want the alias value", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #1017, which landed the `FlagSpec.Input` capability (`--flag @path` / `--flag -`). Reviewing that change after it merged surfaced four defects, one of them a confirmation bypass. No command declares `Input` yet, so nothing shipped is affected today — but every issue below is latent in `main` and would bite the first adopter.

## What was wrong

1. **An empty payload was silently replaced.** `--content @empty.txt` resolved to `""`, which `rawValue` judged unusable, so the flag fell through to alias / env / `Default` — clearing a field with an empty file shipped a different value instead.
2. **The same substitution happened again one stage later.** After fixing `rawValue`, `BuildArgs` still re-substituted `ArgDefault` over the authoritative empty payload, so it still never reached the backend.
3. **Constraints rejected a payload the user did supply.** `at_least_one(content, url)` with `--content @empty.txt` failed with `请至少指定 --content、--url 之一`, because `constraintProvided` judged the empty payload as absent.
4. **Confirmation bypass.** With `ConfirmFirst` the Safety prompt runs before resolution, so it read the piped payload as its answer: a destructive command fed a payload whose first line is `yes` executed with `err=nil`, while the flag itself ended up empty — piped data acting as a control channel.
5. **The shortcut surface corrupted payloads.** `RuntimeContext.Str` TrimSpace'd every read, so `Execute` lost leading/trailing bytes a caller may depend on (a trailing newline covered by a checksum), and `StrFirst` fell through to an alias when a payload was empty.

## What changed

A payload loaded from `@file` / stdin is marked source-resolved (a non-`dws.schema.*` cobra annotation, reset per invocation) and is authoritative through the whole pipeline: `rawValue` returns it verbatim including empty, constraint provision counts it as supplied, `BuildArgs` does not re-substitute `ArgDefault`, and the shortcut runtime returns it untrimmed while `StrFirst` stops at it. Inline values keep their existing semantics, so the 376 existing commands are untouched.

Deliberate exceptions, documented in RFC §5.3: required flags still reject an empty payload, and author-declared `OmitEmpty` / `Transform` still drop it — omitting or converting is a declared payload rule, not a silent substitution of a different value.

`ConfirmFirst` combined with an `InputStdin` flag is now rejected at construction, so the unsafe combination is unrepresentable rather than merely discouraged. The default ordering fails closed with `confirmation_required`, which is now pinned by a regression test rather than only asserted in docs.

`InputResolvedFromSource` is exposed on `corecmd`, `Ctx` and `RuntimeContext` — the escape hatch a domain guard needs so shape heuristics ("this looks like a path — did you forget the `@`?") do not re-reject correct `@file` invocations.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

High-risk, matching what the repository's own classifier did on this head: `internal/corecmd/` and `internal/shortcut/` are interface-sensitive paths in `.github/workflows/ci.yml`, so CI took the `high-risk full admission` branch (full `Test` job and every `Test (race: *)` shard executed; `Test (changed packages)` skipped). The diff also alters the shared `rawValue` → alias → env → `Default` fallback chain read by every command, and adds a construction-time `panic` (`ConfirmFirst` + `InputStdin`).

## Test plan
- [ ] Release fragment: `N/A` — no command declares `Input` yet (only the framework files themselves match), so none of these behaviors is observable by a user today and there is no user-visible change to fragment; same rationale as #1017, which introduced the capability and merged without a fragment. `CHANGELOG.md` is untouched.
- [ ] Release-seal validation: `N/A` — this PR does not modify `CHANGELOG.md`, and `./scripts/policy/check-changelog-pr.sh --content-only` errors by design on a PR that did not touch it.
- [x] `go test ./internal/corecmd/... ./internal/shortcut/... ./internal/helpers/... ./internal/cli/... ./internal/app` — no regressions; `rawValue`, `constraintProvided`, `BuildArgs` and `RuntimeContext.Str` are shared by every command
- [x] New tests pin each fix and its inverse: empty payload authority via main name and alias, `ArgDefault` still applying without a source, constraint satisfied by an empty payload while an inline empty still fails it, per-invocation marker isolation, payload byte-exactness, `Transform` collapse, confirmation fail-closed with and without `--yes`, and the `ConfirmFirst` rejection
- [x] `make policy` → exit 0 (prerequisite: `make build` first — the policy gate needs the `dws` binary at the repo root); `scripts/policy/run-platform-coverage-gate.sh` → `changed code coverage: 100.0000%`
- [x] `go test -race` on the changed packages → no data race
- [x] End-to-end on the built binary: `dws todo +get --task-id "@/tmp/nope.txt" --dry-run -f json` and `--task-id "-"` deliver the value verbatim, confirming no root-level argv preparse mangles `@` / `-` and that resolution stays strictly opt-in for flags without `Input`
