### PR TITLE
fix(ci): shard the focused test job instead of one long-lived run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,7 +612,7 @@ jobs:
               exit 1
             }
           done
-          if [ "$TEST_SHARD" = app ]; then
+          if [ "$TEST_SHARD" = "app" ]; then
             # A single long-lived app test process retains every constructed
             # command tree in framework registries. Isolate Schema assembly and
             # bounded name ranges so each process releases that state on exit.
@@ -620,7 +620,7 @@ jobs:
             ./scripts/ci/run-app-race-tests.sh run "${packages[0]}"
             exit 0
           fi
-          if [ "$TEST_SHARD" = release-scripts ]; then
+          if [ "$TEST_SHARD" = "release-scripts" ]; then
             # Mirror the dedicated release-contract job: these suites shell out
             # to archive tooling and are not race-instrumented there.
             go test -v -count=1 -timeout=10m "${packages[@]}"
@@ -629,8 +629,8 @@ jobs:
           # cli/smoke own heavy NewRootCommand / Schema assembly under -race;
           # give them a dedicated package timeout on slower hosted runners.
           timeout_budget=12m
-          if [ "$TEST_SHARD" = cli ] ||
-             [ "$TEST_SHARD" = smoke ]; then
+          if [ "$TEST_SHARD" = "cli" ] ||
+             [ "$TEST_SHARD" = "smoke" ]; then
             timeout_budget=15m
           fi
           go test -v -race -count=1 -timeout="$timeout_budget" "${packages[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,33 +577,41 @@ jobs:
           if [ -z "$package_output" ]; then
             echo "No buildable Go package in shard $TEST_SHARD is affected by this revision." \
               >> "$GITHUB_STEP_SUMMARY"
+            echo "affected=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          {
-            echo "packages<<SHARD_PACKAGES_EOF"
-            printf '%s\n' "$package_output"
-            echo "SHARD_PACKAGES_EOF"
-          } >> "$GITHUB_OUTPUT"
+          # The package list travels through a file rather than a step output:
+          # reading it with `mapfile < file` has unambiguous line semantics,
+          # whereas a here-string over a multi-line output would append an extra
+          # empty element if the value ever carried a trailing newline, and an
+          # empty element would reach go test as an empty package argument.
+          printf '%s\n' "$package_output" > "$RUNNER_TEMP/focused-shard-packages.txt"
+          echo "affected=true" >> "$GITHUB_OUTPUT"
 
       - name: Build
-        if: ${{ matrix.shard == 'remaining' && steps.select.outputs.packages != '' }}
+        if: ${{ matrix.shard == 'remaining' && steps.select.outputs.affected == 'true' }}
         run: make build
 
       - name: Install archive tooling
-        if: ${{ matrix.shard == 'release-scripts' && steps.select.outputs.packages != '' }}
+        if: ${{ matrix.shard == 'release-scripts' && steps.select.outputs.affected == 'true' }}
         run: sudo apt-get update && sudo apt-get install -y zip unzip
 
       - name: Test shard with Race Detection
-        if: ${{ steps.select.outputs.packages != '' }}
+        if: ${{ steps.select.outputs.affected == 'true' }}
         shell: bash
         env:
           DWS_PACKAGE_VERSION: 0.0.0-test
           TEST_SHARD: ${{ matrix.shard }}
-          SHARD_PACKAGES: ${{ steps.select.outputs.packages }}
         run: |
           set -euo pipefail
-          mapfile -t packages <<< "$SHARD_PACKAGES"
+          mapfile -t packages < "$RUNNER_TEMP/focused-shard-packages.txt"
           test "${#packages[@]}" -gt 0
+          for package in "${packages[@]}"; do
+            test -n "$package" || {
+              echo "shard package list contains an empty entry" >&2
+              exit 1
+            }
+          done
           if [ "$TEST_SHARD" = app ]; then
             # A single long-lived app test process retains every constructed
             # command tree in framework registries. Isolate Schema assembly and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,11 +513,28 @@ jobs:
         run: node .github/reviewer-routing.test.js
 
   test-focused:
