### PR TITLE
fix(ci): merge App-owned PRs synchronously

### DIFF
--- a/.changes/reviewer-router-synchronous-merge.md
+++ b/.changes/reviewer-router-synchronous-merge.md
@@ -2,4 +2,4 @@
 category: Fixed
 ---
 
-- **Reviewer Router merge recovery** — retries exact App-owned merge intents through a SHA-bound synchronous merge after GitHub has enforced approval and required checks.
+- **Reviewer Router merge recovery** — retries exact App-owned merge intents through a SHA-bound synchronous merge after GitHub has enforced approval and nine GitHub Actions source-bound required checks.

--- a/.changes/reviewer-router-synchronous-merge.md
+++ b/.changes/reviewer-router-synchronous-merge.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Reviewer Router merge recovery** — retries exact App-owned merge intents through a SHA-bound synchronous merge after GitHub has enforced approval and required checks.

--- a/.github/workflows/reviewer-router-approval-signal.yml
+++ b/.github/workflows/reviewer-router-approval-signal.yml
@@ -1,0 +1,19 @@
+name: Reviewer Router approval signal
+
+on:
+  pull_request_review:
+    types: [submitted, dismissed]
+
+# This workflow only converts an approval-state change into a trusted
+# workflow_run event. It must never read secrets, check out code, or mutate the
+# pull request; the default-branch Reviewer routing workflow owns reconciliation.
+permissions: {}
+
+jobs:
+  signal:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions: {}
+    steps:
+      - name: Signal approval-state change
+        run: echo "Review state changed; default-branch reconciliation will re-evaluate App-owned merge intents."

--- a/.github/workflows/reviewer-router.yml
+++ b/.github/workflows/reviewer-router.yml
@@ -4,8 +4,13 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, edited, auto_merge_enabled]
+  workflow_run:
+    workflows: [CI, Code Admission — AI Behavior, Reviewer Router approval signal]
+    types: [completed]
   push:
     branches: [main]
+  schedule:
+    - cron: '17,47 * * * *'
   workflow_dispatch:
 
 # pull_request_target deliberately runs only this workflow from the protected
@@ -753,10 +758,12 @@ jobs:
   # Existing ready PRs do not emit a fresh routing event when this workflow is
   # deployed. The protected-main push that deploys it migrates every non-App
   # request, repairs App requests with unreviewed metadata, and clears
