### PR TITLE
feat(help): 优化 DWS Agent 友好 Help（Aone 85675069）

### DIFF
--- a/.changes/85675069-agent-friendly-help.md
+++ b/.changes/85675069-agent-friendly-help.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Agent-friendly Help (Aone 85675069)** — adds a root Agent Quickstart and Safety model, renders complete Safety plus reviewed command-selection guidance on every Agent-visible leaf, and links service/leaf Help to the corresponding embedded DWS Skill and stable deep documentation.

--- a/internal/app/audit_command.go
+++ b/internal/app/audit_command.go
@@ -33,6 +33,12 @@ func newAuditCommand() *cobra.Command {
 	// products.audit). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "audit",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-shared"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("DWS 运行契约", "dingtalk-shared", "references/runtime-contract.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "查看、导出和校验本地操作审计日志",
 			UseWhen: []string{

--- a/internal/app/event_command.go
+++ b/internal/app/event_command.go
@@ -80,6 +80,12 @@ func newEventCommand(globalFlags ...*GlobalFlags) *cobra.Command {
 	// products.event). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "event",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-event"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("事件订阅深度指南", "dingtalk-event", "references/event-im.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "实时监听当前用户相关的个人 IM 与 OA 审批事件，并管理订阅生命周期",
 			UseWhen: []string{

--- a/internal/app/root_help.go
+++ b/internal/app/root_help.go
@@ -49,7 +49,7 @@ func configureRootHelp(root *cobra.Command) {
 	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		if cmd != root {
 			defaultHelpFunc(cmd, args)
-			cli.RenderSafetyAnnotation(cmd)
+			cli.RenderHelpAffordances(cmd)
 			return
 		}
 		renderRootHelp(root)
@@ -97,6 +97,8 @@ func renderRootHelp(root *cobra.Command) {
 		_, _ = fmt.Fprintln(w)
 	}
 	renderRootGlobalFlags(root)
+	renderAgentQuickstart(w)
+	renderSafetyModel(w)
 	_, _ = fmt.Fprintf(w, "%s %s\n", tui.Key("Next"), `Use "dws <service> --help" for more information about a discovered MCP service or "dws <command> --help" for utility commands.`)
 
 	// Render root.Long after the command list so agents see the upgrade
@@ -114,6 +116,25 @@ func renderRootHelp(root *cobra.Command) {
 	// scroll to the end.
 	_, _ = fmt.Fprintln(w)
 	renderRootFeedback(w)
+}
+
+func renderAgentQuickstart(w io.Writer) {
+	_, _ = fmt.Fprintln(w, tui.Section("Agent Quickstart:"))
+	_, _ = fmt.Fprintln(w, "  1. Browse a product: dws <service> --help")
+	_, _ = fmt.Fprintln(w, "  2. Inspect leaf parameters and semantics: dws <path> --help")
+	_, _ = fmt.Fprintln(w, `  3. Read the machine contract: dws schema --cli-path "<path>" --compact -f json`)
+	_, _ = fmt.Fprintln(w, "  4. Prefer structured output. Use dry-run only when the leaf explicitly supports it.")
+	_, _ = fmt.Fprintln(w, "  5. Never add --yes without explicit user confirmation.")
+	_, _ = fmt.Fprintln(w)
+}
+
+func renderSafetyModel(w io.Writer) {
+	_, _ = fmt.Fprintln(w, tui.Section("Safety model:"))
+	_, _ = fmt.Fprintln(w, "  effect=read|write|destructive — whether the command reads, changes, or irreversibly removes state")
+	_, _ = fmt.Fprintln(w, "  risk=low|medium|high — expected impact if the command is used incorrectly")
+	_, _ = fmt.Fprintln(w, "  confirmation=not_required|user_required — whether explicit user approval is required")
+	_, _ = fmt.Fprintln(w, "  idempotency=idempotent|retryable|non_idempotent|unknown — whether repeating the command is safe")
+	_, _ = fmt.Fprintln(w)
 }
 
 // renderRootFeedback prints the user-experience survey entry. The URL occupies

--- a/internal/app/root_help_test.go
+++ b/internal/app/root_help_test.go
@@ -17,12 +17,15 @@ import (
 	"bytes"
 	stderrors "errors"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	authpkg "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/auth"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/runtimeannotate"
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
@@ -76,6 +79,223 @@ func TestRootHelpShowsFeedbackEntry(t *testing.T) {
 	if !strings.Contains(help, "\n    "+feedbackFormURL+"\n") {
 		t.Fatalf("feedback URL must occupy one unwrapped line:\n%s", help)
 	}
+	if !strings.HasSuffix(strings.TrimSpace(help), feedbackFormURL) {
+		t.Fatalf("Feedback must remain the final root Help section:\n%s", help)
+	}
+}
+
+func TestRootHelpShowsAgentQuickstartAndSafetyModel(t *testing.T) {
+	help := executeHelpOutput(t, "--help")
+	for _, want := range []string{
+		"Agent Quickstart:",
+		"dws <service> --help",
+		"dws <path> --help",
+		`dws schema --cli-path "<path>" --compact -f json`,
+		"Prefer structured output",
+		"Use dry-run only when the leaf explicitly supports it",
+		"Never add --yes without explicit user confirmation",
+		"Safety model:",
+		"effect=read|write|destructive",
+		"risk=low|medium|high",
+		"confirmation=not_required|user_required",
+		"idempotency=idempotent|retryable|non_idempotent|unknown",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("root Help missing %q:\n%s", want, help)
+		}
+	}
+	if strings.Index(help, "Agent Quickstart:") > strings.Index(help, "Feedback:") ||
+		strings.Index(help, "Safety model:") > strings.Index(help, "Feedback:") {
+		t.Fatalf("Agent guidance must render before final Feedback section:\n%s", help)
+	}
+}
+
+func TestLeafHelpRendersSelectionSafetyAndReferences(t *testing.T) {
+	for _, tc := range []struct {
+		path         string
+		wantEffect   string
+		wantConfirm  string
+		wantSkill    string
+		wantDocument string
+	}{
+		{path: "dev app list", wantEffect: "read", wantConfirm: "not_required", wantSkill: "dingtalk-misc", wantDocument: "references/devapp.md"},
+		{path: "chat message send", wantEffect: "write", wantConfirm: "not_required", wantSkill: "dingtalk-chat", wantDocument: "references/chat.md"},
+		{path: "dev app delete", wantEffect: "destructive", wantConfirm: "user_required", wantSkill: "dingtalk-misc", wantDocument: "references/devapp.md"},
+	} {
+		t.Run(strings.ReplaceAll(tc.path, " ", "_"), func(t *testing.T) {
+			root := NewRootCommand()
+			meta, ok := cli.ResolveMeta(tc.path)
+			if !ok {
+				t.Fatalf("ResolveMeta(%q) missing", tc.path)
+			}
+			out := executeHelpOutputWithRoot(t, root, append(strings.Fields(tc.path), "--help")...)
+			for _, want := range []string{
+				"When to use:", meta.Selection.UseWhen[0],
+				"Avoid when:", meta.Selection.AvoidWhen[0],
+				"Safety: effect=" + tc.wantEffect,
+				"confirmation=" + tc.wantConfirm,
+				"idempotency=" + meta.Safety.Idempotency,
+				"Related skills:", tc.wantSkill,
+				"Documentation:", tc.wantDocument,
+			} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("%s Help missing %q:\n%s", tc.path, want, out)
+				}
+			}
+			for _, once := range []string{"When to use:", "Avoid when:", "Safety:", "Related skills:", "Documentation:"} {
+				if count := strings.Count(out, once); count != 1 {
+					t.Fatalf("%s Help contains %q %d times, want once:\n%s", tc.path, once, count, out)
+				}
+			}
+			if tc.wantConfirm == "user_required" && !strings.Contains(out, "Do not use --yes until the user explicitly confirms") {
+				t.Fatalf("%s Help missing explicit --yes confirmation boundary:\n%s", tc.path, out)
+			}
+		})
+	}
+}
+
+func TestServiceAndHelpCommandRenderReferencesOnce(t *testing.T) {
+	for _, args := range [][]string{
+		{"chat", "--help"},
+		{"im", "--help"},
+		{"help", "chat"},
+		{"chat", "message", "send", "--help"},
+		{"help", "chat", "message", "send"},
+	} {
+		out := executeHelpOutput(t, args...)
+		for _, heading := range []string{"Related skills:", "Documentation:"} {
+			if count := strings.Count(out, heading); count != 1 {
+				t.Fatalf("dws %s contains %q %d times, want once:\n%s", strings.Join(args, " "), heading, count, out)
+			}
+		}
+		if !strings.Contains(out, "dingtalk-chat") || !strings.Contains(out, "references/chat.md") {
+			t.Fatalf("dws %s missing inherited chat references:\n%s", strings.Join(args, " "), out)
+		}
+	}
+}
+
+func TestProgrammaticLeafHelpRendersAffordancesOnce(t *testing.T) {
+	root := NewRootCommand()
+	target, remaining, err := root.Find([]string{"chat", "message", "send"})
+	if err != nil || target == nil || len(remaining) != 0 {
+		t.Fatalf("find chat message send: target=%v remaining=%v err=%v", target, remaining, err)
+	}
+	var out bytes.Buffer
+	root.SetOut(&out)
+	target.SetOut(&out)
+	if err := target.Help(); err != nil {
+		t.Fatalf("programmatic leaf Help: %v", err)
+	}
+	for _, heading := range []string{"When to use:", "Avoid when:", "Safety:", "Related skills:", "Documentation:"} {
+		if count := strings.Count(out.String(), heading); count != 1 {
+			t.Fatalf("programmatic Help contains %q %d times, want once:\n%s", heading, count, out.String())
+		}
+	}
+}
+
+func TestLeafAliasUsesPrimarySelectionAndReferences(t *testing.T) {
+	primary, ok := cli.ResolveMeta("report inbox list")
+	if !ok || len(primary.Selection.UseWhen) == 0 {
+		t.Fatalf("primary report metadata incomplete: %#v", primary)
+	}
+	aliased, ok := cli.ResolveMeta("report list")
+	if !ok || aliased.Identity.Canonical != primary.Identity.Canonical {
+		t.Fatalf("alias metadata = %#v, want canonical %q", aliased, primary.Identity.Canonical)
+	}
+	for _, path := range []string{"report inbox list", "report list"} {
+		out := executeHelpOutput(t, append(strings.Fields(path), "--help")...)
+		for _, want := range []string{primary.Selection.UseWhen[0], "Safety:", "dingtalk-misc", "references/report.md"} {
+			if !strings.Contains(out, want) {
+				t.Fatalf("%s Help missing primary affordance %q:\n%s", path, want, out)
+			}
+		}
+	}
+}
+
+func TestPublicServicesDeclareExistingHelpReferences(t *testing.T) {
+	root := NewRootCommand()
+	repositoryRoot := filepath.Clean(filepath.Join("..", ".."))
+	const documentationPrefix = "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/blob/main/"
+	for _, service := range visibleMCPRootCommands(root) {
+		decl, ok := contract.LookupProductDecl(service.Name())
+		if !ok {
+			t.Errorf("public service %q has no ProductDecl", service.Name())
+			continue
+		}
+		if len(decl.HelpReferences.RelatedSkills) == 0 || len(decl.HelpReferences.Documentation) == 0 {
+			t.Errorf("public service %q HelpReferences = %#v, want skill and documentation", service.Name(), decl.HelpReferences)
+			continue
+		}
+		for _, skill := range decl.HelpReferences.RelatedSkills {
+			skillPath := filepath.Join(repositoryRoot, "skills", "multi", skill, "SKILL.md")
+			if _, err := os.Stat(skillPath); err != nil {
+				t.Errorf("public service %q related Skill %q does not exist: %v", service.Name(), skill, err)
+			}
+		}
+		for _, document := range decl.HelpReferences.Documentation {
+			parsed, err := url.Parse(document.URL)
+			if err != nil || parsed.Scheme != "https" || !strings.HasPrefix(document.URL, documentationPrefix) {
+				t.Errorf("public service %q documentation URL is not a stable HTTPS repository link: %q", service.Name(), document.URL)
+				continue
+			}
+			relativePath := strings.TrimPrefix(document.URL, documentationPrefix)
+			if _, err := os.Stat(filepath.Join(repositoryRoot, filepath.FromSlash(relativePath))); err != nil {
+				t.Errorf("public service %q documentation %q does not exist: %v", service.Name(), relativePath, err)
+			}
+		}
+	}
+}
+
+func TestAgentVisibleLeavesHaveCompleteRenderableSafetyAndReferences(t *testing.T) {
+	registry, err := cli.AssembleSchemaRegistry(NewSchemaSourceRootCommand())
+	if err != nil {
+		t.Fatalf("assemble Schema registry: %v", err)
+	}
+	validEffect := map[string]bool{"read": true, "write": true, "destructive": true}
+	validRisk := map[string]bool{"low": true, "medium": true, "high": true}
+	validConfirmation := map[string]bool{"not_required": true, "user_required": true}
+	validIdempotency := map[string]bool{"idempotent": true, "retryable": true, "non_idempotent": true, "unknown": true}
+	leaves := 0
+	for _, product := range registry.Products {
+		decl, ok := contract.LookupProductDecl(product.ID)
+		if !ok || len(decl.HelpReferences.RelatedSkills) == 0 || len(decl.HelpReferences.Documentation) == 0 {
+			t.Errorf("Schema product %q has no complete HelpReferences", product.ID)
+		}
+		for _, tool := range product.Tools {
+			leaves++
+			safety := cli.CommandSafety{
+				Effect: tool.Safety.Effect, Risk: tool.Safety.Risk,
+				Confirmation: tool.Safety.Confirmation, Idempotency: tool.Safety.Idempotency,
+			}
+			if !validEffect[safety.Effect] || !validRisk[safety.Risk] ||
+				!validConfirmation[safety.Confirmation] || !validIdempotency[safety.Idempotency] {
+				t.Errorf("leaf %q has incomplete/invalid Safety: %#v", tool.Identity.CLIPath, safety)
+			}
+			if !safety.ShouldRender() {
+				t.Errorf("leaf %q Safety is hidden: %#v", tool.Identity.CLIPath, safety)
+			}
+		}
+	}
+	if leaves == 0 {
+		t.Fatal("assembled Schema contains no Agent-visible leaves")
+	}
+}
+
+func executeHelpOutput(t *testing.T, args ...string) string {
+	t.Helper()
+	return executeHelpOutputWithRoot(t, NewRootCommand(), args...)
+}
+
+func executeHelpOutputWithRoot(t *testing.T, root *cobra.Command, args ...string) string {
+	t.Helper()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("dws %s: %v\n%s", strings.Join(args, " "), err, out.String())
+	}
+	return out.String()
 }
 
 // The feedback entry is deliberately root-only: this CLI is driven mostly by

--- a/internal/cli/canonical.go
+++ b/internal/cli/canonical.go
@@ -36,6 +36,12 @@ func NewMCPCommand() *cobra.Command {
 	// products.mcp). Schema assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "mcp",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-shared"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("Schema 与 MCP 使用指南", "dingtalk-shared", "references/schema-usage.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "解析和管理当前身份可用的 MCP 服务连接信息",
 			UseWhen: []string{

--- a/internal/cli/command_meta.go
+++ b/internal/cli/command_meta.go
@@ -49,10 +49,12 @@ type CommandIdentity struct {
 
 // CommandSelection is the agent-facing selection metadata.
 type CommandSelection struct {
-	AgentSummary string
-	UseWhen      []string
-	AvoidWhen    []string
-	Examples     []string
+	AgentSummary  string
+	UseWhen       []string
+	AvoidWhen     []string
+	Prerequisites []string
+	Tips          []string
+	Examples      []string
 }
 
 var (
@@ -126,10 +128,12 @@ func buildMetaByCLIPathFromRegistry(registry SchemaRegistry) map[string]CommandM
 					Idempotency:  tool.Safety.Idempotency,
 				},
 				Selection: CommandSelection{
-					AgentSummary: tool.Selection.AgentSummary,
-					UseWhen:      append([]string(nil), tool.Selection.UseWhen...),
-					AvoidWhen:    append([]string(nil), tool.Selection.AvoidWhen...),
-					Examples:     append([]string(nil), tool.Selection.Examples...),
+					AgentSummary:  tool.Selection.AgentSummary,
+					UseWhen:       append([]string(nil), tool.Selection.UseWhen...),
+					AvoidWhen:     append([]string(nil), tool.Selection.AvoidWhen...),
+					Prerequisites: append([]string(nil), tool.Selection.Prerequisites...),
+					Tips:          append([]string(nil), tool.Selection.Tips...),
+					Examples:      append([]string(nil), tool.Selection.Examples...),
 				},
 			}
 			lookup[cliPath] = meta
@@ -165,10 +169,12 @@ func buildMetaByCLIPathFromSnapshotTools(tools map[string]map[string]any) map[st
 				Idempotency:  schemaString(tool["idempotency"]),
 			},
 			Selection: CommandSelection{
-				AgentSummary: schemaString(tool["agent_summary"]),
-				UseWhen:      schemaStringSlice(tool["use_when"]),
-				AvoidWhen:    schemaStringSlice(tool["avoid_when"]),
-				Examples:     schemaStringSlice(tool["examples"]),
+				AgentSummary:  schemaString(tool["agent_summary"]),
+				UseWhen:       schemaStringSlice(tool["use_when"]),
+				AvoidWhen:     schemaStringSlice(tool["avoid_when"]),
+				Prerequisites: schemaStringSlice(tool["prerequisites"]),
+				Tips:          schemaStringSlice(tool["tips"]),
+				Examples:      schemaStringSlice(tool["examples"]),
 			},
 		}
 		lookup[cliPath] = meta

--- a/internal/cli/command_safety.go
+++ b/internal/cli/command_safety.go
@@ -30,15 +30,17 @@ type CommandSafety struct {
 	Effect       string // read / write / destructive
 	Risk         string // low / medium / high
 	Confirmation string // not_required / user_required
-	Idempotency  string // idempotent / non_idempotent
+	Idempotency  string // idempotent / retryable / non_idempotent / unknown
 }
 
-// ShouldRender returns true when the safety metadata warrants a visible
-// annotation in --help. Only commands that need confirmation or carry
-// above-low risk are annotated; read-only low-risk commands stay clean.
+// ShouldRender returns true when any reviewed safety metadata is available.
+// Agent-visible leaves render the full tuple even for read/low operations so
+// absence is never mistaken for an unknown or unsafe command.
 func (s CommandSafety) ShouldRender() bool {
-	return s.Confirmation == "user_required" ||
-		(s.Risk != "" && s.Risk != "low")
+	return strings.TrimSpace(s.Effect) != "" ||
+		strings.TrimSpace(s.Risk) != "" ||
+		strings.TrimSpace(s.Confirmation) != "" ||
+		strings.TrimSpace(s.Idempotency) != ""
 }
 
 // SafetyForCLIPath returns the safety metadata for a command identified by its
@@ -61,13 +63,9 @@ func SafetyForCLIPath(cliPath string) (CommandSafety, bool) {
 	return meta.Safety, true
 }
 
-// RenderSafetyAnnotation writes a "Safety:" line to the command's stdout when
-// the command carries above-low risk or requires user confirmation. This is
-// the shared entry point for ALL help rendering paths (root HelpFunc, product
-// group custom HelpFuncs like calendar's). It avoids the timing issue where a
-// group captures origHelp before configureRootHelp sets the root's custom func.
-// Without a registered Schema source root it is a no-op (unit-test synthetic
-// roots); production NewRootCommand always registers the factory.
+// RenderSafetyAnnotation writes the reviewed Safety tuple to the command's
+// stdout. Prefer RenderHelpAffordances for production Help; this focused entry
+// point remains for compatibility and direct safety tests.
 func RenderSafetyAnnotation(cmd *cobra.Command) {
 	if !SchemaSourceRootRegistered() {
 		return
@@ -77,13 +75,17 @@ func RenderSafetyAnnotation(cmd *cobra.Command) {
 	if !ok || !safety.ShouldRender() {
 		return
 	}
+	renderSafety(cmd, safety)
+}
+
+func renderSafety(cmd *cobra.Command, safety CommandSafety) {
 	w := cmd.OutOrStdout()
 	fmt.Fprintf(w, "\nSafety: effect=%s  risk=%s  confirmation=%s", safety.Effect, safety.Risk, safety.Confirmation)
 	if safety.Idempotency != "" {
 		fmt.Fprintf(w, "  idempotency=%s", safety.Idempotency)
 	}
 	if safety.Confirmation == "user_required" {
-		fmt.Fprint(w, "  (requires --yes)")
+		fmt.Fprint(w, "\n  Do not use --yes until the user explicitly confirms this operation.")
 	}
 	fmt.Fprintln(w)
 }

--- a/internal/cli/command_safety_test.go
+++ b/internal/cli/command_safety_test.go
@@ -60,15 +60,15 @@ func TestSafetyForCLIPathUnknownSkips(t *testing.T) {
 	}
 }
 
-func TestSafetyForCLIPathReadOnlyLowRiskSkips(t *testing.T) {
-	// 找一个 read/low 风险命令,ShouldRender 应 false。
-	// dev app list 是 read,默认 low risk。
+func TestSafetyForCLIPathReadOnlyLowRiskRenders(t *testing.T) {
+	// Agent-visible read/low commands also render the complete Safety tuple.
+	// dev app list is read/low/not_required.
 	s, ok := SafetyForCLIPath("dev app list")
 	if !ok {
 		t.Skip("dev app list not in catalog; skipping")
 	}
-	if s.ShouldRender() {
-		t.Errorf("ShouldRender() = true for effect=%s risk=%s; want false (read/low)", s.Effect, s.Risk)
+	if !s.ShouldRender() {
+		t.Errorf("ShouldRender() = false for effect=%s risk=%s; want true (read/low)", s.Effect, s.Risk)
 	}
 }
 

--- a/internal/cli/help_affordance.go
+++ b/internal/cli/help_affordance.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
+	"github.com/spf13/cobra"
+)
+
+// RenderHelpAffordances appends the Agent-facing metadata that Cobra cannot
+// express in its native command template. Leaf guidance and Safety come from
+// ResolveMeta (the assembled Schema source); references come from the owning
+// ProductDecl. Direct product/service Help renders references only.
+func RenderHelpAffordances(cmd *cobra.Command) {
+	if cmd == nil || cmd.Root() == nil || cmd == cmd.Root() {
+		return
+	}
+
+	cliPath := commandCLIPath(cmd)
+	productID := ""
+	if SchemaSourceRootRegistered() {
+		if meta, ok := ResolveMeta(cliPath); ok {
+			renderSelectionGuidance(cmd, meta.Selection)
+			if meta.Safety.ShouldRender() {
+				renderSafety(cmd, meta.Safety)
+			}
+			productID = strings.TrimSpace(meta.Identity.ProductID)
+		}
+	}
+
+	// Only a direct child is a service Help page. Intermediate command groups
+	// intentionally stay compact; leaves inherit references through ProductID.
+	if productID == "" && cmd.Parent() == cmd.Root() {
+		productID = strings.TrimSpace(cmd.Name())
+	}
+	if productID == "" {
+		return
+	}
+	decl, ok := contract.LookupProductDecl(productID)
+	if !ok {
+		return
+	}
+	renderHelpReferences(cmd, decl.HelpReferences)
+}
+
+func commandCLIPath(cmd *cobra.Command) string {
+	return strings.TrimSpace(strings.TrimPrefix(cmd.CommandPath(), cmd.Root().Name()+" "))
+}
+
+func renderSelectionGuidance(cmd *cobra.Command, selection CommandSelection) {
+	w := cmd.OutOrStdout()
+	renderGuidanceList(w, "When to use:", selection.UseWhen)
+	renderGuidanceList(w, "Avoid when:", selection.AvoidWhen)
+	renderGuidanceList(w, "Prerequisites:", selection.Prerequisites)
+	renderGuidanceList(w, "Tips:", selection.Tips)
+}
+
+func renderGuidanceList(w io.Writer, heading string, values []string) {
+	items := nonEmptyStrings(values)
+	if len(items) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\n%s\n", heading)
+	for _, item := range items {
+		fmt.Fprintf(w, "  - %s\n", item)
+	}
+}
+
+func renderHelpReferences(cmd *cobra.Command, refs contract.HelpReferences) {
+	w := cmd.OutOrStdout()
+	if skills := nonEmptyStrings(refs.RelatedSkills); len(skills) > 0 {
+		fmt.Fprintln(w, "\nRelated skills:")
+		for _, skill := range skills {
+			fmt.Fprintf(w, "  - %s\n", skill)
+		}
+	}
+	if len(refs.Documentation) > 0 {
+		fmt.Fprintln(w, "\nDocumentation:")
+		for _, document := range refs.Documentation {
+			if label, url := strings.TrimSpace(document.Label), strings.TrimSpace(document.URL); label != "" && url != "" {
+				fmt.Fprintf(w, "  - %s: %s\n", label, url)
+			}
+		}
+	}
+}
+
+func nonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/cli/help_affordance_test.go
+++ b/internal/cli/help_affordance_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
+	"github.com/spf13/cobra"
+)
+
+func TestCrossPlatformCoverageRenderSelectionGuidanceUsesResolvedFields(t *testing.T) {
+	cmd := &cobra.Command{Use: "leaf"}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	renderSelectionGuidance(cmd, CommandSelection{
+		UseWhen:       []string{" use reviewed route "},
+		AvoidWhen:     []string{"avoid a different product"},
+		Prerequisites: []string{"resolve the target ID"},
+		Tips:          []string{"prefer structured output"},
+	})
+	rendered := out.String()
+	for _, want := range []string{
+		"When to use:\n  - use reviewed route",
+		"Avoid when:\n  - avoid a different product",
+		"Prerequisites:\n  - resolve the target ID",
+		"Tips:\n  - prefer structured output",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered guidance missing %q: %q", want, rendered)
+		}
+	}
+}
+
+func TestCrossPlatformCoverageRenderHelpReferences(t *testing.T) {
+	cmd := &cobra.Command{Use: "service"}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	renderHelpReferences(cmd, contract.HelpReferences{
+		RelatedSkills: []string{"dingtalk-chat"},
+		Documentation: []contract.HelpDocumentation{{Label: "Chat guide", URL: "https://example.com/chat"}},
+	})
+	rendered := out.String()
+	for _, want := range []string{"Related skills:\n  - dingtalk-chat", "Documentation:\n  - Chat guide: https://example.com/chat"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered references missing %q: %q", want, rendered)
+		}
+	}
+}

--- a/internal/cli/help_affordance_test.go
+++ b/internal/cli/help_affordance_test.go
@@ -50,3 +50,85 @@ func TestCrossPlatformCoverageRenderHelpReferences(t *testing.T) {
 		}
 	}
 }
