### PR TITLE
docs(todo): optimize multi-skill routing from train runs

### DIFF
--- a/skills/multi/dingtalk-todo/SKILL.md
+++ b/skills/multi/dingtalk-todo/SKILL.md
@@ -11,11 +11,13 @@ metadata:
 
 # 钉钉待办 Skill
 
-## 前置条件 — 执行操作前必读
+## 执行契约
 
-> **CRITICAL — 执行任何 `dws` 操作前，MUST 先用 Read 工具完整读取 [`dingtalk-shared`](../dingtalk-shared/SKILL.md)。**该轻量文件包含全局执行契约、安全底线及 shared references 的按需加载导航；不要预加载其全部 references。
-
-> 命令参考：[todo.md](references/todo.md)；剧本：[02-task.md](references/02-task.md)。
+- 只用 `dws` 操作钉钉待办，命令统一加 `--format json`，并按结构化业务返回判断结果。
+- 已知路线直接执行；仅在 leaf 参数或安全语义不确定时查精确 Schema，在 flag 不确定时查精确 Help。不要先枚举整个 Catalog，也不要连续猜命令。
+- 后续 ID 必须来自本次真实返回；零匹配、多匹配或类型不明时停止并消歧。
+- 写操作遵循最终 Runtime gate。需要确认时先说明对象、动作和影响，用户确认后才追加 `--yes`；不要把 `--yes` 写进存储示例。
+- 写后必须核验。非幂等写超时、缺少稳定 ID 或读回失败时先对账，禁止盲目重放。
 
 <!-- VISIBLE_SHORTCUTS_START -->
 ## Shortcuts（无专用脚本/recipe 时优先）
@@ -44,80 +46,50 @@ metadata:
 | `dws todo +update` | write | 更新待办并读回验证 |
 <!-- VISIBLE_SHORTCUTS_END -->
 
-## 意图表
+## 路由优先级
 
-| 用户说 | 命令 |
-|--------|------|
-| "建一条待办给张三" | `dws todo task create --title "<标题>" --executors <userId>` |
-| "较高 / 高优先级待办" | `dws todo task create ... --priority 30`（10低/20普通/30较高/40紧急） |
-| "紧急 / 最高优先级 / 立即处理" | `dws todo task create ... --priority 40` |
-| "循环待办（每天）" | `dws todo task create ... --due "<首次截止ISO>" --recurrence "DTSTART:<UTC>\nRRULE:FREQ=DAILY;INTERVAL=1"` |
-| "批量建待办" | 按 SOP-4 逐条创建、收集 `taskId` 并批量回读 |
-| "今天 / 本周未完成待办" | `python scripts/todo_daily_summary.py [today\|tomorrow\|week]` |
-| "逾期待办" | `python scripts/todo_overdue_check.py` |
-| "标记完成 / 重开" | `dws todo task done --task-id <taskId> --status true\|false` |
-| "修改标题/截止时间/优先级" | `dws todo task update --task-id <taskId> ...` |
-| "删除待办" | `dws todo task delete --task-id <taskId>`（需用户确认） |
+上面的通用 shortcut 优先规则只适用于单一、完整命中的请求。本 Skill 的实际优先级是：
 
-## 标准 SOP（必遵流程）
+1. **组合生命周期 → 原子命令闭环**：同一请求含创建后再列表、更新、完成、提醒、评论、附件、成员、子待办、标签或清理时，先读 [组合流程](references/02-task.md)，全程使用 `todo task/comment/tag ...` 原子命令。不要用 `+remind` / `+create` 代替组合流程的第一步，也不要混用两套返回结构。
+2. **确定性批量/汇总 → 脚本**：批量创建、今天/明天/本周汇总、逾期扫描分别用 bundled scripts。
+3. **单一意图 → Shortcut**：只在一个 shortcut 已经覆盖完整目标、校验和结果形态时直接使用。
+4. **未知低频能力 → 精确 Reference/Help**：只读当前操作的小节，不要枚举后试错。
 
-> 命中以下意图**必须**按对应 SOP 顺序执行；**禁止**跳步、替换命令、编造 taskId。每条命令必须带 `--format json`。创建/完成/删除后**必须**回读验证，不要凭创建返回或口头计划就结束。
+## 高频路线
 
-### SOP-1 建待办（create-todo）
+| 用户意图 | 首选入口 | 边界 |
+|---|---|---|
+| 给自己创建一条普通待办 | `dws todo +remind --task "<标题>" [--at "<截止ISO>"] --format json` | `--at` 是截止时间，不是独立提醒 |
+| 按姓名给一人/多人指派一条待办 | `+assign` / `+assign-multi` | 任一姓名不唯一就停止，不能猜 `userId` |
+| 已有 `userId`，只创建并回读一条待办 | `dws todo +create --title "<标题>" --executors <USER_ID> ... --format json` | 结果必须含稳定 `taskId` 且读回一致 |
+| 创建后还要做其他操作 | `dws todo task create ... --format json` | 从 `result.taskId` 进入同一原子命令闭环 |
+| 按状态、优先级、角色、日期或页码枚举 | `dws todo task list ... --format json` | `--status false/true`；`hasMore=true` 继续翻页 |
+| 当前组织我的待办 / 与我相关的全部待办 | `+get-my-tasks` / `+get-related-tasks` | 后者是创建人、执行人、参与人并集 |
+| 按标题关键词定位 / 已知 ID 查详情 | `+search --query ...` / `+get --task-id ...` | 零个或多个候选时停止消歧 |
+| 已知 ID 完成、重开、更新 | `+complete` / `+reopen` / `+update` | shortcut 会做状态检查或读回核验 |
+| 今天到期 / 逾期 | `+due-today` / `+overdue` | 空集合也是成功结果 |
+| 设置或清除独立提醒 | `+reminder` | 上游无提醒查询接口，只能报告写回执，不能声称读回 |
 
-**触发**：建待办/任务提醒/指派任务/TODO。
+## 组合任务闭环
 
-1. **解析执行者（必须）**：指定姓名 → `dws aisearch person --query "<姓名>" --dimension name --format json` 取 `userId`；未指定 → `dws contact user get-self --format json` 取当前用户 `userId`；多人逐个搜索后英文逗号拼接。
-2. **执行（必须）**：`dws todo task create --title "<标题>" --executors <userId>[,<userId2>...] --priority <10/20/30/40> --format json`；有截止时间加 `--due "<ISO>"`；循环待办加 `--due "<首次截止ISO>" --recurrence "DTSTART:<UTC>\nRRULE:FREQ=DAILY;INTERVAL=1"`。
-3. **验证（必须）**：从返回取 `taskId`/`todoTaskId`，立即 `dws todo task get --task-id <taskId> --format json` 回读。
+1. 执行前列出用户要求的全部资源动作及顺序；同一链路使用同一个 profile。
+2. 原子创建必须先取得执行人：未指定执行人用 `dws contact me --format json`；指定姓名用 `dws aisearch person --query "<姓名>" --dimension name --format json` 并唯一匹配。
+3. 创建后只从 `result.taskId` 提取稳定 ID。后续评论、附件和标签编号分别来自 `comment list`、`task list-attachment`、`tag create/list` 的真实返回。
+4. 每次写后使用对应 read/list 核验；提醒例外，只保留终端写回执。最后仅清理本次创建且已经记录 ID 的对象。
 
-**禁止**：跳过执行者解析直接传姓名、用 `task detail` 取详情（正确是 `task get`）、创建后不回读。
+## 关键约束
 