-  # workflow-skipping merge metadata; workflow_dispatch provides an idempotent
-  # recovery path. Null and exact safe App requests remain untouched.
+  # workflow-skipping merge metadata; trusted workflow_run completions retry
+  # exact safe App requests through the synchronous merge endpoint, while
+  # the staggered schedule and workflow_dispatch provide idempotent recovery
+  # paths. Null requests remain untouched.
   reconcile:
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && github.repository == 'DingTalk-Real-AI/dingtalk-workspace-cli'
+    if: github.repository == 'DingTalk-Real-AI/dingtalk-workspace-cli' && (((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main') || github.event_name == 'workflow_run' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
@@ -771,7 +778,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           permission-contents: write
           permission-pull-requests: write
-      - name: Reconcile unsafe auto-merge requests
+      - name: Reconcile and merge App-owned pull requests
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           MINTED_REVIEWER_ROUTER_APP_SLUG: ${{ steps.reviewer-router-reconcile-token.outputs.app-slug }}
@@ -832,46 +839,93 @@ jobs:
               );
             }
             const repositorySource = `${owner}/${repo}`.toLowerCase();
-            const appliedRules = await github.paginate(
-              'GET /repos/{owner}/{repo}/rules/branches/{branch}',
-              {owner, repo, branch: 'main', per_page: 100},
-            );
-            const applicableRulesetIDs = [
-              ...new Set(
-                appliedRules
-                  .map(rule => Number(rule.ruleset_id))
-                  .filter(rulesetID =>
-                    Number.isSafeInteger(rulesetID) && rulesetID > 0,
-                  ),
-              ),
+            const requiredCheckContexts = [
+              'Lint',
+              'Test',
+              'Coverage',
+              'Policy',
+              'Edition',
+              'Interface Integrity',
+              'AI Behavior',
+              'CLI Smoke',
+              'Mock MCP',
             ];
-            const activeMainRulesets = [];
-            for (const rulesetID of applicableRulesetIDs) {
-              const {data: ruleset} = await github.request(
-                'GET /repos/{owner}/{repo}/rulesets/{ruleset_id}',
-                {owner, repo, ruleset_id: rulesetID},
+            function hasExactStringSet(values, expected) {
+              return (
+                Array.isArray(values) &&
+                values.length === expected.length &&
+                new Set(values).size === expected.length &&
+                expected.every(value => values.includes(value))
               );
+            }
+            function hasExactMainRulesetScope(ruleset) {
+              const includes = ruleset?.conditions?.ref_name?.include;
+              const excludes = ruleset?.conditions?.ref_name?.exclude;
+              return (
+                ruleset?.enforcement === 'active' &&
+                ruleset?.target === 'branch' &&
+                ruleset?.source_type === 'Repository' &&
+                ruleset?.source?.toLowerCase() === repositorySource &&
+                Array.isArray(includes) &&
+                includes.length === 1 &&
+                includes[0] === 'refs/heads/main' &&
+                Array.isArray(excludes) &&
+                excludes.length === 0
+              );
+            }
+            function isExactMainProtectionRuleset(ruleset) {
               if (
-                ruleset.enforcement !== 'active' ||
-                ruleset.target !== 'branch'
+                !hasExactMainRulesetScope(ruleset) ||
+                !Array.isArray(ruleset.rules) ||
+                ruleset.rules.length !== 3 ||
+                !hasExactStringSet(
+                  ruleset.rules.map(rule => rule?.type),
+                  ['deletion', 'non_fast_forward', 'pull_request'],
+                )
               ) {
-                throw new Error(
-                  `Applicable ruleset ${ruleset.name || rulesetID} is not an active branch ruleset.`,
-                );
+                return false;
               }
-              activeMainRulesets.push(ruleset);
-            }
-            const writerRulesets = activeMainRulesets.filter(
-              ruleset => ruleset.name === 'main-merge-writers',
-            );
-            if (writerRulesets.length !== 1) {
-              throw new Error(
-                'Expected exactly one active main-merge-writers ruleset on main.',
+              const pullRequestRule = ruleset.rules.find(
+                rule => rule.type === 'pull_request',
+              );
+              const parameters = pullRequestRule?.parameters;
+              return (
+                parameters?.required_approving_review_count === 1 &&
+                parameters.require_last_push_approval === true &&
+                parameters.require_extra_approval_for_unattributed_changes === true &&
+                parameters.dismiss_stale_reviews_on_push === false &&
+                parameters.require_code_owner_review === false &&
+                parameters.required_review_thread_resolution === false &&
+                hasExactStringSet(
+                  parameters.allowed_merge_methods,
+                  ['merge', 'squash', 'rebase'],
+                ) &&
+                parameters.dismissal_restriction?.enabled === false &&
+                Array.isArray(parameters.dismissal_restriction.allowed_actors) &&
+                parameters.dismissal_restriction.allowed_actors.length === 0 &&
+                Array.isArray(parameters.required_reviewers) &&
+                parameters.required_reviewers.length === 0
               );
             }
-            const writerRuleset = writerRulesets[0];
-            const writerIncludes = writerRuleset.conditions?.ref_name?.include || [];
-            const writerExcludes = writerRuleset.conditions?.ref_name?.exclude || [];
+            function isExactMainQualityRuleset(ruleset) {
+              if (
+                !hasExactMainRulesetScope(ruleset) ||
+                !Array.isArray(ruleset.rules) ||
+                ruleset.rules.length !== 1 ||
+                ruleset.rules[0]?.type !== 'required_status_checks'
+              ) {
+                return false;
+              }
+              const parameters = ruleset.rules[0].parameters;
+              const contexts = parameters?.required_status_checks?.map(
+                check => check?.context,
+              );
+              return (
+                parameters?.strict_required_status_checks_policy === true &&
+                parameters.do_not_enforce_on_create === false &&
+                hasExactStringSet(contexts, requiredCheckContexts)
+              );
+            }
             // GitHub's read projection omits the entire parameters property
             // when this exception is disabled. Accept only that exact omission
             // or a one-field object containing exact false.
@@ -916,62 +970,128 @@ jobs:
                 graphRule.parameters.updateAllowsFetchAndMerge === false
               );
             }
-            if (
-              writerRuleset.source_type !== 'Repository' ||
-              writerRuleset.source?.toLowerCase() !== repositorySource ||
-              writerIncludes.length !== 1 ||
-              writerIncludes[0] !== 'refs/heads/main' ||
-              writerExcludes.length !== 0 ||
-              typeof writerRuleset.node_id !== 'string' ||
-              !writerRuleset.node_id ||
-              writerRuleset.rules?.length !== 1 ||
-              !isStrictUpdateRule(writerRuleset.rules[0]) ||
-              writerRuleset.current_user_can_bypass !== 'pull_requests_only'
-            ) {
-              throw new Error(
-                'Reviewer Router App requires the exact repository-owned main writer rule with pull-request-only bypass.',
+            async function assertReviewerRouterRulesetBoundary() {
+              const appliedRules = await github.paginate(
+                'GET /repos/{owner}/{repo}/rules/branches/{branch}',
+                {owner, repo, branch: 'main', per_page: 100},
               );
-            }
-            const {node: graphWriterRuleset} = await github.graphql(
-              `query ReviewerRouterWriterRule($rulesetID: ID!) {
-                node(id: $rulesetID) {
-                  ... on RepositoryRuleset {
-                    databaseId
-                    name
-                    enforcement
-                    target
-                    rules(first: 2) {
-                      totalCount
-                      nodes {
-                        type
-                        parameters {
-                          __typename
-                          ... on UpdateParameters {
-                            updateAllowsFetchAndMerge
+              const applicableRulesetIDs = [
+                ...new Set(
+                  appliedRules
+                    .map(rule => Number(rule.ruleset_id))
+                    .filter(rulesetID =>
+                      Number.isSafeInteger(rulesetID) && rulesetID > 0,
+                    ),
+                ),
+              ];
+              const activeMainRulesets = [];
+              for (const rulesetID of applicableRulesetIDs) {
+                const {data: ruleset} = await github.request(
+                  'GET /repos/{owner}/{repo}/rulesets/{ruleset_id}',
+                  {owner, repo, ruleset_id: rulesetID},
+                );
+                if (
+                  ruleset.enforcement !== 'active' ||
+                  ruleset.target !== 'branch'
+                ) {
+                  throw new Error(
+                    `Applicable ruleset ${ruleset.name || rulesetID} is not an active branch ruleset.`,
+                  );
+                }
+                activeMainRulesets.push(ruleset);
+              }
+              const writerRulesets = activeMainRulesets.filter(
+                ruleset => ruleset.name === 'main-merge-writers',
+              );
+              if (writerRulesets.length !== 1) {
+                throw new Error(
+                  'Expected exactly one active main-merge-writers ruleset on main.',
+                );
+              }
+              const writerRuleset = writerRulesets[0];
+              const writerIncludes = writerRuleset.conditions?.ref_name?.include || [];
+              const writerExcludes = writerRuleset.conditions?.ref_name?.exclude || [];
+              if (
+                !hasExactMainRulesetScope(writerRuleset) ||
+                writerIncludes.length !== 1 ||
+                writerIncludes[0] !== 'refs/heads/main' ||
+                writerExcludes.length !== 0 ||
+                typeof writerRuleset.node_id !== 'string' ||
+                !writerRuleset.node_id ||
+                writerRuleset.rules?.length !== 1 ||
+                !isStrictUpdateRule(writerRuleset.rules[0]) ||
+                writerRuleset.current_user_can_bypass !== 'pull_requests_only'
+              ) {
+                throw new Error(
+                  'Reviewer Router App requires the exact repository-owned main writer rule with pull-request-only bypass.',
+                );
+              }
+              const {node: graphWriterRuleset} = await github.graphql(
+                `query ReviewerRouterWriterRule($rulesetID: ID!) {
+                  node(id: $rulesetID) {
+                    ... on RepositoryRuleset {
+                      databaseId
+                      name
+                      enforcement
+                      target
+                      rules(first: 2) {
+                        totalCount
+                        nodes {
+                          type
+                          parameters {
+                            __typename
+                            ... on UpdateParameters {
+                              updateAllowsFetchAndMerge
+                            }
                           }
                         }
                       }
                     }
                   }
-                }
-              }`,
-              {rulesetID: writerRuleset.node_id},
-            );
-            if (!isStrictGraphQLUpdateRule(writerRuleset, graphWriterRuleset)) {
-              throw new Error(
-                'Reviewer Router App requires GraphQL to expose one strict UPDATE rule with updateAllowsFetchAndMerge=false.',
+                }`,
+                {rulesetID: writerRuleset.node_id},
               );
-            }
-            for (const ruleset of activeMainRulesets) {
-              if (ruleset.id === writerRuleset.id) {
-                continue;
-              }
-              if (ruleset.current_user_can_bypass !== 'never') {
+              if (!isStrictGraphQLUpdateRule(writerRuleset, graphWriterRuleset)) {
                 throw new Error(
-                  `Reviewer Router App must never bypass main ruleset ${ruleset.name || ruleset.id}.`,
+                  'Reviewer Router App requires GraphQL to expose one strict UPDATE rule with updateAllowsFetchAndMerge=false.',
                 );
               }
+              const protectionRulesets = activeMainRulesets.filter(
+                ruleset => ruleset.name === 'main-protection',
+              );
+              if (
+                protectionRulesets.length !== 1 ||
+                protectionRulesets[0].current_user_can_bypass !== 'never' ||
+                !isExactMainProtectionRuleset(protectionRulesets[0])
+              ) {
+                throw new Error(
+                  'Reviewer Router App requires the exact non-bypassable main-protection approval ruleset.',
+                );
+              }
+              const qualityRulesets = activeMainRulesets.filter(
+                ruleset => ruleset.name === 'main-quality',
+              );
+              if (
+                qualityRulesets.length !== 1 ||
+                qualityRulesets[0].current_user_can_bypass !== 'never' ||
+                !isExactMainQualityRuleset(qualityRulesets[0])
+              ) {
+                throw new Error(
+                  'Reviewer Router App requires the exact non-bypassable main-quality ruleset with nine strict checks.',
+                );
+              }
+              for (const ruleset of activeMainRulesets) {
+                if (ruleset.id === writerRuleset.id) {
+                  continue;
+                }
+                if (ruleset.current_user_can_bypass !== 'never') {
+                  throw new Error(
+                    `Reviewer Router App must never bypass main ruleset ${ruleset.name || ruleset.id}.`,
+                  );
+                }
+              }
             }
+            await assertReviewerRouterRulesetBoundary();
             const skipWorkflowPattern =
               /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|\bskip-checks\s*:\s*true\b/i;
             const openPulls = await github.paginate(github.rest.pulls.list, {
@@ -983,7 +1103,123 @@ jobs:
             });
             let migrated = 0;
             let skipped = 0;
+            let merged = 0;
+            let notReady = 0;
             const failures = [];
+
+            function hasSafeAppMergeIntent(
+              pullRequest,
+              safeCommitHeadline,
+              safeCommitBody,
+            ) {
+              const requestOwner =
+                pullRequest.auto_merge?.enabled_by?.login?.toLowerCase();
+              const mergeTexts = [
+                pullRequest.title,
+                pullRequest.auto_merge?.commit_title,
+                pullRequest.auto_merge?.commit_message,
+              ].filter(value => typeof value === 'string');
+              const skipRequested = mergeTexts.some(value =>
+                skipWorkflowPattern.test(value),
+              );
+              return (
+                requestOwner === expectedAppOwner &&
+                pullRequest.auto_merge?.commit_title === safeCommitHeadline &&
+                pullRequest.auto_merge?.commit_message === safeCommitBody &&
+                !skipRequested
+              );
+            }
+
+            function validateAppMergeFinalState(
+              pullRequest,
+              expectedHeadSha,
+              expectedAppLogin,
+              expectedBaseRepository,
+              expectedMergeSha,
+            ) {
+              const mergedBy = pullRequest.merged_by?.login?.toLowerCase();
+              const mergeCommitSha = pullRequest.merge_commit_sha;
+              const baseRepository =
+                pullRequest.base?.repo?.full_name?.toLowerCase();
+              const responseShaRequired = arguments.length >= 5;
+              const responseShaMatches =
+                !responseShaRequired ||
+                (typeof expectedMergeSha === 'string' &&
+                  expectedMergeSha.length > 0 &&
+                  mergeCommitSha === expectedMergeSha);
+              if (
+                pullRequest.state !== 'closed' ||
+                !pullRequest.merged_at ||
+                pullRequest.head.sha !== expectedHeadSha ||
+                pullRequest.base?.ref !== 'main' ||
+                baseRepository !== expectedBaseRepository ||
+                mergedBy !== expectedAppLogin ||
+                typeof mergeCommitSha !== 'string' ||
+                !mergeCommitSha ||
+                !responseShaMatches
+              ) {
+                throw new Error(
+                  `merge result was not attributed exactly to ${expectedAppLogin}`,
+                );
+              }
+              return {mergedBy, mergeCommitSha};
+            }
+
+            function requireSuccessfulMergeResponse(mergeResult) {
+              if (mergeResult?.merged !== true) {
+                throw new Error(
+                  `GitHub returned a successful response without merging: ${mergeResult?.message || 'no explanation'}`,
+                );
+              }
+              if (
+                typeof mergeResult.sha !== 'string' ||
+                !mergeResult.sha
+              ) {
+                throw new Error(
+                  'GitHub returned a successful merge without a merge commit SHA.',
+                );
+              }
+              return mergeResult.sha;
+            }
+
+            function classifyMergeAttemptRecovery(
+              status,
+              latestPull,
+              expectedHeadSha,
+              expectedAppLogin,
+              expectedBaseRepository,
+              responseMergeSha,
+            ) {
+              if (latestPull.merged_at) {
+                const finalState = responseMergeSha === undefined
+                  ? validateAppMergeFinalState(
+                      latestPull,
+                      expectedHeadSha,
+                      expectedAppLogin,
+                      expectedBaseRepository,
+                    )
+                  : validateAppMergeFinalState(
+                      latestPull,
+                      expectedHeadSha,
+                      expectedAppLogin,
+                      expectedBaseRepository,
+                      responseMergeSha,
+                    );
+                return {outcome: 'merged', finalState};
+              }
+              if (latestPull.state !== 'open') {
+                return {outcome: 'closed'};
+              }
+              if (status === 404) {
+                throw new Error(
+                  'merge endpoint returned 404 while the pull request remained open',
+                );
+              }
+              if (status === 405 || status === 409) {
+                return {outcome: 'not_ready'};
+              }
+              throw new Error(`unsupported merge recovery status ${status}`);
+            }
 
             async function disableAutoMerge(pullNumber, pullRequestId, phase) {
               await github.graphql(
@@ -1013,21 +1249,11 @@ jobs:
               const safeCommitHeadline = `Merge pull request #${candidate.number}`;
               const safeCommitBody =
                 `Merged by the dedicated Reviewer Router GitHub App for PR #${candidate.number}.`;
-              const candidateOwner =
-                candidate.auto_merge?.enabled_by?.login?.toLowerCase();
-              const candidateMergeTexts = [
-                candidate.title,
-                candidate.auto_merge?.commit_title,
-                candidate.auto_merge?.commit_message,
-              ].filter(value => typeof value === 'string');
-              const candidateSkipRequested = candidateMergeTexts.some(value =>
-                skipWorkflowPattern.test(value),
+              const candidateHasSafeAppRequest = hasSafeAppMergeIntent(
+                candidate,
+                safeCommitHeadline,
+                safeCommitBody,
               );
-              const candidateHasSafeAppRequest =
-                candidateOwner === expectedAppOwner &&
-                candidate.auto_merge?.commit_title === safeCommitHeadline &&
-                candidate.auto_merge?.commit_message === safeCommitBody &&
-                !candidateSkipRequested;
               if (
                 candidate.draft ||
                 candidate.base.ref !== 'main' ||
@@ -1187,11 +1413,211 @@ jobs:
                 core.error(failure);
               }
             }
+
+            // GitHub's deferred native auto-merge path does not reliably apply
+            // a GitHub App's pull-request-only ruleset bypass. Preserve the
+            // exact App-owned request as the automation intent, then let the
+            // same installation token perform a synchronous, SHA-bound merge.
+            // The App must report `never` on every non-writer ruleset above, so
+            // GitHub still enforces the latest-head approval and required checks.
+            const mergePulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              base: 'main',
+              per_page: 100,
+            });
+            for (const candidate of mergePulls) {
+              const safeCommitHeadline = `Merge pull request #${candidate.number}`;
+              const safeCommitBody =
+                `Merged by the dedicated Reviewer Router GitHub App for PR #${candidate.number}.`;
+              const candidateHasSafeAppRequest = hasSafeAppMergeIntent(
+                candidate,
+                safeCommitHeadline,
+                safeCommitBody,
+              );
+              if (
+                candidate.draft ||
+                candidate.base.ref !== 'main' ||
+                candidate.base.repo?.full_name?.toLowerCase() !== repositorySource ||
+                !candidateHasSafeAppRequest
+              ) {
+                continue;
+              }
+
+              let stage = 'synchronous merge preflight';
+              try {
+                const expectedHeadSha = candidate.head.sha;
+                const expectedBaseSha = candidate.base.sha;
+                const {data: currentPull} = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: candidate.number,
+                });
+                const currentHasSafeAppRequest = hasSafeAppMergeIntent(
+                  currentPull,
+                  safeCommitHeadline,
+                  safeCommitBody,
+                );
+                if (currentPull.merged_at) {
+                  const finalState = validateAppMergeFinalState(
+                    currentPull,
+                    expectedHeadSha,
+                    expectedAppOwner,
+                    repositorySource,
+                  );
+                  merged += 1;
+                  core.info(
+                    `Observed concurrent App merge for PR #${candidate.number} at ${finalState.mergeCommitSha}.`,
+                  );
+                  continue;
+                }
+                if (currentPull.state !== 'open') {
+                  skipped += 1;
+                  core.info(
+                    `PR #${candidate.number} closed without merging before synchronous merge; skipped.`,
+                  );
+                  continue;
+                }
+                if (
+                  currentPull.head.sha !== expectedHeadSha ||
+                  currentPull.base.sha !== expectedBaseSha ||
+                  currentPull.draft ||
+                  currentPull.base.ref !== 'main' ||
+                  currentPull.base.repo?.full_name?.toLowerCase() !== repositorySource ||
+                  !currentHasSafeAppRequest
+                ) {
+                  skipped += 1;
+                  core.info(
+                    `PR #${candidate.number} changed before synchronous merge; skipped.`,
+                  );
+                  continue;
+                }
+
+                stage = 'ruleset revalidation';
+                await assertReviewerRouterRulesetBoundary();
+                stage = 'final synchronous merge preflight';
+                const {data: finalPull} = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: candidate.number,
+                });
+                if (finalPull.merged_at) {
+                  const finalState = validateAppMergeFinalState(
+                    finalPull,
+                    expectedHeadSha,
+                    expectedAppOwner,
+                    repositorySource,
+                  );
+                  merged += 1;
+                  core.info(
+                    `Observed concurrent App merge for PR #${candidate.number} at ${finalState.mergeCommitSha}.`,
+                  );
+                  continue;
+                }
+                if (finalPull.state !== 'open') {
+                  skipped += 1;
+                  core.info(
+                    `PR #${candidate.number} closed without merging at final synchronous merge preflight; skipped.`,
+                  );
+                  continue;
+                }
+                if (
+                  finalPull.head.sha !== expectedHeadSha ||
+                  finalPull.base.sha !== expectedBaseSha ||
+                  finalPull.draft ||
+                  finalPull.base.ref !== 'main' ||
+                  finalPull.base.repo?.full_name?.toLowerCase() !== repositorySource ||
+                  !hasSafeAppMergeIntent(
+                    finalPull,
+                    safeCommitHeadline,
+                    safeCommitBody,
+                  )
+                ) {
+                  skipped += 1;
+                  core.info(
+                    `PR #${candidate.number} changed at final synchronous merge preflight; skipped.`,
+                  );
+                  continue;
+                }
+
+                stage = 'synchronous merge';
+                let responseMergeSha;
+                try {
+                  const {data: mergeResult} = await github.rest.pulls.merge({
+                    owner,
+                    repo,
+                    pull_number: candidate.number,
+                    sha: expectedHeadSha,
+                    merge_method: 'merge',
+                    commit_title: safeCommitHeadline,
+                    commit_message: safeCommitBody,
+                  });
+                  responseMergeSha = requireSuccessfulMergeResponse(mergeResult);
+                  const {data: mergedPull} = await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: candidate.number,
+                  });
+                  const finalState = validateAppMergeFinalState(
+                    mergedPull,
+                    expectedHeadSha,
+                    expectedAppOwner,
+                    repositorySource,
+                    responseMergeSha,
+                  );
+                  merged += 1;
+                  core.info(
+                    `Merged PR #${candidate.number} at ${finalState.mergeCommitSha} with ${finalState.mergedBy}.`,
+                  );
+                } catch (error) {
+                  const status = Number(error.status);
+                  if (![404, 405, 409].includes(status)) {
+                    throw error;
+                  }
+                  const {data: latestPull} = await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: candidate.number,
+                  });
+                  const recovery = classifyMergeAttemptRecovery(
+                    status,
+                    latestPull,
+                    expectedHeadSha,
+                    expectedAppOwner,
+                    repositorySource,
+                    responseMergeSha,
+                  );
+                  if (recovery.outcome === 'merged') {
+                    merged += 1;
+                    core.info(
+                      `Observed concurrent App merge for PR #${candidate.number} at ${recovery.finalState.mergeCommitSha}.`,
+                    );
+                    continue;
+                  }
+                  if (recovery.outcome === 'closed') {
+                    skipped += 1;
+                    core.info(
+                      `PR #${candidate.number} closed without merging during the synchronous merge race; skipped.`,
+                    );
+                    continue;
+                  }
+                  notReady += 1;
+                  core.info(
+                    `PR #${candidate.number} is not ready for synchronous merge (${status}: ${error.message}).`,
+                  );
+                }
+              } catch (error) {
+                const failure = `PR #${candidate.number} failed during ${stage}: ${error.message}`;
+                failures.push(failure);
+                core.error(failure);
+              }
+            }
             core.info(
-              `Reconciliation summary: migrated=${migrated}, skipped=${skipped}, failed=${failures.length}.`,
+              `Reconciliation summary: migrated=${migrated}, merged=${merged}, not_ready=${notReady}, skipped=${skipped}, failed=${failures.length}.`,
             );
             if (failures.length > 0) {
               core.setFailed(
-                `Legacy auto-merge reconciliation had ${failures.length} failure(s): ${failures.join('; ')}`,
+                `Reviewer Router reconciliation had ${failures.length} failure(s): ${failures.join('; ')}`,
               );
             }

