### PR TITLE
fix(doc): preserve output compatibility

### DIFF
--- a/.changes/doc-output-compatibility.md
+++ b/.changes/doc-output-compatibility.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Doc output compatibility** — preserves the empty pagination failure ledger and lets completed import recovery report an unverified result when the original target is unavailable.

--- a/internal/helpers/doc.go
+++ b/internal/helpers/doc.go
@@ -4331,8 +4331,8 @@ CLI 内部自动完成全部流程:
 通常不需要手动调用，dws doc import 会自动完成轮询。
 仅在导入命令超时或中断后，用于手动查询任务状态。建议直接复制导入结果
 中的完整 next_command；其中携带的原目标（--folder 或 --workspace）用于在
-completed 后回读验证真实落点。只传 taskId 仍可查询 processing/failed，
-但 completed 时会返回未验证错误，不会误报成功。
+completed 后回读验证真实落点。只传 taskId 也可查询全部状态；completed 时
+保留服务端成功终态和 nodeId，但返回 verified=false，表示未验证真实落点。
 
 任务状态:
   processing  转换中

--- a/internal/helpers/doc_import_target_test.go
+++ b/internal/helpers/doc_import_target_test.go
@@ -347,23 +347,21 @@ func TestCrossPlatformCoverageDocImportGetCompletedWithoutTargetIsUnverified(t *
 		"query_import_task": {`{"status":"completed","documentUrl":"https://alidocs.dingtalk.com/i/nodes/node-2"}`},
 	}}
 	InitDeps(caller)
+	var output bytes.Buffer
+	deps.Out.w = &output
 	cmd := &cobra.Command{Use: "get"}
 	cmd.Flags().String("task-id", "task-2", "")
 	cmd.Flags().String("folder", "", "")
 	cmd.Flags().String("workspace", "", "")
-	err := runImportGetCommand(cmd, docImportFlowConfig())
-	if err == nil {
-		t.Fatal("completed task without verification target unexpectedly succeeded")
+	if err := runImportGetCommand(cmd, docImportFlowConfig()); err != nil {
+		t.Fatalf("completed task without verification target: %v", err)
 	}
-	var structured *apperrors.Error
-	if !errors.As(err, &structured) {
-		t.Fatalf("error type = %T, want *errors.Error", err)
+	var result map[string]any
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, output.String())
 	}
