### PR TITLE
ci: add base-owned merge authority gate

### DIFF
--- a/.changes/reviewer-router-lightweight-authority.md
+++ b/.changes/reviewer-router-lightweight-authority.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Reviewer Router merge authority** — moves fail-closed writer-rule and auto-merge ownership validation into the trusted base-owned Router before App credentials are read, preparing metadata-only auto-merge changes to stop restarting the full CI suite without weakening protected-main admission or exact-SHA cache production.

--- a/.github/reviewer-merge-authority.js
+++ b/.github/reviewer-merge-authority.js
@@ -36,6 +36,24 @@ function hasWorkflowSkipDirective(pullRequest) {
   return mergeTexts(pullRequest).some(value => SKIP_WORKFLOW_PATTERN.test(value));
 }
 
+function requiresManualWorkflowMerge(files) {
+  if (!Array.isArray(files)) {
+    throw new Error('pull request files must be an array');
+  }
+  return files.some(file => {
+    if (
+      file === null ||
+      typeof file !== 'object' ||
+      Array.isArray(file) ||
+      typeof file.filename !== 'string' ||
+      !file.filename
+    ) {
+      throw new Error('pull request file entry must contain a non-empty filename');
+    }
+    return file.filename.startsWith('.github/workflows/');
+  });
+}
+
 function classifyAutoMergeRequest({
   pullRequest,
   expectedAppOwner,
@@ -241,6 +259,7 @@ module.exports = {
   hasWorkflowSkipDirective,
   isStrictGraphQLUpdateRule,
   isStrictUpdateRule,
+  requiresManualWorkflowMerge,
   reviewedAppSlug,
   safeMergeMetadata,
   verifyBuiltInWriterBoundary,

--- a/.github/reviewer-merge-authority.js
+++ b/.github/reviewer-merge-authority.js
@@ -1,0 +1,247 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+'use strict';
+
+const SKIP_WORKFLOW_PATTERN =
+  /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|\bskip-checks\s*:\s*true\b/i;
+
+function reviewedAppSlug(value) {
+  const appSlug = typeof value === 'string' ? value.trim() : '';
+  if (!appSlug || appSlug !== appSlug.toLowerCase() || appSlug === 'github-actions') {
+    return '';
+  }
+  return appSlug;
+}
+
+function safeMergeMetadata(pullNumber) {
+  if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error('pull number must be a positive safe integer');
+  }
+  return {
+    headline: `Merge pull request #${pullNumber}`,
+    body: `Merged by the dedicated Reviewer Router GitHub App for PR #${pullNumber}.`,
+  };
+}
+
+function mergeTexts(pullRequest) {
+  return [
+    pullRequest?.title,
+    pullRequest?.auto_merge?.commit_title,
+    pullRequest?.auto_merge?.commit_message,
+  ].filter(value => typeof value === 'string');
+}
+
+function hasWorkflowSkipDirective(pullRequest) {
+  return mergeTexts(pullRequest).some(value => SKIP_WORKFLOW_PATTERN.test(value));
+}
+
+function classifyAutoMergeRequest({
+  pullRequest,
+  expectedAppOwner,
+  safeCommitHeadline,
+  safeCommitBody,
+}) {
+  if (!pullRequest?.auto_merge) {
+    return 'none';
+  }
+  const enabledBy = pullRequest.auto_merge.enabled_by?.login?.toLowerCase();
+  if (
+    !hasWorkflowSkipDirective(pullRequest) &&
+    enabledBy === expectedAppOwner &&
+    pullRequest.auto_merge.commit_title === safeCommitHeadline &&
+    pullRequest.auto_merge.commit_message === safeCommitBody
+  ) {
+    return 'safe_app';
+  }
+  return 'unsafe';
+}
+
+function classifyMergeDefaults(repository) {
+  if (
+    repository === null ||
+    typeof repository !== 'object' ||
+    Array.isArray(repository)
+  ) {
+    return 'invalid';
+  }
+  const hasTitle = Object.prototype.hasOwnProperty.call(
+    repository,
+    'merge_commit_title',
+  );
+  const hasMessage = Object.prototype.hasOwnProperty.call(
+    repository,
+    'merge_commit_message',
+  );
+  if (!hasTitle && !hasMessage) {
+    return 'omitted';
+  }
+  if (!hasTitle || !hasMessage) {
+    return 'invalid';
+  }
+  if (
+    repository.merge_commit_title === 'MERGE_MESSAGE' &&
+    ['PR_TITLE', 'BLANK'].includes(repository.merge_commit_message)
+  ) {
+    return 'reviewed';
+  }
+  return 'invalid';
+}
+
+function isStrictUpdateRule(rule) {
+  if (rule?.type !== 'update') {
+    return false;
+  }
+  if (!Object.prototype.hasOwnProperty.call(rule, 'parameters')) {
+    return true;
+  }
+  const parameters = rule.parameters;
+  if (
+    parameters === null ||
+    typeof parameters !== 'object' ||
+    Array.isArray(parameters)
+  ) {
+    return false;
+  }
+  const parameterKeys = Object.keys(parameters);
+  return (
+    parameterKeys.length === 1 &&
+    parameterKeys[0] === 'update_allows_fetch_and_merge' &&
+    parameters.update_allows_fetch_and_merge === false
+  );
+}
+
+function isStrictGraphQLUpdateRule(restRuleset, graphRuleset) {
+  const restRulesetID = Number(restRuleset?.id);
+  const graphRulesetID = Number(graphRuleset?.databaseId);
+  const graphRules = graphRuleset?.rules;
+  const graphRule = graphRules?.nodes?.[0];
+  return (
+    Number.isSafeInteger(restRulesetID) &&
+    restRulesetID > 0 &&
+    graphRulesetID === restRulesetID &&
+    graphRuleset.name === restRuleset.name &&
+    graphRuleset.enforcement === 'ACTIVE' &&
+    graphRuleset.target === 'BRANCH' &&
+    graphRules?.totalCount === 1 &&
+    graphRules.nodes?.length === 1 &&
+    graphRule?.type === 'UPDATE' &&
+    graphRule.parameters?.__typename === 'UpdateParameters' &&
+    graphRule.parameters.updateAllowsFetchAndMerge === false
+  );
+}
+
+async function verifyBuiltInWriterBoundary({github, owner, repo}) {
+  const {data: repository} = await github.rest.repos.get({owner, repo});
+  const mergeDefaultsProjection = classifyMergeDefaults(repository);
+  if (mergeDefaultsProjection === 'invalid') {
+    throw new Error(
+      'Repository merge-message defaults are malformed or changed from their reviewed values.',
+    );
+  }
+
+  const repositorySource = `${owner}/${repo}`.toLowerCase();
+  const appliedRules = await github.paginate(
+    'GET /repos/{owner}/{repo}/rules/branches/{branch}',
+    {owner, repo, branch: 'main', per_page: 100},
+  );
+  const applicableRulesetIDs = [
+    ...new Set(
+      appliedRules
+        .filter(rule =>
+          rule.ruleset_source_type === 'Repository' &&
+          rule.ruleset_source?.toLowerCase() === repositorySource &&
+          Number.isSafeInteger(Number(rule.ruleset_id)) &&
+          Number(rule.ruleset_id) > 0,
+        )
+        .map(rule => Number(rule.ruleset_id)),
+    ),
+  ];
+  const activeMainRulesets = [];
+  for (const rulesetID of applicableRulesetIDs) {
+    const {data: ruleset} = await github.request(
+      'GET /repos/{owner}/{repo}/rulesets/{ruleset_id}',
+      {owner, repo, ruleset_id: rulesetID},
+    );
+    if (
+      ruleset.enforcement !== 'active' ||
+      ruleset.target !== 'branch' ||
+      ruleset.source_type !== 'Repository' ||
+      ruleset.source?.toLowerCase() !== repositorySource
+    ) {
+      throw new Error(
+        `Applicable repository ruleset ${ruleset.name || rulesetID} is not an active branch ruleset owned by this repository.`,
+      );
+    }
+    activeMainRulesets.push(ruleset);
+  }
+
+  const writerRulesetName = 'main-merge-writers';
+  const writerRulesets = activeMainRulesets.filter(
+    ruleset => ruleset.name === writerRulesetName,
+  );
+  if (writerRulesets.length !== 1) {
+    throw new Error(
+      `Expected exactly one active ${writerRulesetName} ruleset on main; found ${writerRulesets.length}.`,
+    );
+  }
+  const writerRuleset = writerRulesets[0];
+  const writerIncludes = writerRuleset.conditions?.ref_name?.include || [];
+  const writerExcludes = writerRuleset.conditions?.ref_name?.exclude || [];
+  if (
+    writerIncludes.length !== 1 ||
+    writerIncludes[0] !== 'refs/heads/main' ||
+    writerExcludes.length !== 0 ||
+    typeof writerRuleset.node_id !== 'string' ||
+    !writerRuleset.node_id ||
+    writerRuleset.rules?.length !== 1 ||
+    !isStrictUpdateRule(writerRuleset.rules[0]) ||
+    writerRuleset.current_user_can_bypass !== 'never'
+  ) {
+    throw new Error(
+      `${writerRulesetName} must target only refs/heads/main, contain only the strict update rule, and deny this built-in Actions identity any bypass.`,
+    );
+  }
+  const {node: graphWriterRuleset} = await github.graphql(
+    `query ReviewerRouterWriterRule($rulesetID: ID!) {
+      node(id: $rulesetID) {
+        ... on RepositoryRuleset {
+          databaseId
+          name
+          enforcement
+          target
+          rules(first: 2) {
+            totalCount
+            nodes {
+              type
+              parameters {
+                __typename
+                ... on UpdateParameters {
+                  updateAllowsFetchAndMerge
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+    {rulesetID: writerRuleset.node_id},
+  );
+  if (!isStrictGraphQLUpdateRule(writerRuleset, graphWriterRuleset)) {
+    throw new Error(
+      `${writerRulesetName} must expose one strict UPDATE rule with updateAllowsFetchAndMerge=false through GraphQL.`,
+    );
+  }
+  return {mergeDefaultsProjection, writerRuleset};
+}
+
+module.exports = {
+  classifyAutoMergeRequest,
+  classifyMergeDefaults,
+  hasWorkflowSkipDirective,
+  isStrictGraphQLUpdateRule,
+  isStrictUpdateRule,
+  reviewedAppSlug,
+  safeMergeMetadata,
+  verifyBuiltInWriterBoundary,
+};

--- a/.github/reviewer-merge-authority.test.js
+++ b/.github/reviewer-merge-authority.test.js
@@ -1,0 +1,212 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+'use strict';
+
+const assert = require('node:assert/strict');
+const {
+  classifyAutoMergeRequest,
+  classifyMergeDefaults,
+  hasWorkflowSkipDirective,
+  isStrictGraphQLUpdateRule,
+  isStrictUpdateRule,
+  reviewedAppSlug,
+  safeMergeMetadata,
+  verifyBuiltInWriterBoundary,
+} = require('./reviewer-merge-authority.js');
+
+const pullNumber = 123;
+const expectedAppOwner = 'dingtalk-dws-reviewer-router[bot]';
+const {headline, body} = safeMergeMetadata(pullNumber);
+
+assert.equal(reviewedAppSlug(' dingtalk-dws-reviewer-router '), 'dingtalk-dws-reviewer-router');
+assert.equal(reviewedAppSlug('DingTalk-DWS-Reviewer-Router'), '');
+assert.equal(reviewedAppSlug('github-actions'), '');
+assert.equal(reviewedAppSlug(''), '');
+assert.throws(() => safeMergeMetadata(0), /positive safe integer/);
+
+const exactAppPull = {
+  title: 'ci: harden merge authority',
+  auto_merge: {
+    enabled_by: {login: expectedAppOwner},
+    commit_title: headline,
+    commit_message: body,
+  },
+};
+assert.equal(
+  classifyAutoMergeRequest({
+    pullRequest: exactAppPull,
+    expectedAppOwner,
+    safeCommitHeadline: headline,
+    safeCommitBody: body,
+  }),
+  'safe_app',
+);
+assert.equal(
+  classifyAutoMergeRequest({
+    pullRequest: {...exactAppPull, auto_merge: null},
+    expectedAppOwner,
+    safeCommitHeadline: headline,
+    safeCommitBody: body,
+  }),
+  'none',
+);
+for (const unsafePull of [
+  {
+    ...exactAppPull,
+    auto_merge: {...exactAppPull.auto_merge, enabled_by: {login: 'github-actions[bot]'}},
+  },
+  {
+    ...exactAppPull,
+    auto_merge: {...exactAppPull.auto_merge, enabled_by: {login: 'maintainer'}},
+  },
+  {
+    ...exactAppPull,
+    auto_merge: {...exactAppPull.auto_merge, commit_title: 'unsafe title'},
+  },
+  {
+    ...exactAppPull,
+    auto_merge: {...exactAppPull.auto_merge, commit_message: 'unsafe body'},
+  },
+  {...exactAppPull, title: 'ci: bypass [skip ci]'},
+]) {
+  assert.equal(
+    classifyAutoMergeRequest({
+      pullRequest: unsafePull,
+      expectedAppOwner,
+      safeCommitHeadline: headline,
+      safeCommitBody: body,
+    }),
+    'unsafe',
+  );
+}
+assert.equal(hasWorkflowSkipDirective({title: 'normal title'}), false);
+assert.equal(hasWorkflowSkipDirective({title: 'unsafe [actions skip]'}), true);
+assert.equal(
+  hasWorkflowSkipDirective({title: 'normal', auto_merge: {commit_message: 'skip-checks: true'}}),
+  true,
+);
+
+assert.equal(classifyMergeDefaults({}), 'omitted');
+assert.equal(
+  classifyMergeDefaults({merge_commit_title: 'MERGE_MESSAGE', merge_commit_message: 'PR_TITLE'}),
+  'reviewed',
+);
+assert.equal(classifyMergeDefaults({merge_commit_title: 'MERGE_MESSAGE'}), 'invalid');
+assert.equal(classifyMergeDefaults(null), 'invalid');
+
+assert.equal(isStrictUpdateRule({type: 'update'}), true);
+assert.equal(
+  isStrictUpdateRule({
+    type: 'update',
+    parameters: {update_allows_fetch_and_merge: false},
+  }),
+  true,
+);
+assert.equal(
+  isStrictUpdateRule({
+    type: 'update',
+    parameters: {update_allows_fetch_and_merge: true},
+  }),
+  false,
+);
+assert.equal(isStrictUpdateRule({type: 'deletion'}), false);
+
+const restRuleset = {id: 42, name: 'main-merge-writers'};
+const graphRuleset = {
+  databaseId: 42,
+  name: 'main-merge-writers',
+  enforcement: 'ACTIVE',
+  target: 'BRANCH',
+  rules: {
+    totalCount: 1,
+    nodes: [
+      {
+        type: 'UPDATE',
+        parameters: {
+          __typename: 'UpdateParameters',
+          updateAllowsFetchAndMerge: false,
+        },
+      },
+    ],
+  },
+};
+assert.equal(isStrictGraphQLUpdateRule(restRuleset, graphRuleset), true);
+assert.equal(
+  isStrictGraphQLUpdateRule(restRuleset, {
+    ...graphRuleset,
+    rules: {
+      ...graphRuleset.rules,
+      nodes: [
+        {
+          ...graphRuleset.rules.nodes[0],
+          parameters: {
+            ...graphRuleset.rules.nodes[0].parameters,
+            updateAllowsFetchAndMerge: true,
+          },
+        },
+      ],
+    },
+  }),
+  false,
+);
+
+async function testWriterBoundary() {
+  const owner = 'DingTalk-Real-AI';
+  const repo = 'dingtalk-workspace-cli';
+  const repositorySource = `${owner}/${repo}`;
+  const writerRuleset = {
+    ...restRuleset,
+    node_id: 'RULE_NODE',
+    enforcement: 'active',
+    target: 'branch',
+    source_type: 'Repository',
+    source: repositorySource,
+    conditions: {
+      ref_name: {include: ['refs/heads/main'], exclude: []},
+    },
+    rules: [{type: 'update'}],
+    current_user_can_bypass: 'never',
+  };
+  function fakeGitHub(ruleset = writerRuleset) {
+    return {
+      rest: {
+        repos: {
+          get: async () => ({data: {}}),
+        },
+      },
+      paginate: async () => [
+        {
+          ruleset_id: 42,
+          ruleset_source_type: 'Repository',
+          ruleset_source: repositorySource,
+        },
+      ],
+      request: async () => ({data: ruleset}),
+      graphql: async () => ({node: graphRuleset}),
+    };
+  }
+
+  assert.deepEqual(
+    await verifyBuiltInWriterBoundary({github: fakeGitHub(), owner, repo}),
+    {mergeDefaultsProjection: 'omitted', writerRuleset},
+  );
+  await assert.rejects(
+    verifyBuiltInWriterBoundary({
+      github: fakeGitHub({
+        ...writerRuleset,
+        current_user_can_bypass: 'pull_requests_only',
+      }),
+      owner,
+      repo,
+    }),
+    /deny this built-in Actions identity any bypass/,
+  );
+}
+
+testWriterBoundary()
+  .then(() => console.log('reviewer merge authority tests passed'))
+  .catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/.github/reviewer-merge-authority.test.js
+++ b/.github/reviewer-merge-authority.test.js
@@ -10,6 +10,7 @@ const {
   hasWorkflowSkipDirective,
   isStrictGraphQLUpdateRule,
   isStrictUpdateRule,
+  requiresManualWorkflowMerge,
   reviewedAppSlug,
   safeMergeMetadata,
   verifyBuiltInWriterBoundary,
@@ -85,6 +86,24 @@ assert.equal(hasWorkflowSkipDirective({title: 'unsafe [actions skip]'}), true);
 assert.equal(
   hasWorkflowSkipDirective({title: 'normal', auto_merge: {commit_message: 'skip-checks: true'}}),
   true,
+);
+assert.equal(
+  requiresManualWorkflowMerge([
+    {filename: '.github/reviewer-router.js'},
+    {filename: 'internal/app/app.go'},
+  ]),
+  false,
+);
+assert.equal(
+  requiresManualWorkflowMerge([
+    {filename: 'docs/ci-pr-gates.md'},
+    {filename: '.github/workflows/ci.yml'},
+  ]),
+  true,
+);
+assert.throws(
+  () => requiresManualWorkflowMerge([{filename: ''}]),
+  /non-empty filename/,
 );
 
 assert.equal(classifyMergeDefaults({}), 'omitted');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,9 +517,11 @@ jobs:
         if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
-      - name: Test reviewer routing policy
+      - name: Test reviewer routing and merge authority policy
         if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
-        run: node .github/reviewer-routing.test.js
+        run: |
+          node .github/reviewer-routing.test.js
+          node .github/reviewer-merge-authority.test.js
 
       - name: Test npm installer smoke (prune, backup, publish)
         if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'

--- a/.github/workflows/draft-ci.yml
+++ b/.github/workflows/draft-ci.yml
@@ -63,8 +63,10 @@ jobs:
       - name: Check GitHub Actions workflows
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
-      - name: Test reviewer routing policy
-        run: node .github/reviewer-routing.test.js
+      - name: Test reviewer routing and merge authority policy
+        run: |
+          node .github/reviewer-routing.test.js
+          node .github/reviewer-merge-authority.test.js
 
       - name: Test npm installer smoke
         env:

--- a/.github/workflows/reviewer-router.yml
+++ b/.github/workflows/reviewer-router.yml
@@ -296,6 +296,7 @@ jobs:
       # cannot update main before touching App credentials. Missing credentials
       # or authority drift then fail closed with manual merge intact.
       - name: Verify and normalize merge authority
+        id: merge-authority
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           REVIEWER_ROUTER_APP_SLUG: ${{ vars.REVIEWER_ROUTER_APP_SLUG }}
@@ -309,10 +310,13 @@ jobs:
             const {
               classifyAutoMergeRequest,
               hasWorkflowSkipDirective,
+              requiresManualWorkflowMerge,
               reviewedAppSlug,
               safeMergeMetadata,
               verifyBuiltInWriterBoundary,
             } = require('./.github/reviewer-merge-authority.js');
+
+            core.setOutput('enable-app-auto-merge', 'false');
 
             async function getExactPull(phase) {
               const {data: currentPull} = await github.rest.pulls.get({
@@ -395,6 +399,25 @@ jobs:
                   `PR #${pullNumber} title or merge metadata contains a GitHub workflow-skip directive.`,
                 );
               }
+              const changedFiles = await github.paginate(
+                github.rest.pulls.listFiles,
+                {owner, repo, pull_number: pullNumber, per_page: 100},
+              );
+              if (requiresManualWorkflowMerge(changedFiles)) {
+                if (currentPull.auto_merge) {
+                  currentPull = await disableAutoMerge(
+                    currentPull,
+                    'workflow-change manual-only cleanup',
+                  );
+                  if (!currentPull) {
+                    return;
+                  }
+                }
+                core.notice(
+                  `PR #${pullNumber} changes .github/workflows/**; GitHub Apps without workflows permission cannot enable auto-merge, so this PR remains manual-only.`,
+                );
+                return;
+              }
 
               const {mergeDefaultsProjection} =
                 await verifyBuiltInWriterBoundary({github, owner, repo});
@@ -423,6 +446,7 @@ jobs:
               core.info(
                 `Verified built-in merge authority for PR #${pullNumber}; auto-merge=${finalRequest}.`,
               );
+              core.setOutput('enable-app-auto-merge', 'true');
             } catch (error) {
               const latestPull = await getExactPull('failure cleanup');
               if (latestPull?.auto_merge) {
@@ -438,6 +462,7 @@ jobs:
             }
       - name: Mint Reviewer Router GitHub App token
         id: reviewer-router-token
+        if: steps.merge-authority.outputs.enable-app-auto-merge == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.REVIEWER_ROUTER_APP_CLIENT_ID }}
@@ -447,6 +472,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
       - name: Enable auto-merge with dedicated App