-    name: Test (changed packages)
+    name: "Test (focused: ${{ matrix.shard }})"
     needs: lint
     if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.full_suite != 'true' }}
     runs-on: ubuntu-latest
+    # Each shard owns one bounded slice of the impacted set, so no single job
+    # carries internal/app together with every reverse dependency. The shard
+    # list and per-shard execution below mirror test-race, which runs the same
+    # shards at full-suite scope; release-scripts is included because its
+    # dedicated job only runs at full-suite or release-sensitive scope, and
+    # dropping it here would stop testing test/scripts changes entirely.
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - app
+          - generators
+          - helpers
+          - cli
+          - smoke
+          - remaining
+          - release-scripts
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -546,23 +563,69 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Test changed packages and reverse dependencies
+      - name: Select impacted packages for shard
+        id: select
         shell: bash
         env:
-          DWS_PACKAGE_VERSION: 0.0.0-test
+          TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
           package_output="$(
             ./scripts/ci/changed-test-packages.sh \
-              list "$TEST_BASE_REF" "$TEST_HEAD_REF"
+              list-shard "$TEST_SHARD" "$TEST_BASE_REF" "$TEST_HEAD_REF"
           )"
           if [ -z "$package_output" ]; then
-            echo "No buildable Go package is affected by this revision." \
+            echo "No buildable Go package in shard $TEST_SHARD is affected by this revision." \
               >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          mapfile -t packages <<< "$package_output"