--- a/.github/workflows/reviewer-router.yml
+++ b/.github/workflows/reviewer-router.yml
@@ -850,12 +850,33 @@ jobs:
               'CLI Smoke',
               'Mock MCP',
             ];
+            // GitHub Actions is the sole reviewed producer for every required
+            // context. A context-only ruleset can be satisfied by another App
+            // or a legacy commit status with the same name.
+            const requiredCheckIntegrationID = 15368;
             function hasExactStringSet(values, expected) {
               return (
                 Array.isArray(values) &&
                 values.length === expected.length &&
                 new Set(values).size === expected.length &&
                 expected.every(value => values.includes(value))
+              );
+            }
+            function hasExactRequiredStatusChecks(checks) {
+              if (
+                !Array.isArray(checks) ||
+                checks.length !== requiredCheckContexts.length
+              ) {
+                return false;
+              }
+              const contexts = checks.map(check => check?.context);
+              return (
+                new Set(contexts).size === requiredCheckContexts.length &&
+                checks.every(
+                  check =>
+                    requiredCheckContexts.includes(check?.context) &&
+                    check?.integration_id === requiredCheckIntegrationID,
+                )
               );
             }
             function hasExactMainRulesetScope(ruleset) {
@@ -917,13 +938,12 @@ jobs:
                 return false;
               }
               const parameters = ruleset.rules[0].parameters;
-              const contexts = parameters?.required_status_checks?.map(
-                check => check?.context,
-              );
               return (
                 parameters?.strict_required_status_checks_policy === true &&
                 parameters.do_not_enforce_on_create === false &&
-                hasExactStringSet(contexts, requiredCheckContexts)
+                hasExactRequiredStatusChecks(
+                  parameters.required_status_checks,
+                )
               );
             }
             // GitHub's read projection omits the entire parameters property
