### PR TITLE
feat(skill): add education product to dingtalk-misc (draft)

### DIFF
--- a/skills/content-qa/mono-multi-coverage.yaml
+++ b/skills/content-qa/mono-multi-coverage.yaml
@@ -112,6 +112,10 @@ coverage:
     multi_skill: dingtalk-misc
     multi_refs:
       - references/recruit.md
+  - mono: education
+    multi_skill: dingtalk-misc
+    multi_refs:
+      - references/education.md
 
 omit_coverage:
   - mono: simple

--- a/skills/mono/references/products/education.md
+++ b/skills/mono/references/products/education.md
@@ -1,0 +1,33 @@
+# 钉钉教育
+
+> **Draft** — 教育能力尚未完整迁入开源 DWS Binary，当前文档为接入预占。
+
+`dws education` 覆盖钉钉教育组织、班级和学生管理。
+
+## Use when
+
+- 用户提到教育组织、学校、班级、学生、家长、老师
+- 用户需要查询或管理班级成员、学生花名册
+- 用户需要发送家校通知或家校消息
+
+## Avoid when
+
+- 用户操作非教育组织的通讯录（使用 `dws contact`）
+- 用户发送普通群聊消息（使用 `dws chat`）
+
+## 命令总览
+
+> 以下为预期命令面，Binary 实现完成后以 `dws education --help` 为准。
+
+| 命令 | 用途 | 备注 |
+|---|---|---|
+| `dws education org get` | 查询教育组织信息 | 只读 |
+| `dws education class list` | 列出班级 | 只读 |
+| `dws education class get` | 查询班级详情 | 只读 |
+| `dws education student list` | 列出学生花名册 | 只读 |
+| `dws education student get` | 查询学生详情 | 只读 |
+
+## 安全规则
+
+- 学生个人信息属于敏感数据，避免在日志中打印完整手机号和身份证号
+- 家校消息发送为写操作，需要用户明确确认

--- a/skills/multi/dingtalk-misc/SKILL.md
+++ b/skills/multi/dingtalk-misc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dingtalk-misc
-description: 长尾产品集合技能，覆盖低频钉钉产品：OA审批查询与处理/考勤/直播/DING紧急消息/开放平台应用管理/Agoal目标管理/日志日报周报/电子表格/开放平台文档搜索/文档内嵌白板/钉钉招聘/DWS技能市场安装/组织大脑Hrbrain/原生Markdown/PAT行为授权/多组织profile。Use when 用户提到上述任一产品，或查待审批/同意拒绝转交撤销审批/打卡/排班/OKR/日报周报/单元格读写/白板节点读写/招聘职位/JD/创建职位/搜索安装技能/开发者后台应用/人才池/员工档案/职业历程/绩效/原生.md文件/PAT授权/切换组织/跨组织/profile 等相关操作。未来审批任务或实例变化的实时监听不属于本 skill，应使用 dingtalk-event。命中后由本 skill 的「产品索引表」定位具体子产品和命令前缀，再按对应子产品说明执行。
+description: 长尾产品集合技能，覆盖低频钉钉产品：OA审批查询与处理/考勤/直播/DING紧急消息/开放平台应用管理/Agoal目标管理/日志日报周报/电子表格/开放平台文档搜索/文档内嵌白板/钉钉招聘/DWS技能市场安装/组织大脑Hrbrain/原生Markdown/PAT行为授权/多组织profile/教育班级学生管理。Use when 用户提到上述任一产品，或查待审批/同意拒绝转交撤销审批/打卡/排班/OKR/日报周报/单元格读写/白板节点读写/招聘职位/JD/创建职位/搜索安装技能/开发者后台应用/人才池/员工档案/职业历程/绩效/原生.md文件/PAT授权/切换组织/跨组织/profile/教育/班级/学生/学校/花名册/家校 等相关操作。未来审批任务或实例变化的实时监听不属于本 skill，应使用 dingtalk-event。命中后由本 skill 的「产品索引表」定位具体子产品和命令前缀，再按对应子产品说明执行。
 metadata:
   cli_version: ">=0.2.14"
   category: product
@@ -37,6 +37,7 @@ metadata:
 | 原生 Markdown / `.md` 原文 / 覆盖 Markdown / 局部替换 Markdown | 原生 `.md` 文件读取、创建、全量覆盖与局部替换 | `dws markdown` | [markdown.md](references/markdown.md) |
 | PAT 授权 / 行为权限 / scope 授权 / 一次性授权 / 会话授权 / 永久授权 / 授权浏览器策略 | PAT 行为授权与本地浏览器策略 | `dws pat` | [pat.md](references/pat.md) |
 | 切换组织 / 换组织 / 跨组织 / 多组织 / profile / 看登录了哪些组织 | 多组织 / profile 管理与跨组织取数 | `dws profile` / `dws auth` / `--profile` | [profile.md](references/profile.md) |