-### SOP-2 查询待办（query-todo）
+- 公开命令统一使用 `--task-id`；不要在新命令中使用隐藏兼容别名 `--id` / `--ids`。
+- 优先级：低=10、普通=20、较高/高/重要=30、紧急/最高/P0=40。
+- `--due` 与 `+remind --at` 表示 deadline；独立 reminder 用 `+reminder` 或原子 `task add-reminder`。
+- `task list` 用 `--status`，不要写 `--done`；详情命令是 `task get`，不存在 `task detail`。
+- “待办标签”始终使用 `dws todo tag ...`，绝不能解释为 Git tag、文档标签或其他产品标签。
+- 本地文件作为待办附件时使用 `task add-attachment --file <绝对路径>`；先确认待办存在，不得用上传动作试探权限。
+- 会后行动项先走 `dingtalk-minutes` 取真实内容；OA 审批走 `dingtalk-misc`；时间块和会议走 `dingtalk-calendar`。
 
-**触发**：查待办/今天本周待办/未完成/已完成。
+## 按需参考
 
-1. **执行（必须）**：`dws todo task list --status false|true --format json`（`false`=未完成、`true`=已完成、不传=全部）；`hasMore=true` 必须翻页。
-2. **摘要脚本（必须）**：今天/本周未完成 → `python scripts/todo_daily_summary.py today|tomorrow|week`；逾期 → `python scripts/todo_overdue_check.py`。
-3. **详情（必须）**：`dws todo task get --task-id <taskId> --format json`；按主题筛选先 `task list` 再按标题过滤，**禁止**编造主题查询 flag。
-
-**禁止**：写 `--done true`（用 `--status true`）、编造主题筛选参数。
-
-### SOP-3 完成 / 重开 / 改 / 删（mutate-todo）
-
-**触发**：标记完成/重开/改标题截止优先级/删待办。
-
-1. **执行（必须）**：完成/重开 `dws todo task done --task-id <taskId> --status true|false --format json`；修改 `dws todo task update --task-id <taskId> ...`；删除 `dws todo task delete --task-id <taskId>`（**必须**先与用户确认）。
-2. **验证（必须）**：`task done`/`update` 后用 `task get` 或对应 `task list --status ...` 回读确认；`delete` 后用 `task get` 确认已不存在或列表已移除。
-
-**禁止**：未确认就删除、用 `update --done`（首选 `task done --status`）、改动后不回读。
-
-### SOP-4 批量建待办（batch-create）
-
-**触发**：批量建待办/一次建多条。
-
-1. **解析（必须）**：执行者姓名先批量解析成真实 `userId`；单批最多 30 条。
-2. **执行（必须）**：对每条待办执行 `dws todo task create --title "<标题>" --executors <userId> --priority <10/20/30/40> [--due "<ISO>"] --format json`，逐条收集返回的 `taskId`/`todoTaskId`。可并行执行，但不得丢失“输入条目 → taskId”对应关系。
-3. **验证（必须）**：对全部新建 `taskId` 执行 `dws todo task get --task-id <taskId> --format json` 回读；多 ID 按共享并行规则处理，全部成功后才能报告批量创建完成。
-
-**禁止**：只统计创建命令退出码、不保留 taskId、创建后不回读、在执行者位置传姓名。
-
-## 参数硬约束
-
-- 任务详情只用 `dws todo task get --task-id <taskId>`；不要写 `task detail`。
-- 完成状态首选 `dws todo task done --task-id <taskId> --status true|false`；若用 `update`，也必须是 `--task-id` + `--done true|false`。
-- 查询列表完成状态用 `dws todo task list --status false|true --format json`。不要写 `--done true` 作为可见参数，虽然兼容但不作为推荐写法。
-- `--id` / `--ids` 是隐藏兼容别名，文档和生成命令统一写 `--task-id`，减少模型漂移。
-- 优先级映射：低=10，普通=20，较高/高/重要=30，紧急/最高/P0/马上处理=40；不要把"较高"写成 40。
-- 截止时间必须是 ISO-8601。相对日期按当前日期计算；例如周五说"下周二"就是紧接下一个自然周的周二，不要再加一周。
-- 创建、标记完成、重开、删除后必须 `task get` 或对应 `task list --status ...` 验证，不要只凭创建返回或口头计划结束。
-- 所有 dws 命令带 `--format json`。
-
-## 跨产品协作
-
-- 执行人是人名 → 先用 `dingtalk-aisearch` 拿 `userId`
-- 会后从听记自动建待办 → 切到 `dingtalk-minutes`
-- 项目进度汇总写文档 → 切到 `dingtalk-doc`
-## 局部意图与短流程
-
-- [局部意图消歧](references/intent-guide.md)；[短流程](references/lite-recipes.md)。
+- [单步与短流程](references/lite-recipes.md)
+- [组合生命周期与动态 ID 传递](references/02-task.md)
+- [局部意图消歧](references/intent-guide.md)
+- [完整原子命令参考](references/todo.md)

--- a/skills/multi/dingtalk-todo/SKILL.md
+++ b/skills/multi/dingtalk-todo/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 - 只用 `dws` 操作钉钉待办，命令统一加 `--format json`，并按结构化业务返回判断结果。
 - 已知路线直接执行；仅在 leaf 参数或安全语义不确定时查精确 Schema，在 flag 不确定时查精确 Help。不要先枚举整个 Catalog，也不要连续猜命令。
-- 后续 ID 必须来自本次真实返回；零匹配、多匹配或类型不明时停止并消歧。
+- 后续 ID 必须来自本次真实返回；跨步骤可混用 shortcut 与原子命令，但只传递规范化后的稳定 ID，不能假设两类命令的完整返回结构相同。零匹配、多匹配或类型不明时停止并消歧。
 - 写操作遵循最终 Runtime gate。需要确认时先说明对象、动作和影响，用户确认后才追加 `--yes`；不要把 `--yes` 写进存储示例。
 - 写后必须核验。非幂等写超时、缺少稳定 ID 或读回失败时先对账，禁止盲目重放。
 
@@ -48,33 +48,35 @@ metadata:
 
 ## 路由优先级
 
-上面的通用 shortcut 优先规则只适用于单一、完整命中的请求。本 Skill 的实际优先级是：
+不要按整段请求强制选择同一类命令；先拆成有序步骤，再逐步选择最窄且完整覆盖该步骤的入口：
 
-1. **组合生命周期 → 原子命令闭环**：同一请求含创建后再列表、更新、完成、提醒、评论、附件、成员、子待办、标签或清理时，先读 [组合流程](references/02-task.md)，全程使用 `todo task/comment/tag ...` 原子命令。不要用 `+remind` / `+create` 代替组合流程的第一步，也不要混用两套返回结构。
-2. **确定性批量/汇总 → 脚本**：批量创建、今天/明天/本周汇总、逾期扫描分别用 bundled scripts。
-3. **单一意图 → Shortcut**：只在一个 shortcut 已经覆盖完整目标、校验和结果形态时直接使用。
-4. **未知低频能力 → 精确 Reference/Help**：只读当前操作的小节，不要枚举后试错。
+1. **确定创建入口**：按姓名指派用 `+assign` / `+assign-multi`。给自己创建且后续只有定位、回读和清理时用 `+remind`；已有 `userId` 的同类短流程用 `+create`。后续若有筛选、资源写入或多个对象，则用原子 `task create`。
+2. **后续逐步路由**：详情、完成、重开、更新、搜索、评论、提醒及评论/附件/子待办列表，优先用完整覆盖该步的 `+get` / `+complete` / `+reopen` / `+update` / `+search` / `+comment` / `+reminder` / `+list-*`。无完整 shortcut 时使用原子命令。
+3. **跨步骤只传稳定 ID**：shortcut 与原子命令可以共存；创建后先提取真实 `taskId`，评论、附件和标签再从各自真实返回取 ID。不要把某个入口的包装字段路径套到另一个入口。
+4. **确定性批量/汇总 → 脚本**：批量创建、今天/明天/本周汇总、逾期扫描分别用 bundled scripts。
+5. **未知低频能力 → 精确 Reference/Help**：只读当前操作的小节，不要枚举后试错。
 
 ## 高频路线
 
 | 用户意图 | 首选入口 | 边界 |
 |---|---|---|