@@ -1077,7 +1097,7 @@ jobs:
                 !isExactMainQualityRuleset(qualityRulesets[0])
               ) {
                 throw new Error(
-                  'Reviewer Router App requires the exact non-bypassable main-quality ruleset with nine strict checks.',
+                  'Reviewer Router App requires the exact non-bypassable main-quality ruleset with nine strict GitHub Actions checks.',
                 );
               }
               for (const ruleset of activeMainRulesets) {

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -155,8 +155,10 @@ before calling the synchronous PR merge endpoint with the exact current head
 SHA. The preflight requires exactly one repository-owned `main-protection`
 ruleset with one latest-head approval and exactly one repository-owned
 `main-quality` ruleset with the reviewed nine strict checks. The App must report
-`never` on both and on every other non-writer ruleset, so deletion or weakening
-of either gate fails closed before merge. HTTP 405 means the PR is not ready,
+`never` on both and on every other non-writer ruleset. Every required context
+must be bound to the GitHub Actions App (`integration_id=15368`); a missing,
+different, or duplicate context/source entry fails closed together with
+deletion or weakening of either gate. HTTP 405 means the PR is not ready,
 while 409 means its revision
 changed; either remains open for the next event. Other failures make
 reconciliation red. A concurrent native merge is accepted only after the final

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -64,8 +64,8 @@ git diff --check
 
 ## Reviewer Router GitHub App
 
-Reviewer requests and native auto-merge intentionally use different
-identities. The base-owned `pull_request_target` workflow may use its built-in
+Reviewer requests and merge authority intentionally use different identities.
+The base-owned `pull_request_target` workflow may use its built-in
 `GITHUB_TOKEN` to request reviewers, but it must mint a dedicated GitHub App
 installation token before enabling auto-merge. GitHub suppresses most workflow
 events created by the built-in token; using it for auto-merge prevents the
@@ -88,9 +88,10 @@ it:
   containing explicit boolean `false`, and reject every other present shape or
   value. They then bind the same ruleset node through GraphQL and require its
   non-null `updateAllowsFetchAndMerge` value to be exactly `false`;
-- give that ruleset exactly two bypass actors: the Reviewer Router App as an
-  `Integration` in `pull_request` mode, and `PeterGuy326` (ID `47820304`) in
-  `always` mode for Formula publication and break-glass recovery;
+- give that ruleset exactly three bypass actors: the Reviewer Router App as an
+  `Integration` in `pull_request` mode, plus `haofeng0705` (ID `30925823`) and
+  `PeterGuy326` (ID `47820304`) in `always` mode for Formula publication and
+  break-glass recovery;
 - never give the App bypass on `main-protection`, `main-quality`, or any other
   ruleset, and never reuse `HOMEBREW_PR_TOKEN`,
   `RELEASE_GOVERNANCE_TOKEN`, or a personal token for Reviewer Router.
@@ -116,7 +117,7 @@ the minted App independently requires `pull_requests_only` on that writer rule
 and `never` on every other active main ruleset. These identity-relative checks
 remain available to low-privilege tokens; GitHub deliberately hides the full
 `bypass_actors` list from callers without ruleset-write access. Operators must
-therefore inspect that list during rollout and keep it at the exact two actors
+therefore inspect that list during rollout and keep it at the exact three actors
 above. The required `Test` context then briefly waits for the concurrent
 router takeover and accepts only a null request or the configured App owner
 with exact fixed metadata. A null request is safe for this failure mode because
@@ -133,14 +134,36 @@ repository's reviewed `MERGE_MESSAGE` title plus `PR_TITLE` or `BLANK` body
 defaults. GitHub does not expose those merge-related settings to the read-only
 admission token: the classifier accepts only both exact reviewed values or the
 complete omission of both properties, and rejects partial omission, `null`, or
-any other value. Before any enable or reconcile mutation, the dedicated App's
-current-repository token (which has `Contents: write`) must observe both exact
-reviewed values. The dedicated App binds the mutation to the exact head OID and
-supplies a fixed safe headline and body, so GitHub cannot copy an unsafe PR
-title into its merge commit.
+any other value. Before any enable, reconcile, or merge mutation, the dedicated
+App's current-repository token (which has `Contents: write`) must observe both
+exact reviewed values. The dedicated App binds each mutation to the exact head
+OID and supplies a fixed safe headline and body, so GitHub cannot copy an unsafe
+PR title into its merge commit.
 After enabling, the workflow requires the owner to equal the token action's
 exact `<app-slug>[bot]` output. If the event base/head changes during the
 mutation window, it removes only that App-owned request and fails the run.
+The App-owned native auto-merge request is the reviewed automation intent, not
+the sole executor: GitHub's deferred auto-merge path does not reliably apply a
+GitHub App's pull-request-only ruleset bypass. A zero-permission approval-signal
+workflow converts submitted or dismissed reviews into `workflow_run`; completed
+admission workflows use the same trusted default-branch trigger. The serialized
+reconcile job treats `workflow_run` only as a wake-up signal: it never reads the
+triggering run's pull-request payload or artifacts and never checks out code
+from that run. It enumerates open `main` PRs again through the API, then
+revalidates the safe App owner, metadata, and ruleset boundary immediately
+before calling the synchronous PR merge endpoint with the exact current head
+SHA. The preflight requires exactly one repository-owned `main-protection`
+ruleset with one latest-head approval and exactly one repository-owned
+`main-quality` ruleset with the reviewed nine strict checks. The App must report
+`never` on both and on every other non-writer ruleset, so deletion or weakening
+of either gate fails closed before merge. HTTP 405 means the PR is not ready,
+while 409 means its revision
+changed; either remains open for the next event. Other failures make
+reconciliation red. A concurrent native merge is accepted only after the final
+PR state proves the exact head, App identity, and non-empty merge SHA.
+A staggered twice-hourly schedule provides eventual recovery if a webhook or
+workflow completion is delayed, and `workflow_dispatch` remains the on-demand
+repair path.
 The break-glass publisher must preserve a safe final commit message;
 `[skip ci]`, `[ci skip]`, `[no ci]`, `[skip actions]`,
 `[actions skip]`, and a `skip-checks: true` trailer are forbidden outside the
@@ -153,24 +176,46 @@ the normal path; if break-glass merge is unavoidable, preserve a safe final
 message so the protected-main push CI remains the authoritative producer.
 
 After installing the App, the protected-main push that deploys this workflow
-runs reconciliation automatically. The job enumerates open, ready `main` PRs
+runs reconciliation automatically. Approval-signal and admission-workflow
+completions run the same serialized recovery path. The job enumerates open,
+ready `main` PRs
 with any non-App owner, unsafe App metadata, or workflow-skip metadata. It
 revalidates each base/head, converges a safe request to the exact dedicated-App
 owner and fixed message, and leaves a workflow-skipping request disabled for
 manual correction. It never enables auto-merge where the request was already
-null. A mid-migration failure leaves the affected PR disabled for a fresh
-routing event or break-glass merge. One PR failure is recorded
+null. Every exact safe App request is then attempted through the synchronous,
+SHA-bound merge endpoint; a server-declared not-ready result remains open for
+the next event. A mid-migration failure leaves the affected PR disabled for a
+fresh routing event or break-glass merge. One PR failure is recorded
 without preventing later legacy owners from being attempted; the batch ends
 red with a per-PR summary. Manually dispatch `Reviewer routing` from `main`
 until the failed count is zero.
+
+Disabling the App-owned auto-merge request before the reconcile job's final PR
+read leaves that PR manual-only. That final read is the cancellation
+linearization point: GitHub's merge API can condition atomically on the head SHA
+but not on the auto-merge request itself, so a disable racing after that read may
+lose to an already-issued merge request. To stop an in-flight attempt
+before the merge endpoint accepts it, close the PR or change its head; if the
+server observes that state first, it rejects the state/SHA-bound merge. No
+client-side action can revoke a merge that GitHub has already accepted.
+The endpoint has no equivalent expected-base parameter. The workflow therefore
+checks `base=main` and the repository before and after merge and fails any
+retargeted result, but a retarget racing after the final read cannot be made
+atomic client-side. Never retarget a PR while its App-owned intent is active:
+disable the request, wait until all running `Reviewer routing` reconciliation
+jobs finish, and only then change the base. Preventing a malicious same-instant
+retarget requires a GitHub-side branch/ruleset control rather than workflow
+code.
 
 A PR that introduces or rotates this identity still runs the old base-owned
 router. Install/configure the App and activate the exact writer ruleset first;
 this blocks its legacy `github-actions[bot]` request from writing `main`. After
 the governance PR's final push, disable that old request, confirm the live
 settings/ruleset contract and all required checks are green for the exact head,
-then have only `PeterGuy326` merge that head with the repository-generated safe
-merge message. Verify the resulting merge SHA has a `CI` run with `event=push`,
+then have only `haofeng0705` or `PeterGuy326` merge that head with the
+repository-generated safe merge message. Verify the resulting merge SHA has a
+`CI` run with `event=push`,
 a successful `Coverage` context, and an exact-SHA baseline cache under
 `refs/heads/main`. Confirm automatic reconciliation reports zero failures and
 zero non-App owners. Finally use a normal canary PR to verify that the dedicated

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -214,8 +214,10 @@ each attempt it revalidates the App's ruleset boundary and PR intent, supplies
 the current head SHA, and treats server-declared not-ready or
 concurrent-revision responses as retriable. The live preflight requires the
 exact repository-owned approval ruleset and exact nine-check strict quality
-ruleset, with the App unable to bypass either; a missing, disabled, or weakened
-gate fails closed before merge. GitHub—not the workflow—decides whether the
+ruleset, with every context bound to the GitHub Actions App
+(`integration_id=15368`) and the Reviewer Router App unable to bypass either;
+a missing, disabled, incorrectly sourced, or weakened gate fails closed before
+merge. GitHub—not the workflow—decides whether the
 merge is admissible. A staggered twice-hourly schedule provides eventual
 recovery, and a manual `workflow_dispatch` from `main` is the immediate
 idempotent retry path.
@@ -403,7 +405,9 @@ tool、parameter、mapping、positional execution、constraint 与 safety 语义
 
 The `main` quality ruleset must enable strict required-status-check policy
 (`strict_required_status_checks_policy=true`) so a PR is revalidated whenever
-`main` advances. It must require these exact contexts and no legacy aliases:
+`main` advances. Every entry must select the GitHub Actions App
+(`integration_id=15368`), not “any source”. It must require these exact
+context/source pairs and no legacy aliases:
 
 - `Lint`
 - `Test`

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -150,10 +150,11 @@ outstanding change requester is preferred for continuity.
 The branch rulesets keep one human approval and all nine strict required
 contexts, require someone other than the latest pusher to approve after the
 most recent head update, and restrict `main` updates to the dedicated Reviewer
-Router App in pull-request mode plus the designated Formula publisher in
-always/break-glass mode. Repository auto-merge is enabled for ready PRs, so the
-App-owned request merges after that approval and the current revision's nine
-checks are green. If `main` advances, strict checks rerun before merge. The
+Router App in pull-request mode plus the designated Formula publishers and
+break-glass identities. Repository auto-merge is enabled for ready PRs, so the
+App-owned request records the automation intent while the App's synchronous
+merge path waits for that approval and the current revision's nine green
+checks. If `main` advances, strict checks rerun before merge. The
 reviewer routing job uses the built-in `GITHUB_TOKEN` to request reviewers with
 `Contents: read` and `Pull requests: write`. A separate base-owned cleanup job
 isolates the merge-authority permissions (`Contents: write` and `Pull
@@ -179,15 +180,17 @@ the same ruleset node through GraphQL and requires its non-null
 own built-in token to report
 `current_user_can_bypass: never`. The minted App separately requires
 `pull_requests_only` on that writer rule and `never` on every other active main
-ruleset before it can enable or reconcile auto-merge. The read-only `Test`
+ruleset before it can enable, reconcile, or synchronously merge. The read-only
+`Test`
 token may receive a repository projection with both merge-default properties
 omitted; it accepts only that complete omission or exact `MERGE_MESSAGE` plus
 `PR_TITLE`/`BLANK`, while partial or malformed projections fail closed. The
 minted App's `Contents: write` token must observe the exact reviewed defaults
 before either mutation path proceeds. GitHub hides the complete
 `bypass_actors` list from low-privilege callers, so the rollout audit must still
-keep the writer list at exactly the Reviewer App plus `PeterGuy326` (ID
-`47820304`). The required check finally accepts a null or exact App-owned
+keep the writer list at exactly the Reviewer App, `haofeng0705` (ID
+`30925823`), and `PeterGuy326` (ID `47820304`). The required check finally
+accepts a null or exact App-owned
 request after a short takeover grace period. Null is safe from the suppressed
 event path because the built-in Actions identity cannot update `main`; other
 permitted identities produce either a main push or the trusted closed-PR
@@ -198,11 +201,42 @@ for readiness, title, and merge-request changes. Router does not react to
 human can deliberately leave the PR manual-only for break-glass handling.
 Reviewer routing remains available. The protected-main push that deploys the
 workflow automatically migrates every open, ready non-App request and repairs
-unsafe App metadata; it disables workflow-skipping requests for correction. A
-manual `workflow_dispatch` from `main` is the idempotent retry path.
+unsafe App metadata; it disables workflow-skipping requests for correction.
+Because GitHub's deferred native auto-merge path does not reliably apply an
+App's pull-request-only ruleset bypass, a zero-permission approval-signal
+workflow and completed `CI` / `Code Admission — AI Behavior` workflows wake the
+same trusted default-branch reconciliation through `workflow_run`. That event
+is only a wake-up signal: the privileged job does not consume its pull-request
+payload or artifacts and does not check out the triggering run's code. It
+re-enumerates open `main` PRs through the API and attempts only an exact
+App-owned request through the synchronous PR merge endpoint. Immediately before
+each attempt it revalidates the App's ruleset boundary and PR intent, supplies
+the current head SHA, and treats server-declared not-ready or
+concurrent-revision responses as retriable. The live preflight requires the
+exact repository-owned approval ruleset and exact nine-check strict quality
+ruleset, with the App unable to bypass either; a missing, disabled, or weakened
+gate fails closed before merge. GitHub—not the workflow—decides whether the
+merge is admissible. A staggered twice-hourly schedule provides eventual
+recovery, and a manual `workflow_dispatch` from `main` is the immediate
+idempotent retry path.
 Reconciliation never enables an originally null request. The reviewer router
 is orchestration, not a quality context, and
 must not be added to the ruleset.
+
+Disabling the App-owned request before the reconcile job's final PR read keeps
+the PR manual-only. GitHub can atomically bind the subsequent merge to the head
+SHA, but it cannot bind that call to the auto-merge intent; a disable racing
+after the final read may therefore lose to the in-flight merge. Closing the PR
+or changing its head blocks the attempt only if GitHub observes that state
+before accepting the merge endpoint call; no client-side action can revoke a
+merge that the server has already accepted.
+
+The merge endpoint has no expected-base precondition. Reconciliation checks
+that the base is this repository's `main` immediately before and after the call,
+but a retarget racing after the final read is not atomically preventable in the
+workflow. Operators must disable the App-owned intent and wait for all running
+`Reviewer routing` reconciliation jobs to finish before retargeting a PR; a
+stronger adversarial guarantee requires a GitHub-side branch/ruleset control.
 
 GitHub may omit `pull_request_target` for security-sensitive head branch names,
 including names that look like commit SHAs. Those PRs cannot use Router App

--- a/test/scripts/reviewer_router_merge_final_state_test.go
+++ b/test/scripts/reviewer_router_merge_final_state_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const appMergeFinalStateHelper = `function validateAppMergeFinalState(
+  pullRequest,
+  expectedHeadSha,
+  expectedAppLogin,
+  expectedBaseRepository,
+  expectedMergeSha,
+) {
+  const mergedBy = pullRequest.merged_by?.login?.toLowerCase();
+  const mergeCommitSha = pullRequest.merge_commit_sha;
+  const baseRepository =
+    pullRequest.base?.repo?.full_name?.toLowerCase();
+  const responseShaRequired = arguments.length >= 5;
+  const responseShaMatches =
+    !responseShaRequired ||
+    (typeof expectedMergeSha === 'string' &&
+      expectedMergeSha.length > 0 &&
+      mergeCommitSha === expectedMergeSha);
+  if (
+    pullRequest.state !== 'closed' ||
+    !pullRequest.merged_at ||
+    pullRequest.head.sha !== expectedHeadSha ||
+    pullRequest.base?.ref !== 'main' ||
+    baseRepository !== expectedBaseRepository ||
+    mergedBy !== expectedAppLogin ||
+    typeof mergeCommitSha !== 'string' ||
+    !mergeCommitSha ||
+    !responseShaMatches
+  ) {
+    throw new Error(
+      ` + "`merge result was not attributed exactly to ${expectedAppLogin}`" + `,
+    );
+  }
+  return {mergedBy, mergeCommitSha};
+}`
+
+const successfulMergeResponseHelper = `function requireSuccessfulMergeResponse(mergeResult) {
+  if (mergeResult?.merged !== true) {
+    throw new Error(
+      ` + "`GitHub returned a successful response without merging: ${mergeResult?.message || 'no explanation'}`" + `,
+    );
+  }
+  if (
+    typeof mergeResult.sha !== 'string' ||
+    !mergeResult.sha
+  ) {
+    throw new Error(
+      'GitHub returned a successful merge without a merge commit SHA.',
+    );
+  }
+  return mergeResult.sha;
+}`
+
+const mergeAttemptRecoveryHelper = `function classifyMergeAttemptRecovery(
+  status,
+  latestPull,
+  expectedHeadSha,
+  expectedAppLogin,
+  expectedBaseRepository,
+  responseMergeSha,
+) {
+  if (latestPull.merged_at) {
+    const finalState = responseMergeSha === undefined
+      ? validateAppMergeFinalState(
+          latestPull,
+          expectedHeadSha,
+          expectedAppLogin,
+          expectedBaseRepository,
+        )
+      : validateAppMergeFinalState(
+          latestPull,
+          expectedHeadSha,
+          expectedAppLogin,
+          expectedBaseRepository,
+          responseMergeSha,
+        );
+    return {outcome: 'merged', finalState};
+  }
+  if (latestPull.state !== 'open') {
+    return {outcome: 'closed'};
+  }
+  if (status === 404) {
+    throw new Error(
+      'merge endpoint returned 404 while the pull request remained open',
+    );
+  }
+  if (status === 405 || status === 409) {
+    return {outcome: 'not_ready'};
+  }
+  throw new Error(` + "`unsupported merge recovery status ${status}`" + `);
+}`
+
+func TestReviewerRouterValidatesAppMergeFinalState(t *testing.T) {
+	t.Parallel()
+
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to verify App merge final-state semantics")
+	}
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	path := filepath.Join(root, ".github", "workflows", "reviewer-router.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var workflow any
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	var scripts []string
+	collectGitHubScripts(workflow, &scripts)
+	checked := 0
+	for _, script := range scripts {
+		if strings.Contains(script, "function validateAppMergeFinalState(") {
+			checked++
+			if got := strings.Count(script, appMergeFinalStateHelper); got != 1 {
+				t.Errorf("App merge final-state helper count = %d, want 1", got)
+			}
+			if got := strings.Count(script, successfulMergeResponseHelper); got != 1 {
+				t.Errorf("successful merge-response helper count = %d, want 1", got)
+			}
+			if got := strings.Count(script, mergeAttemptRecoveryHelper); got != 1 {
+				t.Errorf("merge-attempt recovery helper count = %d, want 1", got)
+			}
+			if got := strings.Count(script, "validateAppMergeFinalState("); got != 6 {
+				t.Errorf("App merge final-state helper/calls = %d, want one helper plus five guarded final-state calls", got)
+			}
+			for _, marker := range []string{"currentPull,", "mergedPull,", "latestPull,"} {
+				if !strings.Contains(script, marker) {
+					t.Errorf("reconciliation script is missing final-state validation marker %q", marker)
+				}
+			}
+		}
+	}
+	if checked != 1 {
+		t.Fatalf("App merge final-state scripts checked = %d, want 1", checked)
+	}
+
+	verification := appMergeFinalStateHelper + "\n" + successfulMergeResponseHelper + "\n" + mergeAttemptRecoveryHelper + `
+const app = 'dingtalk-dws-reviewer-router[bot]';
+const valid = {
+  state: 'closed',
+  merged_at: '2026-08-25T00:00:00Z',
+  head: {sha: 'head-sha'},
+  base: {
+    ref: 'main',
+    repo: {full_name: 'DingTalk-Real-AI/dingtalk-workspace-cli'},
+  },
+  merged_by: {login: 'DingTalk-DWS-Reviewer-Router[bot]'},
+  merge_commit_sha: 'merge-sha',
+};
+const repository = 'dingtalk-real-ai/dingtalk-workspace-cli';
+const observed = validateAppMergeFinalState(valid, 'head-sha', app, repository);
+if (observed.mergedBy !== app || observed.mergeCommitSha !== 'merge-sha') {
+  throw new Error('valid concurrent App merge did not preserve final identity');
+}
+validateAppMergeFinalState(valid, 'head-sha', app, repository, 'merge-sha');
+
+const invalidCases = [
+  ['open PR', {...valid, state: 'open'}],
+  ['missing merged_at', {...valid, merged_at: null}],
+  ['wrong head', {...valid, head: {sha: 'other-head'}}],
+  ['wrong base ref', {...valid, base: {...valid.base, ref: 'release'}}],
+  ['wrong base repository', {...valid, base: {...valid.base, repo: {full_name: 'other/repo'}}}],
+  ['missing base repository', {...valid, base: {ref: 'main', repo: null}}],
+  ['human merger', {...valid, merged_by: {login: 'haofeng0705'}}],
+  ['missing merger', {...valid, merged_by: null}],
+  ['empty merge SHA', {...valid, merge_commit_sha: ''}],
+  ['missing merge SHA', {...valid, merge_commit_sha: null}],
+];
+for (const [name, pull] of invalidCases) {
+  let rejected = false;
+  try {
+    validateAppMergeFinalState(pull, 'head-sha', app, repository);
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw new Error(name + ' was accepted');
+  }
+}
+for (const responseSha of [undefined, '', 'other-merge', null]) {
+  let rejected = false;
+  try {
+    validateAppMergeFinalState(valid, 'head-sha', app, repository, responseSha);
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw new Error('invalid response SHA was accepted: ' + responseSha);
+  }
+}
+
+if (requireSuccessfulMergeResponse({merged: true, sha: 'merge-sha'}) !== 'merge-sha') {
+  throw new Error('successful merge response did not return its SHA');
+}
+for (const response of [
+  {merged: false, sha: 'merge-sha', message: 'not ready'},
+  {merged: true},
+  {merged: true, sha: undefined},
+  {merged: true, sha: ''},
+]) {
+  let rejected = false;
+  try {
+    requireSuccessfulMergeResponse(response);
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw new Error('invalid successful merge response was accepted: ' + JSON.stringify(response));
+  }
+}
+
+for (const status of [405, 409]) {
+  const recovery = classifyMergeAttemptRecovery(
+    status,
+    {...valid, state: 'open', merged_at: null, merge_commit_sha: null},
+    'head-sha',
+    app,
+    repository,
+    undefined,
+  );
+  if (recovery.outcome !== 'not_ready') {
+    throw new Error(status + ' open PR did not remain retriable');
+  }
+}
+for (const responseSha of [undefined, 'merge-sha']) {
+  const recovery = classifyMergeAttemptRecovery(
+    409,
+    valid,
+    'head-sha',
+    app,
+    repository,
+    responseSha,
+  );
+  if (recovery.outcome !== 'merged' || recovery.finalState.mergeCommitSha !== 'merge-sha') {
+    throw new Error('valid concurrent App merge was not accepted');
+  }
+}
+for (const status of [404, 405, 409]) {
+  const recovery = classifyMergeAttemptRecovery(
+    status,
+    {...valid, merged_at: null, merge_commit_sha: null},
+    'head-sha',
+    app,
+    repository,
+    undefined,
+  );
+  if (recovery.outcome !== 'closed') {
+    throw new Error(status + ' closed-unmerged PR did not remain safely closed');
+  }
+}
+for (const [name, status, pull, responseSha] of [
+  ['open 404', 404, {...valid, state: 'open', merged_at: null}, undefined],
+  ['unsupported status', 500, {...valid, state: 'open', merged_at: null}, undefined],
+  ['human concurrent merge', 409, {...valid, merged_by: {login: 'haofeng0705'}}, undefined],
+  ['mismatched successful response SHA', 404, valid, 'other-merge'],
+]) {
+  let rejected = false;
+  try {
+    classifyMergeAttemptRecovery(
+      status,
+      pull,
+      'head-sha',
+      app,
+      repository,
+      responseSha,
+    );
+  } catch {
+    rejected = true;
+  }
+  if (!rejected) {
+    throw new Error(name + ' was accepted');
+  }
+}
+`
+	command := exec.Command(node, "-e", verification)
+	if output, runErr := command.CombinedOutput(); runErr != nil {
+		t.Fatalf("App merge final-state verification failed: %v\n%s", runErr, output)
+	}
+}

--- a/test/scripts/reviewer_router_required_rulesets_test.go
+++ b/test/scripts/reviewer_router_required_rulesets_test.go
@@ -1,0 +1,264 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const reviewerRouterRequiredRulesetHelpers = `function hasExactStringSet(values, expected) {
+  return (
+    Array.isArray(values) &&
+    values.length === expected.length &&
+    new Set(values).size === expected.length &&
+    expected.every(value => values.includes(value))
+  );
+}
+function hasExactMainRulesetScope(ruleset) {
+  const includes = ruleset?.conditions?.ref_name?.include;
+  const excludes = ruleset?.conditions?.ref_name?.exclude;
+  return (
+    ruleset?.enforcement === 'active' &&
+    ruleset?.target === 'branch' &&
+    ruleset?.source_type === 'Repository' &&
+    ruleset?.source?.toLowerCase() === repositorySource &&
+    Array.isArray(includes) &&
+    includes.length === 1 &&
+    includes[0] === 'refs/heads/main' &&
+    Array.isArray(excludes) &&
+    excludes.length === 0
+  );
+}
+function isExactMainProtectionRuleset(ruleset) {
+  if (
+    !hasExactMainRulesetScope(ruleset) ||
+    !Array.isArray(ruleset.rules) ||
+    ruleset.rules.length !== 3 ||
+    !hasExactStringSet(
+      ruleset.rules.map(rule => rule?.type),
+      ['deletion', 'non_fast_forward', 'pull_request'],
+    )
+  ) {
+    return false;
+  }
+  const pullRequestRule = ruleset.rules.find(
+    rule => rule.type === 'pull_request',
+  );
+  const parameters = pullRequestRule?.parameters;
+  return (
+    parameters?.required_approving_review_count === 1 &&
+    parameters.require_last_push_approval === true &&
+    parameters.require_extra_approval_for_unattributed_changes === true &&
+    parameters.dismiss_stale_reviews_on_push === false &&
+    parameters.require_code_owner_review === false &&
+    parameters.required_review_thread_resolution === false &&
+    hasExactStringSet(
+      parameters.allowed_merge_methods,
+      ['merge', 'squash', 'rebase'],
+    ) &&
+    parameters.dismissal_restriction?.enabled === false &&
+    Array.isArray(parameters.dismissal_restriction.allowed_actors) &&
+    parameters.dismissal_restriction.allowed_actors.length === 0 &&
+    Array.isArray(parameters.required_reviewers) &&
+    parameters.required_reviewers.length === 0
+  );
+}
+function isExactMainQualityRuleset(ruleset) {
+  if (
+    !hasExactMainRulesetScope(ruleset) ||
+    !Array.isArray(ruleset.rules) ||
+    ruleset.rules.length !== 1 ||
+    ruleset.rules[0]?.type !== 'required_status_checks'
+  ) {
+    return false;
+  }
+  const parameters = ruleset.rules[0].parameters;
+  const contexts = parameters?.required_status_checks?.map(
+    check => check?.context,
+  );
+  return (
+    parameters?.strict_required_status_checks_policy === true &&
+    parameters.do_not_enforce_on_create === false &&
+    hasExactStringSet(contexts, requiredCheckContexts)
+  );
+}`
+
+func TestReviewerRouterRequiresExactApprovalAndQualityRulesets(t *testing.T) {
+	t.Parallel()
+
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to verify approval and quality ruleset semantics")
+	}
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	path := filepath.Join(root, ".github", "workflows", "reviewer-router.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var workflow any
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	var scripts []string
+	collectGitHubScripts(workflow, &scripts)
+	checked := 0
+	for _, script := range scripts {
+		if !strings.Contains(script, "function isExactMainProtectionRuleset(") {
+			continue
+		}
+		checked++
+		if got := strings.Count(script, reviewerRouterRequiredRulesetHelpers); got != 1 {
+			t.Errorf("approval/quality ruleset helper count = %d, want 1", got)
+		}
+		for _, marker := range []string{
+			"protectionRulesets.length !== 1",
+			"protectionRulesets[0].current_user_can_bypass !== 'never'",
+			"!isExactMainProtectionRuleset(protectionRulesets[0])",
+			"qualityRulesets.length !== 1",
+			"qualityRulesets[0].current_user_can_bypass !== 'never'",
+			"!isExactMainQualityRuleset(qualityRulesets[0])",
+			"exact non-bypassable main-protection approval ruleset",
+			"exact non-bypassable main-quality ruleset with nine strict checks",
+		} {
+			if !strings.Contains(script, marker) {
+				t.Errorf("reconciliation script is missing live ruleset contract marker %q", marker)
+			}
+		}
+	}
+	if checked != 1 {
+		t.Fatalf("approval/quality ruleset scripts checked = %d, want 1 privileged reconcile script", checked)
+	}
+
+	verification := `
+const repositorySource = 'dingtalk-real-ai/dingtalk-workspace-cli';
+const requiredCheckContexts = [
+  'Lint',
+  'Test',
+  'Coverage',
+  'Policy',
+  'Edition',
+  'Interface Integrity',
+  'AI Behavior',
+  'CLI Smoke',
+  'Mock MCP',
+];
+` + reviewerRouterRequiredRulesetHelpers + `
+const clone = value => JSON.parse(JSON.stringify(value));
+const scope = {
+  enforcement: 'active',
+  target: 'branch',
+  source_type: 'Repository',
+  source: 'DingTalk-Real-AI/dingtalk-workspace-cli',
+  conditions: {ref_name: {include: ['refs/heads/main'], exclude: []}},
+  current_user_can_bypass: 'never',
+};
+const protection = {
+  ...scope,
+  name: 'main-protection',
+  rules: [
+    {type: 'deletion'},
+    {type: 'non_fast_forward'},
+    {
+      type: 'pull_request',
+      parameters: {
+        allowed_merge_methods: ['merge', 'squash', 'rebase'],
+        dismiss_stale_reviews_on_push: false,
+        dismissal_restriction: {allowed_actors: [], enabled: false},
+        require_code_owner_review: false,
+        require_extra_approval_for_unattributed_changes: true,
+        require_last_push_approval: true,
+        required_approving_review_count: 1,
+        required_review_thread_resolution: false,
+        required_reviewers: [],
+      },
+    },
+  ],
+};
+const quality = {
+  ...scope,
+  name: 'main-quality',
+  rules: [{
+    type: 'required_status_checks',
+    parameters: {
+      do_not_enforce_on_create: false,
+      strict_required_status_checks_policy: true,
+      required_status_checks: requiredCheckContexts.map(context => ({context})),
+    },
+  }],
+};
+if (!isExactMainProtectionRuleset(protection)) {
+  throw new Error('valid main-protection ruleset was rejected');
+}
+if (!isExactMainQualityRuleset(quality)) {
+  throw new Error('valid main-quality ruleset was rejected');
+}
+
+const invalidProtection = [];
+let candidate = clone(protection);
+candidate.enforcement = 'disabled';
+invalidProtection.push(['disabled', candidate]);
+candidate = clone(protection);
+candidate.conditions.ref_name.include = ['~ALL'];
+invalidProtection.push(['wrong scope', candidate]);
+candidate = clone(protection);
+candidate.rules = candidate.rules.filter(rule => rule.type !== 'pull_request');
+invalidProtection.push(['missing pull-request rule', candidate]);
+for (const [name, key, value] of [
+  ['missing approval', 'required_approving_review_count', 0],
+  ['latest-push approval disabled', 'require_last_push_approval', false],
+  ['unattributed approval disabled', 'require_extra_approval_for_unattributed_changes', false],
+]) {
+  candidate = clone(protection);
+  candidate.rules.find(rule => rule.type === 'pull_request').parameters[key] = value;
+  invalidProtection.push([name, candidate]);
+}
+for (const [name, value] of invalidProtection) {
+  if (isExactMainProtectionRuleset(value)) {
+    throw new Error(name + ' main-protection ruleset was accepted');
+  }
+}
+
+const invalidQuality = [];
+candidate = clone(quality);
+candidate.enforcement = 'disabled';
+invalidQuality.push(['disabled', candidate]);
+candidate = clone(quality);
+candidate.rules = [];
+invalidQuality.push(['missing status-check rule', candidate]);
+candidate = clone(quality);
+candidate.rules[0].parameters.strict_required_status_checks_policy = false;
+invalidQuality.push(['non-strict', candidate]);
+candidate = clone(quality);
+candidate.rules[0].parameters.do_not_enforce_on_create = true;
+invalidQuality.push(['create bypass', candidate]);
+candidate = clone(quality);
+candidate.rules[0].parameters.required_status_checks.pop();
+invalidQuality.push(['missing check', candidate]);
+candidate = clone(quality);
+candidate.rules[0].parameters.required_status_checks[8].context = 'Lint';
+invalidQuality.push(['duplicate check', candidate]);
+candidate = clone(quality);
+candidate.rules[0].parameters.required_status_checks.push({context: 'Unexpected'});
+invalidQuality.push(['extra check', candidate]);
+for (const [name, value] of invalidQuality) {
+  if (isExactMainQualityRuleset(value)) {
+    throw new Error(name + ' main-quality ruleset was accepted');
+  }
+}
+`
+	command := exec.Command(node, "-e", verification)
+	if output, runErr := command.CombinedOutput(); runErr != nil {
+		t.Fatalf("approval/quality ruleset verification failed: %v\n%s", runErr, output)
+	}
+}

--- a/test/scripts/reviewer_router_required_rulesets_test.go
+++ b/test/scripts/reviewer_router_required_rulesets_test.go
@@ -21,6 +21,23 @@ const reviewerRouterRequiredRulesetHelpers = `function hasExactStringSet(values,
     expected.every(value => values.includes(value))
   );
 }
+function hasExactRequiredStatusChecks(checks) {
+  if (
+    !Array.isArray(checks) ||
+    checks.length !== requiredCheckContexts.length
+  ) {
+    return false;
+  }
+  const contexts = checks.map(check => check?.context);
+  return (
+    new Set(contexts).size === requiredCheckContexts.length &&
+    checks.every(
+      check =>
+        requiredCheckContexts.includes(check?.context) &&
+        check?.integration_id === requiredCheckIntegrationID,
+    )
+  );
+}
 function hasExactMainRulesetScope(ruleset) {
   const includes = ruleset?.conditions?.ref_name?.include;
   const excludes = ruleset?.conditions?.ref_name?.exclude;
@@ -80,13 +97,12 @@ function isExactMainQualityRuleset(ruleset) {
     return false;
   }
   const parameters = ruleset.rules[0].parameters;
-  const contexts = parameters?.required_status_checks?.map(
-    check => check?.context,
-  );
   return (
     parameters?.strict_required_status_checks_policy === true &&
     parameters.do_not_enforce_on_create === false &&
-    hasExactStringSet(contexts, requiredCheckContexts)
+    hasExactRequiredStatusChecks(
+      parameters.required_status_checks,
+    )
   );
 }`
 
@@ -122,6 +138,7 @@ func TestReviewerRouterRequiresExactApprovalAndQualityRulesets(t *testing.T) {
 			t.Errorf("approval/quality ruleset helper count = %d, want 1", got)
 		}
 		for _, marker := range []string{
+			"const requiredCheckIntegrationID = 15368;",
 			"protectionRulesets.length !== 1",
 			"protectionRulesets[0].current_user_can_bypass !== 'never'",
 			"!isExactMainProtectionRuleset(protectionRulesets[0])",
@@ -129,7 +146,7 @@ func TestReviewerRouterRequiresExactApprovalAndQualityRulesets(t *testing.T) {
 			"qualityRulesets[0].current_user_can_bypass !== 'never'",
 			"!isExactMainQualityRuleset(qualityRulesets[0])",
 			"exact non-bypassable main-protection approval ruleset",
-			"exact non-bypassable main-quality ruleset with nine strict checks",
+			"exact non-bypassable main-quality ruleset with nine strict GitHub Actions checks",
 		} {
 			if !strings.Contains(script, marker) {
 				t.Errorf("reconciliation script is missing live ruleset contract marker %q", marker)
@@ -153,6 +170,7 @@ const requiredCheckContexts = [
   'CLI Smoke',
   'Mock MCP',
 ];
+const requiredCheckIntegrationID = 15368;
 ` + reviewerRouterRequiredRulesetHelpers + `
 const clone = value => JSON.parse(JSON.stringify(value));
 const scope = {
@@ -193,7 +211,10 @@ const quality = {
     parameters: {
       do_not_enforce_on_create: false,
       strict_required_status_checks_policy: true,
-      required_status_checks: requiredCheckContexts.map(context => ({context})),
+      required_status_checks: requiredCheckContexts.map(context => ({
+        context,
+        integration_id: requiredCheckIntegrationID,
+      })),
     },
   }],
 };
@@ -249,8 +270,23 @@ candidate = clone(quality);
 candidate.rules[0].parameters.required_status_checks[8].context = 'Lint';
 invalidQuality.push(['duplicate check', candidate]);
 candidate = clone(quality);
-candidate.rules[0].parameters.required_status_checks.push({context: 'Unexpected'});
+candidate.rules[0].parameters.required_status_checks.push({
+  context: 'Unexpected',
+  integration_id: requiredCheckIntegrationID,
+});
 invalidQuality.push(['extra check', candidate]);
+candidate = clone(quality);
+delete candidate.rules[0].parameters.required_status_checks[0].integration_id;
+invalidQuality.push(['missing integration', candidate]);
+candidate = clone(quality);
+candidate.rules[0].parameters.required_status_checks[0].integration_id = 1;
+invalidQuality.push(['wrong integration', candidate]);
+candidate = clone(quality);
+candidate.rules[0].parameters.required_status_checks[8] = {
+  context: 'Lint',
+  integration_id: 1,
+};
+invalidQuality.push(['duplicate context from another integration', candidate]);
 for (const [name, value] of invalidQuality) {
   if (isExactMainQualityRuleset(value)) {
     throw new Error(name + ' main-quality ruleset was accepted');

--- a/test/scripts/reviewer_router_workflow_test.go
+++ b/test/scripts/reviewer_router_workflow_test.go
@@ -21,8 +21,26 @@ type reviewerRouterWorkflow struct {
 }
 
 type reviewerRouterTrigger struct {
-	Branches []string `yaml:"branches"`
-	Types    []string `yaml:"types"`
+	Branches  []string                 `yaml:"branches"`
+	Types     []string                 `yaml:"types"`
+	Workflows []string                 `yaml:"workflows"`
+	Schedules []reviewerRouterSchedule `yaml:"-"`
+}
+
+type reviewerRouterSchedule struct {
+	Cron string `yaml:"cron"`
+}
+
+func (trigger *reviewerRouterTrigger) UnmarshalYAML(node *yaml.Node) error {
+	*trigger = reviewerRouterTrigger{}
+	if node.Kind == yaml.SequenceNode {
+		return node.Decode(&trigger.Schedules)
+	}
+	if node.Kind == yaml.ScalarNode && node.Tag == "!!null" {
+		return nil
+	}
+	type plain reviewerRouterTrigger
+	return node.Decode((*plain)(trigger))
 }
 
 type reviewerRouterJob struct {
@@ -35,6 +53,7 @@ type reviewerRouterStep struct {
 	ID   string            `yaml:"id"`
 	Name string            `yaml:"name"`
 	Uses string            `yaml:"uses"`
+	Run  string            `yaml:"run"`
 	Env  map[string]string `yaml:"env"`
 	With map[string]string `yaml:"with"`
 }
@@ -73,8 +92,8 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		}
 	}
 
-	if len(workflow.On) != 3 {
-		t.Fatalf("workflow triggers = %v, want pull_request_target plus protected-main reconciliation", workflow.On)
+	if len(workflow.On) != 5 {
+		t.Fatalf("workflow triggers = %v, want routing plus review/check-driven reconciliation", workflow.On)
 	}
 	trigger, ok := workflow.On["pull_request_target"]
 	if !ok {
@@ -90,9 +109,19 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 	if _, ok := workflow.On["workflow_dispatch"]; !ok {
 		t.Fatalf("workflow triggers = %v, want workflow_dispatch reconciliation", workflow.On)
 	}
+	workflowRun, ok := workflow.On["workflow_run"]
+	if !ok ||
+		!reflect.DeepEqual(workflowRun.Workflows, []string{"CI", "Code Admission — AI Behavior", "Reviewer Router approval signal"}) ||
+		!reflect.DeepEqual(workflowRun.Types, []string{"completed"}) {
+		t.Fatalf("workflow_run trigger = %v, want completed admission and approval-signal workflows", workflowRun)
+	}
 	push, ok := workflow.On["push"]
 	if !ok || !reflect.DeepEqual(push.Branches, []string{"main"}) {
 		t.Fatalf("push trigger = %v, want protected main only", push)
+	}
+	schedule, ok := workflow.On["schedule"]
+	if !ok || !reflect.DeepEqual(schedule.Schedules, []reviewerRouterSchedule{{Cron: "17,47 * * * *"}}) {
+		t.Fatalf("schedule trigger = %v, want staggered recovery twice per hour", schedule)
 	}
 
 	wantPermissions := map[string]string{
@@ -379,14 +408,17 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 	if !ok {
 		t.Fatalf("workflow jobs = %v, want reconcile", workflow.Jobs)
 	}
-	if reconcile.If != "(github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && github.repository == 'DingTalk-Real-AI/dingtalk-workspace-cli'" {
-		t.Fatalf("reconcile.if = %q, want exact protected-main manual guard", reconcile.If)
+	if reconcile.If != "github.repository == 'DingTalk-Real-AI/dingtalk-workspace-cli' && (((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main') || github.event_name == 'workflow_run' || github.event_name == 'schedule')" {
+		t.Fatalf("reconcile.if = %q, want trusted main/review/admission event guard", reconcile.If)
 	}
 	if len(reconcile.Steps) != 2 ||
 		reconcile.Steps[0].ID != "reviewer-router-reconcile-token" ||
 		reconcile.Steps[0].Uses != appTokenSHA ||
 		reconcile.Steps[1].Uses != githubScriptSHA {
 		t.Fatalf("reconcile steps = %#v, want scoped App token followed by pinned migration script", reconcile.Steps)
+	}
+	if reconcile.Steps[1].Name != "Reconcile and merge App-owned pull requests" {
+		t.Fatalf("reconcile script step = %q, want explicit merge ownership", reconcile.Steps[1].Name)
 	}
 	if len(reconcile.Permissions) != 0 {
 		t.Fatalf("reconcile built-in token permissions = %v, want none", reconcile.Permissions)
@@ -424,10 +456,9 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		"state: 'open'",
 		"base: 'main'",
 		"candidate.draft",
-		"const candidateOwner =",
-		"const candidateSkipRequested =",
 		"const candidateHasSafeAppRequest =",
-		"candidateOwner === expectedAppOwner",
+		"const requestOwner =",
+		"requestOwner === expectedAppOwner",
 		"!candidate.auto_merge",
 		"candidateHasSafeAppRequest",
 		"currentPull.head.sha !== expectedHeadSha",
@@ -454,8 +485,8 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		"ruleset.enforcement !== 'active'",
 		"ruleset.target !== 'branch'",
 		"ruleset.name === 'main-merge-writers'",
-		"writerRuleset.source_type !== 'Repository'",
-		"writerRuleset.source?.toLowerCase() !== repositorySource",
+		"function hasExactMainRulesetScope(ruleset)",
+		"!hasExactMainRulesetScope(writerRuleset)",
 		"writerIncludes[0] !== 'refs/heads/main'",
 		"writerExcludes.length !== 0",
 		"writerRuleset.rules?.length !== 1",
@@ -499,6 +530,56 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		"enabledBy !== expectedAppOwner",
 		"unexpected owner cleanup",
 		"unsafe merge-message cleanup",
+		"const mergePulls = await github.paginate(github.rest.pulls.list",
+		"const candidateHasSafeAppRequest =",
+		"currentPull.head.sha !== expectedHeadSha",
+		"currentPull.base.sha !== expectedBaseSha",
+		"currentPull.base.repo?.full_name?.toLowerCase() !== repositorySource",
+		"!currentHasSafeAppRequest",
+		"function hasSafeAppMergeIntent(",
+		"const {data: finalPull} = await github.rest.pulls.get",
+		"finalPull.head.sha !== expectedHeadSha",
+		"finalPull.base.sha !== expectedBaseSha",
+		"finalPull.base.repo?.full_name?.toLowerCase() !== repositorySource",
+		"!hasSafeAppMergeIntent(",
+		"changed at final synchronous merge preflight",
+		"github.rest.pulls.merge",
+		"sha: expectedHeadSha",
+		"merge_method: 'merge'",
+		"commit_title: safeCommitHeadline",
+		"commit_message: safeCommitBody",
+		"function requireSuccessfulMergeResponse(mergeResult)",
+		"mergeResult?.merged !== true",
+		"GitHub returned a successful response without merging",
+		"typeof mergeResult.sha !== 'string'",
+		"GitHub returned a successful merge without a merge commit SHA",
+		"responseMergeSha = requireSuccessfulMergeResponse(mergeResult)",
+		"![404, 405, 409].includes(status)",
+		"function classifyMergeAttemptRecovery(",
+		"return {outcome: 'merged', finalState}",
+		"return {outcome: 'closed'}",
+		"return {outcome: 'not_ready'}",
+		"function validateAppMergeFinalState(",
+		"pullRequest.state !== 'closed'",
+		"pullRequest.head.sha !== expectedHeadSha",
+		"pullRequest.base?.ref !== 'main'",
+		"baseRepository !== expectedBaseRepository",
+		"mergedBy !== expectedAppLogin",
+		"mergeCommitSha === expectedMergeSha",
+		"merge result was not attributed exactly",
+		"if (currentPull.merged_at)",
+		"closed without merging before synchronous merge",
+		"if (latestPull.merged_at)",
+		"latestPull.state !== 'open'",
+		"status === 404",
+		"const {data: mergedPull} = await github.rest.pulls.get",
+		"const finalState = validateAppMergeFinalState(",
+		"expectedAppOwner,",
+		"responseMergeSha,",
+		"responseMergeSha === undefined",
+		"merged=${merged}",
+		"not_ready=${notReady}",
+		"Reviewer Router reconciliation had",
 	} {
 		if !strings.Contains(reconcileScript, want) {
 			t.Errorf("reconciliation script is missing contract marker %q", want)
@@ -509,6 +590,33 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 	}
 	if got := strings.Count(reconcileScript, "const skipWorkflowPattern ="); got != 1 {
 		t.Errorf("reconciliation script skip-workflow pattern declarations = %d, want exactly 1", got)
+	}
+	if got := strings.Count(reconcileScript, "await assertReviewerRouterRulesetBoundary();"); got != 2 {
+		t.Errorf("ruleset boundary validations = %d, want initial validation plus per-merge revalidation", got)
+	}
+	validationIndex := strings.LastIndex(reconcileScript, "await assertReviewerRouterRulesetBoundary();")
+	finalIntentIndex := strings.Index(reconcileScript, "const {data: finalPull} = await github.rest.pulls.get")
+	mergeIndex := strings.Index(reconcileScript, "github.rest.pulls.merge")
+	if validationIndex < 0 || finalIntentIndex <= validationIndex || mergeIndex <= finalIntentIndex {
+		t.Error("synchronous merge must revalidate the ruleset boundary and then the final App intent immediately before merge")
+	}
+	for _, forbidden := range []string{"--admin", "admin: true", "bypass:"} {
+		if strings.Contains(reconcileScript, forbidden) {
+			t.Errorf("synchronous App merge must not request an explicit override through %q", forbidden)
+		}
+	}
+	for _, forbidden := range []string{
+		"context.payload.workflow_run",
+		"context.payload.pull_request",
+		"github.event.workflow_run.pull_requests",
+		"listWorkflowRunArtifacts",
+		"downloadArtifact",
+		"actions/download-artifact",
+		"workflow_run.head_repository",
+	} {
+		if strings.Contains(reconcileScript, forbidden) {
+			t.Errorf("privileged workflow_run reconciliation must treat the event only as a wake-up signal, found %q", forbidden)
+		}
 	}
 	if strings.Contains(reconcileScript, "const unsafeOwner") {
 		t.Error("reconciliation must converge every non-App owner, not only the legacy built-in owner")
@@ -533,6 +641,58 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 	} {
 		if strings.Contains(string(data), forbidden) {
 			t.Errorf("reviewer router must not contain %q", forbidden)
+		}
+	}
+}
+
+func TestReviewerRouterApprovalSignalIsUnprivileged(t *testing.T) {
+	t.Parallel()
+
+	path, err := filepath.Abs(filepath.Join("..", "..", ".github", "workflows", "reviewer-router-approval-signal.yml"))
+	if err != nil {
+		t.Fatalf("Abs(reviewer-router-approval-signal.yml) error = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+
+	var workflow reviewerRouterWorkflow
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("yaml.Unmarshal(%s) error = %v", path, err)
+	}
+	if len(workflow.On) != 1 {
+		t.Fatalf("approval signal triggers = %v, want pull_request_review only", workflow.On)
+	}
+	review, ok := workflow.On["pull_request_review"]
+	if !ok ||
+		len(review.Branches) != 0 ||
+		!reflect.DeepEqual(review.Types, []string{"submitted", "dismissed"}) {
+		t.Fatalf("approval signal trigger = %v, want submitted/dismissed reviews without an unsupported branch filter", review)
+	}
+	if len(workflow.Permissions) != 0 {
+		t.Fatalf("approval signal permissions = %v, want none", workflow.Permissions)
+	}
+	if len(workflow.Jobs) != 1 {
+		t.Fatalf("approval signal jobs = %v, want one signal job", workflow.Jobs)
+	}
+	job, ok := workflow.Jobs["signal"]
+	if !ok || len(job.Permissions) != 0 || len(job.Steps) != 1 {
+		t.Fatalf("approval signal job = %#v, want one zero-permission step", job)
+	}
+	step := job.Steps[0]
+	if step.Uses != "" || step.Run != "echo \"Review state changed; default-branch reconciliation will re-evaluate App-owned merge intents.\"" {
+		t.Fatalf("approval signal step = %#v, want shell-only notification", step)
+	}
+	for _, forbidden := range []string{
+		"secrets.",
+		"actions/checkout",
+		"github-token",
+		"contents: write",
+		"pull-requests: write",
+	} {
+		if strings.Contains(string(data), forbidden) {
+			t.Errorf("approval signal must not contain %q", forbidden)
 		}
 	}
 }


### PR DESCRIPTION
## 变更摘要

- 保留 App 创建的原生 auto-merge 作为经审核的合并意图
- 增加零权限 approval signal、Code Admission 完成事件与错峰定时唤醒
- 由受信 Reviewer Router 重新核验实时 ruleset，并以精确 head SHA 同步合并
- 对合并响应、最终 PR 状态、base 仓库/分支和 merged_by App 身份做闭环校验

## 背景

PR #1135 已证明：即使 App 合并意图、最新 head 审批和九项 required checks 都有效，GitHub 原生延迟 auto-merge 仍可能因 Cannot update this protected ref 长期阻塞。根因是该原生路径不能稳定携带仅针对 pull request 的 ruleset bypass。

## 安全约束

- workflow_run 只作为唤醒信号；不消费事件 PR、artifact 或不受信代码，也不 checkout
- App 必须只有 writer ruleset 的 pull_request bypass，且不能绕过 main-protection 或 main-quality
- 每次合并前重新读取并精确核验 main-protection 和九项 strict required checks
- 每次合并绑定精确 head/base/repository/intent；成功后核验 response SHA 和 App 最终合并身份
- 文档明确记录 GitHub API 无法原子绑定 auto_merge 意图与 base retarget 的剩余竞态

## 验证

- actionlint v1.7.12：通过
- Reviewer Router 工作流、动态最终状态、恢复路径、精确 ruleset 契约测试：通过
- go test ./test/scripts -count=1：通过（268.367s）
- git diff --check：通过

## 变更记录

- 新增 patch changeset：Reviewer Router 改为同步、可恢复且 fail-closed 的 App 合并执行路径