+        if: steps.merge-authority.outputs.enable-app-auto-merge == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           MINTED_REVIEWER_ROUTER_APP_SLUG: ${{ steps.reviewer-router-token.outputs.app-slug }}
@@ -1176,6 +1202,32 @@ jobs:
             await assertReviewerRouterRulesetBoundary();
             const skipWorkflowPattern =
               /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|\bskip-checks\s*:\s*true\b/i;
+            function requiresManualWorkflowMerge(files) {
+              if (!Array.isArray(files)) {
+                throw new Error('pull request files must be an array');
+              }
+              return files.some(file => {
+                if (
+                  file === null ||
+                  typeof file !== 'object' ||
+                  Array.isArray(file) ||
+                  typeof file.filename !== 'string' ||
+                  !file.filename
+                ) {
+                  throw new Error(
+                    'pull request file entry must contain a non-empty filename',
+                  );
+                }
+                return file.filename.startsWith('.github/workflows/');
+              });
+            }
+            async function pullRequiresManualWorkflowMerge(pullNumber) {
+              const files = await github.paginate(
+                github.rest.pulls.listFiles,
+                {owner, repo, pull_number: pullNumber, per_page: 100},
+              );
+              return requiresManualWorkflowMerge(files);
+            }
             const openPulls = await github.paginate(github.rest.pulls.list, {
               owner,
               repo,
@@ -1383,6 +1435,20 @@ jobs:
                   continue;
                 }
 
+                if (await pullRequiresManualWorkflowMerge(candidate.number)) {
+                  stage = 'workflow-change manual-only cleanup';
+                  await disableAutoMerge(
+                    candidate.number,
+                    currentPull.node_id,
+                    stage,
+                  );
+                  skipped += 1;
+                  core.notice(
+                    `PR #${candidate.number} changes .github/workflows/**; cleared auto-merge and left it manual-only.`,
+                  );
+                  continue;
+                }
+
                 stage = skipRequested
                   ? 'disable workflow-skipping auto-merge request'
                   : currentOwner === expectedAppOwner
@@ -1572,6 +1638,20 @@ jobs:
                   skipped += 1;
                   core.info(
                     `PR #${candidate.number} changed before synchronous merge; skipped.`,
+                  );
+                  continue;
+                }
+
+                if (await pullRequiresManualWorkflowMerge(candidate.number)) {
+                  stage = 'workflow-change synchronous-merge cleanup';
+                  await disableAutoMerge(
+                    candidate.number,
+                    currentPull.node_id,
+                    stage,
+                  );
+                  skipped += 1;
+                  core.notice(
+                    `PR #${candidate.number} changes .github/workflows/**; cleared the App request and left it manual-only.`,
                   );
                   continue;
                 }

