### PR TITLE
ci: bound exhaustive coverage test runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,7 +544,8 @@ jobs:
           - app-schema
           - app-a-b
           - app-c-a-l
-          - app-c-m-r
+          - app-c-m-o
+          - app-c-p-r
           - app-c-s-z
           - app-c-other
           - app-d-r
@@ -692,7 +693,8 @@ jobs:
           - app-schema
           - app-a-b
           - app-c-a-l
-          - app-c-m-r
+          - app-c-m-o
+          - app-c-p-r
           - app-c-s-z
           - app-c-other
           - app-d-r

--- a/internal/helpers/connect_exec_fixture_test.go
+++ b/internal/helpers/connect_exec_fixture_test.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -39,7 +41,16 @@ func TestMain(m *testing.M) {
 	if os.Getenv(helpersShellStubEnv) == "1" {
 		os.Exit(runHelpersShellStub())
 	}
+	// Cobra's Windows pre-exec hook walks the process table on every Execute*
+	// call to detect Explorer launches. Helpers tests execute command trees
+	// thousands of times, and none of those in-process invocations can be an
+	// Explorer launch, so keep that production-only check out of the test
+	// process. This also prevents every new exhaustive harness from having to
+	// remember a test-local override.
+	originalMousetrapHelpText := cobra.MousetrapHelpText
+	cobra.MousetrapHelpText = ""
 	code := m.Run()
+	cobra.MousetrapHelpText = originalMousetrapHelpText
 	if helpersShellStubBaseDir != "" {
 		_ = os.RemoveAll(helpersShellStubBaseDir)
 	}

--- a/scripts/ci/run-app-race-tests.sh
+++ b/scripts/ci/run-app-race-tests.sh
@@ -14,7 +14,7 @@ usage() {
 # Single source of truth for the partition set. CI runs one job per partition and
 # pins its shard names to this list, so a name that appears here without a
 # dispatch entry below fails closed rather than silently skipping tests.
-APP_PARTITIONS='schema a-b c-a-l c-m-r c-s-z c-other d-r s-z-example-fuzz'
+APP_PARTITIONS='schema a-b c-a-l c-m-o c-p-r c-s-z c-other d-r s-z-example-fuzz'
 
 mode="${1:-}"
 partition=""
@@ -67,7 +67,8 @@ fi
 schema_count=0
 ab_count=0
 cal_count=0
-cmr_count=0
+cmo_count=0
+cpr_count=0
 csz_count=0
 cother_count=0
 dr_count=0
@@ -79,7 +80,8 @@ while IFS= read -r test_name; do
 		Test*Schema*) schema_count=$((schema_count + 1)) ;;
 		Test[A-B]*) ab_count=$((ab_count + 1)) ;;
 		TestCrossPlatformCoverage[A-L]*) cal_count=$((cal_count + 1)) ;;
-		TestCrossPlatformCoverage[M-R]*) cmr_count=$((cmr_count + 1)) ;;
+		TestCrossPlatformCoverage[M-O]*) cmo_count=$((cmo_count + 1)) ;;
+		TestCrossPlatformCoverage[P-R]*) cpr_count=$((cpr_count + 1)) ;;
 		TestCrossPlatformCoverage[S-Z]*) csz_count=$((csz_count + 1)) ;;
 		TestC*) cother_count=$((cother_count + 1)) ;;
 		Test[D-R]*) dr_count=$((dr_count + 1)) ;;
@@ -103,7 +105,8 @@ for spec in \
 	"schema:$schema_count" \
 	"a-b:$ab_count" \
 	"c-a-l:$cal_count" \
-	"c-m-r:$cmr_count" \
+	"c-m-o:$cmo_count" \
+	"c-p-r:$cpr_count" \
 	"c-s-z:$csz_count" \
 	"c-other:$cother_count" \
 	"d-r:$dr_count" \
@@ -142,14 +145,14 @@ for name in $classified; do
 done
 
 total_count="$(wc -l < "$tests" | tr -d ' ')"
-assigned_count=$((schema_count + ab_count + cal_count + cmr_count + csz_count + cother_count + dr_count + sz_count))
+assigned_count=$((schema_count + ab_count + cal_count + cmo_count + cpr_count + csz_count + cother_count + dr_count + sz_count))
 if [ "$assigned_count" -ne "$total_count" ]; then
 	printf 'app race partitions assigned %s tests, want %s\n' "$assigned_count" "$total_count" >&2
 	exit 1
 fi
 
-printf 'app race partitions cover %s top-level tests exactly once: schema=%s a-b=%s c-a-l=%s c-m-r=%s c-s-z=%s c-other=%s d-r=%s s-z-example-fuzz=%s\n' \
-	"$total_count" "$schema_count" "$ab_count" "$cal_count" "$cmr_count" "$csz_count" "$cother_count" "$dr_count" "$sz_count"
+printf 'app race partitions cover %s top-level tests exactly once: schema=%s a-b=%s c-a-l=%s c-m-o=%s c-p-r=%s c-s-z=%s c-other=%s d-r=%s s-z-example-fuzz=%s\n' \
+	"$total_count" "$schema_count" "$ab_count" "$cal_count" "$cmo_count" "$cpr_count" "$csz_count" "$cother_count" "$dr_count" "$sz_count"
 
 if [ "$mode" = "verify" ]; then
 	exit 0
@@ -208,7 +211,8 @@ run_named_partition() {
 		schema) run_partition schema no-race "$schema_pattern" ;;
 		a-b) run_partition a-b race '^Test[A-B]' "$schema_pattern" ;;
 		c-a-l) run_partition c-a-l race '^TestCrossPlatformCoverage[A-L]' "$schema_pattern" ;;
-		c-m-r) run_partition c-m-r race '^TestCrossPlatformCoverage[M-R]' "$schema_pattern" ;;
+		c-m-o) run_partition c-m-o race '^TestCrossPlatformCoverage[M-O]' "$schema_pattern" ;;
+		c-p-r) run_partition c-p-r race '^TestCrossPlatformCoverage[P-R]' "$schema_pattern" ;;
 		c-s-z) run_partition c-s-z race '^TestCrossPlatformCoverage[S-Z]' "$schema_pattern" ;;
 		c-other) run_partition c-other race '^TestC' '^Test.*Schema|^TestCrossPlatformCoverage' ;;
 		d-r) run_partition d-r race '^Test[D-R]' "$schema_pattern" ;;


### PR DESCRIPTION
## Summary

- split the oversized app CrossPlatformCoverage M-R race shard into M-O and P-R jobs
- keep workflow matrices pinned to the helper's exact partition set
- disable Cobra's Windows Explorer-launch mousetrap hook for the helpers test process, where in-process command executions cannot originate from Explorer

## Why

Large parameter and shortcut changes caused two independent CI timeout modes: the app M-R race process approached hosted-runner reclamation time, and Windows coverage spent most of its 10-minute package budget repeatedly enumerating processes from Cobra's pre-exec hook. These are test-infrastructure concerns and should land independently before product PRs.

## Validation

- app partition verification: 886 top-level tests covered exactly once
- TestCIAppRacePartitionMatrixMatchesHelper
- full internal/helpers test suite
- Windows amd64 helpers test binary cross-compile

No product, parameter-concept, generated alias, or documentation changes are included.