### PR TITLE
policy: support compatibility-visible availability migrations

### DIFF
--- a/internal/interfacesnapshot/command_migrations.go
+++ b/internal/interfacesnapshot/command_migrations.go
@@ -170,8 +170,9 @@ func (m CommandMigration) validate() error {
 			return err
 		}
 	}
-	if !m.Legacy.Before.Present || !m.Legacy.Before.Runnable || m.Legacy.Before.Hidden ||
-		!m.Legacy.After.Present || !m.Legacy.After.Runnable {
+	if m.Kind != CommandMigrationAvailability &&
+		(!m.Legacy.Before.Present || !m.Legacy.Before.Runnable || m.Legacy.Before.Hidden ||
+			!m.Legacy.After.Present || !m.Legacy.After.Runnable) {
 		return fmt.Errorf("legacy command must remain runnable and start visible")
 	}
 	if m.Kind != CommandMigrationAvailability &&
@@ -235,8 +236,8 @@ func (m CommandMigration) validate() error {
 			return fmt.Errorf("flag_extraction legacy_flag no_opt must equal replacement constant %q", wantNoOpt)
 		}
 	case CommandMigrationAvailability:
-		if !m.Legacy.After.Hidden {
-			return fmt.Errorf("schema_availability_hardening legacy command must migrate exactly from visible to hidden")
+		if !isVisibleToHiddenAvailabilityMigration(m) && !isCompatibilityVisibleAvailabilityMigration(m) {
+			return fmt.Errorf("schema_availability_hardening legacy command must migrate exactly from visible to hidden or remain compatibility-visible")
 		}
 		if m.LegacyFlag != (CommandMigrationFlag{}) {
 			return fmt.Errorf("schema_availability_hardening must not declare legacy_flag")
@@ -482,17 +483,42 @@ func evaluateCommandMigrationLifecycle(
 	for _, approved := range authority.Migrations {
 		basePhase := matchCommandMigrationPhase(mergeBase, approved)
 		wantBase := commandMigrationBefore
-		if approved.State == CommandMigrationConsumed {
+		if approved.State == CommandMigrationConsumed && !isCompatibilityVisibleAvailabilityMigration(approved) {
 			wantBase = commandMigrationAfter
 		}
 		if basePhase != wantBase {
 			return nil, fmt.Errorf("approved command migration %s is %s in %s, want exact %s state for %s", approved.displayKey(), basePhase, label, wantBase, approved.State)
 		}
 		proposed, exists := candidateByKey[approved.key()]
-		if exists && !sameCommandMigrationApproval(approved, proposed) {
+		if exists && !sameCommandMigrationApproval(approved, proposed) &&
+			!isPendingAvailabilityCompatibilityRefinement(approved, proposed) {
 			return nil, fmt.Errorf("candidate modified base-owned command migration %s", approved.displayKey())
 		}
 		currentPhase := matchCommandMigrationPhase(current, approved)
+		if isCompatibilityVisibleAvailabilityMigration(approved) {
+			if currentPhase != commandMigrationBefore {
+				return nil, fmt.Errorf("candidate drifted from compatibility-visible command migration %s", approved.displayKey())
+			}
+			if !exists {
+				return nil, fmt.Errorf("candidate must retain compatibility-visible command migration %s", approved.displayKey())
+			}
+			switch approved.State {
+			case CommandMigrationPending:
+				switch proposed.State {
+				case CommandMigrationPending:
+					continue
+				case CommandMigrationConsumed:
+					authorizations = append(authorizations, approved)
+					continue
+				}
+			case CommandMigrationConsumed:
+				if proposed.State != CommandMigrationConsumed {
+					return nil, fmt.Errorf("candidate changed consumed compatibility-visible command migration %s back to pending", approved.displayKey())
+				}
+				authorizations = append(authorizations, approved)
+				continue
+			}
+		}
 		switch approved.State {
 		case CommandMigrationPending:
 			if !exists {
@@ -563,6 +589,28 @@ func sameCommandMigrationApproval(left, right CommandMigration) bool {
 	left.State = ""
 	right.State = ""
 	return reflect.DeepEqual(left, right)
+}
+
+func isVisibleToHiddenAvailabilityMigration(migration CommandMigration) bool {
+	return migration.Kind == CommandMigrationAvailability &&
+		migration.Legacy.Before == (CommandMigrationState{Present: true, Runnable: true}) &&
+		migration.Legacy.After == (CommandMigrationState{Present: true, Runnable: true, Hidden: true})
+}
+
+func isCompatibilityVisibleAvailabilityMigration(migration CommandMigration) bool {
+	visible := CommandMigrationState{Present: true, Runnable: true}
+	return migration.Kind == CommandMigrationAvailability &&
+		migration.Legacy.Before == visible && migration.Legacy.After == visible
+}
+
+func isPendingAvailabilityCompatibilityRefinement(approved, proposed CommandMigration) bool {
+	if approved.State != CommandMigrationPending || proposed.State != CommandMigrationPending ||
+		!isVisibleToHiddenAvailabilityMigration(approved) ||
+		!isCompatibilityVisibleAvailabilityMigration(proposed) {
+		return false
+	}
+	proposed.Legacy.After = approved.Legacy.After
+	return reflect.DeepEqual(approved, proposed)
 }
 
 func matchCommandMigrationPhase(snapshot Snapshot, migration CommandMigration) commandMigrationPhase {

--- a/internal/interfacesnapshot/command_migrations_test.go
+++ b/internal/interfacesnapshot/command_migrations_test.go
@@ -287,6 +287,11 @@ func TestCrossPlatformCoverageSchemaAvailabilityMigrationLifecycle(t *testing.T)
 	}
 
 	valid := pending.Migrations[0]
+	compatibilityVisible := cloneCommandMigration(valid)
+	compatibilityVisible.Legacy.After = compatibilityVisible.Legacy.Before
+	if err := compatibilityVisible.validate(); err != nil {
+		t.Fatalf("compatibility-visible availability migration must validate: %v", err)
+	}
 	for _, test := range []struct {
 		name   string
 		mutate func(*CommandMigration)
@@ -294,7 +299,7 @@ func TestCrossPlatformCoverageSchemaAvailabilityMigrationLifecycle(t *testing.T)
 	}{
 		{"legacy path", func(m *CommandMigration) { m.Legacy.Command = "dws devapp *" }, "legacy must be an exact"},
 		{"replacement", func(m *CommandMigration) { m.Replacement.Command = "dws devapp other" }, "must not declare replacement"},
-		{"visible after", func(m *CommandMigration) { m.Legacy.After.Hidden = false }, "visible to hidden"},
+		{"absent after", func(m *CommandMigration) { m.Legacy.After = CommandMigrationState{} }, "visible to hidden or remain compatibility-visible"},
 		{"legacy flag", func(m *CommandMigration) { m.LegacyFlag.Name = "legacy" }, "must not declare legacy_flag"},
 		{"missing availability", func(m *CommandMigration) { m.Schema.Availability = nil }, "requires availability"},
 		{"wrong availability", func(m *CommandMigration) { m.Schema.Availability.After = "available" }, "requires availability"},
@@ -329,6 +334,58 @@ func TestCrossPlatformCoverageSchemaAvailabilityMigrationLifecycle(t *testing.T)
 	moveSchema.Availability = &CommandAvailabilityChange{Before: "available", After: "unavailable"}
 	if err := moveSchema.validate(CommandMigrationMove); err == nil || !strings.Contains(err.Error(), "must not declare schema availability") {
 		t.Fatalf("ordinary move availability error = %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageCompatibilityVisibleAvailabilityMigrationLifecycle(t *testing.T) {
+	classicPending := availabilityCommandMigrationManifest(CommandMigrationPending)
+	steadyPending := compatibilityVisibleAvailabilityCommandMigrationManifest(CommandMigrationPending)
+	steadyConsumed := compatibilityVisibleAvailabilityCommandMigrationManifest(CommandMigrationConsumed)
+	empty := CommandMigrationManifest{Version: CommandMigrationManifestVersion, Migrations: []CommandMigration{}}
+	visible := testSnapshot(
+		testCommand("dws"),
+		testCommand("dws devapp"),
+		testCommand("dws devapp +event-list"),
+	)
+	hidden := testSnapshot(
+		testCommand("dws"),
+		testCommand("dws devapp"),
+		Command{Path: "dws devapp +event-list", Runnable: true, Hidden: true},
+	)
+	references := map[string]Snapshot{"merge-base": visible, "stable": visible}
+
+	if got, err := AuthorizeCommandMigrations(visible, references, classicPending, steadyPending); err != nil || len(got) != 0 {
+		t.Fatalf("pending compatibility refinement authorizations=%#v error=%v", got, err)
+	}
+	if got, err := AuthorizeCommandMigrations(visible, references, steadyPending, steadyPending); err != nil || len(got) != 0 {
+		t.Fatalf("pending compatibility receipt authorizations=%#v error=%v", got, err)
+	}
+	if got, err := AuthorizeCommandMigrations(visible, references, steadyPending, steadyConsumed); err != nil || len(got) != 1 {
+		t.Fatalf("consumed compatibility receipt authorizations=%#v error=%v", got, err)
+	}
+	if got, err := AuthorizeCommandMigrations(visible, references, steadyConsumed, steadyConsumed); err != nil || len(got) != 1 {
+		t.Fatalf("retained consumed compatibility receipt authorizations=%#v error=%v", got, err)
+	}
+	if got, err := AuthorizeCommandMigrations(visible, references, empty, steadyPending); err != nil || len(got) != 0 {
+		t.Fatalf("candidate-added compatibility receipt authorizations=%#v error=%v", got, err)
+	}
+
+	modified := compatibilityVisibleAvailabilityCommandMigrationManifest(CommandMigrationPending)
+	modified.Migrations[0].Reason = "Changed reason."
+	if _, err := AuthorizeCommandMigrations(visible, references, classicPending, modified); err == nil || !strings.Contains(err.Error(), "modified base-owned") {
+		t.Fatalf("modified compatibility refinement error=%v", err)
+	}
+	if _, err := AuthorizeCommandMigrations(visible, references, classicPending, steadyConsumed); err == nil || !strings.Contains(err.Error(), "modified base-owned") {
+		t.Fatalf("refinement and consumption in one change error=%v", err)
+	}
+	if _, err := AuthorizeCommandMigrations(hidden, references, steadyPending, steadyPending); err == nil || !strings.Contains(err.Error(), "drifted from compatibility-visible") {
+		t.Fatalf("hidden compatibility command error=%v", err)
+	}
+	if _, err := AuthorizeCommandMigrations(visible, references, steadyConsumed, empty); err == nil || !strings.Contains(err.Error(), "must retain compatibility-visible") {
+		t.Fatalf("removed consumed compatibility receipt error=%v", err)
+	}
+	if _, err := AuthorizeCommandMigrations(visible, references, steadyConsumed, steadyPending); err == nil || !strings.Contains(err.Error(), "back to pending") {
+		t.Fatalf("consumed compatibility receipt reverted error=%v", err)
 	}
 }
 
@@ -817,6 +874,12 @@ func availabilityCommandMigrationManifest(state string) CommandMigrationManifest
 			Reason: "Fail closed until terminal pagination evidence is available.",
 		}},
 	}
+}
+
+func compatibilityVisibleAvailabilityCommandMigrationManifest(state string) CommandMigrationManifest {
+	manifest := availabilityCommandMigrationManifest(state)
+	manifest.Migrations[0].Legacy.After = manifest.Migrations[0].Legacy.Before
+	return manifest
 }
 
 func modifiedCommandManifest(source CommandMigrationManifest) CommandMigrationManifest {

--- a/scripts/policy/schema-compat/command_migrations_test.go
+++ b/scripts/policy/schema-compat/command_migrations_test.go
@@ -74,6 +74,16 @@ func TestCrossPlatformCoverageSchemaAvailabilityMigrationNormalizesOnlyAvailabil
 		!strings.Contains(err.Error(), "does not match Schema availability") {
 		t.Fatalf("wrong availability error = %v", err)
 	}
+
+	compatibilityVisible := migration
+	compatibilityVisible.Legacy.After = compatibilityVisible.Legacy.Before
+	if _, err := normalizeSchemaCommandMigrations(baseline, current, []interfacesnapshot.CommandMigration{compatibilityVisible}); err != nil {
+		t.Fatalf("compatibility-visible availability hardening must authorize the exact Schema transition: %v", err)
+	}
+	if _, err := normalizeSchemaCommandMigrations(baseline, baseline, []interfacesnapshot.CommandMigration{compatibilityVisible}); err == nil ||
+		!strings.Contains(err.Error(), "does not match Schema availability") {
+		t.Fatalf("compatibility-visible receipt must not authorize unchanged Schema availability: %v", err)
+	}
 }
 
 func TestCrossPlatformCoverageSchemaCommandMigrationsAuthorizeOnlyExactProjection(t *testing.T) {


### PR DESCRIPTION
## Summary
- support Schema availability hardening while preserving a compatibility-visible CLI leaf
- permit one exact pending-only refinement from visible-to-hidden to compatibility-visible
- keep receipt consumption fail-closed on the exact Schema available-to-unavailable transition

## Safety
- no permanent compatibility exception
- no product Shortcut behavior changes
- no docs, HTML, screenshots, credentials, or E2E payloads committed

## Verification
- `go test ./internal/interfacesnapshot ./scripts/policy/schema-compat -count=1`
- changed-code coverage: 100% (33 statements)
- `make policy`
- `make authoritative-interface-integrity BASE_REF=origin/main STABLE_REF=v1.0.59 CANDIDATE_REF=HEAD`