### PR TITLE
fix(ci): parallelize app test partitions and drop race from the schema partition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,12 +523,22 @@ jobs:
     # shards at full-suite scope; release-scripts is included because its
     # dedicated job only runs at full-suite or release-sensitive scope, and
     # dropping it here would stop testing test/scripts changes entirely.
+    # internal/app is carried by one shard per bounded partition rather than a
+    # single app shard: the partitions used to run end to end inside one job,
+    # where the Schema partition alone owned most of the wall clock. The
+    # app-<partition> names are pinned to the helper's partition set by
+    # TestCIAppRacePartitionMatrixMatchesHelper, so a partition can never lose
+    # its job silently.
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         shard:
-          - app
+          - app-schema
+          - app-a-b
+          - app-c
+          - app-d-r
+          - app-s-z-example-fuzz
           - generators
           - helpers
           - cli
@@ -570,9 +580,16 @@ jobs:
           TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
+          # Every app partition shard tests the same single internal/app
+          # package, so the impacted-package query uses the base shard name and
+          # the partition only selects which tests run.
+          package_shard="$TEST_SHARD"
+          case "$TEST_SHARD" in
+            app-*) package_shard=app ;;
+          esac
           package_output="$(
             ./scripts/ci/changed-test-packages.sh \
-              list-shard "$TEST_SHARD" "$TEST_BASE_REF" "$TEST_HEAD_REF"
+              list-shard "$package_shard" "$TEST_BASE_REF" "$TEST_HEAD_REF"
           )"
           if [ -z "$package_output" ]; then
             echo "No buildable Go package in shard $TEST_SHARD is affected by this revision." \
@@ -612,14 +629,19 @@ jobs:
               exit 1
             }
           done
-          if [ "$TEST_SHARD" = "app" ]; then
-            # A single long-lived app test process retains every constructed
-            # command tree in framework registries. Isolate Schema assembly and
-            # bounded name ranges so each process releases that state on exit.
-            test "${#packages[@]}" -eq 1
-            ./scripts/ci/run-app-race-tests.sh run "${packages[0]}"
-            exit 0
-          fi
+          case "$TEST_SHARD" in
+            app-*)
+              # A single long-lived app test process retains every constructed
+              # command tree in framework registries. Each partition is its own
+              # job, so that state is released when the process exits and the
+              # partitions run concurrently instead of end to end. The helper
+              # still verifies that the partition patterns cover every top-level
+              # test exactly once before running the one it was asked for.
+              test "${#packages[@]}" -eq 1
+              ./scripts/ci/run-app-race-tests.sh run "${packages[0]}" "${TEST_SHARD#app-}"
+              exit 0
+              ;;
+          esac
           if [ "$TEST_SHARD" = "release-scripts" ]; then
             # Mirror the dedicated release-contract job: these suites shell out
             # to archive tooling and are not race-instrumented there.
@@ -640,14 +662,21 @@ jobs:
     needs: lint
     if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.full_suite == 'true' }}
     runs-on: ubuntu-latest
-    # app runs several independently bounded processes; cli/smoke need headroom
-    # beyond go test -timeout for setup + assembly.
+    # internal/app is split across one shard per bounded partition so the
+    # partitions run concurrently and each releases its framework registries
+    # when the process exits; cli/smoke need headroom beyond go test -timeout for
+    # setup + assembly. The app-<partition> names are pinned to the helper's
+    # partition set by TestCIAppRacePartitionMatrixMatchesHelper.
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         shard:
-          - app
+          - app-schema
+          - app-a-b
+          - app-c
+          - app-d-r
+          - app-s-z-example-fuzz
           - generators
           - helpers
           - cli
@@ -673,18 +702,30 @@ jobs:
           TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
-          package_output="$(./scripts/ci/test-packages.sh list "$TEST_SHARD")"
+          # Every app partition shard tests the same single internal/app
+          # package, so the package query uses the base shard name and the
+          # partition only selects which tests run.
+          package_shard="$TEST_SHARD"
+          case "$TEST_SHARD" in
+            app-*) package_shard=app ;;
+          esac
+          package_output="$(./scripts/ci/test-packages.sh list "$package_shard")"
           test -n "$package_output"
           mapfile -t packages <<< "$package_output"
           test "${#packages[@]}" -gt 0