-	if structured.Reason != "doc_import_verification_target_required" || structured.Details["taskStatus"] != "completed" || structured.Details["verified"] != false || structured.Details["nodeId"] != "node-2" {
-		t.Fatalf("structured error = %#v", structured)
-	}
-	if structured.ExecutionStarted == nil || !*structured.ExecutionStarted {
-		t.Fatalf("ExecutionStarted = %#v, want true", structured.ExecutionStarted)
+	if result["status"] != "completed" || result["verified"] != false || result["nodeId"] != "node-2" {
+		t.Fatalf("completed result = %#v", result)
 	}
 	if len(caller.calls) != 1 || caller.calls[0].tool != "query_import_task" {
 		t.Fatalf("calls = %#v", caller.calls)

--- a/internal/helpers/import_flow.go
+++ b/internal/helpers/import_flow.go
@@ -476,33 +476,6 @@ func docImportPlacementError(file preparedImportFile, taskID, nodeID string, obs
 	)
 }
 
-func docImportVerificationTargetRequiredError(taskID, documentURL string) error {
-	details := map[string]any{
-		"taskId":     taskID,
-		"taskStatus": "completed",
-		"verified":   false,
-	}
-	if documentURL != "" {
-		details["documentUrl"] = documentURL
-	}
-	if nodeID := extractNodeIDFromDocURL(documentURL); nodeID != "" {
-		details["nodeId"] = nodeID
-	}
-	return apperrors.NewAPI(
-		"导入任务已经完成，但未提供原导入目标，无法验证真实落点",
-		apperrors.WithOperation("doc.import"),
-		apperrors.WithReason("doc_import_verification_target_required"),
-		apperrors.WithFailureStage("verify_placement"),
-		apperrors.WithExecutionStarted(true),
-		apperrors.WithRetryable(false),
-		apperrors.WithActions(
-			"使用原 --folder 或 --workspace 重新执行当前 doc import get 查询",
-			"若无法确认原目标，请按 nodeId 检查文档位置，并避免重复导入",
-		),
-		apperrors.WithDetails(details),
-	)
-}
-
 func (cfg importFlowConfig) callTool(ctx context.Context, toolName string, args map[string]any) (string, error) {
 	if cfg.serverID != "" {
 		return callMCPToolReturnTextOnServer(ctx, cfg.serverID, toolName, args)
@@ -879,19 +852,20 @@ func runImportGetCommand(cmd *cobra.Command, cfg importFlowConfig) error {
 	message, _ := result["message"].(string)
 	if strings.EqualFold(status, "completed") {
 		documentURL, _ := result["documentUrl"].(string)
-		if cfg.verifyPlacement && target.folder == "" && target.workspace == "" {
-			return docImportVerificationTargetRequiredError(taskID, documentURL)
-		}
 		nodeID := extractNodeIDFromDocURL(documentURL)
 		if cfg.verifyPlacement {
-			var verification map[string]any
-			nodeID, verification, err = verifyImportedDocumentPlacement(ctx, target, taskID, documentURL)
-			if err != nil {
-				return err
+			if target.folder == "" && target.workspace == "" {
+				result["verified"] = false
+			} else {
+				var verification map[string]any
+				nodeID, verification, err = verifyImportedDocumentPlacement(ctx, target, taskID, documentURL)
+				if err != nil {
+					return err
+				}
+				result["verified"] = true
+				result["target"] = importTargetSummary(target)
+				result["verification"] = verification
 			}
-			result["verified"] = true
-			result["target"] = importTargetSummary(target)
-			result["verification"] = verification
 		}
 		if cfg.includeNodeID {
 			result["nodeId"] = nodeID

--- a/internal/shortcut/doc/pagination.go
+++ b/internal/shortcut/doc/pagination.go
@@ -187,6 +187,7 @@ func collectDocPages(
 		"hasMore":         hasMore,
 		"nextCursor":      nextCursor,
 		"stopReason":      stopReason,
+		"failures":        []map[string]any{},
 	}
 	return result, nil
 }

--- a/internal/shortcut/doc/pagination_test.go
+++ b/internal/shortcut/doc/pagination_test.go
@@ -63,7 +63,11 @@ func TestCrossPlatformCoverageDocSearchPublishesExplicitStopReasons(t *testing.T
 			if captured["pagesRead"] != 1 {
 				t.Fatalf("page counters = %#v", captured)
 			}
-			for _, redundant := range []string{"pagesFetched", "paginationKnown", "truncatedByPageLimit", "truncatedByResultLimit", "resumeCursorReliable", "failures"} {
+			failures, ok := captured["failures"].([]map[string]any)
+			if !ok || len(failures) != 0 {
+				t.Fatalf("doc.list.v1 failures = %#v, want empty array", captured["failures"])
+			}
+			for _, redundant := range []string{"pagesFetched", "paginationKnown", "truncatedByPageLimit", "truncatedByResultLimit", "resumeCursorReliable"} {
 				if _, exists := captured[redundant]; exists {
 					t.Fatalf("redundant field %q remains in result: %#v", redundant, captured)
 				}


### PR DESCRIPTION
## Summary

- Restore the empty `failures` ledger on successful `doc.list.v1` pagination results.
- Let `doc import get --task-id` return a completed but explicitly unverified result when the original folder/workspace is unavailable, while preserving strict placement verification when a target is supplied.
- Align `doc import get --help` with the compatible recovery behavior.

## Why

PR #1094 unintentionally introduced two compatibility regressions: successful pagination stopped publishing the established empty failure ledger without changing `contractVersion`, and a completed import task could no longer be queried with only its `taskId`. This follow-up restores those contracts without weakening target-aware placement verification.

## Risk tier

- [ ] Documentation-only
- [ ] Standard
- [x] High-risk: the change is small but touches asynchronous import recovery semantics.

## Compatibility and governance

- Existing command paths, flags, aliases, requiredness, constraints, and Schema declarations are unchanged.
- The pagination change restores an existing response field.
- Target-aware import recovery still performs strict readback and returns `verified=true` only after the observed placement matches.
- Task-ID-only completed recovery returns `verified=false`; it does not claim that placement was verified and does not issue an unrelated verification request.
- No parameter migration or separate governance PR is required.

## Verification

- [x] Release fragment: `.changes/doc-output-compatibility.md`
- [x] Four focused Doc/Import regressions — PASS on the reviewed current Head
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test -count=1 ./internal/helpers ./internal/shortcut/doc`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test -race -count=1 ./internal/helpers ./internal/shortcut/doc`
- [x] `make build`
- [x] `make policy`
- [x] `make edition-test`
- [x] `make test-schema-agent-examples` — 1542 contracts, 116 dry-run examples; `doc/import_get` PASS
- [x] Changed-code coverage — 21/21 executable statements, 100%
- [x] `git diff --check origin/main...HEAD`
- [x] Privacy audit — synthetic task/node IDs only; no credentials or business data
- [ ] GitHub CI — running after the PR was marked Ready

## Agent 测试报告

`make test-schema-agent-examples` passes on the current candidate SHA. A sanitized current-HEAD screenshot remains to be attached for review evidence.

## 指令 CI 集成测试

The focused Doc/Import regression suite passes on the current candidate SHA. A sanitized current-HEAD screenshot remains to be attached for review evidence.

## Known limits / Notes

- Without the original folder/workspace, the command can prove the server-reported terminal task state and expose `nodeId`, but it cannot prove final placement; this is why the result remains `verified=false`.
- This PR is Ready for review. Full GitHub CI is running; the repository Reviewer Router automatically enabled auto-merge, which remains gated on required CI and approval.
