### PR TITLE
fix(aitable): align +workflow-list identifier with server-side flowId

### DIFF
--- a/internal/shortcut/aitable/aitable.go
+++ b/internal/shortcut/aitable/aitable.go
@@ -2058,8 +2058,10 @@ var WorkflowList = shortcut.Shortcut{
 }
 
 // workflowListProject reshapes the raw list_workflows response into a clean
-// workflow list ({workflowId, name, status/enabled}) — output-projection
-// clean output projection. Only an explicit array can establish success.
+// workflow list ({flowId, name, status/enabled}) — output-projection
+// clean output projection. The identifier is emitted as flowId to align with
+// the server-side searchFlows payload; legacy workflowId-style keys are still
+// accepted as input. Only an explicit array can establish success.
 func workflowListProject(data map[string]any) ([]map[string]any, error) {
 	raw, err := workflowListResolveList(data)
 	if err != nil {
@@ -2072,8 +2074,8 @@ func workflowListProject(data map[string]any) ([]map[string]any, error) {
 			return nil, fmt.Errorf("list_workflows response item %d must be an object, got %T", index, item)
 		}
 		row := map[string]any{}
-		if v, ok := workflowListFirst(m, "workflowId", "workflow_id", "id"); ok {
-			row["workflowId"] = v
+		if v, ok := workflowListFirst(m, "flowId", "workflowId", "workflow_id", "id"); ok {
+			row["flowId"] = v
 		}
 		if v, ok := workflowListFirst(m, "name", "workflowName", "title"); ok {
 			row["name"] = v
@@ -2081,8 +2083,8 @@ func workflowListProject(data map[string]any) ([]map[string]any, error) {
 		if v, ok := workflowListFirst(m, "status", "enabled", "isEnabled", "state"); ok {
 			row["status"] = v
 		}
-		if _, ok := row["workflowId"]; !ok {
-			return nil, fmt.Errorf("list_workflows response item %d is missing workflowId", index)
+		if _, ok := row["flowId"]; !ok {
+			return nil, fmt.Errorf("list_workflows response item %d is missing flowId", index)
 		}
 		out = append(out, row)
 	}

--- a/internal/shortcut/aitable/remaining_coverage_gap_test.go
+++ b/internal/shortcut/aitable/remaining_coverage_gap_test.go
@@ -73,9 +73,13 @@ func TestCrossPlatformCoverageAITableProjectionValidAndMissingIdentityShapes(t *
 	if err != nil || len(forms) != 1 {
 		t.Fatalf("form projection = %#v, %v", forms, err)
 	}
-	workflows, err := workflowListProject(map[string]any{"workflows": []any{map[string]any{"workflowId": "w"}}})
-	if err != nil || len(workflows) != 1 {
+	workflows, err := workflowListProject(map[string]any{"workflows": []any{map[string]any{"flowId": "w"}}})
+	if err != nil || len(workflows) != 1 || workflows[0]["flowId"] != "w" {
 		t.Fatalf("workflow projection = %#v, %v", workflows, err)
+	}
+	legacy, err := workflowListProject(map[string]any{"workflows": []any{map[string]any{"workflowId": "legacy"}}})
+	if err != nil || len(legacy) != 1 || legacy[0]["flowId"] != "legacy" {
+		t.Fatalf("workflow legacy workflowId projection = %#v, %v", legacy, err)
 	}
 }
 


### PR DESCRIPTION
Accept flowId as the primary identifier returned by the server-side searchFlows payload, emit flowId in projected workflow rows, and keep workflowId/workflow_id/id as backward-compatible input aliases. Adds regression coverage for both the server payload and the legacy workflowId shape. Test: DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/shortcut/aitable -run '^TestCrossPlatformCoverageAITableProjectionValidAndMissingIdentityShapes$' -count=1. Fixes #1102.