### PR TITLE
ci: stop rerunning admission for auto-merge metadata

### DIFF
--- a/.changes/ci-auto-merge-retrigger.md
+++ b/.changes/ci-auto-merge-retrigger.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Pull request CI scheduling** — stops metadata-only auto-merge enable and disable events from restarting the complete admission graph for an unchanged commit, while the base-owned Reviewer Router continues to enforce merge authority.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, edited, auto_merge_enabled, auto_merge_disabled]
+    # Auto-merge metadata is governed by the base-owned Reviewer Router. It
+    # does not change the head SHA, so it must not restart this full admission
+    # graph or evict useful in-flight work for the same revision.
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, edited]
 
 permissions:
   contents: read

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -132,10 +132,12 @@ the built-in Actions identity cannot pass the writer rule; other permitted
 identities emit either a protected-main push or the trusted closed-PR repair.
 Draft PRs skip this identity check; the explicit `ready_for_review` trigger
 reruns admission when they become merge-eligible,
-while `edited` and `auto_merge_enabled` rerun both workflows when the PR title
-or merge request changes. A human `auto_merge_disabled` event reruns CI without
-silently re-enabling the request, leaving it available only to the designated
-break-glass identity. The required `Test` context rejects GitHub workflow-skip
+while `edited` reruns admission and Router when the PR title changes.
+`auto_merge_enabled` wakes only the lightweight base-owned Router; it does not
+restart full admission for the unchanged head SHA. A human
+`auto_merge_disabled` event starts neither workflow, so the request remains
+manual-only for the designated break-glass identity. The required `Test`
+context rejects GitHub workflow-skip
 directives in the PR title or an existing auto-merge request and verifies the
 repository's reviewed `MERGE_MESSAGE` title plus `PR_TITLE` or `BLANK` body
 defaults. GitHub does not expose those merge-related settings to the read-only

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -241,10 +241,12 @@ request after a short takeover grace period. Null is safe from the suppressed
 event path because the built-in Actions identity cannot update `main`; other
 permitted identities produce either a main push or the trusted closed-PR
 repair. Drafts skip the identity step, while `ready_for_review`, `edited`,
-`auto_merge_enabled`, and `auto_merge_disabled` explicitly start fresh admission
-for readiness, title, and merge-request changes. Router does not react to
-`auto_merge_disabled`, so a
-human can deliberately leave the PR manual-only for break-glass handling.
+and revision events explicitly start fresh admission for readiness, title, and
+code changes. `auto_merge_enabled` wakes only the lightweight base-owned
+Router; because it does not change the head SHA, it reuses the existing nine
+admission results instead of restarting the full graph. Neither CI nor Router
+reacts to `auto_merge_disabled`, so a human can deliberately leave the PR
+manual-only for break-glass handling.
 Reviewer routing remains available. The protected-main push that deploys the
 workflow automatically migrates every open, ready non-App request and repairs
 unsafe App metadata; it disables workflow-skipping requests for correction.

--- a/test/scripts/reviewer_router_workflow_test.go
+++ b/test/scripts/reviewer_router_workflow_test.go
@@ -788,8 +788,19 @@ func TestCodeAdmissionEnforcesReviewerRouterWriterBoundary(t *testing.T) {
 		t.Fatalf("ReadFile(ci.yml) error = %v", err)
 	}
 	workflow := string(data)
-	if !strings.Contains(workflow, "pull_request:\n    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, edited, auto_merge_enabled, auto_merge_disabled]") {
-		t.Error("CI must rerun admission when Draft state or merge metadata changes")
+	if !strings.Contains(workflow, "pull_request:\n    # Auto-merge metadata is governed by the base-owned Reviewer Router.") ||
+		!strings.Contains(workflow, "types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, edited]") {
+		t.Error("CI must rerun admission only when the revision, readiness, or reviewed title changes")
+	}
+	headerEnd := strings.Index(workflow, "\npermissions:\n")
+	if headerEnd < 0 {
+		t.Fatal("CI workflow missing permissions boundary")
+	}
+	triggerHeader := workflow[:headerEnd]
+	for _, forbidden := range []string{"auto_merge_enabled", "auto_merge_disabled"} {
+		if strings.Contains(triggerHeader, forbidden) {
+			t.Errorf("CI pull_request triggers must not include metadata-only event %q", forbidden)
+		}
 	}
 	start := strings.Index(workflow, "\n  test:\n")
 	end := strings.Index(workflow, "\n  test-darwin:\n")


### PR DESCRIPTION
## Summary

- remove `auto_merge_enabled` and `auto_merge_disabled` from the full CI `pull_request` triggers
- keep revision, readiness, draft-state, and title-change admission triggers unchanged
- leave auto-merge authority and reconciliation with the base-owned Reviewer Router introduced by #1153
- document and test that metadata-only merge changes reuse the nine checks already bound to the same head SHA

## Safety boundary

This PR does not remove or rename any of the nine required contexts, weaken strict status checks, change coverage enforcement, or change protected-main push CI. Because it changes `.github/workflows/**`, the Reviewer Router must leave it manual-only without minting the merge App token.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml .github/workflows/reviewer-router.yml`
- `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run '^(TestReviewerRouterWorkflowContract|TestCodeAdmissionEnforcesReviewerRouterWriterBoundary|TestGitHubScriptWorkflowJavaScriptParses|TestCIAppRacePartitionMatrixMatchesHelper)$' -count=1`\n- `make test-plan`\n- `staticcheck ./test/scripts`\n- `./scripts/policy/check-release-fragments.sh origin/main HEAD`\n- `git diff --check`\n\n## Rollout acceptance\n\n- this workflow-changing PR gets an explicit manual-only Router result rather than a GitHub App `workflows` permission failure\n- full admission runs once for the opened head revision\n- after merge, a normal PR can enable App-owned auto-merge without creating a second full CI run for the same SHA\n