### PR TITLE
fix(ci): handle consumed flag extraction after merge

### DIFF
--- a/scripts/policy/schema-compat/command_migrations_test.go
+++ b/scripts/policy/schema-compat/command_migrations_test.go
@@ -113,6 +113,44 @@ func TestCrossPlatformCoverageSchemaCommandMigrationsAuthorizeOnlyExactProjectio
 	}
 }
 
+func TestCrossPlatformCoverageSchemaConsumedFlagExtractionAfterBaseline(t *testing.T) {
+	before := schemaCommandMigrationContract(false)
+	after := schemaCommandMigrationContract(true)
+	for _, contract := range []*schemaContract{&before, &after} {
+		product := contract.Products["chat"]
+		delete(product.Tools, "chat.move")
+		contract.Products["chat"] = product
+	}
+	migration := schemaCommandMigrationAuthorizations()[1]
+	migration.State = interfacesnapshot.CommandMigrationConsumed
+
+	normalized, err := normalizeSchemaCommandMigrations(after, after, []interfacesnapshot.CommandMigration{migration})
+	if err != nil {
+		t.Fatalf("consumed extraction should be inert for an after-state baseline: %v", err)
+	}
+	if failures := checkCompatibility(normalized, after); len(failures) != 0 {
+		t.Fatalf("after-state extraction remained incompatible: %v", failures)
+	}
+
+	normalized, err = normalizeSchemaCommandMigrations(before, after, []interfacesnapshot.CommandMigration{migration})
+	if err != nil {
+		t.Fatalf("consumed extraction should still normalize a stable before-state baseline: %v", err)
+	}
+	if failures := checkCompatibility(normalized, after); len(failures) != 0 {
+		t.Fatalf("stable before-state extraction remained incompatible: %v", failures)
+	}
+
+	republished := cloneContract(after)
+	product := republished.Products["chat"]
+	tool := product.Tools["chat.create_group"]
+	tool.Parameters["thread"] = before.Products["chat"].Tools["chat.create_group"].Parameters["thread"]
+	product.Tools["chat.create_group"] = tool
+	republished.Products["chat"] = product
+	if _, err := normalizeSchemaCommandMigrations(after, republished, []interfacesnapshot.CommandMigration{migration}); err == nil {
+		t.Fatal("consumed extraction accepted a current Schema that republished the extracted parameter")
+	}
+}
+
 func TestCrossPlatformCoverageSchemaCommandMigrationsFailClosedOnDrift(t *testing.T) {
 	baseline := schemaCommandMigrationContract(false)
 	migrations := schemaCommandMigrationAuthorizations()

--- a/scripts/policy/schema-compat/main.go
+++ b/scripts/policy/schema-compat/main.go
@@ -1858,6 +1858,26 @@ func normalizeSchemaCommandMigrations(
 		}
 		legacyPath := strings.TrimPrefix(migration.Legacy.Command, "dws ")
 		replacementPath := strings.TrimPrefix(migration.Replacement.Command, "dws ")
+		if migration.Kind == interfacesnapshot.CommandMigrationFlagExtraction &&
+			migration.State == interfacesnapshot.CommandMigrationConsumed {
+			_, historicalPublishesLegacy := oldTool.Parameters[migration.LegacyFlag.Name]
+			_, currentPublishesLegacy := newSource.Parameters[migration.LegacyFlag.Name]
+			historicalReplacement, historicalReplacementExists := oldProduct.Tools[migration.Schema.ReplacementToolID]
+			currentReplacement, currentReplacementExists := newProduct.Tools[migration.Schema.ReplacementToolID]
+			if oldTool.PrimaryCLIPath == legacyPath &&
+				newSource.PrimaryCLIPath == legacyPath &&
+				!historicalPublishesLegacy &&
+				!currentPublishesLegacy &&
+				historicalReplacementExists &&
+				historicalReplacement.PrimaryCLIPath == replacementPath &&
+				currentReplacementExists &&
+				currentReplacement.PrimaryCLIPath == replacementPath {
+				// The merge-base has already reached the extraction's after state.
+				// Retain the receipt for older stable baselines without replaying it
+				// against the already-extracted source tool.
+				continue
+			}
+		}
 		if oldTool.PrimaryCLIPath == replacementPath {
 			// A consumed receipt can still be needed for the stable baseline after
 			// main has already reached the after state.


### PR DESCRIPTION
## Summary

- Treat a consumed `flag_extraction` receipt as inert when both the merge-base Schema and candidate Schema already match the exact after state.
- Keep replaying the same receipt for older stable baselines that still publish the extracted parameter.
- Fail closed when the candidate republishes the extracted parameter or either source/replacement path is not in the reviewed after state.

This is needed because #1054 merged the Thread extraction in `e9de6856`, but subsequent PRs #1160 and #1157 still fail while checking that after-state merge-base with:

```text
approved flag extraction "dws chat group create" historical Schema tool lacks parameter "thread"
```

The failure is not stale CI state: both jobs explicitly use `COMPATIBILITY_BASE_REF=e9de6856d1ec989c9eb8063f2f131db48879179a`.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

- [x] Release fragment added for a user-visible behavior/interface change (otherwise `N/A`):
  N/A — this only fixes internal compatibility-governance lifecycle handling.
- [x] Release-seal validation (otherwise `N/A`):
  N/A — no release fragment or release-seal content changed.
- [x] Targeted test/check commands and results:
  - `GOWORK=off GOCACHE=/private/tmp/dws-schema-compat-go-cache go test ./scripts/policy/schema-compat -run '^TestCrossPlatformCoverageSchemaConsumedFlagExtractionAfterBaseline$' -count=1` — passed.
  - `GOWORK=off GOCACHE=/private/tmp/dws-schema-compat-go-cache go test ./internal/interfacesnapshot ./scripts/policy/schema-compat -count=1` — passed.
  - `git diff --check upstream/main...HEAD` — passed.
- [x] Behavior evidence (test name, CLI output shape, or before/after result):
  - Before the fix, `TestCrossPlatformCoverageSchemaConsumedFlagExtractionAfterBaseline` failed with `historical Schema tool lacks parameter "thread"` for an already-after baseline.
  - After the fix, the after-state baseline is inert, the stable before-state still normalizes, and republishing `thread` remains rejected.
- [x] Documentation links/content/rendering checked (documentation-only, otherwise
  `N/A`): N/A.
- [x] Full local suite run because the change is high-risk (optional for other
  tiers; record command/result or `N/A`): N/A — focused policy packages were run; CI supplies the expanded high-risk suite.
- [x] `./scripts/policy/check-generated-drift.sh`
  (when generator inputs or generated artifacts may change): N/A — no generator input or generated artifact changed.
- [x] `./scripts/policy/check-command-surface.sh --strict` (if command surface changed): N/A — no command surface changed.
- [x] `./scripts/release/verify-package-managers.sh`
  (after `make package`, if packaging or installer surfaces changed): N/A.

## Notes

- Scope is limited to `scripts/policy/schema-compat/main.go` and its existing command-migration test file.
- No product command, migration ledger, Help, Skill, Catalog, workflow, or governance documentation is changed.
- The authority launcher intentionally builds the checker from the PR merge-base. Therefore this governance PR's own Interface Integrity job will still run the old `e9de6856` checker and reproduce the same failure; the candidate checker cannot authorize itself. Once this fix is merged, subsequent PRs use the corrected base-owned checker.
- Related failures: #1160 and #1157.
