### PR TITLE
ci: govern pending command migration amendments

### DIFF
--- a/docs/cli-interface-flag-migrations.md
+++ b/docs/cli-interface-flag-migrations.md
@@ -106,6 +106,8 @@ replacement 必须保留 source 已发布的 dry-run 能力：历史 `dry_run` �
 
 跨命令清单复用下文同一套 `pending → consumed → inert/cleanup` 生命周期。治理 PR 只能新增 `pending` 且产品 surface 必须仍是 before；后续产品 PR 才能一次性切到 after 并改为 `consumed`。candidate 新增的 pending 记录不能批准自己的改动。
 
+已经登记但尚未消费的迁移如果需要改目标，必须先走独立治理 PR。该 PR 只能把同一 legacy 命令、kind、legacy 状态、legacy flag、产品与 source tool 谱系下的记录替换为新的 `pending` 记录，并且新旧迁移在 merge-base 和 candidate 都必须保持精确 before surface。治理 PR 不得同时隐藏旧入口、发布 replacement 或把记录改为 `consumed`；这些 interface 变化仍由后续产品 PR 消费。
+
 当前首批 pending 记录覆盖 `chat topic` 收口：`chat group create --thread` 拆到 `chat topic create`，以及 `chat message list-topic-replies` / `forward-topic` 迁到对应的 `chat topic` 命令。前一条完整登记 `name` / `type` / `users` 的同名承接，以及 `thread` → `convThreadEnabled=true` 的常量承接。产品 PR 消费这些记录时只能把三条 `state` 改为 `consumed`，不得改写其 before、after、Schema mapping、constant 或 reason。
 
 ## 两阶段迁移与回执清理

--- a/internal/interfacesnapshot/command_migrations.go
+++ b/internal/interfacesnapshot/command_migrations.go
@@ -479,6 +479,7 @@ func evaluateCommandMigrationLifecycle(
 	}
 	authorityByKey := commandMigrationIndex(authority)
 	candidateByKey := commandMigrationIndex(candidate)
