### PR TITLE
fix(ci): align multi-profile skill paths with canonical setup

### DIFF
--- a/scripts/dev/test-multi-profile-e2e.sh
+++ b/scripts/dev/test-multi-profile-e2e.sh
@@ -638,13 +638,13 @@ MONO_HOME="$WORKDIR/home-mono"
 MULTI_HOME="$WORKDIR/home-multi"
 mkdir -p "$MONO_HOME" "$MULTI_HOME"
 capture "$OUT_DIR/skill-mono-setup.txt" env HOME="$MONO_HOME" "$BIN" skill setup --mode mono --target codex --source "$ROOT" --yes
-expect_contains "$MONO_HOME/.codex/skills/dws/SKILL.md" "corpId:userId"
-expect_contains "$MONO_HOME/.codex/skills/dws/SKILL.md" "禁止选择第一项、最近登录或最近使用账号"
-expect_contains "$MONO_HOME/.codex/skills/dws/references/global-reference.md" "userId/userName"
+expect_contains "$MONO_HOME/.agents/skills/dws/SKILL.md" "corpId:userId"
+expect_contains "$MONO_HOME/.agents/skills/dws/SKILL.md" "禁止选择第一项、最近登录或最近使用账号"
+expect_contains "$MONO_HOME/.agents/skills/dws/references/global-reference.md" "userId/userName"
 capture "$OUT_DIR/skill-multi-setup.txt" env HOME="$MULTI_HOME" "$BIN" skill setup --mode multi --target codex --source "$ROOT" --yes
-expect_contains "$MULTI_HOME/.codex/skills/dingtalk-shared/SKILL.md" "禁止选择第一项、最近登录或最近使用账号"
-expect_contains "$MULTI_HOME/.codex/skills/dingtalk-misc/references/profile.md" "corpId:userId"
-expect_contains "$MULTI_HOME/.codex/skills/dingtalk-misc/references/profile.md" "isOrgCurrent"
+expect_contains "$MULTI_HOME/.agents/skills/dingtalk-shared/SKILL.md" "禁止选择第一项、最近登录或最近使用账号"
+expect_contains "$MULTI_HOME/.agents/skills/dingtalk-misc/references/profile.md" "corpId:userId"
+expect_contains "$MULTI_HOME/.agents/skills/dingtalk-misc/references/profile.md" "isOrgCurrent"
 
 log "verifying empty profile list"
 capture "$OUT_DIR/list-empty.json" "$BIN" profile list --format json


### PR DESCRIPTION
## 目标

Fixes #996 的主线 Multi-profile E2E 回归：`dws skill setup --target codex` 已按 #996 统一安装到 `~/.agents/skills`，但 E2E 仍断言退役的 `~/.codex/skills`。

## 实现

- 仅将 mono/multi Skill 安装断言切换到 canonical `.agents/skills` 路径。
- 不修改 #996 的实现或安装行为。

## 风险与回滚

标准风险，仅更正测试期望；回滚该单个测试脚本提交即可恢复旧断言。

## 验证

| 检查 | 结果 |
| --- | --- |
| `bash -n scripts/dev/test-multi-profile-e2e.sh` | 通过 |
| `git diff --check` | 通过 |
| `test -f` 验证 mono/multi canonical 安装产物且旧路径不存在 | 通过 |
| `bash scripts/dev/test-multi-profile-e2e.sh --skip-go-tests --keep-workdir --verbose` | 已真实构建 CLI 并通过本次 Skill 路径断言；工具未返回脚本尾部退出码，完整 E2E 由 CI/Main Integration 复验 |

不添加 release fragment：这是测试断言修复，没有用户可见行为变更。