-| 给自己创建一条普通待办 | `dws todo +remind --task "<标题>" [--at "<截止ISO>"] --format json` | `--at` 是截止时间，不是独立提醒 |
+| 给自己创建，随后只定位、看详情或清理 | `dws todo +remind --task "<标题>" [--at "<截止ISO>"] --format json` | `--at` 是截止时间，不是独立提醒；若后续有列表筛选或资源写入则改用原子创建 |
 | 按姓名给一人/多人指派一条待办 | `+assign` / `+assign-multi` | 任一姓名不唯一就停止，不能猜 `userId` |
-| 已有 `userId`，只创建并回读一条待办 | `dws todo +create --title "<标题>" --executors <USER_ID> ... --format json` | 结果必须含稳定 `taskId` 且读回一致 |
-| 创建后还要做其他操作 | `dws todo task create ... --format json` | 从 `result.taskId` 进入同一原子命令闭环 |
+| 已有 `userId`，只创建、回读和清理一条待办 | `dws todo +create --title "<标题>" --executors <USER_ID> ... --format json` | 结果必须含稳定 `taskId` 且读回一致 |
+| 创建后还要筛选或修改资源 | `dws todo task create ... --format json` | 从 `result.taskId` 进入后续步骤；后续读取仍可选 `+get` 等 shortcut |
 | 按状态、优先级、角色、日期或页码枚举 | `dws todo task list ... --format json` | `--status false/true`；`hasMore=true` 继续翻页 |
 | 当前组织我的待办 / 与我相关的全部待办 | `+get-my-tasks` / `+get-related-tasks` | 后者是创建人、执行人、参与人并集 |
 | 按标题关键词定位 / 已知 ID 查详情 | `+search --query ...` / `+get --task-id ...` | 零个或多个候选时停止消歧 |
 | 已知 ID 完成、重开、更新 | `+complete` / `+reopen` / `+update` | shortcut 会做状态检查或读回核验 |
 | 今天到期 / 逾期 | `+due-today` / `+overdue` | 空集合也是成功结果 |
 | 设置或清除独立提醒 | `+reminder` | 上游无提醒查询接口，只能报告写回执，不能声称读回 |
+| 创建、改名、列出或删除待办标签 | `tag create` / `tag update` / `tag list` / `tag delete` | “待办标签”属于 Todo，不是通讯录标签、Git tag 或其他产品标签 |
 
 ## 组合任务闭环
 
-1. 执行前列出用户要求的全部资源动作及顺序；同一链路使用同一个 profile。
+1. 执行前列出用户要求的全部资源动作及顺序，并为每一步单独选 shortcut 或原子命令；同一链路使用同一个 profile。
 2. 原子创建必须先取得执行人：未指定执行人用 `dws contact me --format json`；指定姓名用 `dws aisearch person --query "<姓名>" --dimension name --format json` 并唯一匹配。
-3. 创建后只从 `result.taskId` 提取稳定 ID。后续评论、附件和标签编号分别来自 `comment list`、`task list-attachment`、`tag create/list` 的真实返回。
+3. 原子创建从 `result.taskId` 取 ID；创建 shortcut 从其成功结果的 `taskId` 取 ID。后续评论、附件和标签编号分别来自 `+comment`/`comment list`、`task list-attachment`、`tag create/list` 的真实返回；不要跨入口猜字段层级。
 4. 每次写后使用对应 read/list 核验；提醒例外，只保留终端写回执。最后仅清理本次创建且已经记录 ID 的对象。
 
 ## 关键约束

--- a/skills/multi/dingtalk-todo/references/02-task.md
+++ b/skills/multi/dingtalk-todo/references/02-task.md
@@ -1,19 +1,61 @@
-# 任务管理
+# Todo 组合生命周期
 
-> **SKILL.md** 中 #2 仅内联 **lite**：`create-todo`、`todo-query-ops`。其中 `todo-query-ops` 统一覆盖 list/get/complete/reopen/topic-filter。下列 recipe 已迁出速查表，命中时读本文件对应行。重型 **full** 见下表「行动指南」。命令细节见 [todo.md](./todo.md)。
+当一个请求包含两个以上资源动作，特别是“创建 → 操作 → 查看 → 清理”时，使用本文件。组合链路统一走原子命令，不把 shortcut 与原子返回结构混在一起。
 
-## Recipe 速查（非 SKILL lite）
+## 通用骨架
 
-| Recipe | 步骤（命令均须 `--format json`，下略）                                                                                                                                                                                                                        |
-|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `create-priority-todo` | 1. 确定执行者（同 [SKILL.md](../SKILL.md) 中 `create-todo` 步骤 1）<br>2. `todo task create --title "<标题>" --executors <userId>[,<userId2>...] --priority <10/20/30/40>`（可选 `--due "<截止ISO>"`；10低/20普通/30较高/40紧急）→ 取 `todoTaskId`<br>3. `todo task get --task-id <todoTaskId>` 回读标题、执行者、优先级和截止时间 |
-| `create-recurring-todo` | 1. 确定执行者（同 `create-todo` 步骤 1）<br>2. `todo task create --title "<标题>" --executors <userId> --due "<首次截止ISO>" --priority <10/20/30/40> --recurrence "DTSTART:<UTC时间>\nRRULE:FREQ=DAILY;INTERVAL=1"`（`--due` 必填；仅支持按天循环，见 [todo.md](./todo.md)）→ 取 `todoTaskId`<br>3. `todo task get --task-id <todoTaskId>` 回读循环规则和任务字段 |
-| `reschedule-todo` | 1. `todo task list --status false` → 取 `todoTaskId`<br>2. `todo task update --task-id <todoTaskId> --due "<新截止时间>"`                                                                                                                                |
+1. 先列出完整动作序列和需要传递的 ID，不要边执行边发现路线。
+2. 未指定执行人时运行 `dws contact me --format json`；指定姓名时运行 `dws aisearch person --query "<姓名>" --dimension name --format json`，唯一匹配后取 `userId`。
+3. 创建父待办：
 
-## Full / 组合（固定路线）
+   ```bash
+   dws todo task create --title "<标题>" --executors <USER_ID> [--priority 10|20|30|40] [--due "<截止ISO>"] [--recurrence "<规则>"] --format json
+   ```
 
