### PR TITLE
fix(ci): review batch remove confirmation hardening

### DIFF
--- a/scripts/policy/schema-compat/main.go
+++ b/scripts/policy/schema-compat/main.go
@@ -79,6 +79,38 @@ type parameterSchema struct {
 	Enum             []string `json:"enum,omitempty"`
 }
 
+type reviewedCompatibilityException struct {
+	Field string
+	Old   string
+	New   string
+}
+
+// reviewedCompatibilityExceptions is intentionally exact: safety fixes may
+// need to tighten a historical contract, but that must not turn arbitrary
+// confirmation drift into a compatible change.
+var reviewedCompatibilityExceptions = map[string]reviewedCompatibilityException{
+	// PR #1085: batch permission/member remove is destructive at container
+	// scope — one call can revoke access for up to 30 USER / DEPT /
+	// CONVERSATION / TAG members, and departments, chats, and role groups
+	// can indirectly affect many more users. The review therefore asked for
+	// the same user confirmation gate as other destructive removes.
+	"doc/doc.remove_permission": {
+		Field: "confirmation",
+		Old:   "not_required",
+		New:   "user_required",
+	},
+	"drive/drive.permission_remove": {
+		Field: "confirmation",
+		Old:   "not_required",
+		New:   "user_required",
+	},
+	"wiki/wiki.remove_member": {
+		Field: "confirmation",
+		Old:   "not_required",
+		New:   "user_required",
+	},
+}
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }
@@ -708,7 +740,7 @@ func checkToolCompatibility(toolPath string, oldTool, newTool toolSchema) []stri
 		{name: "confirmation", old: oldTool.Confirmation, new: newTool.Confirmation},
 		{name: "idempotency", old: oldTool.Idempotency, new: newTool.Idempotency},
 	} {
-		if field.old != field.new {
+		if field.old != field.new && !isReviewedCompatibilityException(toolPath, field.name, field.old, field.new) {
 			failures = append(failures, fmt.Sprintf("schema tool %q changed %s", toolPath, field.name))
 		}
 	}
@@ -742,6 +774,11 @@ func checkToolCompatibility(toolPath string, oldTool, newTool toolSchema) []stri
 	}
 	sort.Strings(failures)
 	return failures
+}
+
+func isReviewedCompatibilityException(toolPath, field, oldValue, newValue string) bool {
+	exception, ok := reviewedCompatibilityExceptions[toolPath]
+	return ok && exception.Field == field && exception.Old == oldValue && exception.New == newValue
 }
 
 // reviewedInterfaceRefRedirect enumerates the exact, individually reviewed

--- a/scripts/policy/schema-compat/main_test.go
+++ b/scripts/policy/schema-compat/main_test.go
@@ -415,6 +415,39 @@ func TestSchemaCompatibilityRejectsContractDrift(t *testing.T) {
 	}
 }
 
+func TestSchemaCompatibilityAcceptsReviewedRemoveConfirmationHardening(t *testing.T) {
+	oldTool := baselineContract().Products["doc"].Tools["doc.create"]
+	newTool := oldTool
+	newTool.Confirmation = "user_required"
+
+	for _, toolPath := range []string{
+		"doc/doc.remove_permission",
+		"drive/drive.permission_remove",
+		"wiki/wiki.remove_member",
+	} {
+		if failures := checkToolCompatibility(toolPath, oldTool, newTool); len(failures) != 0 {
+			t.Fatalf("reviewed confirmation hardening for %s failures = %v", toolPath, failures)
+		}
+	}
+	if failures := checkToolCompatibility("doc/doc.other_remove", oldTool, newTool); len(failures) == 0 {
+		t.Fatal("unreviewed confirmation hardening unexpectedly passed")
+	}
+
+	// A reviewed tool is only exempt for the exact reviewed transition: an
+	// unrelated field drift on the same tool must still be reported.
+	riskTool := oldTool
+	riskTool.Risk = "high"
+	if failures := checkToolCompatibility("doc/doc.remove_permission", oldTool, riskTool); len(failures) == 0 {
+		t.Fatal("reviewed tool risk drift unexpectedly passed")
+	}
+
+	oldTool.Confirmation = "user_required"
+	newTool.Confirmation = "not_required"
+	if failures := checkToolCompatibility("doc/doc.remove_permission", oldTool, newTool); len(failures) == 0 {
+		t.Fatal("reviewed tool confirmation weakening unexpectedly passed")
+	}
+}
+
 func TestMergeContracts(t *testing.T) {
 	historical := baselineContract()
 	current := cloneContract(historical)


### PR DESCRIPTION
## Summary
- Rebuild the exact-entry `reviewedCompatibilityExceptions` carve-out in the base-owned schema-compat checker for three destructive batch-remove tools: `doc/doc.remove_permission`, `drive/drive.permission_remove`, `wiki/wiki.remove_member` (confirmation `not_required` → `user_required`).
- This is the governance precondition for #1085, whose P1 review asked for user-confirmation gates on those batch permission/member remove entry points (one call can revoke access for up to 30 USER/DEPT/CONVERSATION/TAG members, and departments, chats, and role groups can indirectly affect many more users). Because `check-authoritative-schema-compatibility.sh` builds the checker from the PR merge-base, the carve-out must land on `main` first; #1085 then merges `main` and re-runs CI.
- Same mechanism and shape as the historical `e02410da` carve-out (`chat/chat.update_streaming_card`), which was later removed in `82dfee72` together with that tool's loosening. This PR changes no tool contract by itself — it only registers the three reviewed transitions ahead of #1085.

## Risk tier (必选一项)
- [ ] Documentation-only: prose/assets only; no executable, generated, workflow, packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: workflow/policy, package graph, generated Schema/registry, platform, auth/keychain, installer, packaging, release, transport, recovery, or another fail-closed infrastructure change

## Verification
- [ ] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`): N/A — pure CI gate governance, no user-visible behavior change
- [ ] Release-seal validation (otherwise `N/A`): N/A
- [x] Targeted test/check commands and results:
  - `go test ./scripts/policy/schema-compat/ -count=1` — ok (full package, including the existing `changed confirmation` rejection case for an unlisted tool)
  - `gofmt -l scripts/policy/schema-compat/` + `go vet ./scripts/policy/schema-compat/` — clean
  - changed lines 100% covered: `isReviewedCompatibilityException` and `checkToolCompatibility` both report 100.0%
  - `make schema-compatibility BASE_REF=<merge-base> STABLE_REF=v1.0.59 CANDIDATE_REF=HEAD` — clean against both the merge-base and stable v1.0.59 (this PR changes no tool contract, so no carve-out entry is exercised)
- [x] Behavior evidence: `TestSchemaCompatibilityAcceptsReviewedRemoveConfirmationHardening` asserts the three reviewed tools pass the exact `not_required` → `user_required` transition, while an unlisted tool, an unrelated field drift on a listed tool, and the reverse weakening direction are all still rejected
- [ ] Documentation links/content/rendering checked (documentation-only, otherwise `N/A`): N/A
- [ ] Full local suite run because the change is high-risk: targeted verification above; the checker package tests are the authoritative suite for this tool
- [ ] `./scripts/policy/check-generated-drift.sh`: N/A (no generator input or output touched)
- [ ] `./scripts/policy/check-command-surface.sh --strict`: N/A (no Cobra surface change)

## Notes
- The carve-out only accepts the exact tool + exact field + exact old→new triple; any other confirmation drift — including weakening a reviewed tool back to `not_required`, or drifting a different field on a listed tool — keeps failing the gate.
- After this lands, #1085 will merge `main` and push so its CI re-resolves the merge-base to a commit that owns these entries.