-          go test -v -race -count=1 -timeout=15m "${packages[@]}"
+          {
+            echo "packages<<SHARD_PACKAGES_EOF"
+            printf '%s\n' "$package_output"
+            echo "SHARD_PACKAGES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        if: ${{ matrix.shard == 'remaining' && steps.select.outputs.packages != '' }}
+        run: make build
+
+      - name: Install archive tooling
+        if: ${{ matrix.shard == 'release-scripts' && steps.select.outputs.packages != '' }}
+        run: sudo apt-get update && sudo apt-get install -y zip unzip
+
+      - name: Test shard with Race Detection
+        if: ${{ steps.select.outputs.packages != '' }}
+        shell: bash
+        env:
+          DWS_PACKAGE_VERSION: 0.0.0-test
+          TEST_SHARD: ${{ matrix.shard }}
+          SHARD_PACKAGES: ${{ steps.select.outputs.packages }}
+        run: |
+          set -euo pipefail
+          mapfile -t packages <<< "$SHARD_PACKAGES"
+          test "${#packages[@]}" -gt 0
+          if [ "$TEST_SHARD" = app ]; then
+            # A single long-lived app test process retains every constructed
+            # command tree in framework registries. Isolate Schema assembly and
+            # bounded name ranges so each process releases that state on exit.
+            test "${#packages[@]}" -eq 1
+            ./scripts/ci/run-app-race-tests.sh run "${packages[0]}"
+            exit 0
+          fi
+          if [ "$TEST_SHARD" = release-scripts ]; then
+            # Mirror the dedicated release-contract job: these suites shell out
+            # to archive tooling and are not race-instrumented there.
+            go test -v -count=1 -timeout=10m "${packages[@]}"
+            exit 0
+          fi
+          # cli/smoke own heavy NewRootCommand / Schema assembly under -race;
+          # give them a dedicated package timeout on slower hosted runners.
+          timeout_budget=12m
+          if [ "$TEST_SHARD" = cli ] ||
+             [ "$TEST_SHARD" = smoke ]; then
+            timeout_budget=15m
+          fi
+          go test -v -race -count=1 -timeout="$timeout_budget" "${packages[@]}"
 
   test-race:
     name: "Test (race: ${{ matrix.shard }})"
@@ -715,7 +778,7 @@ jobs:
           failed=0
           if [ "$CHANGELOG_ONLY" = true ] || [ "$DOCS_ONLY" = true ]; then
             for shard in \
-              "changed packages:$FOCUSED_RESULT" \
+              "focused shards:$FOCUSED_RESULT" \
               "race shards:$RACE_RESULT" \
               "release scripts:$RELEASE_SCRIPTS_RESULT" \
               "cross-platform compile:$CROSS_PLATFORM_RESULT" \
@@ -744,7 +807,7 @@ jobs:
             release_expected=success
           fi
           for shard in \
-            "changed packages:$FOCUSED_RESULT:$focused_expected" \
+            "focused shards:$FOCUSED_RESULT:$focused_expected" \
             "race shards:$RACE_RESULT:$race_expected" \
             "release scripts:$RELEASE_SCRIPTS_RESULT:$release_expected" \
             "cross-platform compile:$CROSS_PLATFORM_RESULT:success"

--- a/scripts/ci/changed-test-packages.sh
+++ b/scripts/ci/changed-test-packages.sh
@@ -7,16 +7,32 @@ set -eu
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 
 usage() {
-  printf '%s\n' "usage: $0 <changed|list> BASE_REF HEAD_REF" >&2
+  printf '%s\n' \
+    "usage: $0 <changed|list> BASE_REF HEAD_REF" \
+    "       $0 list-shard SHARD BASE_REF HEAD_REF" >&2
   exit 2
 }
 
-[ "${1:-}" = changed ] || [ "${1:-}" = list ] || usage
-[ "$#" -eq 3 ] || usage
-
-MODE="$1"
-BASE_REF="$2"
-HEAD_REF="$3"
+# list-shard narrows the impacted set to one test shard so focused CI runs can
+# fan the same package plan across the shard matrix instead of testing every
+# impacted package in a single long-lived job.
+SHARD=""
+case "${1:-}" in
+  changed|list)
+    [ "$#" -eq 3 ] || usage
+    MODE="$1"
+    BASE_REF="$2"
+    HEAD_REF="$3"
+    ;;
+  list-shard)
+    [ "$#" -eq 4 ] || usage
+    MODE="$1"
+    SHARD="$2"
+    BASE_REF="$3"
+    HEAD_REF="$4"
+    ;;
+  *) usage ;;
+esac
 
 cd "$ROOT"
 git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null || {
@@ -116,9 +132,29 @@ while IFS= read -r file; do
   [ "$embedded_owner_found" = true ] || continue
 done < "$files"
 
+# emit_selection prints the planned packages, restricted to SHARD when the
+# caller asked for one. Restriction reuses scripts/ci/test-packages.sh as the
+# single source of shard membership, which also means an unknown shard name
+# aborts there instead of being reported as an empty selection: a silently empty
+# shard would let a mistyped CI shard name skip every test and still succeed.
+emit_selection() {
+  selection="$1"
+  if [ -z "$SHARD" ]; then
+    cat "$selection"
+    return 0
+  fi
+  shard_packages="$workdir/shard-packages"
+  "$ROOT/scripts/ci/test-packages.sh" list "$SHARD" > "$shard_packages"
+  LC_ALL=C sort -u "$shard_packages" -o "$shard_packages"
+  LC_ALL=C sort -u "$selection" -o "$selection"
+  # An empty intersection is a normal outcome for a shard no change touched, so
+  # comm's silence must not be treated as an error.
+  LC_ALL=C comm -12 "$selection" "$shard_packages"
+}
+
 LC_ALL=C sort -u "$changed_packages" -o "$changed_packages"
 if [ "$MODE" = changed ] || [ ! -s "$changed_packages" ]; then
-  cat "$changed_packages"
+  emit_selection "$changed_packages"
   exit 0
 fi
 
@@ -133,4 +169,5 @@ while IFS= read -r package; do
 done < "$all_packages" > "$impacted_packages"
 
 cat "$changed_packages" >> "$impacted_packages"
-LC_ALL=C sort -u "$impacted_packages"
+LC_ALL=C sort -u "$impacted_packages" -o "$impacted_packages"
+emit_selection "$impacted_packages"

--- a/test/scripts/changed_test_packages_test.go
+++ b/test/scripts/changed_test_packages_test.go
@@ -129,6 +129,245 @@ func Value() string {
 	}
 }
 
