### PR TITLE
perf: skip redundant JSON validation when projecting typed Schema values

### DIFF
--- a/.changes/schema-catalog-json-projection.md
+++ b/.changes/schema-catalog-json-projection.md
@@ -1,0 +1,8 @@
+---
+category: Changed
+---
+
+- **Faster Schema Catalog assembly** — projects typed values into payload JSON
+  without re-running a validation scan over documents `json.Marshal` has just
+  produced, cutting roughly a third of the projection work across the full tool
+  set. Untrusted JSON input keeps its existing validation.

--- a/internal/cli/schema_contract_model.go
+++ b/internal/cli/schema_contract_model.go
@@ -1127,21 +1127,37 @@ func putRawJSON(payload map[string]any, key string, raw json.RawMessage) error {
 	return nil
 }
 
+// rawJSONValue decodes a JSON value that may come from an untrusted source, so
+// it validates before decoding. Callers holding output that json.Marshal just
+// produced should use typedJSONValue instead of paying the validation scan.
 func rawJSONValue(raw json.RawMessage) (any, error) {
 	if !json.Valid(raw) {
 		return nil, fmt.Errorf("invalid JSON value")
 	}
+	return decodeValidJSONValue(raw), nil
+}
+
+// decodeValidJSONValue decodes JSON whose validity the caller has already
+// established, either by json.Valid or by having just marshaled it. Decode
+// errors are unreachable under that precondition and are therefore discarded,
+// exactly as this path behaved when the decode was inlined into rawJSONValue.
+func decodeValidJSONValue(raw json.RawMessage) any {
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.UseNumber()
 	var value any
 	_ = decoder.Decode(&value)
-	return value, nil
+	return value
 }
 
+// typedJSONValue projects a typed value into the generic JSON shape the payload
+// renderers consume. json.Marshal output is valid by construction, so this path
+// decodes it directly: routing through rawJSONValue re-scanned every marshaled
+// document with json.Valid, which measured ~34% of Schema Catalog assembly time
+// across the 1121-tool set (26.0s -> 17.2s for the internal/app schema suite).
 func typedJSONValue(value any) (any, error) {
 	data, err := json.Marshal(value)
 	if err != nil {
 		return nil, err
 	}
-	return rawJSONValue(data)
+	return decodeValidJSONValue(data), nil
 }


### PR DESCRIPTION
## Summary

- `typedJSONValue` marshaled a typed value and then routed the result through
  `rawJSONValue`, which runs `json.Valid` before decoding. On that path the input
  is whatever `json.Marshal` has just produced, so the validation scan can only
  ever succeed — it re-read every marshaled document for nothing. The decode step
  is now shared by both entry points: `rawJSONValue` keeps its `json.Valid` check
  because it still accepts untrusted input, while `typedJSONValue` decodes what it
  marshaled directly.
- Schema Catalog assembly is allocation- and JSON-bound, and this scan was a
  measurable share of it across the 1121-tool set. A CPU profile of the assembly
  attributes roughly 39% to `ToolSpec.ToPayload`, 31% to `typedJSONValue` and 24%
  to `rawJSONValue`, with `encoding/json.checkValid` plus `stateInString` alone
  around 10% of samples. Removing the redundant scan cuts about a third of that
  work.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

Selected High-risk because the changed function sits on the generated Schema
Catalog projection path, even though the delivered Catalog is unchanged.

## Verification

- [x] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`):
  `.changes/schema-catalog-json-projection.md`; `CHANGELOG.md` is untouched.
  `./scripts/policy/check-release-fragments.sh "$(git merge-base HEAD origin/main)" HEAD` — `exit 0`.
- [ ] Release-seal validation (otherwise `N/A`): `N/A` — this is not a release-seal
  PR. The command requires an in-place `CHANGELOG.md` modification and exits 1
  here by design, since this PR adds a fragment instead.
- [x] Targeted test/check commands and results:
  - `go test ./internal/cli` — `ok 115.0s`, 0 failures (the package that owns both changed functions and their error-contract tests)
  - `go test -run '^Test.*Schema' ./internal/app` — `ok 17.2s` (was 26.0s)
  - `go test -race -run '^Test.*Schema' ./internal/app` — `ok 241.0s` (was 291.1s)
  - `make policy` — `exit 0`, including `check-generated-drift`, `check-schema-catalog`, `check-schema-binary` and `test-schema-agent-examples`
  - `gofmt -l` / `go vet ./internal/cli` — clean
- [x] Behavior evidence (test name, CLI output shape, or before/after result):
  - Uninstrumented `internal/app` schema suite: **26.0s → 17.2s** (−34%).
    Under `-race`: **291.1s → 241.0s** (−17%); the smaller relative gain is
    expected, since instrumenting every memory access inflates the non-JSON work
    too and dilutes this optimization's share.
  - The delivered Catalog is byte-for-byte unchanged: three independent
    regenerations inside `make policy` all report
    `source_hash=sha256:93b8d44eb163bd2898c78397d22af92d378e3dc4e20f56b33277b51e4342e2e6`
    and `registry_hash=sha256:16b4698ed64a2ae24e6d9b03bff26ebdddd0363116b247697389d54bf1a6e9e2`.
  - Both error contracts still hold, as asserted by the existing tests in
    `internal/cli/schema_contract_model_coverage_more_test.go`: `typedJSONValue`
    rejects a value `json.Marshal` cannot encode (a func), and `rawJSONValue`
    rejects invalid JSON.
  - No unreachable branch was introduced: the shared decode keeps the original
    `_ = decoder.Decode(...)` form rather than adding an error path that the
    caller's precondition makes impossible to cover.
- [ ] Documentation links/content/rendering checked (documentation-only, otherwise
  `N/A`): `N/A`
- [ ] Full local suite run because the change is high-risk (optional for other
  tiers; record command/result or `N/A`): partial — `./internal/cli` in full,
  the `internal/app` schema partition in full both with and without `-race`, and
  `make policy` end to end.
- [x] `./scripts/policy/check-generated-drift.sh`
  (when generator inputs or generated artifacts may change): passed as part of
  `make policy`; the regenerated Catalog matches, see the hashes above.
- [x] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed):
  passed as part of `make policy`. The command surface is not expected to change
  and does not.
- [ ] `./scripts/release/verify-package-managers.sh`
  (after `make package`, if packaging or installer surfaces changed): `N/A` —
  packaging and installer surfaces unchanged.

## Notes

- **Why the scan is safe to skip.** `json.Valid` is not being weakened for
  untrusted input: `rawJSONValue` still runs it, and it is still the entry point
  for anything decoded from outside. Only the marshal-then-decode round trip skips
  it, where the bytes come from `json.Marshal` in the immediately preceding
  statement.
- **Where the win lands.** Uninstrumented callers benefit most, which includes
  local development and the `Coverage (current: app)` job. The instrumented shards
  see about half the relative gain.
