### PR TITLE
ci: extend Policy job timeout for large Schema surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1599,7 +1599,10 @@ jobs:
     name: Policy
     needs: lint
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Full policy regenerates and validates the runtime Schema several times.
+    # Keep job-level headroom for large reviewed command-surface additions;
+    # individual policy gates retain their own fail-closed checks.
+    timeout-minutes: 15
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -1106,6 +1106,9 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 		t.Fatal("Code Admission workflow missing Policy job boundaries")
 	}
 	policyJob := admission[policyStart:policyEnd]
+	if !strings.Contains(policyJob, "timeout-minutes: 15") {
+		t.Error("Policy job must retain enough headroom for full Schema policy validation")
+	}
 	requirePolicyEnv := func(step, nextStep string) {
 		t.Helper()
 		start := strings.Index(policyJob, "      - name: "+step+"\n")


### PR DESCRIPTION
## 背景

PR #1101 将 Agent Schema 从 28 个产品 / 1214 个工具扩展到 33 个产品 / 1370 个工具。CI Run `32704740858` 的 Policy job `97363548703` 在完成多轮 Schema Catalog 生成后触及固定的 10 分钟 job 预算，被 GitHub Actions 取消；日志没有 Schema 断言失败，末尾为 `The operation was canceled.`。

## 变更

- 将 Code Admission 的 Policy job 超时从 10 分钟提高到 15 分钟。
- 保留 `make policy` 内全部 fail-closed 门禁，不修改或跳过任何检查。
- 在现有工作流契约测试中固定 15 分钟预算，防止后续误退回已证实不足的 10 分钟。

## 验证

| 检查 | 结果 |
|---|---|
| `go test ./test/scripts -run '^TestChangelogPRFastPathWorkflowContract$' -count=1` | PASS |
| `go test ./test/scripts -count=1` | PASS，281.086s |
| `make test-plan` | PASS；default 125 packages、coverage 97 packages 精确覆盖一次 |
| `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12` | PASS |
| `make format-check` / `go vet ./...` | PASS |
| `git diff --check` | PASS |
| `make lint` | NOT VERIFIED as an aggregate：format 与 vet 已通过；本机 staticcheck 被当前 `main` 的既有无关告警阻断，本 PR 两个修改文件均未出现在告警中 |

## 风险与边界

- 风险等级：High-risk（GitHub Actions workflow 变更）。
- 只增加 Policy 的 job-level headroom，不解决重复 Schema assembly 的长期性能优化问题。
- 不改变 CLI、Schema wire、产品行为、发布内容或 required context 名称，因此不添加 release fragment。

## 回滚

回退本提交即可恢复 10 分钟预算；不会留下数据或接口迁移状态。

关联：#1101、Actions Run `32704740858`。
