### PR TITLE
ci: notify a secondary DingTalk webhook

### DIFF
--- a/.github/workflows/issue-to-dingtalk.yml
+++ b/.github/workflows/issue-to-dingtalk.yml
@@ -14,9 +14,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const webhook = process.env.DINGTALK_WEBHOOK;
-            if (!webhook) {
-              console.log('⚠️ DINGTALK_WEBHOOK not set, skipping notification');
+            const webhooks = [
+              process.env.DINGTALK_WEBHOOK,
+              process.env.DINGTALK_WEBHOOK_SECONDARY
+            ].filter(Boolean);
+            if (webhooks.length === 0) {
+              console.log('⚠️ No DingTalk webhook configured, skipping notification');
               return;
             }
             
@@ -39,12 +42,15 @@ jobs:
               }
             };
             
-            await fetch(webhook, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(message)
-            });
+            await Promise.all(webhooks.map(webhook =>
+              fetch(webhook, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(message)
+              })
+            ));
             
-            console.log('✅ DingTalk notification sent');
+            console.log(`✅ DingTalk notification sent to ${webhooks.length} webhook(s)`);
         env:
           DINGTALK_WEBHOOK: ${{ secrets.DINGTALK_WEBHOOK }}
+          DINGTALK_WEBHOOK_SECONDARY: ${{ secrets.DINGTALK_WEBHOOK_SECONDARY }}


### PR DESCRIPTION
## 目标

将 Issue 通知同步到第二个钉钉群机器人。

## 实现

- 新增可选的 `DINGTALK_WEBHOOK_SECONDARY` Actions Secret。
- 同一 Issue 事件向已配置的主、次 webhook 各发送一次；未配置次 Secret 时保持原有单群行为。
- 未将 webhook 或 token 写入仓库。

## 验证

| 检查 | 结果 |
| --- | --- |
| `git diff --check` | 通过 |
| Ruby YAML 解析 | 通过 |

## 限制与回滚

- 需在仓库 Actions Secrets 配置轮换后的 `DINGTALK_WEBHOOK_SECONDARY` 才会发送到第二个群。
- 该改动保留既有 HTTP 状态处理语义；回滚可移除次 Secret 或还原此提交。