--- a/.github/workflows/reviewer-router.yml
+++ b/.github/workflows/reviewer-router.yml
@@ -284,14 +284,21 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check out trusted merge authority policy
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
       # Auto-merge must use a dedicated identity. GitHub suppresses most
       # workflow events created by the built-in GITHUB_TOKEN, including the
       # main push that produces post-merge admission and baseline caches.
-      # Clear the known-unsafe owner and any workflow-skipping merge request
-      # before touching App credentials. Missing credentials then fail closed
-      # with manual merge intact.
-      - name: Clear unsafe auto-merge request
+      # Normalize every non-reviewed request and prove that this built-in token
+      # cannot update main before touching App credentials. Missing credentials
+      # or authority drift then fail closed with manual merge intact.
+      - name: Verify and normalize merge authority
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          REVIEWER_ROUTER_APP_SLUG: ${{ vars.REVIEWER_ROUTER_APP_SLUG }}
         with:
           script: |
             const owner = context.repo.owner;
@@ -299,81 +306,136 @@ jobs:
             const pullNumber = context.payload.pull_request.number;
             const eventHeadSha = context.payload.pull_request.head.sha;
             const eventBaseSha = context.payload.pull_request.base.sha;
-            const unsafeOwner = 'github-actions[bot]';
-            const skipWorkflowPattern =
-              /\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]|\bskip-checks\s*:\s*true\b/i;
+            const {
+              classifyAutoMergeRequest,
+              hasWorkflowSkipDirective,
+              reviewedAppSlug,
+              safeMergeMetadata,
+              verifyBuiltInWriterBoundary,
+            } = require('./.github/reviewer-merge-authority.js');
 