-          if [ "$TEST_SHARD" = "app" ]; then
-            # A single long-lived app test process retains every constructed
-            # command tree in framework registries. Isolate Schema assembly and
-            # bounded name ranges so each process releases that state on exit.
-            test "${#packages[@]}" -eq 1
-            ./scripts/ci/run-app-race-tests.sh run "${packages[0]}"
-            exit 0
-          fi
+          case "$TEST_SHARD" in
+            app-*)
+              # A single long-lived app test process retains every constructed
+              # command tree in framework registries. Each partition is its own
+              # job, so that state is released when the process exits and the
+              # partitions run concurrently instead of end to end. The helper
+              # still verifies that the partition patterns cover every top-level
+              # test exactly once before running the one it was asked for.
+              test "${#packages[@]}" -eq 1
+              ./scripts/ci/run-app-race-tests.sh run "${packages[0]}" "${TEST_SHARD#app-}"
+              exit 0
+              ;;
+          esac
           # cli/smoke own heavy NewRootCommand / Schema assembly under -race;
           # give them a dedicated package timeout on slower hosted runners.
           timeout_budget=12m

--- a/scripts/ci/run-app-race-tests.sh
+++ b/scripts/ci/run-app-race-tests.sh
@@ -6,16 +6,35 @@ ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 usage() {
 	printf '%s\n' \
 		"usage: $0 verify <app-package>" \
-		"       $0 run <app-package>" >&2
+		"       $0 run <app-package> [partition]" \
+		"       $0 list-partitions" >&2
 	exit 2
 }
 
-[ "$#" -eq 2 ] || usage
-mode="$1"
-app_package="$2"
+# Single source of truth for the partition set. CI runs one job per partition and
+# pins its shard names to this list, so a name that appears here without a
+# dispatch entry below fails closed rather than silently skipping tests.
+APP_PARTITIONS='schema a-b c d-r s-z-example-fuzz'
 
+mode="${1:-}"
+partition=""
 case "$mode" in
-	verify|run) ;;
+	list-partitions)
+		[ "$#" -eq 1 ] || usage
+		for name in $APP_PARTITIONS; do
+			printf '%s\n' "$name"
+		done
+		exit 0
+		;;
+	verify)
+		[ "$#" -eq 2 ] || usage
+		app_package="$2"
+		;;
+	run)
+		[ "$#" -eq 2 ] || [ "$#" -eq 3 ] || usage
+		app_package="$2"
+		partition="${3:-}"
+		;;
 	*) usage ;;
 esac
 
@@ -70,19 +89,47 @@ if [ "$unmatched_count" -ne 0 ]; then
 	exit 1
 fi
 
-for partition in \
+# The loop variable is deliberately not named "partition": that name holds the
+# partition requested on the command line, and run mode still executes this
+# discovery pass before dispatching.
+classified=''
+for spec in \
 	"schema:$schema_count" \
 	"a-b:$ab_count" \
 	"c:$c_count" \
 	"d-r:$dr_count" \
 	"s-z-example-fuzz:$sz_count"
 do
-	name="${partition%%:*}"
-	count="${partition#*:}"
+	name="${spec%%:*}"
+	count="${spec#*:}"
+	classified="$classified $name"
 	if [ "$count" -eq 0 ]; then
 		printf 'app race partition %s is empty\n' "$name" >&2
 		exit 1
 	fi
+done
+
+# The counters above and APP_PARTITIONS must describe the same set in both
+# directions. A counted partition missing from APP_PARTITIONS would never be
+# dispatched by any CI job, and a dispatchable partition with no counter would
+# escape the exact-coverage check above.
+for name in $APP_PARTITIONS; do
+	case " $classified " in
+		*" $name "*) ;;
+		*)
+			printf 'app partition %s has no coverage counter\n' "$name" >&2
+			exit 1
+			;;
+	esac
+done
+for name in $classified; do
+	case " $APP_PARTITIONS " in
+		*" $name "*) ;;
+		*)
+			printf 'counted partition %s is not a dispatchable app partition\n' "$name" >&2
+			exit 1
+			;;
+	esac
 done
 
 total_count="$(wc -l < "$tests" | tr -d ' ')"