+// shardChangedPackagesShards mirrors the shard names scripts/ci/test-packages.sh
+// asserts complete coverage for in its verify mode. Keeping the list here in
+// full is deliberate: the union assertion below fails if a shard is added
+// upstream without being selected, and an unknown-shard error fails if one is
+// removed, so shard-plan drift cannot silently shrink focused-test coverage.
+var shardChangedPackagesShards = []string{
+	"app",
+	"generators",
+	"helpers",
+	"cli",
+	"smoke",
+	"remaining",
+	"release-scripts",
+}
+
+func TestChangedTestPackagesShardSelectionCoversEveryImpactedPackageExactlyOnce(t *testing.T) {
+	repository := newShardChangedPackagesRepository(t)
+	baseRef := commitChangedTestPackagesFixture(t, repository, "initial shard fixture")
+
+	writeChangedTestPackagesFixture(t, repository, "core/core.go", `package core
+
+func Value() string {
+	return "changed"
+}
+`)
+	headRef := commitChangedTestPackagesFixture(t, repository, "change core")
+
+	impacted := runChangedTestPackages(t, repository, "list", baseRef, headRef)
+	if len(impacted) == 0 {
+		t.Fatal("shard fixture produced no impacted packages")
+	}
+
+	owner := map[string]string{}
+	union := make([]string, 0, len(impacted))
+	for _, shard := range shardChangedPackagesShards {
+		for _, pkg := range runChangedTestPackagesShard(t, repository, shard, baseRef, headRef) {
+			if previous, ok := owner[pkg]; ok {
+				t.Fatalf("package %q selected by both shard %q and %q", pkg, previous, shard)
+			}
+			owner[pkg] = shard
+			union = append(union, pkg)
+		}
+	}
+
+	slices.Sort(union)
+	if !slices.Equal(union, impacted) {
+		t.Fatalf("shard selection union = %q, want every impacted package %q", union, impacted)
+	}
+}
+
+func TestChangedTestPackagesShardSelectionFailsClosedOnUnknownShard(t *testing.T) {
+	repository := newShardChangedPackagesRepository(t)
+	baseRef := commitChangedTestPackagesFixture(t, repository, "initial shard fixture")
+
+	writeChangedTestPackagesFixture(t, repository, "core/core.go", `package core
+
+func Value() string {
+	return "changed"
+}
+`)
+	headRef := commitChangedTestPackagesFixture(t, repository, "change core")
+
+	script := filepath.Join(repository, "scripts", "ci", "changed-test-packages.sh")
+	command := exec.Command(script, "list-shard", "nonexistent", baseRef, headRef)
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("unknown shard unexpectedly succeeded:\n%s", output)
+	}
+	// An unknown shard must abort rather than report an empty selection: a
+	// silently empty shard would let a mistyped CI shard name skip every test
+	// while still reporting success.
+	if !strings.Contains(string(output), "unknown test package shard") {
+		t.Fatalf("unknown shard failure = %q, want fail-closed diagnostic", output)
+	}
+	if strings.TrimSpace(string(output)) == "" {
+		t.Fatal("unknown shard produced empty output instead of a diagnostic")
+	}
+}
+
+func TestChangedTestPackagesShardSelectionIsEmptyForUnaffectedShard(t *testing.T) {
+	repository := newShardChangedPackagesRepository(t)
+	baseRef := commitChangedTestPackagesFixture(t, repository, "initial shard fixture")
+
+	writeChangedTestPackagesFixture(t, repository, "internal/helpers/helpers.go", `package helpers
+
+import "example.com/shardfixture/core"
+
+func Value() string {
+	return core.Value() + " helpers changed"
+}
+`)
+	headRef := commitChangedTestPackagesFixture(t, repository, "change helpers only")
+
+	if selected := runChangedTestPackagesShard(t, repository, "helpers", baseRef, headRef); len(selected) == 0 {
+		t.Fatal("helpers shard selected nothing for a helpers-only change")
+	}
+	// An unaffected shard is a normal outcome and must exit zero with no
+	// output so the CI step can no-op instead of failing the job.
+	if selected := runChangedTestPackagesShard(t, repository, "app", baseRef, headRef); len(selected) != 0 {
+		t.Fatalf("app shard = %q, want empty for a helpers-only change", selected)
+	}
+}
+
+func TestChangedTestPackagesShardSelectionRejectsMissingShardArgument(t *testing.T) {
+	repository := newShardChangedPackagesRepository(t)
+	baseRef := commitChangedTestPackagesFixture(t, repository, "initial shard fixture")
+
+	script := filepath.Join(repository, "scripts", "ci", "changed-test-packages.sh")
+	command := exec.Command(script, "list-shard", baseRef, baseRef)
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("list-shard without a shard argument unexpectedly succeeded:\n%s", output)
+	}
+	if !strings.Contains(string(output), "usage:") {
+		t.Fatalf("missing shard argument failure = %q, want usage diagnostic", output)
+	}
+}
+
+func runChangedTestPackagesShard(t *testing.T, repository, shard, baseRef, headRef string) []string {
+	t.Helper()
+
+	output := runChangedTestPackagesCommand(
+		t,
+		repository,
+		filepath.Join(repository, "scripts", "ci", "changed-test-packages.sh"),
+		"list-shard",
+		shard,
+		baseRef,
+		headRef,
+	)
+	return strings.Fields(output)
+}
+
+// newShardChangedPackagesRepository builds a fixture whose directory layout
+// matches every shard scripts/ci/test-packages.sh knows about, so shard
+// selection can be exercised without depending on the real repository's working
+// tree state. Every package imports core, letting a single core edit mark the
+// whole module impacted.
+func newShardChangedPackagesRepository(t *testing.T) string {
+	t.Helper()
+
+	repository := t.TempDir()
+	for path, contents := range map[string]string{
+		"go.mod": `module example.com/shardfixture
+
+go 1.22
+`,
+		"core/core.go": `package core
+
+func Value() string {
+	return "core"
+}
+`,
+		"internal/app/app.go": `package app
+
+import "example.com/shardfixture/core"
+
+func Value() string {
+	return core.Value() + " app"
+}
+`,
+		"internal/generator/gen/gen.go": `package gen
+
+import "example.com/shardfixture/core"
+
+func Value() string {
+	return core.Value() + " gen"
+}
+`,
+		"internal/helpers/helpers.go": `package helpers
+
+import "example.com/shardfixture/core"
+
+func Value() string {
+	return core.Value() + " helpers"
+}
+`,
+		"internal/cli/cli.go": `package cli
+
+import "example.com/shardfixture/core"
+
+func Value() string {
+	return core.Value() + " cli"
+}
+`,
+		"test/smoke/smoke.go": `package smoke
+
+import "example.com/shardfixture/core"
+
+func Value() string {
+	return core.Value() + " smoke"
+}
+`,
+		"test/scripts/scripts.go": `package scripts
+
+import "example.com/shardfixture/core"
+
+func Value() string {
+	return core.Value() + " scripts"
+}
+`,
+		"pkg/extra/extra.go": `package extra
+
+import "example.com/shardfixture/core"
+
+func Value() string {
+	return core.Value() + " extra"
+}
+`,
+	} {
+		writeChangedTestPackagesFixture(t, repository, path, contents)
+	}
+
+	projectRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve project root: %v", err)
+	}
+	for _, name := range []string{"changed-test-packages.sh", "test-packages.sh"} {
+		script, err := os.ReadFile(filepath.Join(projectRoot, "scripts", "ci", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		scriptPath := filepath.Join(repository, "scripts", "ci", name)
+		if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+			t.Fatalf("create script directory: %v", err)
+		}
+		if err := os.WriteFile(scriptPath, script, 0o755); err != nil {
+			t.Fatalf("copy %s: %v", name, err)
+		}
+	}
+
+	runChangedTestPackagesCommand(t, repository, "git", "init", "-q", "-b", "main")
+	runChangedTestPackagesCommand(t, repository, "git", "config", "user.name", "DWS CI")
+	runChangedTestPackagesCommand(t, repository, "git", "config", "user.email", "dws-ci@example.invalid")
+	return repository
+}
+
 func newChangedTestPackagesRepository(t *testing.T) string {
 	t.Helper()
 

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -1151,13 +1151,13 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 		"filename.startsWith('pkg/cmdutil/')",
 		"filename === 'skills_embed.go'",
 		"filename.startsWith('test/mock_mcp/')",
-		"name: Test (changed packages)",
+		`name: "Test (focused: ${{ matrix.shard }})"`,
 		"changed-test-packages.sh",
 		"Verify authoritative synthetic merge",
 		`test "$(git rev-parse HEAD^1)" = "$PR_BASE_SHA"`,
 		`test "$(git rev-parse HEAD^2)" = "$PR_HEAD_SHA"`,
 		`echo "TEST_HEAD_REF=$(git rev-parse HEAD)"`,
-		"list \"$TEST_BASE_REF\" \"$TEST_HEAD_REF\"",
+		`list-shard "$TEST_SHARD" "$TEST_BASE_REF" "$TEST_HEAD_REF"`,
 		"needs.lint.outputs.full_suite != 'true'",
 		`name: "Test (race: ${{ matrix.shard }})"`,
 		"name: Test (workflow and release contracts)",
@@ -1217,8 +1217,30 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 	if !strings.Contains(focusedJob, "timeout-minutes: 20") {
 		t.Error("focused test job must allow the scoped race suite up to 20 minutes")
 	}
-	if !strings.Contains(focusedJob, `go test -v -race -count=1 -timeout=15m "${packages[@]}"`) {
-		t.Error("focused race tests must retain enough package-level time for internal/app")
+	// The focused path fans the impacted set across the same shards as test-race
+	// and runs each shard the way test-race runs it, so no single job carries
+	// internal/app together with its reverse dependencies. internal/app keeps its
+	// package-level headroom through the process-isolating helper instead of one
+	// long -timeout, which is strictly stronger: every process releases the
+	// framework registries it populated. release-scripts is asserted because its
+	// dedicated job only runs at full-suite or release-sensitive scope, so losing
+	// it here would silently stop testing test/scripts changes.
+	for _, want := range []string{
+		`if [ "$TEST_SHARD" = "app" ]; then`,
+		`test "${#packages[@]}" -eq 1`,
+		`./scripts/ci/run-app-race-tests.sh run "${packages[0]}"`,
+		`if [ "$TEST_SHARD" = "release-scripts" ]; then`,
+		`go test -v -count=1 -timeout=10m "${packages[@]}"`,
+		"timeout_budget=12m",
+		`if [ "$TEST_SHARD" = "cli" ] ||`,
+		`[ "$TEST_SHARD" = "smoke" ]; then`,
+		"timeout_budget=15m",
+		`go test -v -race -count=1 -timeout="$timeout_budget" "${packages[@]}"`,
+		"- release-scripts",
+	} {
+		if !strings.Contains(focusedJob, want) {
+			t.Errorf("focused test job missing shard contract %q", want)
+		}
 	}
 
 	raceStart := focusedEnd


### PR DESCRIPTION
## Summary

The focused test path (`Test (changed packages)`) tested every impacted package
in a single job with a plain `go test -race`, so `internal/app` ran inside one
long-lived process alongside all of its reverse dependencies.

That is precisely the shape `scripts/ci/run-app-race-tests.sh` exists to avoid.
Its own comment states the mechanism: *a single long-lived app test process
retains every constructed command tree in framework registries*, so Schema
assembly and each name range must run in separate processes. `test-race` routes
`internal/app` through that helper and passes in 10–13 minutes; the focused path
did not, and grew past the package timeout.

Evidence that this path was broken independently of any one PR:

| Run | Duration | Outcome |
|---|---|---|
| #1019 attempt 1 | 7m56s | every test `PASS`, then `The runner has received a shutdown signal`, exit 143 |
| #1019 attempt 2 | 25m | `cancelled` at the 20m job timeout |
| #1019 attempt 3 | 10m48s | same as attempt 1 — no `--- FAIL`, exit 143 |
| an earlier unrelated PR | 17m48s | `FAIL internal/app 902.651s` — 2.65s past `-timeout=15m` |

Across the last 40 CI runs this job has **never** succeeded when it actually
ran; every other PR skipped it, because adding or removing any `.go` file sets
`goPackageShapeChange` and routes the PR to `full_suite`/`test-race` instead.
The practical effect was inverted incentives: the *more* ordinary a change, the
more fragile the CI path it took.

## What changed

- `test-focused` now fans the impacted package plan across the same shard matrix
  `test-race` uses, and runs each shard the way `test-race` runs it:
  `internal/app` through the process-isolating helper, `cli`/`smoke` with their
  wider package budget, `release-scripts` without `-race` and with archive
  tooling. No single job carries `internal/app` plus its reverse dependencies.
- `changed-test-packages.sh` gains `list-shard SHARD BASE HEAD`, intersecting the
  impacted set with `scripts/ci/test-packages.sh` shard membership so shard
  definitions stay single-sourced. Reusing that script also means an unknown
  shard name **aborts** rather than reporting an empty selection — a silently
  empty shard would let a mistyped shard name skip every test and still report
  success.
- The shard package list travels through a file in `RUNNER_TEMP` rather than a
  step output. `mapfile < file` has unambiguous line semantics, whereas a
  here-string over a multi-line step output would append an empty array element
  if the value ever carried a trailing newline — and that element would reach
  `go test` as an empty package argument. Because this job cannot execute on its
  own pull request (see Notes), the implementation deliberately avoids depending
  on platform trailing-newline behavior that local verification cannot observe.
  An explicit empty-entry guard fails closed if the file is ever malformed.
- The workflow contract in `changelog_pr_gate_test.go` pinned this path by
  literal — the job name `Test (changed packages)`, the unsharded
  `list "$TEST_BASE_REF" "$TEST_HEAD_REF"` call, and one `-timeout=15m` line
  standing in for `internal/app`'s headroom. Sharding changed all three, so the
  contract is updated to assert the new shape rather than relaxed: the matrix
  job must exist, selection must still come from the authoritative synthetic
  merge base/head (now with a shard argument), and `internal/app`'s headroom is
  asserted through the process-isolating helper plus the per-shard budgets —
  mirroring what the contract already asserts for `test-race`, and stronger
  than the old single `-timeout` because it pins the mechanism, not the number.
  `release-scripts` matrix membership is asserted for the same reason it is in
  the matrix. The focused job's shard comparisons are quoted so the job reads
  verbatim like `test-race`'s.

- `release-scripts` is in the matrix deliberately. Its dedicated job only runs at
  full-suite or release-sensitive scope, so omitting it here would stop testing
  `test/scripts` changes altogether — a silent coverage loss. This very PR
  demonstrates it: its only impacted package lands in that shard.

The aggregate `Test` context is unchanged. It reads `needs.test-focused.result`,
which aggregates matrix results, so a matrix implementation needs no adjustment —
and `docs/ci-pr-gates.md` already states that parallel helper jobs may implement
`Test`. Shards with no impacted package no-op inside the step rather than via a
job-level `if`, which keeps the aggregate `success` instead of `skipped`.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

- [x] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`):
  `N/A` — CI-internal change; no user-visible CLI behavior or interface changes.
- [x] Release-seal validation (otherwise `N/A`): `N/A` — ordinary PR, `CHANGELOG.md`
  untouched.
- [x] Targeted test/check commands and results:
  - `go test ./test/scripts/ -run TestChangedTestPackages` → 9/9 `PASS`
    (4 new shard tests plus all 5 pre-existing tests, no regression)
  - `go test ./test/scripts/ -run TestChangelogPRFastPathWorkflowContract` →
    `PASS` (was failing on 3 assertions before the contract update)
  - `go test ./test/scripts/` (full package) → `ok` — this is the package the
    `Test (workflow and release contracts)` job runs
  - `make format-check` → exit 0; `go vet ./test/scripts/` → exit 0
  - `python3 -c "yaml.safe_load(...)"` on the workflow → parses
- [x] Behavior evidence (test name, CLI output shape, or before/after result):
  - End-to-end on the real repository, simulating an `internal/app` edit (the
    exact shape of #1019): impacted set is 19 packages, and `list-shard`
    partitions it as app **1**, generators 6, cli 1, smoke 1, remaining 10,
    helpers 0, release-scripts 0. Union equals the full impacted set with no
    duplicates. The `app` shard resolves to exactly one package, satisfying the
    helper's `-eq 1` precondition.
  - End-to-end on this PR's own diff: 1 impacted package, selected only by the
    `release-scripts` shard — which is why that shard is in the matrix.
  - `TestChangedTestPackagesShardSelectionCoversEveryImpactedPackageExactlyOnce`
    pins the partition property, so shard-plan drift cannot silently shrink
    focused coverage.
  - `TestChangedTestPackagesShardSelectionFailsClosedOnUnknownShard` pins that a
    mistyped shard aborts instead of selecting nothing.
  - Guard-strength check on the updated contract, ablating the implementation
    one change at a time: removing the app helper call, dropping
    `release-scripts` from the matrix, selecting from `HEAD~1` instead of the
    synthetic merge base, collapsing the matrix back to a single unsharded job,
    and dropping the `cli`/`smoke` budget each turn the contract **red** (5/5).
    `ci.yml` was restored byte-identical afterwards. The updated assertions are
    load-bearing, not decorative.
- [x] Documentation links/content/rendering checked (documentation-only, otherwise
  `N/A`): `N/A` — `docs/ci-pr-gates.md` already permits parallel helper jobs to
  implement `Test`; no contract text needed changing.
- [x] Full local suite run because the change is high-risk (optional for other
  tiers; record command/result or `N/A`): not run locally. The changed behavior
  is a CI job topology that cannot be reproduced on a workstation; the shard
  selection logic it depends on is covered by the targeted tests above, and this
  PR's own CI exercises the full suite.
- [x] `./scripts/policy/check-generated-drift.sh`: `N/A` — no generator inputs or
  generated artifacts touched.
- [x] `./scripts/policy/check-command-surface.sh --strict`: `N/A` — no CLI command
  or flag changed.
- [x] `./scripts/release/verify-package-managers.sh`: `N/A` — packaging and
  installer surfaces untouched.

## Notes

- **Verification limit, stated plainly:** this PR edits a workflow, so
  `isHighRisk` routes it to `full_suite` — which means `test-focused` is
  *skipped* on this very PR and the new matrix does not execute here. The shard
  selection is verified by the tests and the real-repository runs above; the new
  job topology gets its first live exercise on the next ordinary PR, and #1019 is
  the natural candidate to confirm it.
- Cost: an ordinary PR now starts up to 7 short jobs instead of 1 long one.
  Wall-clock should improve (previously ~15+ minutes serial and frequently
  reclaimed; now bounded by the slowest shard), while total runner minutes rise
  modestly. Shards with nothing impacted exit almost immediately.
- Not addressed here, worth a separate look: `internal/app`'s suite takes ~633s
  locally under `-race`, and a single test, `TestFinalSchemaToolsHaveExecutableBaseCommands`,
  accounts for 214s of it (34%). Sharding stops that from failing the job, but
  the underlying cost remains.


