### PR TITLE
chore: prepare v1.0.59 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+## [1.0.59] - 2026-08-20
+
+This release promotes the sealed `v1.0.59-beta.5` contents to stable.
+
+### Changed
+
+- **Chat personal emotions** — adds commands to list, send, and favorite the current user's personal favorite emotions.
+
+- **Minutes, DingTalk tasks, and Wiki parameter aliases** — adds reviewed parameter-name normalization, ambiguity guards, and end-to-end payload coverage.
+
+- **Shortcut functional workflows** — fixes Drive preview accuracy, AITable write verification and deletion accounting, Wiki feeds, and false-success handling across task, Contact, Minutes, and Wiki operations.
+
 ## [1.0.59-beta.5] - 2026-08-20
 
 ### Added


### PR DESCRIPTION
Stable release seal for `v1.0.59`, promoting the delivered `v1.0.59-beta.5` scope.\n\nValidated:\n- `git diff --check origin/main...HEAD`\n- `./scripts/policy/check-changelog-pr.sh --fast-path origin/main HEAD`\n- `./scripts/policy/check-release-fragments.sh origin/main HEAD`