@@ -142,8 +189,32 @@ run_partition() {
 # build is allocation-heavy, and -race made the partition roughly 11x slower
 # (26s -> 291s locally, 357s in CI) without being able to report anything.
 schema_pattern='^Test.*Schema'
-run_partition schema no-race "$schema_pattern"
-run_partition a-b race '^Test[A-B]' "$schema_pattern"
-run_partition c race '^TestC' "$schema_pattern"
-run_partition d-r race '^Test[D-R]' "$schema_pattern"
-run_partition s-z-example-fuzz race '^(Test[S-Z]|Example|Fuzz)' "$schema_pattern"
+
+# Dispatch table for the partition set declared in APP_PARTITIONS. CI passes one
+# partition per job so they run concurrently; running without a partition keeps
+# the original end-to-end behaviour for local use and for any caller that wants
+# the whole package in one invocation.
+run_named_partition() {
+	case "$1" in
+		schema) run_partition schema no-race "$schema_pattern" ;;
+		a-b) run_partition a-b race '^Test[A-B]' "$schema_pattern" ;;
+		c) run_partition c race '^TestC' "$schema_pattern" ;;
+		d-r) run_partition d-r race '^Test[D-R]' "$schema_pattern" ;;
+		s-z-example-fuzz)
+			run_partition s-z-example-fuzz race '^(Test[S-Z]|Example|Fuzz)' "$schema_pattern"
+			;;
+		*)
+			printf 'unknown app partition: %s\n' "$1" >&2
+			exit 1
+			;;
+	esac
+}
+
+if [ -n "$partition" ]; then
+	run_named_partition "$partition"
+	exit 0
+fi
+
+for name in $APP_PARTITIONS; do
+	run_named_partition "$name"
+done

--- a/scripts/ci/run-app-race-tests.sh
+++ b/scripts/ci/run-app-race-tests.sh
@@ -101,26 +101,49 @@ fi
 
 run_partition() {
 	name="$1"
-	run_pattern="$2"
-	skip_pattern="${3:-}"
+	instrumentation="$2"
+	run_pattern="$3"
+	skip_pattern="${4:-}"
 
-	printf 'running internal/app race partition %s\n' "$name"
+	# Fail closed on an unrecognized mode: a typo must not silently drop race
+	# instrumentation from a partition that is supposed to carry it.
+	case "$instrumentation" in
+		race|no-race) ;;
+		*)
+			printf 'unknown instrumentation %s for app partition %s\n' \
+				"$instrumentation" "$name" >&2
+			exit 1
+			;;
+	esac
+
+	printf 'running internal/app %s partition %s\n' "$instrumentation" "$name"
+	set -- -v -count=1 -timeout=15m -run "$run_pattern"
 	if [ -n "$skip_pattern" ]; then
-		go test -v -race -count=1 -timeout=15m \
-			-run "$run_pattern" -skip "$skip_pattern" "$app_package"
-	else
-		go test -v -race -count=1 -timeout=15m \
-			-run "$run_pattern" "$app_package"
+		set -- "$@" -skip "$skip_pattern"
 	fi
+	if [ "$instrumentation" = race ]; then
+		set -- -race "$@"
+	fi
+	go test "$@" "$app_package"
 }
 
 # Schema assembly has the largest transient memory footprint. Run those tests
 # in a fresh process, then keep each remaining name range in its own process so
 # command trees retained by process-global registries are released between
 # partitions. The complementary run/skip patterns preserve the full test set.
+#
+# The schema partition runs uninstrumented. Its tests assert structural
+# Schema-to-Cobra contracts over a single goroutine: none of them call
+# t.Parallel or start a goroutine, so the race detector has no concurrent access
+# to observe here. The process-global lazy metadata that does need race coverage
+# (schema_source_root's atomic.Value, the parameter-binding lazy loaders) is
+# exercised by internal/cli's concurrent tests, which stay instrumented. The
+# instrumentation is not free on this partition: its shared sync.Once Catalog
+# build is allocation-heavy, and -race made the partition roughly 11x slower
+# (26s -> 291s locally, 357s in CI) without being able to report anything.
 schema_pattern='^Test.*Schema'