+	amendedCandidateKeys := make(map[string]bool)
 	authorizations := make([]CommandMigration, 0, len(authority.Migrations))
 	for _, approved := range authority.Migrations {
 		basePhase := matchCommandMigrationPhase(mergeBase, approved)
@@ -490,6 +491,29 @@ func evaluateCommandMigrationLifecycle(
 			return nil, fmt.Errorf("approved command migration %s is %s in %s, want exact %s state for %s", approved.displayKey(), basePhase, label, wantBase, approved.State)
 		}
 		proposed, exists := candidateByKey[approved.key()]
+		if !exists && approved.State == CommandMigrationPending {
+			amendment, found, err := findPendingCommandMigrationAmendment(approved, candidate)
+			if err != nil {
+				return nil, err
+			}
+			if found {
+				if amendment.State != CommandMigrationPending {
+					return nil, fmt.Errorf("candidate amendment of pending command migration %s must remain pending", approved.displayKey())
+				}
+				if matchCommandMigrationPhase(current, approved) != commandMigrationBefore ||
+					matchCommandMigrationPhase(current, amendment) != commandMigrationBefore {
+					return nil, fmt.Errorf("candidate cannot amend pending command migration %s after applying an interface change", approved.displayKey())
+				}
+				if matchCommandMigrationPhase(mergeBase, amendment) != commandMigrationBefore {
+					return nil, fmt.Errorf("candidate amendment of pending command migration %s does not match the merge-base before state", approved.displayKey())
+				}
+				if amendedCandidateKeys[amendment.key()] {
+					return nil, fmt.Errorf("candidate command migration %s amends more than one pending approval", amendment.displayKey())
+				}
+				amendedCandidateKeys[amendment.key()] = true
+				continue
+			}
+		}
 		if exists && !sameCommandMigrationApproval(approved, proposed) &&
 			!isPendingAvailabilityCompatibilityRefinement(approved, proposed) {
 			return nil, fmt.Errorf("candidate modified base-owned command migration %s", approved.displayKey())
@@ -564,6 +588,9 @@ func evaluateCommandMigrationLifecycle(
 		if _, exists := authorityByKey[proposed.key()]; exists {
 			continue
 		}
+		if amendedCandidateKeys[proposed.key()] {
+			continue
+		}
 		if proposed.State != CommandMigrationPending {
 			return nil, fmt.Errorf("candidate-added command migration %s must start pending", proposed.displayKey())
 		}
@@ -589,6 +616,34 @@ func sameCommandMigrationApproval(left, right CommandMigration) bool {
 	left.State = ""
 	right.State = ""
 	return reflect.DeepEqual(left, right)
+}
+
+func findPendingCommandMigrationAmendment(approved CommandMigration, candidate CommandMigrationManifest) (CommandMigration, bool, error) {
+	var found CommandMigration
+	matches := 0
+	for _, proposed := range candidate.Migrations {
+		if proposed.key() == approved.key() || !samePendingCommandMigrationLineage(approved, proposed) {
+			continue
+		}
+		found = proposed
+		matches++
+	}
+	if matches > 1 {
+		return CommandMigration{}, false, fmt.Errorf("candidate declares multiple amendments for pending command migration %s", approved.displayKey())
+	}
+	return found, matches == 1, nil
+}
+
+func samePendingCommandMigrationLineage(approved, proposed CommandMigration) bool {
+	if approved.State != CommandMigrationPending ||
+		(approved.Kind != CommandMigrationMove && approved.Kind != CommandMigrationFlagExtraction) {
+		return false
+	}
+	return approved.Kind == proposed.Kind &&
+		reflect.DeepEqual(approved.Legacy, proposed.Legacy) &&
+		reflect.DeepEqual(approved.LegacyFlag, proposed.LegacyFlag) &&
+		approved.Schema.ProductID == proposed.Schema.ProductID &&
+		approved.Schema.SourceToolID == proposed.Schema.SourceToolID
 }
 
 func isVisibleToHiddenAvailabilityMigration(migration CommandMigration) bool {

--- a/internal/interfacesnapshot/command_migrations_test.go
+++ b/internal/interfacesnapshot/command_migrations_test.go
@@ -614,6 +614,39 @@ func TestCrossPlatformCoveragePendingCommandMigrationAmendmentRequiresGovernance
 	if _, err := AuthorizeCommandMigrations(after, map[string]Snapshot{"main": before, "stable": before}, approved, amended); err == nil || !strings.Contains(err.Error(), "after applying an interface change") {
 		t.Fatalf("self-authorizing amendment error=%v, want governance-only rejection", err)
 	}
+
+	multipleAmendments := amended
+	multipleAmendments.Migrations = append([]CommandMigration(nil), amended.Migrations...)
+	secondAmendment := cloneCommandMigration(amended.Migrations[0])
+	secondAmendment.Replacement.Command = "dws chat thread alternate"
+	multipleAmendments.Migrations = append(multipleAmendments.Migrations, secondAmendment)
+	if _, err := AuthorizeCommandMigrations(before, map[string]Snapshot{"main": before, "stable": before}, approved, multipleAmendments); err == nil || !strings.Contains(err.Error(), "multiple amendments") {
+		t.Fatalf("multiple amendments error=%v, want ambiguity rejection", err)
+	}
+
+	baseWithAmendedTarget := before
+	baseWithAmendedTarget.Commands = append(append([]Command(nil), before.Commands...), testCommand("dws chat thread new", Flag{Name: "new-id", Type: "string", Required: true}))
+	if _, err := AuthorizeCommandMigrations(before, map[string]Snapshot{"main": baseWithAmendedTarget, "stable": before}, approved, amended); err == nil || !strings.Contains(err.Error(), "merge-base before state") {
+		t.Fatalf("merge-base amendment error=%v, want before-state rejection", err)
+	}
+
+	twoApprovals := approved
+	twoApprovals.Migrations = append([]CommandMigration(nil), approved.Migrations...)
+	secondApproval := cloneCommandMigration(approved.Migrations[0])
+	secondApproval.Replacement.Command = "dws chat topic alternate"
+	twoApprovals.Migrations = append(twoApprovals.Migrations, secondApproval)
+	if _, err := AuthorizeCommandMigrations(before, map[string]Snapshot{"main": before, "stable": before}, twoApprovals, amended); err == nil || !strings.Contains(err.Error(), "amends more than one") {
+		t.Fatalf("shared amendment error=%v, want one-to-one rejection", err)
+	}
+
+	candidateWithReceipt := amended
+	candidateWithReceipt.Migrations = append([]CommandMigration{approved.Migrations[0]}, amended.Migrations...)
+	if _, found, err := findPendingCommandMigrationAmendment(approved.Migrations[0], candidateWithReceipt); err != nil || !found {
+		t.Fatalf("amendment lookup with retained receipt found=%t, err=%v", found, err)
+	}
+	if samePendingCommandMigrationLineage(commandMigrationManifest(CommandMigrationConsumed).Migrations[0], amended.Migrations[0]) {
+		t.Fatal("consumed migration matched pending amendment lineage")
+	}
 }
 
 func TestCrossPlatformCoverageCommandMigrationLifecycleAndExactFiltering(t *testing.T) {

--- a/internal/interfacesnapshot/command_migrations_test.go
+++ b/internal/interfacesnapshot/command_migrations_test.go
@@ -591,6 +591,31 @@ func TestCrossPlatformCoverageCommandMigrationLifecycleEdges(t *testing.T) {
 	}
 }
 
+func TestCrossPlatformCoveragePendingCommandMigrationAmendmentRequiresGovernanceOnlyChange(t *testing.T) {
+	before := commandMigrationSnapshot(false, false)
+	approved := singleCommandMigrationManifest(CommandMigrationPending)
+	amended := retargetPendingCommandMigrationManifest(approved, CommandMigrationPending)
+
+	if got, err := AuthorizeCommandMigrations(before, map[string]Snapshot{"main": before, "stable": before}, approved, amended); err != nil || len(got) != 0 {
+		t.Fatalf("governance-only pending amendment=%#v, %v", got, err)
+	}
+
+	consumed := retargetPendingCommandMigrationManifest(approved, CommandMigrationConsumed)
+	if _, err := AuthorizeCommandMigrations(before, map[string]Snapshot{"main": before, "stable": before}, approved, consumed); err == nil || !strings.Contains(err.Error(), "must remain pending") {
+		t.Fatalf("amendment consumption error=%v, want pending-only rejection", err)
+	}
+
+	after := commandMigrationSnapshot(true, false)
+	for index := range after.Commands {
+		if after.Commands[index].Path == "dws chat topic new" {
+			after.Commands[index].Path = "dws chat thread new"
+		}
+	}
+	if _, err := AuthorizeCommandMigrations(after, map[string]Snapshot{"main": before, "stable": before}, approved, amended); err == nil || !strings.Contains(err.Error(), "after applying an interface change") {
+		t.Fatalf("self-authorizing amendment error=%v, want governance-only rejection", err)
+	}
+}
+
 func TestCrossPlatformCoverageCommandMigrationLifecycleAndExactFiltering(t *testing.T) {
 	before := commandMigrationSnapshot(false, false)
 	after := commandMigrationSnapshot(true, false)
@@ -887,6 +912,15 @@ func modifiedCommandManifest(source CommandMigrationManifest) CommandMigrationMa
 	modified.Migrations = append([]CommandMigration(nil), source.Migrations...)
 	modified.Migrations[0].Reason = "Modified reason."
 	return modified
+}
+
+func retargetPendingCommandMigrationManifest(source CommandMigrationManifest, state string) CommandMigrationManifest {
+	retargeted := source
+	retargeted.Migrations = append([]CommandMigration(nil), source.Migrations...)
+	retargeted.Migrations[0].Replacement.Command = "dws chat thread new"
+	retargeted.Migrations[0].State = state
+	retargeted.Migrations[0].Reason = "Retarget the pending migration before changing the command surface."
+	return retargeted
 }
 
 func commandMigrationSnapshot(after, removeUnrelated bool) Snapshot {


### PR DESCRIPTION
## Summary

- Allow an existing `pending` command migration plan to be retargeted by a governance-only PR when its legacy lineage is unchanged.
- Require both the old and replacement plans to remain in the exact `before` interface state, and require the amended receipt to remain `pending`.
- Add regression coverage proving the amendment cannot publish the replacement command, hide the legacy command, or consume itself in the same PR.

This is needed because pending migration targets can become stale before a product PR consumes them. Without a guarded amendment path, changing the approved target requires either publishing an obsolete intermediate command or weakening the two-stage lifecycle in the product PR.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

- [x] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`): N/A — governance-only; command and Schema surfaces are unchanged.
- [x] Release-seal validation (otherwise `N/A`): N/A — no release fragment or user-visible change.
- [x] Targeted test/check commands and results:
  - `go test ./internal/interfacesnapshot -run '^(TestCrossPlatformCoveragePendingCommandMigrationAmendmentRequiresGovernanceOnlyChange|TestCrossPlatformCoverageCommandMigrationLifecycleEdges)$' -count=1` — pass
  - `go test ./internal/interfacesnapshot ./scripts/policy/commandcompat -count=1` — pass
  - `go test ./scripts/policy/schemacompat -count=1` — pass
  - `make authoritative-interface-integrity BASE_REF=upstream/main CANDIDATE_REF=HEAD` — compatible
- [x] Behavior evidence: `TestCrossPlatformCoveragePendingCommandMigrationAmendmentRequiresGovernanceOnlyChange` accepts a pending before-state amendment and rejects both same-PR consumption and same-PR interface changes.
- [x] Documentation links/content/rendering checked: updated `docs/cli-interface-flag-migrations.md` lifecycle guidance.
- [ ] Full local suite run because the change is high-risk: delegated to the repository high-risk CI matrix; targeted authority and package suites above passed locally.
- [x] `./scripts/policy/check-generated-drift.sh`: N/A — no generator inputs or generated artifacts changed.
- [x] `./scripts/policy/check-command-surface.sh --strict`: N/A — command surface is unchanged; authoritative interface comparison reported compatible.
- [x] `./scripts/release/verify-package-managers.sh`: N/A — packaging and installer surfaces are unchanged.

## Notes

- This PR intentionally does not retarget any migration record. A follow-up governance PR will amend the pending Chat target while the command surface remains unchanged; the product PR consumes it only after that amendment lands.