-            const {data: currentPull} = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: pullNumber,
-            });
-            if (
-              currentPull.head.sha !== eventHeadSha ||
-              currentPull.base.sha !== eventBaseSha ||
-              currentPull.state !== 'open' ||
-              currentPull.draft ||
-              currentPull.base.ref !== 'main'
-            ) {
-              core.info(
-                `PR #${pullNumber} state or revision no longer matches this ready-main event; unsafe-owner cleanup stopped.`,
-              );
-              return;
+            async function getExactPull(phase) {
+              const {data: currentPull} = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pullNumber,
+              });
+              if (
+                currentPull.head.sha !== eventHeadSha ||
+                currentPull.base.sha !== eventBaseSha ||
+                currentPull.state !== 'open' ||
+                currentPull.draft ||
+                currentPull.base.ref !== 'main'
+              ) {
+                core.info(
+                  `PR #${pullNumber} state or revision no longer matches this ready-main event during ${phase}; merge-authority verification stopped.`,
+                );
+                return null;
+              }
+              return currentPull;
             }
 
-            const enabledBy = currentPull.auto_merge?.enabled_by?.login?.toLowerCase();
-            const mergeTexts = [
-              currentPull.title,
-              currentPull.auto_merge?.commit_title,
-              currentPull.auto_merge?.commit_message,
-            ].filter(value => typeof value === 'string');
-            const skipRequested = mergeTexts.some(value =>
-              skipWorkflowPattern.test(value),
-            );
-            if (!currentPull.auto_merge || (enabledBy !== unsafeOwner && !skipRequested)) {
-              core.info(
-                currentPull.auto_merge
-                  ? `PR #${pullNumber} auto-merge is owned by ${enabledBy || 'an unknown actor'}; preserving it.`
-                  : `PR #${pullNumber} has no auto-merge request to clear.`,
-              );
-              return;
-            }
-
-            await github.graphql(
-              `mutation DisableAutoMerge($pullRequestId: ID!) {
-                disablePullRequestAutoMerge(
-                  input: {pullRequestId: $pullRequestId}
-                ) {
-                  pullRequest {
-                    id
+            async function disableAutoMerge(pullRequest, phase) {
+              await github.graphql(
+                `mutation DisableAutoMerge($pullRequestId: ID!) {
+                  disablePullRequestAutoMerge(
+                    input: {pullRequestId: $pullRequestId}
+                  ) {
+                    pullRequest { id }
                   }
-                }
-              }`,
-              {pullRequestId: currentPull.node_id},
-            );
-            const {data: cleanedPull} = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: pullNumber,
-            });
-            const cleanedOwner = cleanedPull.auto_merge?.enabled_by?.login?.toLowerCase();
-            if (
-              cleanedPull.head.sha === eventHeadSha &&
-              cleanedPull.base.sha === eventBaseSha &&
-              cleanedPull.state === 'open' &&
-              !cleanedPull.draft &&
-              cleanedPull.base.ref === 'main' &&
-              cleanedPull.auto_merge
-            ) {
-              throw new Error(
-                `PR #${pullNumber} still has auto-merge owned by ${cleanedOwner || 'an unknown actor'} after unsafe-request cleanup.`,
+                }`,
+                {pullRequestId: pullRequest.node_id},
               );
+              const cleanedPull = await getExactPull(`${phase} cleanup`);
+              if (cleanedPull?.auto_merge) {
+                throw new Error(
+                  `PR #${pullNumber} retained auto-merge owned by ${cleanedPull.auto_merge.enabled_by?.login || 'an unknown actor'} after ${phase}.`,
+                );
+              }
+              core.info(`Cleared PR #${pullNumber} auto-merge during ${phase}.`);
+              return cleanedPull;
             }