-run_partition schema "$schema_pattern"
-run_partition a-b '^Test[A-B]' "$schema_pattern"
-run_partition c '^TestC' "$schema_pattern"
-run_partition d-r '^Test[D-R]' "$schema_pattern"
-run_partition s-z-example-fuzz '^(Test[S-Z]|Example|Fuzz)' "$schema_pattern"
+run_partition schema no-race "$schema_pattern"
+run_partition a-b race '^Test[A-B]' "$schema_pattern"
+run_partition c race '^TestC' "$schema_pattern"
+run_partition d-r race '^Test[D-R]' "$schema_pattern"
+run_partition s-z-example-fuzz race '^(Test[S-Z]|Example|Fuzz)' "$schema_pattern"

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -1157,7 +1157,7 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 		`test "$(git rev-parse HEAD^1)" = "$PR_BASE_SHA"`,
 		`test "$(git rev-parse HEAD^2)" = "$PR_HEAD_SHA"`,
 		`echo "TEST_HEAD_REF=$(git rev-parse HEAD)"`,
-		`list-shard "$TEST_SHARD" "$TEST_BASE_REF" "$TEST_HEAD_REF"`,
+		`list-shard "$package_shard" "$TEST_BASE_REF" "$TEST_HEAD_REF"`,
 		"needs.lint.outputs.full_suite != 'true'",
 		`name: "Test (race: ${{ matrix.shard }})"`,
 		"name: Test (workflow and release contracts)",
@@ -1219,16 +1219,20 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 	}
 	// The focused path fans the impacted set across the same shards as test-race
 	// and runs each shard the way test-race runs it, so no single job carries
-	// internal/app together with its reverse dependencies. internal/app keeps its
-	// package-level headroom through the process-isolating helper instead of one
-	// long -timeout, which is strictly stronger: every process releases the
-	// framework registries it populated. release-scripts is asserted because its
-	// dedicated job only runs at full-suite or release-sensitive scope, so losing
-	// it here would silently stop testing test/scripts changes.
+	// internal/app together with its reverse dependencies. internal/app is split
+	// further into one shard per bounded partition, which keeps its package-level
+	// headroom through the process-isolating helper instead of one long -timeout
+	// and is strictly stronger than a single app job: every partition process
+	// releases the framework registries it populated, and the partitions run
+	// concurrently rather than end to end. Each partition shard still selects the
+	// same single internal/app package, so the impacted-package query maps the
+	// shard name back to app. release-scripts is asserted because its dedicated
+	// job only runs at full-suite or release-sensitive scope, so losing it here
+	// would silently stop testing test/scripts changes.
 	for _, want := range []string{
-		`if [ "$TEST_SHARD" = "app" ]; then`,
+		`app-*) package_shard=app ;;`,
 		`test "${#packages[@]}" -eq 1`,
-		`./scripts/ci/run-app-race-tests.sh run "${packages[0]}"`,
+		`./scripts/ci/run-app-race-tests.sh run "${packages[0]}" "${TEST_SHARD#app-}"`,
 		`if [ "$TEST_SHARD" = "release-scripts" ]; then`,
 		`go test -v -count=1 -timeout=10m "${packages[@]}"`,
 		"timeout_budget=12m",
@@ -1249,14 +1253,16 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 		t.Fatal("Code Admission workflow missing race test job boundaries")
 	}
 	raceJob := admission[raceStart:raceEnd]
-	// The app shard uses independently bounded test processes so process-global
-	// command registries are released before the Schema assembly peak. Other full
-	// race shards retain the dynamic package timeout: default/floor 12m, with
-	// cli/smoke raised to 15m on slower hosted runners.
+	// internal/app is carried by one shard per bounded partition, so process-global
+	// command registries are released with each partition process and the Schema
+	// assembly peak no longer sits in front of the other partitions. Each
+	// partition shard resolves back to the same single internal/app package.
+	// Other full race shards retain the dynamic package timeout: default/floor
+	// 12m, with cli/smoke raised to 15m on slower hosted runners.
 	for _, want := range []string{
-		`if [ "$TEST_SHARD" = "app" ]; then`,
+		`app-*) package_shard=app ;;`,
 		`test "${#packages[@]}" -eq 1`,
-		`./scripts/ci/run-app-race-tests.sh run "${packages[0]}"`,
+		`./scripts/ci/run-app-race-tests.sh run "${packages[0]}" "${TEST_SHARD#app-}"`,
 		"timeout_budget=12m",
 		`if [ "$TEST_SHARD" = "cli" ] ||`,
 		`[ "$TEST_SHARD" = "smoke" ]; then`,

--- a/test/scripts/ci_test_package_plan_test.go
+++ b/test/scripts/ci_test_package_plan_test.go
@@ -99,6 +99,74 @@ func TestCIAppRacePartitionsCoverTopLevelTestsExactlyOnce(t *testing.T) {
 	}
 }
 