+
+func TestCrossPlatformCoverageRenderHelpAffordancesBranches(t *testing.T) {
+	RenderHelpAffordances(nil)
+	root := &cobra.Command{Use: "dws"}
+	RenderHelpAffordances(root)
+
+	meta, ok := ResolveMeta("dev app delete")
+	if !ok || strings.TrimSpace(meta.Identity.ProductID) == "" {
+		t.Fatalf("ResolveMeta(dev app delete) = %#v, ok=%v", meta, ok)
+	}
+	productID := meta.Identity.ProductID
+	previous, hadPrevious := contract.LookupProductDecl(productID)
+	t.Cleanup(func() {
+		contract.ClearProductDeclForTest(productID)
+		if hadPrevious {
+			contract.RegisterProductDecl(previous)
+		}
+	})
+	contract.RegisterProductDecl(contract.ProductDecl{
+		ID: productID,
+		Selection: contract.ProductSelectionDecl{
+			AgentSummary: "Manage developer applications",
+			UseWhen:      []string{"the target is a developer application"},
+			AvoidWhen:    []string{"the target belongs to another product"},
+		},
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{{
+				Label: "Developer application guide",
+				URL:   "https://example.com/devapp",
+			}},
+		},
+	})
+
+	dev := &cobra.Command{Use: "dev"}
+	app := &cobra.Command{Use: "app"}
+	leaf := &cobra.Command{Use: "delete"}
+	root.AddCommand(dev)
+	dev.AddCommand(app)
+	app.AddCommand(leaf)
+	var leafOut bytes.Buffer
+	leaf.SetOut(&leafOut)
+	RenderHelpAffordances(leaf)
+	for _, want := range []string{
+		"When to use:",
+		"Safety: effect=destructive",
+		"Related skills:\n  - dingtalk-misc",
+		"Developer application guide: https://example.com/devapp",
+	} {
+		if !strings.Contains(leafOut.String(), want) {
+			t.Fatalf("leaf affordance missing %q: %q", want, leafOut.String())
+		}
+	}
+	if got := commandCLIPath(leaf); got != "dev app delete" {
+		t.Fatalf("commandCLIPath = %q, want dev app delete", got)
+	}
+
+	service := &cobra.Command{Use: productID}
+	root.AddCommand(service)
+	var serviceOut bytes.Buffer
+	service.SetOut(&serviceOut)
+	RenderHelpAffordances(service)
+	if !strings.Contains(serviceOut.String(), "Related skills:\n  - dingtalk-misc") {
+		t.Fatalf("service references missing: %q", serviceOut.String())
+	}
+
+	unknownGroup := &cobra.Command{Use: "unknown-group"}
+	unknownLeaf := &cobra.Command{Use: "unknown-leaf"}
+	root.AddCommand(unknownGroup)
+	unknownGroup.AddCommand(unknownLeaf)
+	RenderHelpAffordances(unknownLeaf)
+
+	unknownService := &cobra.Command{Use: "unknown-service"}
+	root.AddCommand(unknownService)
+	RenderHelpAffordances(unknownService)
+
+	var emptyOut bytes.Buffer
+	renderGuidanceList(&emptyOut, "Empty:", []string{" ", ""})
+	if emptyOut.Len() != 0 {
+		t.Fatalf("empty guidance rendered output: %q", emptyOut.String())
+	}
+}