+| 教育 / 班级 / 学生 / 学校 / 家长 / 花名册 / 家校 / 班级圈 / 成长记录 | 教育组织、班级和学生管理（Draft，Binary 命令待就绪） | `dws education` | [education.md](references/education.md) |
 | 宜搭 / AI应用脚本 / 财务辅助脚本（未产品化） | **无**稳定命令面；仅仓库内辅助脚本 | （非默认路由） | [unsupported-scripts.md](references/unsupported-scripts.md) |
 
 ## 说明

--- a/skills/multi/dingtalk-misc/references/education.md
+++ b/skills/multi/dingtalk-misc/references/education.md
@@ -1,0 +1,55 @@
+# 钉钉教育
+
+> **Draft** — 教育能力尚未完整迁入开源 DWS Binary，当前文档为接入预占。
+> Binary 命令就绪后补充命令 Schema、示例和安全规则。
+
+`dws education` 覆盖钉钉教育组织、班级和学生管理，包括组织信息查询、
+班级管理、学生管理和家校消息等场景。
+
+所有命令都应加 `--format json`。组织标识由登录身份及 MCP Connector
+注入，不要要求用户提供或猜测 `corpId`。
+
+## Use when
+
+- 用户提到教育组织、学校、班级、学生、家长、老师
+- 用户需要查询或管理班级成员、学生花名册
+- 用户需要发送家校通知或家校消息
+- 用户提到班级圈、成长记录
+
+## Avoid when
+
+- 用户操作通讯录中非教育组织的部门或成员（使用 `dws contact`）
+- 用户需要发送普通群聊消息（使用 `dws chat`）
+- 用户需要管理待办（使用 `dws todo`）
+
+## 命令总览
+
+> 以下为预期命令面，Binary 实现完成后以 `dws education --help` 为准。
+
+| 命令 | 用途 | 必填参数 | 备注 |
+|---|---|---|---|
+| `dws education org get` | 查询教育组织信息 | — | 只读 |
+| `dws education class list` | 列出班级 | `--org-id` | 只读 |
+| `dws education class get` | 查询班级详情 | `--class-id` | 只读 |
+| `dws education student list` | 列出学生花名册 | `--class-id` | 只读 |
+| `dws education student get` | 查询学生详情 | `--student-id` | 只读 |
+
+## 意图判断
+
+- "查一下 XX 班级" / "班级列表" → `dws education class list`
+- "学生花名册" / "XX 班的学生" → `dws education student list`
+- "XX 学生的信息" → `dws education student get`
+- "教育组织" / "学校信息" → `dws education org get`
+
+## 安全规则
+
+- 所有查询命令加 `--format json`
+- 组织、业务标识和当前操作人由登录身份注入，不要猜测 `corpId`、`opUserId`
+- 学生个人信息属于敏感数据，输出时避免在日志中打印完整手机号和身份证号
+- 家校消息发送为写操作，需要用户明确确认
+
+## 跨产品协作
+
+- 需要发送群消息通知时，使用 `dws chat`（见本包 [chat.md](../../dingtalk-chat/references/chat.md)）
+- 需要创建待办任务时，使用 `dws todo`
+- 需要查询通讯录中非教育成员时，使用 `dws contact`


### PR DESCRIPTION
## Summary

- Add education (教育) product routing and documentation to `dingtalk-misc` skill, covering 教育组织、班级管理、学生花名册、家校消息等场景
- This is a **draft** placeholder — `dws education` binary commands are not yet available in the open-source DWS CLI; binary migration must be completed before promotion

## Risk tier

- [x] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

- [x] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`):
  `N/A` — draft documentation only, no user-visible behavior change yet
- [x] Release-seal validation (otherwise `N/A`): `N/A`
- [x] Targeted test/check commands and results: `N/A` — no executable code changed
- [x] Behavior evidence (test name, CLI output shape, or before/after result): `N/A`
- [x] Documentation links/content/rendering checked (documentation-only, otherwise
  `N/A`): Yes — reviewed all new `.md` files for correct relative links and table formatting
- [x] Full local suite run because the change is high-risk: `N/A`
- [x] `./scripts/policy/check-generated-drift.sh`: `N/A` — no generated artifacts affected
- [x] `./scripts/policy/check-command-surface.sh --strict`: `N/A` — no command surface changed
- [x] `./scripts/release/verify-package-managers.sh`: `N/A` — no packaging change

## Notes

- Binary commands (`dws education`) do not exist yet; this PR only adds Skill documentation as a routing placeholder
- Follow-up: once `dws education` commands are implemented in the Go binary, update reference docs with real Schema, examples, and safety rules
- mono-multi-coverage.yaml updated to register `education` → `dingtalk-misc` mapping