+// TestCIAppRacePartitionMatrixMatchesHelper pins the workflow's app partition
+// shards to the partition set the helper actually runs. The partitions are
+// separate CI jobs now, so the helper's own "covered exactly once" check can no
+// longer prove the whole package ran: a partition the helper knows about but no
+// matrix shard dispatches would silently stop running while every job stays
+// green. Both directions are asserted so a stale matrix shard fails too.
+func TestCIAppRacePartitionMatrixMatchesHelper(t *testing.T) {
+	root := testPackagePlanRoot(t)
+	script := filepath.Join(root, "scripts", "ci", "run-app-race-tests.sh")
+	cmd := exec.Command("sh", script, "list-partitions")
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s list-partitions failed: %v\n%s", script, err, output)
+	}
+	partitions := strings.Fields(string(output))
+	if len(partitions) == 0 {
+		t.Fatalf("list-partitions returned no partitions: %q", output)
+	}
+
+	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read ci.yml: %v", err)
+	}
+	admission := string(workflow)
+
+	for _, job := range []struct {
+		name      string
+		startMark string
+		endMark   string
+	}{
+		{"test-focused", "\n  test-focused:\n", "\n  test-race:\n"},
+		{"test-race", "\n  test-race:\n", "\n  test-release-scripts:\n"},
+	} {
+		start := strings.Index(admission, job.startMark)
+		end := strings.Index(admission, job.endMark)
+		if start < 0 || end <= start {
+			t.Fatalf("ci.yml is missing %s job boundaries", job.name)
+		}
+		body := admission[start:end]
+
+		for _, partition := range partitions {
+			want := "- app-" + partition
+			if !strings.Contains(body, want) {
+				t.Errorf("%s matrix is missing shard %q for a partition the helper runs", job.name, want)
+			}
+		}
+
+		for _, line := range strings.Split(body, "\n") {
+			shard := strings.TrimSpace(line)
+			if !strings.HasPrefix(shard, "- app-") {
+				continue
+			}
+			name := strings.TrimPrefix(shard, "- app-")
+			matched := false
+			for _, partition := range partitions {
+				if partition == name {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				t.Errorf("%s matrix shard %q has no matching helper partition", job.name, shard)
+			}
+		}
+	}
+}
+
 func TestCITestPackagePlanFailsClosedWhenGoListFails(t *testing.T) {
 	root := testPackagePlanRoot(t)
 	fakeBin := t.TempDir()


### PR DESCRIPTION
## Summary

- Each of the five `internal/app` test partitions is now its own CI matrix shard
  (`app-schema`, `app-a-b`, `app-c`, `app-d-r`, `app-s-z-example-fuzz`) instead of
  running end to end inside a single `app` shard, and the `schema` partition runs
  without `-race`.
- The app shard's wall clock was the sum of all five partitions: **780s** in CI, of
  which the `schema` partition alone owned **357s**. Inside that partition
  `TestFinalSchemaToolsHaveExecutableBaseCommands` accounted for **262s** — not
  because the test is expensive, but because it is the first caller to pay for the
  `sync.Once` Catalog snapshot that five tests share; its 1121 subtests together
  measure 0.00s. `-race` was the multiplier: the partition takes 26s
  uninstrumented versus 291s instrumented locally (~11x), and its tests assert
  structural Schema-to-Cobra contracts over a single goroutine, so the detector
  has no concurrent access to observe there.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

- [ ] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`):
  `N/A` — CI orchestration only; no user-visible behavior or interface change.
- [ ] Release-seal validation (otherwise `N/A`): `N/A`
- [x] Targeted test/check commands and results:
  - `go test -run 'TestCIAppRacePartition|TestChangelogPRFastPathWorkflowContract' ./test/scripts` — PASS (3 tests, run against this branch's base)
  - `go test ./test/scripts` — `ok 541.9s`, 0 failures
  - `make test-plan` — 116 default and 88 full-suite packages covered exactly once
  - `sh scripts/ci/run-app-race-tests.sh run ./internal/app` — `exit 0`, 855 top-level tests covered exactly once, all five partitions green
  - Single-partition dispatch: `schema` 16.6s, `a-b` 6.3s, `s-z-example-fuzz` 31.0s, each `exit 0`
- [x] Behavior evidence (test name, CLI output shape, or before/after result):
  - Partition timings after the change (local): schema **16.6s** (was 291s under `-race`), a-b 6.1s, c 255.8s, d-r 103.4s, s-z-example-fuzz 28.7s
  - Per-partition command lines verified with a stub `go` on `PATH`: `schema` runs
    `go test -v -count=1 -timeout=15m -run '^Test.*Schema'` with **no** `-race`;
    the other four keep `-race` and the complementary `-skip '^Test.*Schema'`
  - Fail-closed ablations, each confirmed to exit non-zero rather than skipping work:
    - unknown instrumentation mode (`RACE`) → `exit 1`
    - `APP_PARTITIONS` entry with no coverage counter → `exit 1`
    - counted partition absent from `APP_PARTITIONS` → `exit 1`
    - `- app-c` removed from a matrix → `TestCIAppRacePartitionMatrixMatchesHelper` fails, reporting both jobs
    - `- app-bogus` added to a matrix → same test fails
- [ ] Documentation links/content/rendering checked (documentation-only, otherwise
  `N/A`): `N/A`
- [ ] Full local suite run because the change is high-risk (optional for other
  tiers; record command/result or `N/A`): partial — the whole `internal/app`
  package ran end to end through the helper (855 tests across all five partitions,
  `exit 0`) and `./test/scripts` ran in full. `make policy` ran green on the same
  working tree before this branch was split out, but it covers neither CI
  orchestration nor these contract tests.
- [ ] `./scripts/policy/check-generated-drift.sh`
  (when generator inputs or generated artifacts may change): `N/A` — no generator
  input or generated artifact is touched.
- [ ] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed):
  `N/A` — command surface unchanged.
- [ ] `./scripts/release/verify-package-managers.sh`
  (after `make package`, if packaging or installer surfaces changed): `N/A` —
  packaging and installer surfaces unchanged.

## Notes

- **Wall clock versus runner time, measured on this PR's own CI run.** The five
  app jobs came in at `app-c` 225s, `app-d-r` 209s, `app-s-z-example-fuzz` 105s,
  `app-a-b` 82s and `app-schema` 68s. Wall clock for the app work is therefore its
  slowest job, **225s**, against **780s** for the previous single job, and the five
  jobs total 689s — so the split did not cost extra runner time overall. The
  `schema` partition leaving `-race` is what pays for the four extra setups and
  test-binary compiles: 68s including setup and compile, where that partition
  previously took 357s of test time alone. One caveat on comparing against the
  reference run: unchanged shards were faster on this runner (`helpers` 324s versus
  385s), so the honest reading is a large wall-clock reduction with roughly flat
  runner time, not a reduction in both. The two commits stay independent in that
  direction — the first reduces both numbers on its own, so the second can be
  reverted alone if the extra jobs are not wanted.
- **Job count.** `test-race` goes from 6 to 10 shards and `test-focused` from 7 to
  11. On this run all five app shards started immediately with no queueing; the
  reference run had 29 jobs with the longest wait at 80s. Queue pressure at peak
  is still the main thing to watch after merge.
- **Two verification gaps.** `actionlint` was not run locally, so its shellcheck
  pass over the new `run:` blocks is unverified here; the Lint job covers it. The
  focused path's package selection was also not exercised locally, because
  `changed-test-packages.sh` requires a clean tracked worktree; only its
  dependency was checked, namely that `test-packages.sh list app` returns exactly
  one package and so satisfies the `-eq 1` assertion.