-            core.info(
-              skipRequested
-                ? `Cleared workflow-skipping auto-merge metadata from PR #${pullNumber}.`
-                : `Cleared built-in GITHUB_TOKEN auto-merge ownership from PR #${pullNumber}.`,
-            );
+
+            let currentPull = await getExactPull('initial read');
+            if (!currentPull) {
+              return;
+            }
+
+            try {
+              const appSlug = reviewedAppSlug(
+                process.env.REVIEWER_ROUTER_APP_SLUG,
+              );
+              if (!appSlug) {
+                throw new Error(
+                  'Reviewer Router App slug repository variable is missing or unsafe.',
+                );
+              }
+              const expectedAppOwner = `${appSlug}[bot]`;
+              const {
+                headline: safeCommitHeadline,
+                body: safeCommitBody,
+              } = safeMergeMetadata(pullNumber);
+              const initialRequest = classifyAutoMergeRequest({
+                pullRequest: currentPull,
+                expectedAppOwner,
+                safeCommitHeadline,
+                safeCommitBody,
+              });
+              if (initialRequest === 'unsafe') {
+                currentPull = await disableAutoMerge(
+                  currentPull,
+                  'pre-credential normalization',
+                );
+                if (!currentPull) {
+                  return;
+                }
+              }
+              if (hasWorkflowSkipDirective(currentPull)) {
+                throw new Error(
+                  `PR #${pullNumber} title or merge metadata contains a GitHub workflow-skip directive.`,
+                );
+              }
+
+              const {mergeDefaultsProjection} =
+                await verifyBuiltInWriterBoundary({github, owner, repo});
+              if (mergeDefaultsProjection === 'omitted') {
+                core.info(
+                  'Built-in merge-authority verification cannot observe repository merge-message defaults; exact validation remains delegated to the dedicated App.',
+                );
+              }
+
+              currentPull = await getExactPull('final authority read');
+              if (!currentPull) {
+                return;
+              }
+              const finalRequest = classifyAutoMergeRequest({
+                pullRequest: currentPull,
+                expectedAppOwner,
+                safeCommitHeadline,
+                safeCommitBody,
+              });
+              if (finalRequest === 'unsafe') {
+                await disableAutoMerge(currentPull, 'final authority read');
+                throw new Error(
+                  `PR #${pullNumber} acquired an unsafe auto-merge request during merge-authority verification.`,
+                );
+              }
+              core.info(
+                `Verified built-in merge authority for PR #${pullNumber}; auto-merge=${finalRequest}.`,
+              );
+            } catch (error) {
+              const latestPull = await getExactPull('failure cleanup');
+              if (latestPull?.auto_merge) {
+                try {
+                  await disableAutoMerge(latestPull, 'fail-closed authority cleanup');
+                } catch (cleanupError) {
+                  throw new Error(
+                    `${error.message}; fail-closed cleanup also failed: ${cleanupError.message}`,
+                  );
+                }
+              }
+              throw error;
+            }
       - name: Mint Reviewer Router GitHub App token
         id: reviewer-router-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -100,19 +100,18 @@ The workflow limits each minted token to the current repository, requests the
 two permissions explicitly, and lets the token action revoke it at job end.
 It also requires the minted App slug to equal the reviewed repository variable;
 there is no `GITHUB_TOKEN` fallback. Before reading App credentials, the