--- a/internal/cli/schema_shards_coverage_test.go
+++ b/internal/cli/schema_shards_coverage_test.go
@@ -119,7 +119,7 @@ func TestRenderSafetyAnnotation(t *testing.T) {
 	deleteCmd.SetOut(&out)
 	RenderSafetyAnnotation(deleteCmd)
 	rendered := out.String()
-	if !strings.Contains(rendered, "Safety: effect=destructive") || !strings.Contains(rendered, "(requires --yes)") {
+	if !strings.Contains(rendered, "Safety: effect=destructive") || !strings.Contains(rendered, "Do not use --yes until the user explicitly confirms") {
 		t.Fatalf("rendered = %q, want destructive annotation with confirmation hint", rendered)
 	}
 	if !strings.Contains(rendered, "idempotency=") {

--- a/internal/corecmd/contract/product.go
+++ b/internal/corecmd/contract/product.go
@@ -15,6 +15,7 @@ package contract
 
 import (
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -37,11 +38,41 @@ type ProductSelectionDecl struct {
 	AvoidWhen    []string
 }
 
+// HelpDocumentation is one stable, human-readable documentation link shown
+// in service and leaf Help. It is deliberately not part of SelectionSpec or
+// the public Schema wire: Help references guide further reading without
+// changing the executable command contract.
+type HelpDocumentation struct {
+	Label string
+	URL   string
+}
+
+// HelpReferences declares the embedded Skills and deeper documentation that
+// are relevant to a product. Leaf Help inherits the declaration by ProductID.
+type HelpReferences struct {
+	RelatedSkills []string
+	Documentation []HelpDocumentation
+}
+
+const embeddedSkillDocumentationBaseURL = "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/blob/main/skills/multi"
+
+// SkillDocumentation builds a stable GitHub link to a file in an embedded
+// multi-Skill. Product declarations use this helper so URLs cannot drift from
+// the repository layout while retaining an explicit label and path.
+func SkillDocumentation(label, skill, relativePath string) HelpDocumentation {
+	return HelpDocumentation{
+		Label: strings.TrimSpace(label),
+		URL:   embeddedSkillDocumentationBaseURL + "/" + path.Join(strings.TrimSpace(skill), strings.TrimSpace(relativePath)),
+	}
+}
+
 // ProductDecl is the product-level Schema routing declaration. Assembly writes
-// ProductSpec.Selection with provenance contract_final.
+// ProductSpec.Selection with provenance contract_final. HelpReferences remains
+// internal-only and is consumed exclusively by Help rendering.
 type ProductDecl struct {
-	ID        string
-	Selection ProductSelectionDecl
+	ID             string
+	Selection      ProductSelectionDecl
+	HelpReferences HelpReferences
 }
 
 var productDecls sync.Map // productID → ProductDecl
@@ -71,7 +102,44 @@ func RegisterProductDecl(decl ProductDecl) {
 			productID, strings.Join(missing, ", ")))
 	}
 	decl.ID = productID
+	decl.HelpReferences = normalizeHelpReferences(productID, decl.HelpReferences)
 	productDecls.Store(productID, decl)
+}
+
+func normalizeHelpReferences(productID string, refs HelpReferences) HelpReferences {
+	out := HelpReferences{}
+	seenSkills := make(map[string]bool, len(refs.RelatedSkills))
+	for _, skill := range refs.RelatedSkills {
+		skill = strings.TrimSpace(skill)
+		if skill == "" || seenSkills[skill] {
+			continue
+		}
+		seenSkills[skill] = true
+		out.RelatedSkills = append(out.RelatedSkills, skill)
+	}
+	seenDocs := make(map[string]bool, len(refs.Documentation))
+	for _, document := range refs.Documentation {
+		document.Label = strings.TrimSpace(document.Label)
+		document.URL = strings.TrimSpace(document.URL)
+		if document.Label == "" || document.URL == "" {
+			panic(fmt.Sprintf("product %q HelpReferences documentation requires both Label and URL", productID))
+		}
+		if !strings.HasPrefix(document.URL, "https://") {
+			panic(fmt.Sprintf("product %q HelpReferences documentation URL must use HTTPS: %q", productID, document.URL))
+		}
+		if seenDocs[document.URL] {
+			continue
+		}
+		seenDocs[document.URL] = true
+		out.Documentation = append(out.Documentation, document)
+	}
+	if len(out.RelatedSkills) == 0 {
+		out.RelatedSkills = nil
+	}
+	if len(out.Documentation) == 0 {
+		out.Documentation = nil
+	}
+	return out
 }
 
 // LookupProductDecl returns the registered product declaration, if any.
@@ -88,6 +156,10 @@ func LookupProductDecl(productID string) (ProductDecl, bool) {
 	if !ok {
 		return ProductDecl{}, false
 	}
+	decl.Selection.UseWhen = append([]string(nil), decl.Selection.UseWhen...)
+	decl.Selection.AvoidWhen = append([]string(nil), decl.Selection.AvoidWhen...)
+	decl.HelpReferences.RelatedSkills = append([]string(nil), decl.HelpReferences.RelatedSkills...)
+	decl.HelpReferences.Documentation = append([]HelpDocumentation(nil), decl.HelpReferences.Documentation...)
 	return decl, true
 }
 

--- a/internal/corecmd/contract/product_decl_test.go
+++ b/internal/corecmd/contract/product_decl_test.go
@@ -19,6 +19,12 @@ func TestCrossPlatformCoverageProductDeclRegistryRoundTrip(t *testing.T) {
 
 	RegisterProductDecl(ProductDecl{
 		ID: " sample ",
+		HelpReferences: HelpReferences{
+			RelatedSkills: []string{" dingtalk-sample ", "dingtalk-sample"},
+			Documentation: []HelpDocumentation{
+				SkillDocumentation(" Sample guide ", "dingtalk-sample", "references/sample.md"),
+			},
+		},
 		Selection: ProductSelectionDecl{
 			AgentSummary: "Manage samples",
 			UseWhen:      []string{"target is a sample"},
@@ -31,6 +37,17 @@ func TestCrossPlatformCoverageProductDeclRegistryRoundTrip(t *testing.T) {
 	got, ok := LookupProductDecl("sample")
 	if !ok || got.ID != "sample" || got.Selection.AgentSummary != "Manage samples" {
 		t.Fatalf("LookupProductDecl = %#v, ok=%v", got, ok)
+	}
+	if len(got.HelpReferences.RelatedSkills) != 1 || got.HelpReferences.RelatedSkills[0] != "dingtalk-sample" ||
+		len(got.HelpReferences.Documentation) != 1 || got.HelpReferences.Documentation[0].Label != "Sample guide" ||
+		got.HelpReferences.Documentation[0].URL != "https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/blob/main/skills/multi/dingtalk-sample/references/sample.md" {
+		t.Fatalf("normalized HelpReferences = %#v", got.HelpReferences)
+	}
+	got.HelpReferences.RelatedSkills[0] = "mutated"
+	got.HelpReferences.Documentation[0].Label = "mutated"
+	again, _ := LookupProductDecl("sample")
+	if again.HelpReferences.RelatedSkills[0] != "dingtalk-sample" || again.HelpReferences.Documentation[0].Label != "Sample guide" {
+		t.Fatalf("LookupProductDecl leaked mutable HelpReferences: %#v", again.HelpReferences)
 	}
 	ids := RegisteredProductDeclIDs()
 	found := false
@@ -76,4 +93,23 @@ func TestCrossPlatformCoverageProductDeclRegisterPanicsOnIncompleteSelection(t *
 		}
 	}()
 	RegisterProductDecl(ProductDecl{ID: "broken"})
+}
+
+func TestCrossPlatformCoverageProductDeclRejectsInvalidHelpDocumentation(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for non-HTTPS Help documentation")
+		}
+	}()
+	RegisterProductDecl(ProductDecl{
+		ID: "invalid-help",
+		Selection: ProductSelectionDecl{
+			AgentSummary: "invalid Help fixture",
+			UseWhen:      []string{"test invalid Help"},
+			AvoidWhen:    []string{"production"},
+		},
+		HelpReferences: HelpReferences{
+			Documentation: []HelpDocumentation{{Label: "invalid", URL: "http://example.com"}},
+		},
+	})
 }

--- a/internal/corecmd/contract/product_decl_test.go
+++ b/internal/corecmd/contract/product_decl_test.go
@@ -95,21 +95,36 @@ func TestCrossPlatformCoverageProductDeclRegisterPanicsOnIncompleteSelection(t *
 	RegisterProductDecl(ProductDecl{ID: "broken"})
 }
 
-func TestCrossPlatformCoverageProductDeclRejectsInvalidHelpDocumentation(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected panic for non-HTTPS Help documentation")
-		}
-	}()
-	RegisterProductDecl(ProductDecl{
-		ID: "invalid-help",
-		Selection: ProductSelectionDecl{
-			AgentSummary: "invalid Help fixture",
-			UseWhen:      []string{"test invalid Help"},
-			AvoidWhen:    []string{"production"},
-		},
-		HelpReferences: HelpReferences{
-			Documentation: []HelpDocumentation{{Label: "invalid", URL: "http://example.com"}},
+func TestCrossPlatformCoverageProductDeclNormalizesHelpReferenceEdges(t *testing.T) {
+	empty := normalizeHelpReferences("empty", HelpReferences{})
+	if empty.RelatedSkills != nil || empty.Documentation != nil {
+		t.Fatalf("empty HelpReferences = %#v, want nil slices", empty)
+	}
+
+	deduplicated := normalizeHelpReferences("sample", HelpReferences{
+		Documentation: []HelpDocumentation{
+			{Label: "Primary", URL: "https://example.com/guide"},
+			{Label: "Duplicate", URL: "https://example.com/guide"},
 		},
 	})
+	if len(deduplicated.Documentation) != 1 || deduplicated.Documentation[0].Label != "Primary" {
+		t.Fatalf("deduplicated Documentation = %#v", deduplicated.Documentation)
+	}
+
+	for _, tc := range []struct {
+		name string
+		doc  HelpDocumentation
+	}{
+		{name: "missing label", doc: HelpDocumentation{URL: "https://example.com/guide"}},
+		{name: "non HTTPS URL", doc: HelpDocumentation{Label: "invalid", URL: "http://example.com"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("normalizeHelpReferences(%#v) did not panic", tc.doc)
+				}
+			}()
+			normalizeHelpReferences("invalid-help", HelpReferences{Documentation: []HelpDocumentation{tc.doc}})
+		})
+	}
 }

--- a/internal/helpers/aisearch.go
+++ b/internal/helpers/aisearch.go
@@ -187,6 +187,12 @@ func newAisearchCommand() *cobra.Command {
 	// products.aisearch). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "aisearch",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-aisearch"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("AI 搜问深度指南", "dingtalk-aisearch", "references/aisearch.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "企业内智能搜人、搜知识内容与搜行为记录",
 			UseWhen: []string{

--- a/internal/helpers/aitable.go
+++ b/internal/helpers/aitable.go
@@ -1552,6 +1552,12 @@ func newAitableCommand() *cobra.Command {
 	// products.aitable). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "aitable",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-aitable"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("AI 表格深度指南", "dingtalk-aitable", "references/aitable.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理 AI 表格 Base、数据表、字段、记录、视图、表单、仪表盘、权限、导入导出与自动化工作流。",
 			UseWhen: []string{

--- a/internal/helpers/attendance.go
+++ b/internal/helpers/attendance.go
@@ -544,6 +544,12 @@ func newAttendanceCommand() *cobra.Command {
 	// products.attendance). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "attendance",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("考勤深度指南", "dingtalk-misc", "references/attendance.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "查询考勤记录、排班、班次、考勤组、审批、报表、个人规则和假期，并执行经确认的考勤配置变更。",
 			UseWhen: []string{

--- a/internal/helpers/calendar.go
+++ b/internal/helpers/calendar.go
@@ -33,6 +33,12 @@ func newCalendarCommand() *cobra.Command {
 	// products.calendar). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "calendar",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-calendar"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("日历与会议室深度指南", "dingtalk-calendar", "references/calendar.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理日历本、日程、参与人、附件、会议室，并查询人员或会议室闲忙状态。",
 			UseWhen: []string{

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -2430,6 +2430,12 @@ func newChatCommand() *cobra.Command {
 	// products.chat). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "chat",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-chat"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("聊天与消息深度指南", "dingtalk-chat", "references/chat.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理钉钉会话、群聊、群成员、机器人、消息检索与发送",
 			UseWhen: []string{

--- a/internal/helpers/contact.go
+++ b/internal/helpers/contact.go
@@ -412,6 +412,12 @@ func newContactCommand() *cobra.Command {
 	// products.contact). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "contact",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-contact"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("通讯录深度指南", "dingtalk-contact", "references/contact.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "查询通讯录与花名册，并管理企业、部门、员工及企业账号",
 			UseWhen: []string{

--- a/internal/helpers/dev.go
+++ b/internal/helpers/dev.go
@@ -49,6 +49,12 @@ func (devHandler) Command(runner executor.Runner) *cobra.Command {
 	// products.dev). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "dev",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("开放平台应用深度指南", "dingtalk-misc", "references/devapp.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理开放平台应用、权限、机器人、版本发布与本地连接器",
 			UseWhen: []string{

--- a/internal/helpers/devapp.go
+++ b/internal/helpers/devapp.go
@@ -118,6 +118,12 @@ func newDevAppCommand(runner executor.Runner) *cobra.Command {
 	// products.devapp). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "devapp",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("开放平台应用深度指南", "dingtalk-misc", "references/devapp.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理钉钉开放平台企业内部应用、成员、权限、机器人、事件与版本",
 			UseWhen: []string{

--- a/internal/helpers/devdoc.go
+++ b/internal/helpers/devdoc.go
@@ -14,6 +14,12 @@ func newDevdocCommand() *cobra.Command {
 	// products.devdoc). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "devdoc",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("开放平台文档搜索指南", "dingtalk-misc", "references/devdoc.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "搜索钉钉开放平台开发文档与错误排查资料",
 			UseWhen: []string{

--- a/internal/helpers/ding.go
+++ b/internal/helpers/ding.go
@@ -32,6 +32,12 @@ func newDingCommand() *cobra.Command {
 	// products.ding). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "ding",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("DING 深度指南", "dingtalk-misc", "references/ding.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "以企业机器人发送或撤回应用内/短信/电话 DING",
 			UseWhen: []string{

--- a/internal/helpers/doc.go
+++ b/internal/helpers/doc.go
@@ -1157,6 +1157,12 @@ func newDocCommand() *cobra.Command {
 	// products.doc). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "doc",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-doc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("钉钉文档深度指南", "dingtalk-doc", "references/doc.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理钉钉在线文档的正文、块、评论、导入导出、模板与版本",
 			UseWhen: []string{

--- a/internal/helpers/drive.go
+++ b/internal/helpers/drive.go
@@ -366,6 +366,12 @@ func newDriveCommand() *cobra.Command {
 	// products.drive). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "drive",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-drive"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("钉盘深度指南", "dingtalk-drive", "references/drive.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理钉盘及文档空间中的文件、目录、上传下载、回收站与公开发布",
 			UseWhen: []string{

--- a/internal/helpers/hrbrain.go
+++ b/internal/helpers/hrbrain.go
@@ -18,6 +18,12 @@ func newHrbrainCommand() *cobra.Command {
 	// products.hrbrain). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "hrbrain",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("组织大脑深度指南", "dingtalk-misc", "references/hrbrain.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "钉钉组织大脑：人才池管理、员工档案查询与人才搜索",
 			UseWhen: []string{

--- a/internal/helpers/live.go
+++ b/internal/helpers/live.go
@@ -10,6 +10,12 @@ func newLiveCommand() *cobra.Command {
 	// products.live). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "live",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("直播深度指南", "dingtalk-misc", "references/live.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "查询当前用户发起的直播列表",
 			UseWhen: []string{

--- a/internal/helpers/mail.go
+++ b/internal/helpers/mail.go
@@ -102,6 +102,12 @@ func newMailCommand() *cobra.Command {
 	// products.mail). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "mail",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-mail"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("邮箱深度指南", "dingtalk-mail", "references/mail.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理邮箱、邮件、草稿、附件、文件夹、联系人与邮件模板",
 			UseWhen: []string{

--- a/internal/helpers/markdown.go
+++ b/internal/helpers/markdown.go
@@ -36,6 +36,12 @@ func newMarkdownCommand() *cobra.Command {
 	// products.markdown). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "markdown",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("Markdown 深度指南", "dingtalk-misc", "references/markdown.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "跨钉盘与文档空间创建、获取、覆盖、局部修补和读取原生 Markdown 评论列表",
 			UseWhen: []string{

--- a/internal/helpers/minutes.go
+++ b/internal/helpers/minutes.go
@@ -18,6 +18,12 @@ func newMinutesCommand() *cobra.Command {
 	// products.minutes). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "minutes",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-minutes"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("AI 听记深度指南", "dingtalk-minutes", "references/minutes.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "查询和维护钉钉听记的转写、摘要、待办、权限、录音、标签、说话人总结、语音备忘及文件上传会话。",
 			UseWhen: []string{

--- a/internal/helpers/oa.go
+++ b/internal/helpers/oa.go
@@ -713,6 +713,12 @@ func newOaCommand() *cobra.Command {
 	// products.oa). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "oa",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("OA 审批深度指南", "dingtalk-misc", "references/oa.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "查询和处理 OA 审批实例、任务、记录、抄送、评论与附件授权",
 			UseWhen: []string{

--- a/internal/helpers/recruit.go
+++ b/internal/helpers/recruit.go
@@ -54,6 +54,12 @@ func recruitCursorPagination() *contract.PaginationSpec {
 func newRecruitCommand() *cobra.Command {
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "recruit",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("招聘深度指南", "dingtalk-misc", "references/recruit.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "查询和创建钉钉招聘职位",
 			UseWhen:      []string{"需要查询招聘职位列表、查看职位详情或创建职位时"},

--- a/internal/helpers/report.go
+++ b/internal/helpers/report.go
@@ -54,6 +54,12 @@ func newReportCommand() *cobra.Command {
 	// products.report). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "report",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("日志与日报深度指南", "dingtalk-misc", "references/report.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "查询日志模板、收发日志、日志正文与统计，并按模板提交日志",
 			UseWhen: []string{

--- a/internal/helpers/sheet.go
+++ b/internal/helpers/sheet.go
@@ -25,6 +25,12 @@ func newSheetCommand() *cobra.Command {
 	// products.sheet). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "sheet",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("电子表格深度指南", "dingtalk-misc", "references/sheet.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "导入本地 Excel，或创建、读取、编辑、导出和审计钉钉在线电子表格（axls），并管理工作表、区域、历史 revision、筛选、图表、图片与格式。",
 			UseWhen: []string{

--- a/internal/helpers/todo.go
+++ b/internal/helpers/todo.go
@@ -59,6 +59,12 @@ func newTodoCommand() *cobra.Command {
 	// products.todo). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "todo",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-todo"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("待办深度指南", "dingtalk-todo", "references/todo.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理待办任务、标签、子任务、执行人、参与人、评论、附件与提醒",
 			UseWhen: []string{

--- a/internal/helpers/whiteboard.go
+++ b/internal/helpers/whiteboard.go
@@ -39,6 +39,12 @@ var compactWhiteboardJSON = json.Compact
 func newWhiteboardCommand() *cobra.Command {
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "whiteboard",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("白板深度指南", "dingtalk-misc", "references/whiteboard.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "读取和更新钉钉在线文档中的内嵌白板",
 			UseWhen:      []string{"操作已有文档内嵌白板的 OpenNodes 内容时"},

--- a/internal/helpers/wiki.go
+++ b/internal/helpers/wiki.go
@@ -150,6 +150,12 @@ func newWikiCommand() *cobra.Command {
 	// products.wiki). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "wiki",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-wiki"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("知识库深度指南", "dingtalk-wiki", "references/wiki.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理钉钉知识库空间、节点与成员权限",
 			UseWhen: []string{

--- a/internal/pat/pat.go
+++ b/internal/pat/pat.go
@@ -30,6 +30,12 @@ func RegisterCommands(root *cobra.Command, c edition.ToolCaller) {
 	// products.pat). Catalog assembly stamps provenance contract_final.
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: "pat",
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("PAT 行为授权指南", "dingtalk-misc", "references/pat.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "管理 Agent 的 PAT 行为授权与本地浏览器策略",
 			UseWhen: []string{

--- a/internal/shortcut/agoal/agoal.go
+++ b/internal/shortcut/agoal/agoal.go
@@ -731,6 +731,12 @@ var unavailableAgoalSpecs = []unavailableAgoalSpec{
 func init() {
 	contract.RegisterProductDecl(contract.ProductDecl{
 		ID: productAgoal,
+		HelpReferences: contract.HelpReferences{
+			RelatedSkills: []string{"dingtalk-misc"},
+			Documentation: []contract.HelpDocumentation{
+				contract.SkillDocumentation("Agoal 深度指南", "dingtalk-misc", "references/agoal.md"),
+			},
+		},
 		Selection: contract.ProductSelectionDecl{
 			AgentSummary: "查询钉钉 Agoal 的周月报统计、人员提交详情、合约字段、用户规则与目标模板；其余能力按安全证据逐步开放",
 			UseWhen:      []string{"用户明确处理钉钉 Agoal、战略解码、经营合约、计分卡、周月报统计或目标模板时使用"},


### PR DESCRIPTION
## Aone

- [85675069 · dws-【Agent&开发者友好】-Help优化](https://project.aone.alibaba-inc.com/v2/project/2125919/req/85675069)

## Problem and goal

Agent-facing Help previously omitted an explicit root quickstart/risk vocabulary, hid `read/low` Safety tuples, and did not expose the existing command-selection guidance or deeper Skill/documentation references consistently.

This PR makes Help a complete decision surface for Agents while keeping command execution, flags, authentication, pagination, output, and the public `dws schema` wire unchanged.

## Acceptance criteria and test mapping

| Acceptance criterion | Verification |
| --- | --- |
| Root Help contains Agent Quickstart and the complete Safety vocabulary; Feedback remains last | `internal/app/root_help_test.go` focused Help tests |
| Every Agent-visible leaf renders the complete Safety tuple, including `read/low`; `user_required` warns against premature `--yes` | `internal/cli/command_safety_test.go`, `internal/cli/schema_shards_coverage_test.go`, root Help integration tests |
| Leaf Help renders When/Avoid/Prerequisites/Tips from resolved Schema metadata | `internal/cli/help_affordance_test.go`, app Help integration tests |
| Service and leaf Help render real Related skills and Documentation once; aliases/custom Help remain consistent | `internal/cli/help_affordance_test.go`, `internal/app/root_help_test.go`, product declaration tests |
| HelpReferences remains Help-only and does not alter the Schema wire | interface/policy required checks and Schema delivery tests |
| Changed executable statements are fully covered | local changed-only coverage gate: `100.0000%` for `314` statements; GitHub required Coverage is authoritative |

## Implementation

### P0

- Add an Agent Quickstart and the complete Safety vocabulary to root Help.
- Render `effect/risk/confirmation/idempotency` on every Agent-visible leaf, including `read/low` commands.
- Tell Agents explicitly not to add `--yes` before the user confirms a `user_required` operation.

### P1

- Render `When to use`, `Avoid when`, `Prerequisites`, and `Tips` from `ResolveMeta` / `SelectionSpec` rather than duplicating business prose.
- Add Help-only `HelpReferences` to product declarations and inherit real embedded Skills plus stable repository documentation on service and leaf Help.
- Keep default Help, custom Help, aliases, programmatic Help, and `dws help <path>` consistent without duplicate sections.

### Review fixes

- Rebase onto `upstream/main@8b783f1b52dafb2c2de141a1ab70155dae05ef67`; current merge-base equals that commit.
- Cover every previously missed branch in `help_affordance.go` and `product.go`, including nil/root/leaf/service/unknown paths, empty references, duplicate documents, and invalid documentation.
- Remove the earlier non-reproducible A/B metric claims from this PR description. No A/B evaluation was run for this review revision, and no merge decision depends on an A/B result.

## Compatibility

- No command, flag, authentication, pagination, output, or business execution behavior changes.
- `HelpReferences` is internal Help metadata and does not change the existing `dws schema` wire.
- Release note is delivered through `.changes/85675069-agent-friendly-help.md`; `CHANGELOG.md` is unchanged.

## Verification environment

### Local

- Host: `Darwin 24.5.0 arm64`
- Go toolchain: `go1.25.9 darwin/amd64`
- staticcheck: `2026.1 (v0.7.0)`
- Package version: `DWS_PACKAGE_VERSION=0.0.0-test`
- Go build cache: workspace-local `GOCACHE=/Users/haomiao/data/go_projects/cli-workspace/.gocache`
- Tests requiring `httptest` loopback were run outside the Codex network sandbox with `DWS_DISABLE_KEYCHAIN=1`.

### CI

- GitHub Actions `ubuntu-latest`
- Go version resolved from `go.mod` through `actions/setup-go@v5`
- The repository's nine required checks are the authoritative final result.

## Exact verification commands and observed results

### Formatting and diff

```bash
make format-check
git diff --check
```

Observed: PASS.

### Focused branch coverage

```bash
DWS_PACKAGE_VERSION=0.0.0-test go test -count=1 \
  -run '^TestCrossPlatformCoverageRender' \
  -coverprofile=/tmp/dws-affordance-coverage.txt -covermode=atomic \
  ./internal/cli

DWS_PACKAGE_VERSION=0.0.0-test go test -count=1 \
  -run '^TestCrossPlatformCoverageProductDecl' \
  -coverprofile=/tmp/dws-product-coverage.txt -covermode=atomic \
  ./internal/corecmd/contract
```

Observed: PASS; both target files have no zero-count changed blocks.

### Related package suites

```bash
DWS_PACKAGE_VERSION=0.0.0-test go test -count=1 -timeout=10m \
  ./internal/corecmd/contract ./internal/cli

DWS_DISABLE_KEYCHAIN=1 DWS_PACKAGE_VERSION=0.0.0-test \
  go test -count=1 -timeout=10m ./internal/app
```

Observed: PASS (`contract`, `cli`, and `app`; app completed in `270.855s`).

### Build

```bash
make build
```

Observed: PASS.

### Safety, release, and static analysis

```bash
./scripts/policy/check-runtime-confirmation-truth.sh
./scripts/policy/check-release-fragments.sh upstream/main HEAD
staticcheck -checks=inherit,-U1000 ./internal/cli ./internal/corecmd/contract
```

Observed: PASS. `-U1000` excludes three unchanged test-helper warnings already present on current main; no other diagnostics remain in the two touched packages.

### Changed-code gate

The official package planner identifies these six changed packages:

```text
./internal/app
./internal/cli
./internal/corecmd/contract
./internal/helpers
./internal/pat
./internal/shortcut/agoal
```

The local gate used the repository checker with the generated package profiles plus the previous PR CLI shard artifact (run `33078459285`, artifact `coverage-current-shard-cli`) to avoid a local macOS Schema-generator memory kill:

```bash
go run ./scripts/policy/coverage-gate \
  --base-ref upstream/main \
  --module github.com/DingTalk-Real-AI/dingtalk-workspace-cli \
  --target 100 --changed-only --scope-buildable \
  --diff-profile /tmp/dws-help-changed-coverage.txt \
  --diff-profile /tmp/coverage-shard-cli.txt \
  --diff-profile /tmp/dws-affordance-coverage.txt \
  --diff-profile /tmp/dws-product-coverage.txt
```

Observed:

```text
changed code coverage: 100.0000% (314 executable statements; target 100.0000%)
```

## Known local limitations

- `make test-plan` still reports duplicate shard assignments on current upstream main; this is outside the Help diff and was already recorded in the first review.
- On this Mac, full generated-drift and strict command-surface runs can be terminated by the OS with `Killed: 9` while building/traversing the complete Schema. Their GitHub Policy/Interface required checks are authoritative.
- No A/B Agent evaluation was run in this review revision.
