### PR TITLE
chore(policy): approve group role flag migration

### DIFF
--- a/scripts/policy/interface-migrations/approved-flag-migrations-v1.json
+++ b/scripts/policy/interface-migrations/approved-flag-migrations-v1.json
@@ -761,6 +761,39 @@
       "reason": "保留旧 argv 兼容性，并将 IM ID 规范 flag 设为唯一可见入口"
     },
     {
+      "command": "dws chat group-role set-user",
+      "legacy": {
+        "name": "role-ids",
+        "before": {
+          "present": true,
+          "type": "string",
+          "scope": "local",
+          "required": true
+        },
+        "after": {
+          "present": true,
+          "type": "string",
+          "scope": "local",
+          "hidden": true,
+          "alias_of": "role-id"
+        }
+      },
+      "canonical": {
+        "name": "role-id",
+        "before": {
+          "present": false
+        },
+        "after": {
+          "present": true,
+          "type": "string",
+          "scope": "local",
+          "required": true
+        }
+      },
+      "state": "pending",
+      "reason": "保留旧 argv 兼容性，并将单值群身份 flag 设为唯一可见入口"
+    },
+    {
       "command": "dws chat group-role update",
       "legacy": {
         "name": "group",


### PR DESCRIPTION
## Summary

- Add a `pending` flag-migration approval for `dws chat group-role set-user`.
- Authorize the future `--role-ids` to `--role-id` migration while preserving the legacy argv spelling.
- Do not change the current command, Help, Schema, or runtime behavior in this PR.

## Why

The product migration in #1058 hides the required legacy `--role-ids` flag and exposes required `--role-id` as the canonical single-value spelling. Repository governance requires this exact migration to be approved in the merge base before the product PR can consume it.

This approval is intentionally limited to the native `dws chat group-role set-user` command. Shortcut behavior is out of scope.

## Risk tier

- [x] High-risk: policy data governing CLI and Schema compatibility

## Verification

- `go test ./internal/interfacesnapshot ./scripts/policy/commandcompat ./scripts/policy/schemacompat -count=1`
- `make interface-integrity BASE_REF=c198d8577d938919629bfdb3a76de357b38a4709 CANDIDATE_REF=6240584a`
- `make schema-compatibility BASE_REF=c198d8577d938919629bfdb3a76de357b38a4709 CANDIDATE_REF=6240584a`
- `git diff --check`

All checks passed. The authoritative comparison confirms that this PR leaves the current CLI and Schema surfaces unchanged.

## Notes

- Release fragment: N/A because this approval record has no user-visible behavior by itself.
- After this PR merges, #1058 can change the record from `pending` to `consumed` while applying the exact native flag migration.