-base-owned workflow revalidates the event's exact base/head and uses its
-built-in token only to disable an existing request owned by
-`github-actions[bot]` or one whose title or merge metadata requests that GitHub
-skip workflows. A mint or permission failure therefore leaves that PR
-manual-merge only. The built-in token's `Contents: write` permission is
-isolated to this trusted cleanup job and is never used to enable auto-merge;
-review routing keeps `Contents: read`. Existing requests owned by a human or
-another non-built-in identity are replaced with the exact dedicated-App
-request after token minting. Only an already App-owned request with the fixed
-headline/body is preserved. The required `Test` context reads the live
-repository settings and applied rulesets, verifies the exact writer-rule
-shape, and requires its own built-in Actions identity to report
-`current_user_can_bypass: never`. Before enabling or reconciling auto-merge,
+base-owned workflow checks out only the exact event base policy, revalidates the
+live event base/head, and uses its built-in token to clear every request that is
+not already owned by the reviewed App with the exact fixed headline/body. It
+also rejects workflow-skip metadata and verifies the exact writer-rule shape,
+including REST/GraphQL agreement and
+`current_user_can_bypass: never`, before reading the private key. Any authority
+failure clears a remaining request; a mint or permission failure therefore
+leaves that PR manual-only. The built-in token's `Contents: write` permission
+is isolated to this trusted normalization job and is never used to enable
+auto-merge; review routing keeps `Contents: read`. During staged rollout, the
+required `Test` context independently repeats the built-in boundary and live
+request checks as a shadow assertion. Before enabling or reconciling auto-merge,
 the minted App independently requires `pull_requests_only` on that writer rule
 and `never` on every other active main ruleset. These identity-relative checks
 remain available to low-privilege tokens; GitHub deliberately hides the full

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -77,6 +77,9 @@ it:
 
 - install it only on `DingTalk-Real-AI/dingtalk-workspace-cli`;
 - grant only `Contents: read and write` and `Pull requests: read and write`;
+- do not grant `Workflows: read and write`. A PR that changes
+  `.github/workflows/**` is deliberately left manual-only, because allowing the
+  merge App to update workflow files would broaden its release and CI authority;
 - set repository variable `REVIEWER_ROUTER_APP_CLIENT_ID` to its client ID;
 - set `REVIEWER_ROUTER_APP_SLUG` to its exact lowercase slug;
 - set repository secret `REVIEWER_ROUTER_APP_PRIVATE_KEY` to its private key;
@@ -109,7 +112,12 @@ including REST/GraphQL agreement and
 failure clears a remaining request; a mint or permission failure therefore
 leaves that PR manual-only. The built-in token's `Contents: write` permission
 is isolated to this trusted normalization job and is never used to enable