-| Recipe | 行动指南（固定路线）                                                                                                                                                                                                                                                                                                                                                                                    |
-|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| generate-progress-report | 1. 按[「多源并行采集」](recipes/conventions.md#多源并行采集公共模式)执行<br>2. 交叉比对各源数据<br>3. `doc create --name "<报告名>" --content "<报告内容>"`                                                                                                                                                                                                                                                                    |
-| batch-create-todo | 1. 按[「多源并行采集」](recipes/conventions.md#多源并行采集公共模式)执行 → 从结果提取任务条目<br>2. 每条：`aisearch person --query "<姓名>" --dimension name` → 取真实 `userId`；同名时先消歧<br>3. 逐条执行 `todo task create --title "<标题>" --executors <userId> --priority <10/20/30/40>`，从每次响应收集真实 `todoTaskId`；单批超 30 条须用户确认<br>4. 对全部 `todoTaskId` 并行执行 `todo task get --task-id <todoTaskId>`，逐项核对标题、执行者、优先级和截止时间；不能只以退出码或创建响应作为成功证据 |
-| assign-and-notify | 1. `aisearch person --query "<姓名>" --dimension name` → 取 `userId`<br>2. `todo task create --title "<标题>" --executors <userId> --priority <10/20/30/40>` → 取 `todoTaskId`<br>3. `todo task get --task-id <todoTaskId>` 回读任务，确认无误后再通知<br>4. `chat search --query "<群名>"` → 取 `openConversationId` → `chat message send --conversation-id <openConversationId> --content "<通知内容>"` |
+4. 只从成功响应的 `result.taskId` 取 ID，立即 `dws todo task get --task-id <TASK_ID> --format json` 核验。
+5. 按下表执行后续动作；每一步都复用真实 ID，并用对应读取命令核验。
+6. 只清理本次创建且已记录 ID 的对象；删除类操作先走 Runtime 确认门。删除后 `task get` 不存在或列表移除才算清理完成。
+
+## 原子路线表
+
+| 意图 | 写命令 | 核验 / ID 来源 |
+|---|---|---|
+| 按状态/优先级/角色/日期查询 | `task list --status ... --priority ... --role-types ... --plan-finish-date-start ... --plan-finish-date-end ...` | 遍历 `result.todoCards[]`；`hasMore=true` 时递增 `--page` |
+| 更新标题/优先级/截止时间 | `task update --task-id <TASK_ID> ...` | `task get --task-id <TASK_ID>` 逐字段核验 |
+| 完成 / 重开 | `task done --task-id <TASK_ID> --status true|false` | `task get` 或对应状态的 `task list` |
+| 创建子待办 | `task create-sub --parent-id <PARENT_ID> --title "<标题>" --executors <USER_ID>` | 取响应 `result.taskId`；`task list-sub --task-id <PARENT_ID>` |
+| 增删执行人 | `task add-executor --task-id <TASK_ID> --executors <USER_ID>` / `task remove-executor --task-id <TASK_ID> --executors <USER_ID>` | `task get`；只移除本次明确添加的人 |
+| 增删参与人 | `task add-participant --task-id <TASK_ID> --participants <USER_ID>` / `task remove-participant --task-id <TASK_ID> --participants <USER_ID>` | `task get`；执行人与参与人不可混用 |
+| 添加评论 | `comment add --task-id <TASK_ID> --content "<内容>"` | 从 `comment list` 的 `result.comments[].id` 取真实评论 ID 并核对内容 |
+| 删除评论 | `comment delete --task-id <TASK_ID> --comment-id <COMMENT_ID>` | 再次 `comment list` 确认目标不存在 |
+| 上传附件 | `task add-attachment --task-id <TASK_ID> --file <绝对路径>` | `task list-attachment` 取真实 `attachmentId` 并核对文件名 |
+| 移除附件 | `task remove-attachment --task-id <TASK_ID> --attachment-id <ATTACHMENT_ID>` | 再次 `task list-attachment` |
+| 添加截止前提醒 | `task add-reminder --task-id <TASK_ID> --base-time dueTime --due-date-offset -30` | 只有终端写回执；待办必须已有截止时间 |
+| 添加独立提醒 | `task add-reminder --task-id <TASK_ID> --base-time customTime --reminder-time-stamp "<提醒ISO>"` | 只有终端写回执 |
+| 替换/清空提醒 | `task reset-reminder --task-id <TASK_ID> [--reminder-rules '<JSON数组>']` | 不传规则即清空；不能声称已读回规则 |
+| 创建/列出标签 | `tag create --name "<名称>"` / `tag list` | 创建前后比较 `result.userTags[]`，只接受唯一新增的 `code` |
+| 关联标签 | `tag add --task-id <TASK_ID> --tag-codes <TAG_CODE_1>[,<TAG_CODE_2>]` | `task get` 或写回执；最多两个标签 |
+| 改名标签 | `tag update --user-tags '[{"code":"<TAG_CODE>","name":"<新名称>"}]'` | `tag list` 核对同一 `code` 的名称 |
+| 删除标签定义 | `tag delete --tag-codes <TAG_CODE>` | `tag list` 确认标签定义不存在 |
+| 删除待办 | `task delete --task-id <TASK_ID>` | `task get` 不存在或对应列表已移除 |
+
+所有表中命令都加前缀 `dws todo` 和后缀 `--format json`。
+
+## 动态 ID 账本
+
+| ID | 只允许来自 | 禁止来源 |
+|---|---|---|
+| `taskId` | `task create/create-sub/get/list` 的业务返回 | 标题、URL、展示序号、其他 case |
+| `commentId` | 同一 `taskId` 的 `comment list` 返回 `result.comments[].id` | 评论文本或猜测 |
+| `attachmentId` | 同一 `taskId` 的 `task list-attachment` 返回 `attachments[].attachmentId` | 文件名或本地路径 |
+| `tagCode` | `todo tag create/list` 返回 `result.userTags[].code` | 标签名或 Git tag |
+| `userId` | `contact me` 或 `aisearch person` 的唯一匹配 | 姓名、手机号片段、其他 profile |
+
+“待办标签”只能调用 `dws todo tag ...`；禁止运行 `git tag`。本地待办附件只能调用 `dws todo task add-attachment`，不要改走 Drive。
+
+## 失败与恢复
+
+- `unknown command/flag`：查该 leaf 的 `--help` 后最多修正一次，不要轮询相似命令。
+- 创建、评论等非幂等写超时或返回不明：保留“可能已提交”，先按标题/父 ID 查询对账，不自动重试。
+- 提醒接口没有查询能力：成功时只报告服务端接受写入；失败时保留原错误。
+- 任一步失败后仍要按账本清理已创建的临时对象；未取得稳定 ID 的对象不得猜 ID 清理。

--- a/skills/multi/dingtalk-todo/references/02-task.md
+++ b/skills/multi/dingtalk-todo/references/02-task.md
@@ -1,19 +1,19 @@
 # Todo 组合生命周期
 
-当一个请求包含两个以上资源动作，特别是“创建 → 操作 → 查看 → 清理”时，使用本文件。组合链路统一走原子命令，不把 shortcut 与原子返回结构混在一起。
+当一个请求包含多个资源动作并需要传递 `taskId`、`commentId`、`attachmentId` 或 `tagCode` 时使用本文件。组合链路可以逐步混用 shortcut 与原子命令，但只能传递已经规范化的稳定 ID，不能把一种入口的完整返回结构当成另一种入口的结构。
 
 ## 通用骨架
 
 1. 先列出完整动作序列和需要传递的 ID，不要边执行边发现路线。
 2. 未指定执行人时运行 `dws contact me --format json`；指定姓名时运行 `dws aisearch person --query "<姓名>" --dimension name --format json`，唯一匹配后取 `userId`。
-3. 创建父待办：
+3. 选择创建入口：后续只有搜索、详情回读和清理时可用 `+remind` / `+create`；若要列表筛选、资源写入、创建子资源或一次创建多个对象，使用原子创建：
 
    ```bash
    dws todo task create --title "<标题>" --executors <USER_ID> [--priority 10|20|30|40] [--due "<截止ISO>"] [--recurrence "<规则>"] --format json
    ```
 
-4. 只从成功响应的 `result.taskId` 取 ID，立即 `dws todo task get --task-id <TASK_ID> --format json` 核验。
-5. 按下表执行后续动作；每一步都复用真实 ID，并用对应读取命令核验。
+4. 原子创建从成功响应的 `result.taskId` 取 ID；创建 shortcut 从其成功结果的 `taskId` 取 ID。需要详情时优先 `dws todo +get --task-id <TASK_ID> --format json`。
+5. 按下表执行后续动作；每一步都复用真实 ID。表中原子命令是保底路径；若对应 `+get`、`+search`、`+complete`、`+reopen`、`+update`、`+comment`、`+reminder` 或 `+list-*` 完整覆盖当前步骤，则优先使用 shortcut 自带的校验。
 6. 只清理本次创建且已记录 ID 的对象；删除类操作先走 Runtime 确认门。删除后 `task get` 不存在或列表移除才算清理完成。
 
 ## 原子路线表
@@ -45,8 +45,8 @@
 
 | ID | 只允许来自 | 禁止来源 |
 |---|---|---|
-| `taskId` | `task create/create-sub/get/list` 的业务返回 | 标题、URL、展示序号、其他 case |
-| `commentId` | 同一 `taskId` 的 `comment list` 返回 `result.comments[].id` | 评论文本或猜测 |
+| `taskId` | 原子 `task create/create-sub/get/list` 或 Todo shortcut 的成功业务返回 | 标题、URL、展示序号、其他 case |
+| `commentId` | 同一 `taskId` 的 `+comment` 成功结果或 `comment list` 的 `result.comments[].id` | 评论文本或猜测 |
 | `attachmentId` | 同一 `taskId` 的 `task list-attachment` 返回 `attachments[].attachmentId` | 文件名或本地路径 |
 | `tagCode` | `todo tag create/list` 返回 `result.userTags[].code` | 标签名或 Git tag |
 | `userId` | `contact me` 或 `aisearch person` 的唯一匹配 | 姓名、手机号片段、其他 profile |

--- a/skills/multi/dingtalk-todo/references/intent-guide.md
+++ b/skills/multi/dingtalk-todo/references/intent-guide.md
@@ -1,11 +1,15 @@
-# todo 局部意图消歧
+# Todo 局部意图消歧
 
-本文件从单 Skill `intent-guide.md` 拆分而来，仅保留与本产品相关的跨产品消歧规则。
+| 用户说 | 应该用 | 不要用 | 边界 |
+|---|---|---|---|
+| “帮我记一下明天要做的事” | `todo +remind` | `doc` | 这是个人待办；`--at` 写截止时间 |
+| “给自己留一个明天下午的时间块” | `calendar event create` | `todo` | 时间块属于日历事件 |
+| “明早 9 点提醒我提交周报” | 先创建待办，再用 `todo +reminder --base-time customTime --at ...` | 把 `+remind --at` 当提醒 | 独立提醒与截止时间是两个字段 |
+| “截止前 30 分钟提醒” | `todo +reminder --base-time dueTime --due-date-offset -30` | `calendar` | 待办必须先有截止时间 |
+| “每天重复提醒我” | `todo task create --due ... --recurrence ...`，必要时再加 reminder | 只写 reminder | recurrence 管重复待办；reminder 管单条待办提醒 |
+| “创建/修改/删除待办标签” | `dws todo tag ...` | `git tag`、文档标签 | 标签名不是 `tagCode`，后续使用真实返回 |
+| “提交日报/周报” | `dingtalk-misc` | `todo` | 日志产品不是个人待办 |
+| “审批这个申请” | `dingtalk-misc` | `todo` | OA 审批任务与个人待办不同 |
+| “把会议行动项建成待办” | 先用 `dingtalk-minutes` 取真实行动项，再进入 Todo | 凭标题猜行动项 | 来源证据归听记，任务对象归 Todo |
 
-| 用户说... | 真实意图 | 应该用 | 不要用 | 理由 |
-|---|---|---|---|---|
-| "帮我记一下明天要做的事" | 创建个人待办 | `todo` | `doc` | 个人待办提醒，非文档内容 |
-| "给自己留一个明天下午的时间块/建个个人日程" | 创建个人日程 | `calendar event create` | `todo` | 个人 schedule 仍属于日历事件，不是待办 |
-| "明早 9 点提醒我提交周报" | 创建个人待办，但需先声明 reminder 边界 | `todo` | `calendar` | todo 当前只支持 dueTime 截止时间，不支持独立精确 reminder |
-| "帮我创建一个待办提醒" | 个人待办 | `todo` | `report` | 个人任务提醒，不是日志汇报 |
-| "把最近几次关于XX的会议汇总成报告" | 按主题汇总多次听记 | #5 generate-topic-report | #7 meeting-followup | #7 是单次会议听记跟进；多次会议按主题汇总属于工作汇报 |
+提醒写入目前没有对应查询接口，成功响应只能证明服务端接受了写请求，不能声称已经读回核验规则。

--- a/skills/multi/dingtalk-todo/references/lite-recipes.md
+++ b/skills/multi/dingtalk-todo/references/lite-recipes.md
@@ -1,151 +1,57 @@
-# todo Lite Recipe
+# Todo 单步与短流程
 
-本文件从单 Skill `lite-recipes.md` 拆分而来，仅保留与本产品相关的轻量流程。
+只在请求是单一 Todo 意图时使用本文件；创建后还要继续操作资源时，改读 [02-task.md](02-task.md)。
 
-## #2 任务管理
+## 创建一条待办
 
-### create-todo
-
-1. 确定执行者：指定姓名 → `aisearch person --query "<姓名>" --dimension name` → `userId`；未指定 → `contact user get-self` → `userId`；多人 → 逐个搜索逗号拼接。
-2. 创建：`todo task create --title "<标题>" --executors <userId>[,<userId2>...] --priority <优先级>`（可选 `--due "<截止ISO>"`）→ `todoTaskId`
-
-### todo-query-ops
-
-- 查询：`todo task list [--status false|true]`（不传=全部）
-- 详情：`todo task get --task-id <id>`
-- 完成/重开：`todo task done --task-id <id> --status <true|false>`
-- 按主题筛选：list 后按标题关键词过滤
-
-
-## #7 听记与会后
-
-> 产品命令完整参考见 [minutes.md](../../dingtalk-minutes/references/minutes.md)。full recipe 见 [07-minutes.md](../../dingtalk-minutes/references/07-minutes.md)。
-
-### minutes-query（查询与获取）
-
-> **scope 选择铁律（P2 真实 badcase）**：`list` 后的 scope 决定查询范围，最高频误判是把"我能访问的所有听记"错选成 `mine`：
-> - `mine` = **仅我自己创建/发起**的听记（范围最窄）
-> - `shared` = **仅他人共享给我**的听记
-> - `all` = **我可访问的全部**（= mine ∪ shared，范围最广）
-> - **判定口诀**：query 含"访问/权限/可见/能看到/所有/我的"等覆盖范围语义 → 一律走 `all`；**仅当**明确说"我创建的/我发起的/我录的" → 才走 `mine`。**不要因为句子里有"我"字就退化成 `mine`。**
-> - 错误：`我能访问的所有听记` → `list mine`（漏掉共享给我的，判定不通过）
-> - 正确：`我能访问的所有听记` → `dws minutes list all --format json`
-
-> **选对象铁律（0605 P2 EDD badcase 提炼，命令对了但选错听记 = 整任务失败）**：list/搜索拿到结果后，必须按语义精准锁定目标听记，详见 [minutes.md](../../dingtalk-minutes/references/minutes.md)「选对象铁律 S1~S6」。速记：
-> - **S1 跨组织汇总**：以 list 返回的 `taskUuid + title + organizationName` 三元组为准逐条照抄，组织与听记不可张冠李戴。
-> - **S2 "最近一次某类会议"**：先 `--query "<主题词>"`（如周会）过滤出该类，再在候选里取时间最新；主题匹配优先级高于时间。
-> - **S3 比时长最长**：必须读 `durationMicros` 字段做数值比较，禁止凭印象/标题猜，口头结论与操作的 taskUuid 须自洽。
-> - **S4 内容为空**：锁定 taskUuid 后所有 get/update 复用同一 id；某字段为空就如实说，**禁止偷偷切换到另一条听记**。
-> - **S5 模糊日期匹配不到**：日期可能是"会议主题日期"而非"创建日期"，按标题关键词搜，精确日期没命中就放宽 ±7 天/同主题候选请用户确认，**禁止直接报"找不到"**。搜索回退策略：① 先 `--query "<主题关键词>"` 不带日期搜 → ② 若结果过多则加 `--start/--end` 扩大到 ±7 天 → ③ 列出候选让用户确认。
-> - **S6 给标题没给 id**：必须先 `list all --query "<标题关键词>"` 定位 taskUuid 再 update/get，禁止凭记忆直接填 `--id` 跳过定位。
-
-**列表查询**（`list` 后**必须**跟 scope：`mine`/`shared`/`all`，默认补 `all`）：
+给自己：
 
 ```bash
-# 我可访问的所有听记（默认）
-dws minutes list all --format json
-# 按关键词服务端搜索（严禁全量拉取后本地 grep）
-dws minutes list all --query "周会" --format json
-# 按时间范围筛选（ISO-8601 格式）
-dws minutes list mine --start "2026-05-01T00:00:00+08:00" --end "2026-05-25T23:59:59+08:00" --format json
-# 关键词 + 时间组合
-dws minutes list all --query "需求评审" --start "2026-05-25T00:00:00+08:00" --end "2026-05-25T23:59:59+08:00" --format json
-# 限制条数
-dws minutes list mine --limit 5 --format json
-# 共享给我的听记
-dws minutes list shared --query "ROI" --format json
+dws todo +remind --task "<标题>" [--at "<截止ISO>"] --format json
 ```
 
-| 参数 | 说明 |
-|------|------|
-| `--query "<关键词>"` | 服务端关键词搜索 |
-| `--start "<ISO-8601>"` | 开始时间 |
-| `--end "<ISO-8601>"` | 结束时间 |
-| `--limit <N>` | 每页条数，默认 10（`--max` 为兼容别名） |
-| `--cursor "<token>"` | 分页 token，首页留空（`--next-token` 为兼容别名） |
-
-**获取详情**：
-
-- 批量基础信息：`minutes get batch --ids <uuid1,uuid2,...>`
-- 单篇摘要：`minutes get summary --id <taskUuid>`
-- 转写原文（自动翻页）：`minutes get transcription --id <taskUuid>`（返回 `nextToken` 时用 `--next-token <token>` 继续）
-- 关键词：`minutes get keywords --id <taskUuid>`
-- 待办事项：`minutes get todos --id <taskUuid>`
-- 基础信息：`minutes get info --id <taskUuid>`
-- 音频地址：`minutes get audio --id <taskUuid>`
-
-> `--id`/`--uuid`/`--task-uuid` 三者等价。推荐 `--id`。
-
-### minutes-edit（编辑与替换）
-
-- **替换转写文字**：`minutes replace-text --id <taskUuid> --search "旧文字" --replace "新文字"`
-  - 执行前检查特殊字符（引号/书名号/括号等），若包含先提示用户确认去除
-  - 替换成功后追问是否加热词：`minutes hot-word add --words "新文字"`
-- **替换发言人**：先统一搜人取得 dingUid → `minutes speaker replace --id <taskUuid> --from "发言人X" --to "姓名" --target-uid <userId>`
-  - 查询 dingUid：`aisearch person --query "姓名" --dimension name --format json` → 取 `userId`
-  - 多个匹配 → 列出候选让用户选；无匹配 → 不带 `--target-uid` 执行
-- **修改标题**：`minutes update title --id <taskUuid> --title "新标题"`
-- **修改摘要**：`minutes update summary --id <taskUuid> --content "新内容"`
-- **热词管理**：`minutes hot-word add --words "词1,词2"` / `minutes hot-word list`
-- **思维导图**：`minutes mind-graph create --id <taskUuid>` → `mind-graph status --id <taskUuid>` 轮询至完成
-
-### minutes-tag（标签/分组查询）
-
-- 查询标签列表：`minutes tag list` → 返回用户在听记页面创建的所有标签/分组（含 tagId 和名称）
-- 按标签查听记：`minutes tag query --tag-id <tagId> [--limit 20] [--cursor <token>]`
-  - tagId 来自 `tag list` 返回值，不可编造
-  - 支持分页，`--cursor` 传入上一次返回的 nextToken
-
-**典型链路**：用户说"帮我看看'周会'标签下的听记" →
-1. `dws minutes tag list --format json` → 按名称匹配找到 tagId
-2. `dws minutes tag query --tag-id <tagId> --format json`
-
-### minutes-permission（权限管理）
-
-- 添加成员：`minutes permission add --ids <uuid1,uuid2> --member-uids <uid1,uid2> --policy 4`
-  - 需先通过 `aisearch person --query "<姓名>" --dimension name` 获取目标 userId
-  - policy：0=不可见 / 1=仅查看 / 2=查看+下载 / 3=查看+下载+编辑 / 4=全部权限
-- 移除成员：`minutes permission remove --ids <uuid1,uuid2> --member-uids <uid1,uid2>`
-
-### minutes-upload（音频上传）
+按姓名指派：
 
 ```bash
-# 创建上传会话
-dws minutes upload create --file-name "meeting.mp3" --file-size 61565431 --format json
-# 上传完成后确认
-dws minutes upload complete --session-id <sid> --format json
-# 取消上传
-dws minutes upload cancel --session-id <sid> --format json
+dws todo +assign --to "<姓名>" --task "<标题>" --format json
+dws todo +assign-multi --to "<姓名1>,<姓名2>" --task "<标题>" --format json
 ```
 
-### 最佳实践案例速查（详见 [minutes.md](../../dingtalk-minutes/references/minutes.md)）
+已经有真实 `userId`：
 
-| 案例 | 场景 | 正确链路 |
-|------|------|----------|
-| 案例 1 | 听记 URL + 创建思维导图 | 提取 taskUuid → `mind-graph create` → `mind-graph status` 轮询；**禁止**走 app-development 或前端库 |
-| 案例 2 | 替换文字后未引导热词 | 检查特殊字符 → `replace-text` → 追问加热词 `hot-word add` |
-| 案例 3 | 查听记拉了不必要的转写 | 用户只要列表 → `list` 即可，**不要**自动拉 `get transcription` |
-| 案例 4 | 拉完转写只输出时间线原文 | 拉完后追问按发言人聚类 → 引导匹配 → 调用 `speaker replace` 写回 |
-| 案例 5 | 查某人说了什么不引导替换 | 推断发言人 → **用户确认** → 结构化总结 → 引导 `speaker replace` |
-| 案例 6 | 通讯录+部门+转写三路印证 | Step 3 画像 + Step 4 `aisearch person` 并发 → 置信度 ≥70% → 确认 → 替换 |
-| 案例 7 | grep 花名误判未参会 | **禁止**在转写文本里 grep 人名判参会；**必须**调 `aisearch person` |
-| 案例 8 | 听记类 query 不走 dws | **禁止**用 session_search/browser_use/activity:search 替代 dws；模糊请求先 `list mine` |
-| 案例 9 | 按标签筛选听记 | `tag list` → 按名称匹配 tagId → `tag query --tag-id <tagId>`；**禁止**编造 tagId |
+```bash
+dws todo +create --title "<标题>" --executors <USER_ID> [--priority 10|20|30|40] [--due "<截止ISO>"] --format json
+```
 
-### 听记取数深度约束（0609 点踩 case 提炼）
+成功结果必须含稳定 `taskId` 并完成读回。超时、缺少 ID 或 `verified!=true` 时先用搜索/列表对账，禁止重放非幂等创建。
 
-> 详细说明见 [minutes.md](../../dingtalk-minutes/references/minutes.md)。
+## 查询与定位
 
-- **转写原文硬约束**：用户诉求含「聚焦原话/逐字/沟通细节/具体讨论了什么」等词时，**必须先调 `get transcription` 翻页拉全**，禁止仅凭 summary 出稿
-- **数据源下钻**：听记维度**必须 `get summary`（或 `get transcription`）读正文**，严禁只取标题列表；scope 用 `all`；空时换窗重试或标注
-- **听记链接解析**：聊天消息中遇到听记链接（`flash_minutes_detail`/`SHANJI`）→ 解析 `minutesId` → 调 `minutes get summary/transcription`，禁止把链接降级为关键词
-- **忠实性约束**：源数据无某要素（行动项/责任人/数字）时禁止生成；统计字段基于实际取数计数，不得编造
-- **多源全覆盖**：用户枚举多数据源时每个来源都必须调对应工具；瞬时错误重试；如实声明缺失来源，禁编无来源数字
+```bash
+dws todo +get-my-tasks --all --status false --format json
+dws todo +get-related-tasks --format json
+dws todo +search --query "<标题关键词>" --format json
+dws todo +get --task-id <TASK_ID> --format json
+```
 
-### 间接意图识别铁律
+- list 用于枚举，search 用于标题关键词，get 用于已知稳定 ID。
+- 空集合是成功；零匹配或多匹配时不得自行选第一条。
+- 用户明确要求状态、优先级、角色、日期或页码筛选时，使用 `todo task list` 的对应 flag，不要拉全后猜。
 
-query 未提"听记"但任务产出依赖会议讨论内容时（报告/总结/日报/复盘/商业分析/市场感知），听记采集是**必跑前置步骤**：
+## 完成、重开与更新
 
-1. **铁律 A**：任务含"会议/讨论/沟通"信息需求 → `dws minutes list` 必跑
-2. **铁律 B**：用户说"文档啥也没有" → 听记优先级更高（唯一结构化数据源）
-3. **铁律 C**：多源聚合场景 → 每个被提及的数据源都必须有采集动作，听记侧 0 调用 = 严重失败
+```bash
+dws todo +complete --task-id <TASK_ID> --format json
+dws todo +reopen --task-id <TASK_ID> --format json
+dws todo +update --task-id <TASK_ID> --title "<新标题>" --format json
+```
+
+只记得标题时用 `+todo-done --task "<关键词>"`；它只在唯一命中时修改。
+
+## 提醒、汇总与批量
+
+- `+remind --at` 设置截止时间；独立提醒使用 `+reminder --base-time customTime --at "<提醒ISO>"`。
+- 截止前提醒使用 `+reminder --base-time dueTime --due-date-offset -30`，待办必须已有截止时间。
+- 今天/明天/本周汇总：`python scripts/todo_daily_summary.py today|tomorrow|week`。
+- 逾期扫描：`python scripts/todo_overdue_check.py`。
+- 批量创建：`python scripts/todo_batch_create.py <todos.json>`；单批最多 30 条，以逐项 ledger 为准。

--- a/skills/multi/dingtalk-todo/references/lite-recipes.md
+++ b/skills/multi/dingtalk-todo/references/lite-recipes.md
@@ -1,6 +1,6 @@
 # Todo 单步与短流程
 
-只在请求是单一 Todo 意图时使用本文件；创建后还要继续操作资源时，改读 [02-task.md](02-task.md)。
+用于单步 Todo 意图，也用于组合请求中被 shortcut 完整覆盖的独立步骤。涉及动态子资源 ID 或原子特有操作时，同时读 [02-task.md](02-task.md)。
 
 ## 创建一条待办
 
@@ -23,7 +23,7 @@ dws todo +assign-multi --to "<姓名1>,<姓名2>" --task "<标题>" --format jso
 dws todo +create --title "<标题>" --executors <USER_ID> [--priority 10|20|30|40] [--due "<截止ISO>"] --format json
 ```
 
-成功结果必须含稳定 `taskId` 并完成读回。超时、缺少 ID 或 `verified!=true` 时先用搜索/列表对账，禁止重放非幂等创建。
+后续只有搜索、详情回读和清理时可保留上述创建 shortcut；若还要列表筛选、更新状态/字段、提醒、评论、附件、成员、子待办、标签或创建多个对象，创建步骤改用原子 `task create`。成功结果必须含稳定 `taskId` 并完成读回。超时、缺少 ID 或 `verified!=true` 时先用搜索/列表对账，禁止重放非幂等创建。
 
 ## 查询与定位
 

--- a/skills/multi/dingtalk-todo/references/todo.md
+++ b/skills/multi/dingtalk-todo/references/todo.md
@@ -108,7 +108,6 @@ Usage:
   dws todo task delete [flags]
 Example:
   dws todo task delete --task-id <taskId>
-  dws todo task delete --task-id <taskId> --yes
 Flags:
       --task-id string   待办任务 ID (必填)
 ```
@@ -146,7 +145,6 @@ Usage:
   dws todo comment delete [flags]
 Example:
   dws todo comment delete --task-id <taskId> --comment-id <commentId>
-  dws todo comment delete --task-id <taskId> --comment-id <commentId> --yes
 Flags:
       --task-id string      待办任务 ID (必填)
       --comment-id string   评论 ID (必填)
@@ -237,7 +235,6 @@ Usage:
   dws todo task remove-attachment [flags]
 Example:
   dws todo task remove-attachment --task-id <taskId> --attachment-id <attachmentId>
-  dws todo task remove-attachment --task-id <taskId> --attachment-id <attachmentId> --yes
 Flags:
       --attachment-id string   待办附件 ID (必填)
       --task-id string         待办任务 ID (必填)
@@ -314,7 +311,6 @@ Usage:
   dws todo tag delete [flags]
 Example:
   dws todo tag delete --tag-codes code1,code2
-  dws todo tag delete --tag-codes code1,code2 --yes
 Flags:
       --tag-codes string   要删除的标签编码列表,逗号分隔 (必填)
       --yes                跳过交互确认，直接执行删除
@@ -384,7 +380,7 @@ Flags:
 ## 核心工作流
 
 ```bash
-# 1. 创建待办 — 提取 todoTaskId
+# 1. 创建待办 — 提取 result.taskId
 dws todo task create --title "修复线上Bug" --executors userId1,userId2 \
   --priority 40 --due "2026-03-10T18:00:00+08:00" --format json
 
@@ -409,8 +405,8 @@ dws todo task update --task-id <taskId> --title "新标题" --priority 40 --form
 # 5. 标记待办完成
 dws todo task done --task-id <taskId> --status true --format json
 
-# 6. 删除待办
-dws todo task delete --task-id <taskId> --yes --format json
+# 6. 删除待办（先按 Runtime gate 取得用户确认）
+dws todo task delete --task-id <taskId> --format json
 
 # 7. 给待办新增评论
 dws todo comment add --task-id <taskId> --content "已开始处理" --format json
@@ -418,8 +414,8 @@ dws todo comment add --task-id <taskId> --content "已开始处理" --format jso
 # 8. 查看待办评论列表
 dws todo comment list --task-id <taskId> --page 1 --size 20 --format json
 
-# 9. 删除待办评论
-dws todo comment delete --task-id <taskId> --comment-id <commentId> --yes --format json
+# 9. 删除待办评论（先按 Runtime gate 取得用户确认）
+dws todo comment delete --task-id <taskId> --comment-id <commentId> --format json
 
 # 10. 添加待办执行人
 dws todo task add-executor --task-id <taskId> --executors userId1,userId2 --format json
@@ -445,8 +441,8 @@ dws todo task list-sub --task-id <taskId> --format json
 dws todo task add-attachment --task-id <taskId> --file /path/to/file.pdf --format json
 # 20. 查询待办附件列表
 dws todo task list-attachment --task-id <taskId> --format json
-# 21. 删除待办附件
-dws todo task remove-attachment --task-id <taskId> --attachment-id <attachmentId> --yes --format json
+# 21. 删除待办附件（先按 Runtime gate 取得用户确认）
+dws todo task remove-attachment --task-id <taskId> --attachment-id <attachmentId> --format json
 
 # 22. 查询待办标签列表
 dws todo tag list --format json
@@ -455,30 +451,29 @@ dws todo tag create --name "标签名" --format json
 # 24. 给待办打标签
 dws todo tag add --task-id <taskId> --tag-codes code1,code2 --format json
 # 25. 更新待办标签
-dws todo tag update --user-tags '[{"tagCode":"code1","name":"新名称"}]' --format json
-# 26. 删除待办标签
-dws todo tag delete --tag-codes code1,code2 --yes --format json
+dws todo tag update --user-tags '[{"code":"code1","name":"新名称"}]' --format json
+# 26. 删除待办标签（先按 Runtime gate 取得用户确认）
+dws todo tag delete --tag-codes code1,code2 --format json
 ```
 
 ## 上下文传递表
 
 | 操作 | 从返回中提取 | 用于                                          |
 |------|-------------|---------------------------------------------|
-| `task create` | `todoTaskId` | update/done/get/delete 的 --task-id          |
-| `task list` | `result[].id` | update/done/get/delete 的 --task-id          |
-| `task create` | `todoTaskId` | update/done/get/delete/comment 的 --task-id  |
-| `task list` | `result[].id` | update/done/get/delete/comment/add-executor/remove-executor/add-participant/remove-participant 的 --task-id |
+| `task create` / `task create-sub` | `result.taskId` | update/done/get/delete/comment 的 `--task-id` |
+| `task list` | `result.todoCards[].taskId` | update/done/get/delete/comment/member 操作的 `--task-id` |
 | `task get` | `result.todoDetailModel.subTodos[]` | 获取子待办列表，提取子待办的 `taskId` 用于后续操作              |
-| `comment list` | `result[].commentId` | `comment delete` 的 --comment-id             |
-| `task list-attachment` | `result[].attachmentId` | `task remove-attachment` 的 --attachment-id |
+| `comment list` | `result.comments[].id` | `comment delete` 的 `--comment-id` |
+| `task list-attachment` | `attachments[].attachmentId` | `task remove-attachment` 的 `--attachment-id` |
 
 ## 注意事项
 
 - 优先级值: 10=低, 20=普通, 30=较高, 40=紧急
 - `--due` 是截止时间 dueTime，不是提醒时间；使用 ISO-8601 格式（如 2026-03-10T18:00:00+08:00）
-- 当前不支持单独的 `reminder` / `remind-at` 精确提醒能力；不要把 `--due` 解释成“几点提醒”
+- `--due` 与 `todo +remind --at` 都是截止时间；不要把它们解释成独立提醒
 - `--recurrence`：仅在与 `--due` 同时设置时有效；当前仅支持按天循环。字符串内需含换行，示例：`DTSTART:20260320T020000Z\nRRULE:FREQ=DAILY;INTERVAL=1`（DTSTART 表示首次截止时间，需与业务约定一致）
-- 若用户的真实诉求是“到点提醒我”，需要先说明能力边界；当前 CLI 只能表达 deadline / recurrence，不能表达独立 reminder schedule
+- 独立提醒使用 `todo +reminder --base-time customTime --at <ISO>`，或原子命令 `task add-reminder --base-time customTime --reminder-time-stamp <ISO>`
+- 截止前提醒使用 `todo +reminder --base-time dueTime --due-date-offset <分钟>`，或对应原子命令；上游没有提醒查询接口，只能报告写回执
 - `task list` 的 `--status` 对应 MCP `get_user_todos_in_current_org` 的 `todoStatus` 参数
 - `task list` 的 `--priority` 支持逗号分隔多个优先级值（如 `40,30,10`），用于同时筛选多个优先级
 - `task list` 的 `--role-types` 支持 `creator`/`executor`/`participant`，可在一次调用中同时传入多个角色用逗号分隔（如 `--role-types creator,executor`），无需分多次查询；不传时默认按 `executor` 查询
@@ -486,7 +481,7 @@ dws todo tag delete --tag-codes code1,code2 --yes --format json
 - todo 是个人待办管理产品
 - `task update` 可同时修改标题/优先级/截止时间/完成状态
 - `task done` 专用于修改执行者的完成状态，与 `task update --done` 作用不同
-- `task delete` 为不可逆操作，建议加 `--yes` 并与用户确认
+- `task delete` 为不可逆操作；按 Runtime gate 取得用户确认后执行
 - `comment delete` 同样为不可逆操作，执行前需用户确认；`--comment-id` 可通过 `comment list` 获取
 - `task add-executor` / `task remove-executor` 用于管理待办的执行人，`--executors` 支持逗号分隔的多个 userId
 - `task add-participant` / `task remove-participant` 用于管理待办的参与人，`--participants` 支持逗号分隔的多个 userId
@@ -501,7 +496,7 @@ dws todo tag delete --tag-codes code1,code2 --yes --format json
 - `tag add` 用于给指定待办打标签，`--task-id` 可通过 `task list` 或 `task create` 获取；`--tag-codes` 可通过 `tag list` 获取
 - `tag create` 用于创建新标签，`--name` 为标签名称 (必填)
 - `tag update` 用于更新已有标签信息，`--user-tags` 格式同 `tag create`
-- `tag delete` 用于删除标签定义，为不可逆操作，执行前需用户确认；传 `--yes` 可跳过交互提示，建议加 `--yes` 并与用户确认
+- `tag delete` 用于删除标签定义，为不可逆操作；按 Runtime gate 取得用户确认后执行
 - `tag add`（给待办打标签）与 `tag delete`（删除标签定义）作用不同：前者是关联关系，后者是删除标签本身
 
 


### PR DESCRIPTION
## Summary
- refine Todo multi-skill routing using two training-run traces
- choose shortcuts and atomic commands per lifecycle step
- preserve stable ID handoff and Todo tag product boundaries
- reduce the original five-file skill footprint while retaining runtime safety gates

## Validation
- skill command integrity check
- skill context budget check
- skill quick validation
- generated drift check
- go build
- Todo shortcut tests and internal/app tests

This is a draft candidate pending held-out evaluation.