### PR TITLE
fix(ci): extend schema-compat exceptions to multi-field per tool

### DIFF
--- a/scripts/policy/schema-compat/main.go
+++ b/scripts/policy/schema-compat/main.go
@@ -87,27 +87,52 @@ type reviewedCompatibilityException struct {
 
 // reviewedCompatibilityExceptions is intentionally exact: safety fixes may
 // need to tighten a historical contract, but that must not turn arbitrary
-// confirmation drift into a compatible change.
-var reviewedCompatibilityExceptions = map[string]reviewedCompatibilityException{
+// confirmation drift into a compatible change. Each tool may have multiple
+// field transitions (e.g. confirmation + risk + effect tightened together).
+var reviewedCompatibilityExceptions = map[string][]reviewedCompatibilityException{
 	// PR #1085: batch permission/member remove is destructive at container
 	// scope — one call can revoke access for up to 30 USER / DEPT /
 	// CONVERSATION / TAG members, and departments, chats, and role groups
 	// can indirectly affect many more users. The review therefore asked for
 	// the same user confirmation gate as other destructive removes.
 	"doc/doc.remove_permission": {
-		Field: "confirmation",
-		Old:   "not_required",
-		New:   "user_required",
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
 	},
 	"drive/drive.permission_remove": {
-		Field: "confirmation",
-		Old:   "not_required",
-		New:   "user_required",
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
 	},
 	"wiki/wiki.remove_member": {
-		Field: "confirmation",
-		Old:   "not_required",
-		New:   "user_required",
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+	},
+	// PR #1097 (issue #1096): 6 commands that affect other users and are
+	// irreversible were incorrectly marked not_required / medium. Tightened
+	// to user_required / high; calendar event delete and minutes replace-text
+	// additionally escalated to destructive effect.
+	"calendar/calendar.delete_calendar_event": {
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+		{Field: "risk", Old: "medium", New: "high"},
+		{Field: "effect", Old: "write", New: "destructive"},
+	},
+	"calendar/calendar.remove_calendar_participant": {
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+		{Field: "risk", Old: "medium", New: "high"},
+	},
+	"calendar/calendar.delete_meeting_room": {
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+		{Field: "risk", Old: "medium", New: "high"},
+	},
+	"chat/chat.remove_group_member": {
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+		{Field: "risk", Old: "medium", New: "high"},
+	},
+	"minutes/minutes.replace_minutes_text": {
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+		{Field: "risk", Old: "medium", New: "high"},
+		{Field: "effect", Old: "write", New: "destructive"},
+	},
+	"doc/doc.update_permission": {
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+		{Field: "risk", Old: "medium", New: "high"},
 	},
 }
 
@@ -777,8 +802,12 @@ func checkToolCompatibility(toolPath string, oldTool, newTool toolSchema) []stri
 }
 
 func isReviewedCompatibilityException(toolPath, field, oldValue, newValue string) bool {
-	exception, ok := reviewedCompatibilityExceptions[toolPath]
-	return ok && exception.Field == field && exception.Old == oldValue && exception.New == newValue
+	for _, exception := range reviewedCompatibilityExceptions[toolPath] {
+		if exception.Field == field && exception.Old == oldValue && exception.New == newValue {
+			return true
+		}
+	}
+	return false
 }
 
 // reviewedInterfaceRefRedirect enumerates the exact, individually reviewed

--- a/scripts/policy/schema-compat/main_test.go
+++ b/scripts/policy/schema-compat/main_test.go
@@ -448,6 +448,56 @@ func TestSchemaCompatibilityAcceptsReviewedRemoveConfirmationHardening(t *testin
 	}
 }
 
+func TestSchemaCompatibilityAcceptsMultiFieldConfirmationHardening(t *testing.T) {
+	oldTool := baselineContract().Products["doc"].Tools["doc.create"]
+	oldTool.Confirmation = "not_required"
+	oldTool.Risk = "medium"
+	oldTool.Effect = "write"
+
+	// Multi-field tightening: confirmation + risk together.
+	newTool := oldTool
+	newTool.Confirmation = "user_required"
+	newTool.Risk = "high"
+	for _, toolPath := range []string{
+		"calendar/calendar.remove_calendar_participant",
+		"calendar/calendar.delete_meeting_room",
+		"chat/chat.remove_group_member",
+		"doc/doc.update_permission",
+	} {
+		if failures := checkToolCompatibility(toolPath, oldTool, newTool); len(failures) != 0 {
+			t.Fatalf("reviewed multi-field hardening for %s failures = %v", toolPath, failures)
+		}
+	}
+
+	// Multi-field tightening: confirmation + risk + effect together.
+	destructiveTool := oldTool
+	destructiveTool.Confirmation = "user_required"
+	destructiveTool.Risk = "high"
+	destructiveTool.Effect = "destructive"
+	for _, toolPath := range []string{
+		"calendar/calendar.delete_calendar_event",
+		"minutes/minutes.replace_minutes_text",
+	} {
+		if failures := checkToolCompatibility(toolPath, oldTool, destructiveTool); len(failures) != 0 {
+			t.Fatalf("reviewed destructive hardening for %s failures = %v", toolPath, failures)
+		}
+	}
+
+	// An unreviewed tool with the same transitions must still fail.
+	if failures := checkToolCompatibility("calendar/calendar.other_delete", oldTool, destructiveTool); len(failures) == 0 {
+		t.Fatal("unreviewed multi-field hardening unexpectedly passed")
+	}
+
+	// A reviewed tool with an extra unreviewed field drift must still fail.
+	idempotencyTool := oldTool
+	idempotencyTool.Confirmation = "user_required"
+	idempotencyTool.Risk = "high"
+	idempotencyTool.Idempotency = "idempotent"
+	if failures := checkToolCompatibility("chat/chat.remove_group_member", oldTool, idempotencyTool); len(failures) == 0 {
+		t.Fatal("reviewed tool with unreviewed idempotency drift unexpectedly passed")
+	}
+}
+
 func TestMergeContracts(t *testing.T) {
 	historical := baselineContract()
 	current := cloneContract(historical)


### PR DESCRIPTION
## 背景

`reviewedCompatibilityExceptions` 当前是每 tool 单字段（`map[string]reviewedCompatibilityException`），无法表达 #1097 对 6 条命令同时收紧 confirmation + risk (+ effect) 的多字段变更。checker 从 merge-base 构建，因此本 PR 必须先于 #1097 合入。

## 修改

- 将 `reviewedCompatibilityExceptions` 值类型从 `reviewedCompatibilityException` 扩展为 `[]reviewedCompatibilityException`
- `isReviewedCompatibilityException` 改为遍历 slice 匹配
- 新增 6 条精确例外（tool + field + old → new）：
  - `calendar/calendar.delete_calendar_event`: confirmation + risk + effect
  - `calendar/calendar.remove_calendar_participant`: confirmation + risk
  - `calendar/calendar.delete_meeting_room`: confirmation + risk
  - `chat/chat.remove_group_member`: confirmation + risk
  - `minutes/minutes.replace_minutes_text`: confirmation + risk + effect
  - `doc/doc.update_permission`: confirmation + risk

## 安全保证

条目集仍然精确：任何未列入的 tool/field/方向变更（包括将 user_required 弱化回 not_required）依旧触发 gate 失败。新增 `TestSchemaCompatibilityAcceptsMultiFieldConfirmationHardening` 覆盖正向通过、未审查 tool 拒绝、额外字段漂移拒绝三个场景。

## 依赖

本 PR 是 #1097 的前置（checker 从 merge-base 构建）。