-auto-merge; review routing keeps `Contents: read`. During staged rollout, the
+auto-merge. Before minting an App token, it lists the exact PR revision's files;
+when `.github/workflows/**` changes, it records an explicit manual-only notice
+and skips both token minting and auto-merge enablement. Reconciliation clears
+any older App request before leaving the PR manual-only, so scheduled recovery
+cannot re-enable or synchronously merge it. Review routing keeps `Contents:
+read`. During staged rollout, the
 required `Test` context independently repeats the built-in boundary and live
 request checks as a shadow assertion. Before enabling or reconciling auto-merge,
 the minted App independently requires `pull_requests_only` on that writer rule

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -188,20 +188,24 @@ checks. If `main` advances, strict checks rerun before merge. The
 reviewer routing job uses the built-in `GITHUB_TOKEN` to request reviewers with
 `Contents: read` and `Pull requests: write`. A separate base-owned cleanup job
 isolates the merge-authority permissions (`Contents: write` and `Pull
-requests: write`), revalidates the exact event base/head, and uses the built-in
-token only to disable an existing request owned by `github-actions[bot]` or one
-whose title or merge metadata requests that GitHub skip workflows; it never
-enables auto-merge. The job then mints a current-repository installation token
+requests: write`), checks out only the exact event base policy, and revalidates
+the live event base/head. Before reading App credentials, its built-in token
+normalizes every request that is not already owned by the reviewed App with the
+fixed headline/body, rejects workflow-skip metadata, and proves that the exact
+repository-owned `main-merge-writers` rule denies that token any bypass. It
+never enables auto-merge. Any authority failure clears a remaining request and
+leaves the PR manual-only. The job then mints a current-repository installation token
 for the dedicated Reviewer Router GitHub App, proves its emitted slug matches
-the reviewed `REVIEWER_ROUTER_APP_SLUG`, replaces every non-App request, and
+the reviewed `REVIEWER_ROUTER_APP_SLUG`, rechecks the App-side ruleset boundary, and
 enables native auto-merge with fixed metadata. This
 identity boundary is required because GitHub suppresses
 most workflow events created by the built-in token; using it for auto-merge would
 silently skip the merge commit's protected-main CI and baseline-cache
 producer. Token minting or takeover fails closed without falling back to
-`GITHUB_TOKEN`: the unsafe request is cleared before credentials are read, and
-the required `Test` context live-verifies the exact `main-merge-writers` update
-rule. GitHub's read APIs may omit `parameters` for the strict
+`GITHUB_TOKEN`: every non-reviewed request is cleared before credentials are
+read. During the staged migration away from metadata-triggered full admission,
+the required `Test` context independently repeats the same built-in-identity
+check as a shadow assertion. GitHub's read APIs may omit `parameters` for the strict
 `update_allows_fetch_and_merge: false` value, so the gate accepts only that
 exact omission or a one-field `parameters` object containing explicit boolean
 `false`; every other present shape or value fails closed. The gate then binds

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -193,7 +193,11 @@ the live event base/head. Before reading App credentials, its built-in token
 normalizes every request that is not already owned by the reviewed App with the
 fixed headline/body, rejects workflow-skip metadata, and proves that the exact
 repository-owned `main-merge-writers` rule denies that token any bypass. It
-never enables auto-merge. Any authority failure clears a remaining request and
+never enables auto-merge. A PR that changes `.github/workflows/**` is an
+explicit manual-only case: the trusted step skips App token minting and
+auto-merge enablement instead of granting the App `Workflows` permission, and
+reconciliation clears any older App-owned request rather than merging it. Any
+authority failure clears a remaining request and
 leaves the PR manual-only. The job then mints a current-repository installation token
 for the dedicated Reviewer Router GitHub App, proves its emitted slug matches
 the reviewed `REVIEWER_ROUTER_APP_SLUG`, rechecks the App-side ruleset boundary, and

--- a/test/scripts/reviewer_router_workflow_test.go
+++ b/test/scripts/reviewer_router_workflow_test.go
@@ -51,6 +51,7 @@ type reviewerRouterJob struct {
 
 type reviewerRouterStep struct {
 	ID   string            `yaml:"id"`
+	If   string            `yaml:"if"`
 	Name string            `yaml:"name"`
 	Uses string            `yaml:"uses"`
 	Run  string            `yaml:"run"`
@@ -102,6 +103,7 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		"function hasWorkflowSkipDirective",
 		"function isStrictGraphQLUpdateRule",
 		"function isStrictUpdateRule",
+		"function requiresManualWorkflowMerge",
 		"function reviewedAppSlug",
 		"function safeMergeMetadata",
 		"async function verifyBuiltInWriterBoundary",
@@ -222,6 +224,10 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 	}
 
 	appToken := autoMergeJob.Steps[2]
+	wantEnableGuard := "steps.merge-authority.outputs.enable-app-auto-merge == 'true'"
+	if appToken.If != wantEnableGuard {
+		t.Fatalf("reviewer-router token if = %q, want %q", appToken.If, wantEnableGuard)
+	}
 	if len(appToken.With) != 6 {
 		t.Fatalf("reviewer-router token inputs = %v, want exactly the reviewed repository scope and two permissions", appToken.With)
 	}
@@ -296,6 +302,9 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 	if authorityStep.Name != "Verify and normalize merge authority" {
 		t.Fatalf("merge-authority step name = %q", authorityStep.Name)
 	}
+	if authorityStep.ID != "merge-authority" {
+		t.Fatalf("merge-authority step id = %q, want merge-authority", authorityStep.ID)
+	}
 	if _, ok := authorityStep.With["github-token"]; ok {
 		t.Error("merge-authority verification must use only the job-scoped built-in token")
 	}
@@ -307,6 +316,7 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		"require('./.github/reviewer-merge-authority.js')",
 		"classifyAutoMergeRequest",
 		"hasWorkflowSkipDirective",
+		"requiresManualWorkflowMerge",
 		"reviewedAppSlug",
 		"safeMergeMetadata",
 		"verifyBuiltInWriterBoundary",
@@ -320,6 +330,10 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		"pre-credential normalization",
 		"disablePullRequestAutoMerge",
 		"hasWorkflowSkipDirective(currentPull)",
+		"github.rest.pulls.listFiles",
+		"requiresManualWorkflowMerge(changedFiles)",
+		"workflow-change manual-only cleanup",
+		"changes .github/workflows/**",
 		"mergeDefaultsProjection === 'omitted'",
 		"await verifyBuiltInWriterBoundary({github, owner, repo})",
 		"getExactPull('final authority read')",
@@ -327,6 +341,7 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		"getExactPull('failure cleanup')",
 		"fail-closed authority cleanup",
 		"Verified built-in merge authority",
+		"core.setOutput('enable-app-auto-merge', 'true')",
 		"throw new Error",
 	} {
 		if !strings.Contains(authorityScript, want) {
@@ -341,6 +356,9 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 	}
 
 	autoMergeStep := autoMergeJob.Steps[3]
+	if autoMergeStep.If != wantEnableGuard {
+		t.Fatalf("auto-merge step if = %q, want %q", autoMergeStep.If, wantEnableGuard)
+	}
 	if got, want := autoMergeStep.With["github-token"], "${{ steps.reviewer-router-token.outputs.token }}"; got != want {
 		t.Fatalf("auto-merge github-token = %q, want %q", got, want)
 	}
@@ -565,6 +583,14 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		"ruleset.current_user_can_bypass !== 'never'",
 		"Reviewer Router App must never bypass main ruleset",
 		"const skipWorkflowPattern =",
+		"function requiresManualWorkflowMerge(files)",
+		"async function pullRequiresManualWorkflowMerge(pullNumber)",
+		"github.rest.pulls.listFiles",
+		"await pullRequiresManualWorkflowMerge(candidate.number)",
+		"workflow-change manual-only cleanup",
+		"workflow-change synchronous-merge cleanup",
+		"changes .github/workflows/**; cleared auto-merge and left it manual-only",
+		"changes .github/workflows/**; cleared the App request and left it manual-only",
 		"const skipRequested =",
 		"workflow-skip directive found in merge metadata; left manual-merge only",
 		"const safeCommitHeadline = `Merge pull request #${candidate.number}`",

--- a/test/scripts/reviewer_router_workflow_test.go
+++ b/test/scripts/reviewer_router_workflow_test.go
@@ -91,6 +91,42 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 			t.Errorf("reviewer routing policy is missing contract marker %q", want)
 		}
 	}
+	authorityPolicyPath := filepath.Join(filepath.Dir(filepath.Dir(path)), "reviewer-merge-authority.js")
+	authorityPolicy, err := os.ReadFile(authorityPolicyPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", authorityPolicyPath, err)
+	}
+	for _, want := range []string{
+		"function classifyAutoMergeRequest",
+		"function classifyMergeDefaults",
+		"function hasWorkflowSkipDirective",
+		"function isStrictGraphQLUpdateRule",
+		"function isStrictUpdateRule",
+		"function reviewedAppSlug",
+		"function safeMergeMetadata",
+		"async function verifyBuiltInWriterBoundary",
+		"GET /repos/{owner}/{repo}/rules/branches/{branch}",
+		"GET /repos/{owner}/{repo}/rulesets/{ruleset_id}",
+		"ruleset.name === writerRulesetName",
+		"writerIncludes[0] !== 'refs/heads/main'",
+		"writerExcludes.length !== 0",
+		"writerRuleset.rules?.length !== 1",
+		"writerRuleset.current_user_can_bypass !== 'never'",
+		"query ReviewerRouterWriterRule($rulesetID: ID!)",
+		"!isStrictGraphQLUpdateRule(writerRuleset, graphWriterRuleset)",
+	} {
+		if !strings.Contains(string(authorityPolicy), want) {
+			t.Errorf("reviewer merge-authority policy is missing contract marker %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"REVIEWER_ROUTER_APP_PRIVATE_KEY",
+		"enablePullRequestAutoMerge",
+	} {
+		if strings.Contains(string(authorityPolicy), forbidden) {
+			t.Errorf("reviewer merge-authority policy must not contain %q", forbidden)
+		}
+	}
 
 	if len(workflow.On) != 5 {
 		t.Fatalf("workflow triggers = %v, want routing plus review/check-driven reconciliation", workflow.On)
@@ -174,15 +210,18 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 	if !reflect.DeepEqual(autoMergeJob.Permissions, wantAutoPermissions) {
 		t.Fatalf("manage-auto-merge permissions = %v, want exactly %v", autoMergeJob.Permissions, wantAutoPermissions)
 	}
-	if len(autoMergeJob.Steps) != 3 ||
-		autoMergeJob.Steps[0].Uses != githubScriptSHA ||
-		autoMergeJob.Steps[1].ID != "reviewer-router-token" ||
-		autoMergeJob.Steps[1].Uses != appTokenSHA ||
-		autoMergeJob.Steps[2].Uses != githubScriptSHA {
-		t.Fatalf("manage-auto-merge steps = %#v, want unsafe-owner cleanup before dedicated App enable", autoMergeJob.Steps)
+	if len(autoMergeJob.Steps) != 4 ||
+		autoMergeJob.Steps[0].Uses != checkoutSHA ||
+		autoMergeJob.Steps[0].With["ref"] != "${{ github.event.pull_request.base.sha }}" ||
+		autoMergeJob.Steps[0].With["persist-credentials"] != "false" ||
+		autoMergeJob.Steps[1].Uses != githubScriptSHA ||
+		autoMergeJob.Steps[2].ID != "reviewer-router-token" ||
+		autoMergeJob.Steps[2].Uses != appTokenSHA ||
+		autoMergeJob.Steps[3].Uses != githubScriptSHA {
+		t.Fatalf("manage-auto-merge steps = %#v, want trusted base policy, built-in authority verification, then dedicated App enable", autoMergeJob.Steps)
 	}
 
-	appToken := autoMergeJob.Steps[1]
+	appToken := autoMergeJob.Steps[2]
 	if len(appToken.With) != 6 {
 		t.Fatalf("reviewer-router token inputs = %v, want exactly the reviewed repository scope and two permissions", appToken.With)
 	}
@@ -253,41 +292,55 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		}
 	}
 
-	cleanupStep := autoMergeJob.Steps[0]
-	if _, ok := cleanupStep.With["github-token"]; ok {
-		t.Error("unsafe-owner cleanup must use only the job-scoped built-in token")
+	authorityStep := autoMergeJob.Steps[1]
+	if authorityStep.Name != "Verify and normalize merge authority" {
+		t.Fatalf("merge-authority step name = %q", authorityStep.Name)
 	}
-	cleanupScript := cleanupStep.With["script"]
+	if _, ok := authorityStep.With["github-token"]; ok {
+		t.Error("merge-authority verification must use only the job-scoped built-in token")
+	}
+	if got, want := authorityStep.Env["REVIEWER_ROUTER_APP_SLUG"], "${{ vars.REVIEWER_ROUTER_APP_SLUG }}"; got != want {
+		t.Fatalf("merge-authority App slug = %q, want %q", got, want)
+	}
+	authorityScript := authorityStep.With["script"]
 	for _, want := range []string{
+		"require('./.github/reviewer-merge-authority.js')",
+		"classifyAutoMergeRequest",
+		"hasWorkflowSkipDirective",
+		"reviewedAppSlug",
+		"safeMergeMetadata",
+		"verifyBuiltInWriterBoundary",
+		"getExactPull('initial read')",
 		"currentPull.head.sha !== eventHeadSha",
 		"currentPull.base.sha !== eventBaseSha",
 		"currentPull.state !== 'open'",
 		"currentPull.draft",
 		"currentPull.base.ref !== 'main'",
-		"const unsafeOwner = 'github-actions[bot]'",
-		"const skipWorkflowPattern =",
-		"currentPull.title",
-		"currentPull.auto_merge?.commit_title",
-		"currentPull.auto_merge?.commit_message",
-		"const skipRequested =",
-		"enabledBy !== unsafeOwner",
+		"initialRequest === 'unsafe'",
+		"pre-credential normalization",
 		"disablePullRequestAutoMerge",
-		"cleanedPull.auto_merge",
-		"Cleared workflow-skipping auto-merge metadata",
+		"hasWorkflowSkipDirective(currentPull)",
+		"mergeDefaultsProjection === 'omitted'",
+		"await verifyBuiltInWriterBoundary({github, owner, repo})",
+		"getExactPull('final authority read')",
+		"finalRequest === 'unsafe'",
+		"getExactPull('failure cleanup')",
+		"fail-closed authority cleanup",
+		"Verified built-in merge authority",
 		"throw new Error",
 	} {
-		if !strings.Contains(cleanupScript, want) {
-			t.Errorf("unsafe-owner cleanup is missing contract marker %q", want)
+		if !strings.Contains(authorityScript, want) {
+			t.Errorf("merge-authority verification is missing contract marker %q", want)
 		}
 	}
-	if strings.Contains(cleanupScript, "enablePullRequestAutoMerge") {
-		t.Error("built-in cleanup token must never enable auto-merge")
+	if strings.Contains(authorityScript, "enablePullRequestAutoMerge") {
+		t.Error("built-in merge-authority token must never enable auto-merge")
 	}
-	if got := strings.Count(cleanupScript, "const skipWorkflowPattern ="); got != 1 {
-		t.Errorf("unsafe-request cleanup skip-workflow pattern declarations = %d, want exactly 1", got)
+	if strings.Contains(authorityScript, "REVIEWER_ROUTER_APP_PRIVATE_KEY") {
+		t.Error("merge-authority verification must run before and without App credentials")
 	}
 
-	autoMergeStep := autoMergeJob.Steps[2]
+	autoMergeStep := autoMergeJob.Steps[3]
 	if got, want := autoMergeStep.With["github-token"], "${{ steps.reviewer-router-token.outputs.token }}"; got != want {
 		t.Fatalf("auto-merge github-token = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- Move the built-in-token `main-merge-writers` proof into the trusted `pull_request_target` Reviewer Router before App credentials are read.
- Normalize every non-reviewed auto-merge request to manual-only before minting the dedicated App token, while preserving an exact App-owned request with fixed metadata.
- Add a tested merge-authority policy module and keep the existing required `Test` identity check as a shadow assertion for this first rollout stage.
- Keep `auto_merge_enabled` and `auto_merge_disabled` in the full CI trigger. Removing those triggers is intentionally deferred to a second PR after live evidence confirms this gate.

No linked issue; this is a maintainer-requested staged CI-throughput change.

## Risk tier

- [ ] Documentation-only
- [ ] Standard
- [x] High-risk: protected-main workflow and merge-authority behavior

## Verification

- [x] Release fragment: `.changes/reviewer-router-lightweight-authority.md`
- [x] `node .github/reviewer-routing.test.js`
- [x] `node .github/reviewer-merge-authority.test.js`
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run 'Test(ReviewerRouterWorkflowContract|CodeAdmissionEnforcesReviewerRouterWriterBoundary|GitHubScriptWorkflowJavaScriptParses|ReleaseCommandRejectsDifferentFetchAndPushRepositories)$' -count=1`
- [x] `staticcheck ./test/scripts`
- [x] `make test-plan`
- [x] `./scripts/policy/check-release-fragments.sh origin/main HEAD`
- [x] `git diff origin/main...HEAD --check`
- [ ] Full `go test ./test/scripts -count=1`: attempted, but the package hit its existing 10-minute global timeout while a release test was polling npm registry propagation. The reported active test and all changed-path tests pass independently.
- [ ] Generated drift: N/A; no generator inputs or generated artifacts changed.
- [ ] Command surface: N/A.
- [ ] Package-manager verification: N/A.

## Behavior evidence

The base-owned `manage-auto-merge` job now executes in this order:

1. check out only `pull_request.base.sha` with persisted credentials disabled;
2. bind the live PR to the event base/head;
3. clear non-App, unsafe-metadata, or workflow-skipping auto-merge requests;
4. prove the built-in token reports `current_user_can_bypass=never` for the exact REST/GraphQL `main-merge-writers` rule;
5. only then read the App private key and mint the repository-scoped token;
6. retain the existing App-side ruleset and exact-head verification before enable/merge.

The built-in step contains no App private key and no `enablePullRequestAutoMerge` path. On authority drift it clears any remaining request and fails closed.

## Risks and rollback

- This PR adds a second live assertion before App token minting; it does not reduce required checks or remove any CI event.
- A false negative leaves the PR manual-only and makes Reviewer routing red; it cannot fall back to `GITHUB_TOKEN` auto-merge.
- Rollback is a normal revert of this PR. No ruleset, App permission, release workflow, nine-context list, Coverage cache key, or `push: main` producer changes are required.
- Follow-up PR 2 will remove only `auto_merge_enabled` / `auto_merge_disabled` from heavy CI after this gate is observed on real PRs.
