### PR TITLE
fix(drive): harden shortcut pagination and verification

### DIFF
--- a/.changes/drive-shortcut-pagination-verification.md
+++ b/.changes/drive-shortcut-pagination-verification.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Drive shortcut verification** — adds bounded automatic pagination for list, search, and recent results, rejects metadata-only statistics, and preserves committed resource evidence when create or upload read-back names differ.

--- a/.changes/drive-shortcut-pagination-verification.md
+++ b/.changes/drive-shortcut-pagination-verification.md
@@ -2,4 +2,4 @@
 category: Fixed
 ---
 
-- **Drive shortcut verification** — adds bounded automatic pagination for list, search, and recent results, rejects metadata-only statistics, and preserves committed resource evidence when create or upload read-back names differ.
+- **Drive shortcut verification** — adds bounded automatic pagination for list, search, and recent results, preserves existing data fields alongside unified pagination metadata, identifies pagination failures by their actual operation, rejects metadata-only statistics, and preserves committed resource evidence when create or upload read-back names differ.

--- a/internal/app/param_alias_e2e_test.go
+++ b/internal/app/param_alias_e2e_test.go
@@ -162,8 +162,10 @@ func (c *paramAliasCaptureCaller) paramAliasResponseForTool(tool string) string 
 		}
 		encoded, _ := json.Marshal(map[string]any{"success": true, "result": map[string]any{"fileId": "node-1", "name": name}})
 		return string(encoded)
-	case "get_cover", "get_node_stats":
+	case "get_cover":
 		return `{"success":true,"result":{"nodeId":"node-1"}}`
+	case "get_node_stats":
+		return `{"success":true,"result":{"nodeId":"node-1","views":1}}`
 	case "get_file_publish_status":
 		return `{"success":true,"result":{"fileId":"node-1","published":false}}`
 	case "create_folder", "create_shortcut":

--- a/internal/shortcut/drive/catalog_operations.go
+++ b/internal/shortcut/drive/catalog_operations.go
@@ -494,7 +494,15 @@ var Upload = shortcut.Shortcut{
 			return driveResponseError("drive/commit_upload", "readback_id_mismatch", fmt.Sprintf("上传后读回文件 ID %q 与提交 ID %q 不一致", remoteID, nodeID))
 		}
 		if remoteName := firstString(verified, "name", "fileName"); !driveReadbackNameMatches(verified, name) {
-			return driveResponseError("drive/commit_upload", "readback_mismatch", fmt.Sprintf("上传后读回名称 %q 与请求 %q 不一致", remoteName, name))
+			return driveCommittedWriteMismatch(
+				"drive/commit_upload",
+				"readback_mismatch",
+				fmt.Sprintf("上传后读回名称 %q 与请求 %q 不一致", remoteName, name),
+				nodeID,
+				name,
+				remoteName,
+				verified,
+			)
 		}
 		remoteSize, ok := firstInt64(verified, "fileSize", "size", "byteSize", "length")
 		if !ok {

--- a/internal/shortcut/drive/common.go
+++ b/internal/shortcut/drive/common.go
@@ -60,7 +60,7 @@ func driveCollectionResult(collection, description string) *contract.ResultSpec 
 	return &contract.ResultSpec{
 		Outcomes: []contract.ResultOutcome{contract.ResultOutcomeSuccess},
 		DataSchema: json.RawMessage(fmt.Sprintf(
-			`{"type":"object","description":%q,"properties":{"count":{"type":"integer","description":"本页有效结果数量"},%q:{"type":"array","description":%q,"items":{"type":"object","description":"Drive 资源条目","additionalProperties":true}},"nextCursor":{"type":"string","description":"下一页游标"},"hasMore":{"type":"boolean","description":"服务端是否仍有下一页"}},"required":["count",%q],"additionalProperties":true}`,
+			`{"type":"object","description":%q,"properties":{"count":{"type":"integer","description":"本次返回的有效结果数量"},%q:{"type":"array","description":%q,"items":{"type":"object","description":"Drive 资源条目","additionalProperties":true}},"pagesRead":{"type":"integer","description":"本次实际读取页数"},"complete":{"type":"boolean","description":"是否已经读取到服务端末页"},"truncated":{"type":"boolean","description":"是否因 max-pages 或 max-items 上限提前停止"},"stopReason":{"type":"string","description":"提前停止或分页不可证明的原因"},"nextCursor":{"type":"string","description":"下一页游标"},"hasMore":{"type":"boolean","description":"服务端是否仍有下一页"}},"required":["count",%q,"pagesRead","complete","truncated"],"additionalProperties":true}`,
 			description, collection, description, collection,
 		)),
 	}
@@ -119,6 +119,35 @@ func requireDriveObject(data map[string]any, operation string) (map[string]any, 
 		return nil, driveResponseError(operation, "missing_business_result", "响应没有可验证的业务对象")
 	}
 	return data, nil
+}
+
+func requireDriveStats(data map[string]any, operation string) (map[string]any, error) {
+	stats, err := requireDriveObject(data, operation)
+	if err != nil {
+		return nil, err
+	}
+	if hasDriveStatMeasure(stats) {
+		return stats, nil
+	}
+	return nil, driveResponseError(operation, "missing_stats_measures", "统计响应没有任何可验证的统计数值")
+}
+
+func hasDriveStatMeasure(data map[string]any) bool {
+	measureKeys := []string{
+		"views", "viewCount", "visitCount", "visitorCount", "viewerCount",
+		"readCount", "readerCount", "readUserCount", "uniqueViewCount",
+		"editCount", "editorCount", "commentCount", "likeCount",
+		"previewCount", "downloadCount",
+	}
+	if _, ok := firstInt64(data, measureKeys...); ok {
+		return true
+	}
+	for _, wrapper := range []string{"stats", "statistics", "result", "data"} {
+		if nested, ok := data[wrapper].(map[string]any); ok && hasDriveStatMeasure(nested) {
+			return true
+		}
+	}
+	return false
 }
 
 func requireDriveWrite(data map[string]any, operation string) (map[string]any, error) {
@@ -271,5 +300,26 @@ func driveResponseErrorWithDetails(operation, reason, message string, details ma
 		apperrors.WithRetryable(false),
 		apperrors.WithReason(reason),
 		apperrors.WithDetails(details),
+	)
+}
+
+func driveCommittedWriteMismatch(operation, reason, message, nodeID, requestedName, actualName string, resource map[string]any) error {
+	return apperrors.NewAPI(message,
+		apperrors.WithOperation(operation),
+		apperrors.WithOrigin("mcp"),
+		apperrors.WithFailureStage("readback_verification"),
+		apperrors.WithExecutionStarted(true),
+		apperrors.WithRetryable(false),
+		apperrors.WithReason(reason),
+		apperrors.WithHint("远端写入已经提交；请根据 error.details 核对或修正资源，禁止盲目重试创建或上传"),
+		apperrors.WithDetails(map[string]any{
+			"status":        "partial_success",
+			"complete":      false,
+			"retrySafe":     false,
+			"nodeId":        nodeID,
+			"requestedName": requestedName,
+			"actualName":    actualName,
+			"resource":      resource,
+		}),
 	)
 }

--- a/internal/shortcut/drive/common.go
+++ b/internal/shortcut/drive/common.go
@@ -60,7 +60,7 @@ func driveCollectionResult(collection, description string) *contract.ResultSpec 
 	return &contract.ResultSpec{
 		Outcomes: []contract.ResultOutcome{contract.ResultOutcomeSuccess},
 		DataSchema: json.RawMessage(fmt.Sprintf(
-			`{"type":"object","description":%q,"properties":{"count":{"type":"integer","description":"本次返回的有效结果数量"},%q:{"type":"array","description":%q,"items":{"type":"object","description":"Drive 资源条目","additionalProperties":true}},"pagesRead":{"type":"integer","description":"本次实际读取页数"},"complete":{"type":"boolean","description":"是否已经读取到服务端末页"},"truncated":{"type":"boolean","description":"是否因 max-pages 或 max-items 上限提前停止"},"stopReason":{"type":"string","description":"提前停止或分页不可证明的原因"},"nextCursor":{"type":"string","description":"下一页游标"},"hasMore":{"type":"boolean","description":"服务端是否仍有下一页"}},"required":["count",%q,"pagesRead","complete","truncated"],"additionalProperties":true}`,
+			`{"type":"object","description":%q,"properties":{%q:{"type":"array","description":%q,"items":{"type":"object","description":"Drive 资源条目","additionalProperties":true}}},"required":[%q],"additionalProperties":false}`,
 			description, collection, description, collection,
 		)),
 	}

--- a/internal/shortcut/drive/common.go
+++ b/internal/shortcut/drive/common.go
@@ -60,7 +60,7 @@ func driveCollectionResult(collection, description string) *contract.ResultSpec 
 	return &contract.ResultSpec{
 		Outcomes: []contract.ResultOutcome{contract.ResultOutcomeSuccess},
 		DataSchema: json.RawMessage(fmt.Sprintf(
-			`{"type":"object","description":%q,"properties":{%q:{"type":"array","description":%q,"items":{"type":"object","description":"Drive 资源条目","additionalProperties":true}}},"required":[%q],"additionalProperties":false}`,
+			`{"type":"object","description":%q,"properties":{"count":{"type":"integer","description":"本次有效结果数量"},%q:{"type":"array","description":%q,"items":{"type":"object","description":"Drive 资源条目","additionalProperties":true}},"nextCursor":{"type":"string","description":"下一页游标"},"hasMore":{"type":"boolean","description":"服务端是否仍有下一页"}},"required":["count",%q],"additionalProperties":true}`,
 			description, collection, description, collection,
 		)),
 	}

--- a/internal/shortcut/drive/drive.go
+++ b/internal/shortcut/drive/drive.go
@@ -58,9 +58,9 @@ var List = shortcut.Shortcut{
 		{Name: "folder", Type: shortcut.FlagString, Desc: "父节点 ID (dentryUuid)，不传则列出空间根目录"},
 		{Name: "limit", Type: shortcut.FlagInt, Default: "20", Desc: "每页返回数量 (默认 20，最大 50)"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标，首次不传"},
-		{Name: "page-all", Type: shortcut.FlagBool, Desc: "自动连续读取后续页，默认只读一页"},
-		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "自动翻页最多读取页数"},
-		{Name: "max-items", Type: shortcut.FlagInt, Default: "500", Desc: "自动翻页最多累计条目数"},
+		{Name: "page-all", Type: shortcut.FlagBool, Desc: "有界读取全部后续页；--max-pages/--max-items 仅在 --page-all 时生效且必须大于 0"},
+		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "--page-all 最多读取页数，必须大于 0"},
+		{Name: "max-items", Type: shortcut.FlagInt, Default: "500", Desc: "--page-all 最多累计条目数，必须大于 0"},
 		{Name: "order-by", Type: shortcut.FlagString, Desc: "排序字段: createTime|modifyTime|name"},
 		{Name: "order", Type: shortcut.FlagString, Desc: "排序方向: asc|desc (默认 desc)"},
 		{Name: "thumbnail", Type: shortcut.FlagBool, Desc: "是否返回缩略图信息"},
@@ -69,6 +69,8 @@ var List = shortcut.Shortcut{
 		`dws drive +list --limit 20`,
 		`dws drive +list --folder <dentryUuid> --order-by name --order asc`,
 	},
+	Validate:    validateDriveAutoPagination,
+	Constraints: driveAutoPaginationConstraints(),
 	Execute: func(rt *shortcut.RuntimeContext) error {
 		params := map[string]any{}
 		if rt.Changed("space-id") {
@@ -111,7 +113,7 @@ var List = shortcut.Shortcut{
 		if err != nil {
 			return err
 		}
-		return rt.Output(out)
+		return outputDrivePageResult(rt, out)
 	},
 }
 
@@ -279,14 +281,16 @@ var Search = shortcut.Shortcut{
 		{Name: "modified-to", Type: shortcut.FlagInt, Desc: "修改时间截止 (毫秒时间戳，含)"},
 		{Name: "limit", Type: shortcut.FlagInt, Desc: "每页返回数量 (默认 10，最大 30)"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标，从上次返回的 nextCursor 获取"},
-		{Name: "page-all", Type: shortcut.FlagBool, Desc: "自动连续读取后续页，默认只读一页"},
-		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "自动翻页最多读取页数"},
-		{Name: "max-items", Type: shortcut.FlagInt, Default: "500", Desc: "自动翻页最多累计条目数"},
+		{Name: "page-all", Type: shortcut.FlagBool, Desc: "有界读取全部后续页；--max-pages/--max-items 仅在 --page-all 时生效且必须大于 0"},
+		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "--page-all 最多读取页数，必须大于 0"},
+		{Name: "max-items", Type: shortcut.FlagInt, Default: "500", Desc: "--page-all 最多累计条目数，必须大于 0"},
 	},
 	Tips: []string{
 		`dws drive +search --query "季度汇报"`,
 		`dws drive +search --query "合同" --target file --extensions pdf,docx`,
 	},
+	Validate:    validateDriveAutoPagination,
+	Constraints: driveAutoPaginationConstraints(),
 	Execute: func(rt *shortcut.RuntimeContext) error {
 		params := map[string]any{"keyword": rt.Str("query")}
 		if rt.Changed("target") {
@@ -339,7 +343,7 @@ var Search = shortcut.Shortcut{
 		if err != nil {
 			return err
 		}
-		return rt.Output(out)
+		return outputDrivePageResult(rt, out)
 	},
 }
 
@@ -635,14 +639,16 @@ var Recent = shortcut.Shortcut{
 		{Name: "creator-type", Type: shortcut.FlagInt, Desc: "创建人过滤: 0=全部, 1=我创建, 2=他人创建"},
 		{Name: "limit", Type: shortcut.FlagInt, Desc: "每页数量 (默认 20，最大 20)"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标 (从上次结果的 nextCursor 获取)"},
-		{Name: "page-all", Type: shortcut.FlagBool, Desc: "自动连续读取后续页，默认只读一页"},
-		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "自动翻页最多读取页数"},
-		{Name: "max-items", Type: shortcut.FlagInt, Default: "500", Desc: "自动翻页最多累计条目数"},
+		{Name: "page-all", Type: shortcut.FlagBool, Desc: "有界读取全部后续页；--max-pages/--max-items 仅在 --page-all 时生效且必须大于 0"},
+		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "--page-all 最多读取页数，必须大于 0"},
+		{Name: "max-items", Type: shortcut.FlagInt, Default: "500", Desc: "--page-all 最多累计条目数，必须大于 0"},
 	},
 	Tips: []string{
 		`dws drive +recent`,
 		`dws drive +recent --operate-type 1 --creator-type 1`,
 	},
+	Validate:    validateDriveAutoPagination,
+	Constraints: driveAutoPaginationConstraints(),
 	Execute: func(rt *shortcut.RuntimeContext) error {
 		params := map[string]any{}
 		if rt.Changed("operate-type") {
@@ -679,7 +685,7 @@ var Recent = shortcut.Shortcut{
 		if err != nil {
 			return err
 		}
-		return rt.Output(out)
+		return outputDrivePageResult(rt, out)
 	},
 }
 

--- a/internal/shortcut/drive/drive.go
+++ b/internal/shortcut/drive/drive.go
@@ -58,6 +58,9 @@ var List = shortcut.Shortcut{
 		{Name: "folder", Type: shortcut.FlagString, Desc: "父节点 ID (dentryUuid)，不传则列出空间根目录"},
 		{Name: "limit", Type: shortcut.FlagInt, Default: "20", Desc: "每页返回数量 (默认 20，最大 50)"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标，首次不传"},
+		{Name: "page-all", Type: shortcut.FlagBool, Desc: "自动连续读取后续页，默认只读一页"},
+		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "自动翻页最多读取页数"},
+		{Name: "max-items", Type: shortcut.FlagInt, Default: "500", Desc: "自动翻页最多累计条目数"},
 		{Name: "order-by", Type: shortcut.FlagString, Desc: "排序字段: createTime|modifyTime|name"},
 		{Name: "order", Type: shortcut.FlagString, Desc: "排序方向: asc|desc (默认 desc)"},
 		{Name: "thumbnail", Type: shortcut.FlagBool, Desc: "是否返回缩略图信息"},
@@ -67,15 +70,12 @@ var List = shortcut.Shortcut{
 		`dws drive +list --folder <dentryUuid> --order-by name --order asc`,
 	},
 	Execute: func(rt *shortcut.RuntimeContext) error {
-		params := map[string]any{"maxResults": rt.Int("limit")}
+		params := map[string]any{}
 		if rt.Changed("space-id") {
 			params["spaceId"] = rt.Str("space-id")
 		}
 		if rt.Changed("folder") {
 			params["parentId"] = rt.Str("folder")
-		}
-		if rt.Changed("cursor") {
-			params["nextToken"] = rt.Str("cursor")
 		}
 		if rt.Changed("order-by") {
 			params["orderBy"] = rt.Str("order-by")
@@ -86,23 +86,31 @@ var List = shortcut.Shortcut{
 		if rt.Bool("thumbnail") {
 			params["withThumbnail"] = true
 		}
-		data, err := rt.CallMCPData("drive", "list_files", params)
-		if err != nil {
-			return err
-		}
-		items, page, err := requireDriveCollection(data, "drive/list_files", "items", "files", "dentries", "entries", "nodes", "list")
-		if err != nil {
-			return err
-		}
-		files := projectDriveRows(items, map[string][]string{
-			"name":     {"name", "fileName", "dentryName", "title"},
-			"type":     {"type", "dentryType", "fileType", "spaceType"},
-			"nodeId":   {"fileId", "dentryUuid", "nodeId", "id"},
-			"dentryId": {"dentryId"},
-			"fileSize": {"fileSize", "size", "byteSize", "length"},
+		out, err := collectDrivePages(rt, params, drivePageOptions{
+			PageAll:        rt.Bool("page-all"),
+			PageSize:       rt.Int("limit"),
+			MaxPages:       rt.Int("max-pages"),
+			MaxItems:       rt.Int("max-items"),
+			Cursor:         rt.Str("cursor"),
+			Server:         "drive",
+			Tool:           "list_files",
+			OutputKey:      "files",
+			PageSizeParam:  "maxResults",
+			CursorParam:    "nextToken",
+			CollectionKeys: []string{"items", "files", "dentries", "entries", "nodes", "list"},
+			Project: func(items []any) []map[string]any {
+				return projectDriveRows(items, map[string][]string{
+					"name":     {"name", "fileName", "dentryName", "title"},
+					"type":     {"type", "dentryType", "fileType", "spaceType"},
+					"nodeId":   {"fileId", "dentryUuid", "nodeId", "id"},
+					"dentryId": {"dentryId"},
+					"fileSize": {"fileSize", "size", "byteSize", "length"},
+				})
+			},
 		})
-		out := map[string]any{"count": len(files), "files": files}
-		addDrivePagination(out, page)
+		if err != nil {
+			return err
+		}
 		return rt.Output(out)
 	},
 }
@@ -269,8 +277,11 @@ var Search = shortcut.Shortcut{
 		{Name: "created-to", Type: shortcut.FlagInt, Desc: "创建时间截止 (毫秒时间戳，含)"},
 		{Name: "modified-from", Type: shortcut.FlagInt, Desc: "修改时间起始 (毫秒时间戳，含)"},
 		{Name: "modified-to", Type: shortcut.FlagInt, Desc: "修改时间截止 (毫秒时间戳，含)"},
-		{Name: "limit", Type: shortcut.FlagInt, Desc: "每页返回数量 (默认 10，最大 30)"},
+		{Name: "limit", Type: shortcut.FlagInt, Default: "10", Desc: "每页返回数量 (默认 10，最大 30)"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标，从上次返回的 nextCursor 获取"},
+		{Name: "page-all", Type: shortcut.FlagBool, Desc: "自动连续读取后续页，默认只读一页"},
+		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "自动翻页最多读取页数"},
+		{Name: "max-items", Type: shortcut.FlagInt, Default: "500", Desc: "自动翻页最多累计条目数"},
 	},
 	Tips: []string{
 		`dws drive +search --query "季度汇报"`,
@@ -302,30 +313,32 @@ var Search = shortcut.Shortcut{
 		if rt.Changed("modified-to") {
 			params["modifiedTimeTo"] = rt.Int("modified-to")
 		}
-		if rt.Changed("limit") {
-			params["pageSize"] = rt.Int("limit")
-		}
-		if rt.Changed("cursor") {
-			params["pageToken"] = rt.Str("cursor")
-		}
-		data, err := rt.CallMCPData("drive", "search_files", params)
-		if err != nil {
-			return err
-		}
-		items, page, err := requireDriveCollection(data, "drive/search_files", "items", "files", "dentries", "entries", "nodes", "list")
-		if err != nil {
-			return err
-		}
-		files := projectDriveRows(items, map[string][]string{
-			"name":      {"name", "fileName", "dentryName", "title"},
-			"type":      {"type", "dentryType", "fileType", "spaceType"},
-			"nodeId":    {"fileId", "dentryUuid", "nodeId", "id"},
-			"dentryId":  {"dentryId"},
-			"fileSize":  {"fileSize", "size", "byteSize", "length"},
-			"creatorId": {"creatorId", "creatorUserId", "creator", "creatorUid"},
+		out, err := collectDrivePages(rt, params, drivePageOptions{
+			PageAll:        rt.Bool("page-all"),
+			PageSize:       rt.Int("limit"),
+			MaxPages:       rt.Int("max-pages"),
+			MaxItems:       rt.Int("max-items"),
+			Cursor:         rt.Str("cursor"),
+			Server:         "drive",
+			Tool:           "search_files",
+			OutputKey:      "files",
+			PageSizeParam:  "pageSize",
+			CursorParam:    "pageToken",
+			CollectionKeys: []string{"items", "files", "dentries", "entries", "nodes", "list"},
+			Project: func(items []any) []map[string]any {
+				return projectDriveRows(items, map[string][]string{
+					"name":      {"name", "fileName", "dentryName", "title"},
+					"type":      {"type", "dentryType", "fileType", "spaceType"},
+					"nodeId":    {"fileId", "dentryUuid", "nodeId", "id"},
+					"dentryId":  {"dentryId"},
+					"fileSize":  {"fileSize", "size", "byteSize", "length"},
+					"creatorId": {"creatorId", "creatorUserId", "creator", "creatorUid"},
+				})
+			},
 		})
-		out := map[string]any{"count": len(files), "files": files}
-		addDrivePagination(out, page)
+		if err != nil {
+			return err
+		}
 		return rt.Output(out)
 	},
 }
@@ -620,8 +633,11 @@ var Recent = shortcut.Shortcut{
 	Flags: []shortcut.Flag{
 		{Name: "operate-type", Type: shortcut.FlagInt, Desc: "操作类型: 0=最近访问(默认), 1=最近编辑"},
 		{Name: "creator-type", Type: shortcut.FlagInt, Desc: "创建人过滤: 0=全部, 1=我创建, 2=他人创建"},
-		{Name: "limit", Type: shortcut.FlagInt, Desc: "每页数量 (默认 20，最大 20)"},
+		{Name: "limit", Type: shortcut.FlagInt, Default: "20", Desc: "每页数量 (默认 20，最大 20)"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标 (从上次结果的 nextCursor 获取)"},
+		{Name: "page-all", Type: shortcut.FlagBool, Desc: "自动连续读取后续页，默认只读一页"},
+		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "自动翻页最多读取页数"},
+		{Name: "max-items", Type: shortcut.FlagInt, Default: "500", Desc: "自动翻页最多累计条目数"},
 	},
 	Tips: []string{
 		`dws drive +recent`,
@@ -635,32 +651,34 @@ var Recent = shortcut.Shortcut{
 		if rt.Changed("creator-type") {
 			params["creatorType"] = rt.Int("creator-type")
 		}
-		if rt.Changed("limit") {
-			params["maxResults"] = rt.Int("limit")
-		}
-		if rt.Changed("cursor") {
-			params["nextToken"] = rt.Str("cursor")
-		}
 		// Project the verbose raw response (logId + per-item giant docUrl noise)
 		// down to a clean {count, items:[…], nextCursor, hasMore}.
-		data, err := rt.CallMCPData("doc", "get_recent_list", params)
-		if err != nil {
-			return err
-		}
-		items, page, err := requireDriveCollection(data, "doc/get_recent_list", "recentItems")
-		if err != nil {
-			return err
-		}
-		rows := projectDriveRows(items, map[string][]string{
-			"name":        {"name"},
-			"nodeType":    {"nodeType"},
-			"contentType": {"contentType"},
-			"accessTime":  {"accessTime"},
-			"docUrl":      {"docUrl"},
-			"nodeId":      {"nodeId"},
+		out, err := collectDrivePages(rt, params, drivePageOptions{
+			PageAll:        rt.Bool("page-all"),
+			PageSize:       rt.Int("limit"),
+			MaxPages:       rt.Int("max-pages"),
+			MaxItems:       rt.Int("max-items"),
+			Cursor:         rt.Str("cursor"),
+			Server:         "doc",
+			Tool:           "get_recent_list",
+			OutputKey:      "items",
+			PageSizeParam:  "maxResults",
+			CursorParam:    "nextToken",
+			CollectionKeys: []string{"recentItems"},
+			Project: func(items []any) []map[string]any {
+				return projectDriveRows(items, map[string][]string{
+					"name":        {"name"},
+					"nodeType":    {"nodeType"},
+					"contentType": {"contentType"},
+					"accessTime":  {"accessTime"},
+					"docUrl":      {"docUrl"},
+					"nodeId":      {"nodeId"},
+				})
+			},
 		})
-		out := map[string]any{"count": len(rows), "items": rows}
-		addDrivePagination(out, page)
+		if err != nil {
+			return err
+		}
 		return rt.Output(out)
 	},
 }

--- a/internal/shortcut/drive/drive.go
+++ b/internal/shortcut/drive/drive.go
@@ -277,7 +277,7 @@ var Search = shortcut.Shortcut{
 		{Name: "created-to", Type: shortcut.FlagInt, Desc: "创建时间截止 (毫秒时间戳，含)"},
 		{Name: "modified-from", Type: shortcut.FlagInt, Desc: "修改时间起始 (毫秒时间戳，含)"},
 		{Name: "modified-to", Type: shortcut.FlagInt, Desc: "修改时间截止 (毫秒时间戳，含)"},
-		{Name: "limit", Type: shortcut.FlagInt, Default: "10", Desc: "每页返回数量 (默认 10，最大 30)"},
+		{Name: "limit", Type: shortcut.FlagInt, Desc: "每页返回数量 (默认 10，最大 30)"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标，从上次返回的 nextCursor 获取"},
 		{Name: "page-all", Type: shortcut.FlagBool, Desc: "自动连续读取后续页，默认只读一页"},
 		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "自动翻页最多读取页数"},
@@ -315,7 +315,7 @@ var Search = shortcut.Shortcut{
 		}
 		out, err := collectDrivePages(rt, params, drivePageOptions{
 			PageAll:        rt.Bool("page-all"),
-			PageSize:       rt.Int("limit"),
+			PageSize:       drivePageSize(rt, "limit", 10),
 			MaxPages:       rt.Int("max-pages"),
 			MaxItems:       rt.Int("max-items"),
 			Cursor:         rt.Str("cursor"),
@@ -633,7 +633,7 @@ var Recent = shortcut.Shortcut{
 	Flags: []shortcut.Flag{
 		{Name: "operate-type", Type: shortcut.FlagInt, Desc: "操作类型: 0=最近访问(默认), 1=最近编辑"},
 		{Name: "creator-type", Type: shortcut.FlagInt, Desc: "创建人过滤: 0=全部, 1=我创建, 2=他人创建"},
-		{Name: "limit", Type: shortcut.FlagInt, Default: "20", Desc: "每页数量 (默认 20，最大 20)"},
+		{Name: "limit", Type: shortcut.FlagInt, Desc: "每页数量 (默认 20，最大 20)"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标 (从上次结果的 nextCursor 获取)"},
 		{Name: "page-all", Type: shortcut.FlagBool, Desc: "自动连续读取后续页，默认只读一页"},
 		{Name: "max-pages", Type: shortcut.FlagInt, Default: "20", Desc: "自动翻页最多读取页数"},
@@ -655,7 +655,7 @@ var Recent = shortcut.Shortcut{
 		// down to a clean {count, items:[…], nextCursor, hasMore}.
 		out, err := collectDrivePages(rt, params, drivePageOptions{
 			PageAll:        rt.Bool("page-all"),
-			PageSize:       rt.Int("limit"),
+			PageSize:       drivePageSize(rt, "limit", 20),
 			MaxPages:       rt.Int("max-pages"),
 			MaxItems:       rt.Int("max-items"),
 			Cursor:         rt.Str("cursor"),

--- a/internal/shortcut/drive/drive_shortcuts_test.go
+++ b/internal/shortcut/drive/drive_shortcuts_test.go
@@ -4,6 +4,7 @@
 package drive
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -68,8 +69,19 @@ func driveJSON(value any) string {
 
 func runDriveCoverage(t *testing.T, declaration shortcut.Shortcut, caller *driveCoverageCaller, args ...string) error {
 	t.Helper()
+	return runDriveCoverageTo(t, declaration, caller, io.Discard, args...)
+}
+
+func runDriveCoverageRaw(t *testing.T, declaration shortcut.Shortcut, caller *driveCoverageCaller, args ...string) (string, error) {
+	t.Helper()
+	var stdout bytes.Buffer
+	err := runDriveCoverageTo(t, declaration, caller, &stdout, args...)
+	return stdout.String(), err
+}
+
+func runDriveCoverageTo(t *testing.T, declaration shortcut.Shortcut, caller *driveCoverageCaller, writer io.Writer, args ...string) error {
+	t.Helper()
 	helpers.InitDeps(caller)
-	declaration.OutputRollout = output.RolloutLegacyOnly
 	root := &cobra.Command{Use: "dws", SilenceErrors: true, SilenceUsage: true}
 	root.PersistentFlags().Bool("yes", false, "")
 	root.PersistentFlags().Bool("dry-run", false, "")
@@ -77,10 +89,23 @@ func runDriveCoverage(t *testing.T, declaration shortcut.Shortcut, caller *drive
 	service := &cobra.Command{Use: "drive"}
 	service.AddCommand(corecmd.New(shortcut.FromShortcut(declaration)))
 	root.AddCommand(service)
-	root.SetOut(io.Discard)
+	ctx, _ := output.WithResultStore(context.Background())
+	root.SetContext(ctx)
+	root.SetOut(writer)
 	root.SetErr(io.Discard)
 	root.SetArgs(append([]string{"drive", declaration.Command}, args...))
-	return root.Execute()
+	executed, err := root.ExecuteC()
+	if err != nil || !output.UsesUnifiedResult(executed) {
+		return err
+	}
+	code, _, emitErr := output.EmitStoredResult(executed)
+	if emitErr != nil {
+		return emitErr
+	}
+	if code != 0 {
+		return fmt.Errorf("command result exit code %d", code)
+	}
+	return nil
 }
 
 func TestCrossPlatformCoverageDriveCollectionsRejectFalseEmptySuccess(t *testing.T) {
@@ -261,6 +286,12 @@ func TestCrossPlatformCoverageDriveBoundedAutoPagination(t *testing.T) {
 	if err == nil || !errors.As(err, &typed) || typed.Reason != "drive_pagination_stalled_cursor" {
 		t.Fatalf("stalled cursor error = %#v", err)
 	}
+	if typed.Details["nextCursor"] != nil || typed.Details["retryCursor"] != nil || typed.Details["requestCursor"] != "same" {
+		t.Fatalf("stalled cursor exposed an unsafe continuation: details=%#v", typed.Details)
+	}
+	if strings.Contains(strings.Join(typed.Actions, " "), "nextCursor") {
+		t.Fatalf("stalled cursor actions recommend an unsafe continuation: %#v", typed.Actions)
+	}
 
 	maxPages := &driveCoverageCaller{responses: map[string][]string{
 		"list_files": {
@@ -281,13 +312,6 @@ func TestCrossPlatformCoverageDriveBoundedAutoPagination(t *testing.T) {
 		responses []string
 		want      string
 	}{
-		{
-			name: "non-positive bounds use defensive defaults",
-			args: []string{"--limit", "1", "--page-all", "--max-pages", "0", "--max-items", "0"},
-			responses: []string{
-				`{"success":true,"items":[{"name":"anonymous"}],"hasMore":false}`,
-			},
-		},
 		{
 			name: "server exceeds requested page size",
 			args: []string{"--limit", "2", "--page-all", "--max-items", "1"},
@@ -333,6 +357,162 @@ func TestCrossPlatformCoverageDriveBoundedAutoPagination(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCrossPlatformCoverageDriveUnifiedPaginationContract(t *testing.T) {
+	tests := []struct {
+		name        string
+		declaration shortcut.Shortcut
+		tool        string
+		args        []string
+		outputKey   string
+		responses   []string
+	}{
+		{
+			name: "list", declaration: List, tool: "list_files", outputKey: "files",
+			args: []string{"--limit", "1", "--page-all"},
+			responses: []string{
+				`{"success":true,"items":[{"fileId":"list-1"}],"hasMore":true,"nextToken":"list-c2"}`,
+				`{"success":true,"items":[{"fileId":"list-2"}],"hasMore":false}`,
+			},
+		},
+		{
+			name: "search", declaration: Search, tool: "search_files", outputKey: "files",
+			args: []string{"--query", "synthetic", "--limit", "1", "--page-all"},
+			responses: []string{
+				`{"success":true,"items":[{"fileId":"search-1"}],"hasMore":true,"nextPageToken":"search-c2"}`,
+				`{"success":true,"items":[{"fileId":"search-2"}],"hasMore":false}`,
+			},
+		},
+		{
+			name: "recent", declaration: Recent, tool: "get_recent_list", outputKey: "items",
+			args: []string{"--limit", "1", "--page-all"},
+			responses: []string{
+				`{"success":true,"recentItems":[{"nodeId":"recent-1"}],"hasMore":true,"nextCursor":"recent-c2"}`,
+				`{"success":true,"recentItems":[{"nodeId":"recent-2"}],"hasMore":false}`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &driveCoverageCaller{responses: map[string][]string{tc.tool: tc.responses}}
+			raw, err := runDriveCoverageRaw(t, tc.declaration, caller, tc.args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var envelope map[string]any
+			if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+				t.Fatalf("decode output %q: %v", raw, err)
+			}
+			data, _ := envelope["data"].(map[string]any)
+			rows, _ := data[tc.outputKey].([]any)
+			if len(rows) != 2 {
+				t.Fatalf("business data=%#v", data)
+			}
+			for _, leaked := range []string{"count", "pagesRead", "complete", "truncated", "hasMore", "nextCursor", "stopReason"} {
+				if _, found := data[leaked]; found {
+					t.Fatalf("business data leaked pagination field %q: %#v", leaked, data)
+				}
+			}
+			meta, _ := envelope["meta"].(map[string]any)
+			pagination, _ := meta["pagination"].(map[string]any)
+			if meta["count"] != float64(2) || pagination["endpoint_exhausted"] != true || pagination["pages"] != float64(2) || pagination["items"] != float64(2) || pagination["next_token"] != nil {
+				t.Fatalf("meta=%#v", meta)
+			}
+		})
+	}
+
+	limited := &driveCoverageCaller{responses: map[string][]string{
+		"list_files": {`{"success":true,"items":[{"fileId":"limited-1"}],"hasMore":true,"nextToken":"limited-c2"}`},
+	}}
+	raw, err := runDriveCoverageRaw(t, List, limited, "--limit", "1", "--page-all", "--max-pages", "1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	meta, _ := envelope["meta"].(map[string]any)
+	pagination, _ := meta["pagination"].(map[string]any)
+	if pagination["endpoint_exhausted"] != false || pagination["next_token"] != "limited-c2" {
+		t.Fatalf("bounded pagination=%#v", pagination)
+	}
+}
+
+func TestCrossPlatformCoverageDrivePaginationValidationAndSchema(t *testing.T) {
+	for _, declaration := range []shortcut.Shortcut{List, Search, Recent} {
+		if declaration.OutputRollout != output.RolloutUnifiedActive || declaration.Contract.Pagination == nil || declaration.Validate == nil || len(declaration.Constraints) != 1 {
+			t.Fatalf("%s pagination declaration is incomplete: rollout=%q pagination=%v validate=%v constraints=%#v", declaration.Command, declaration.OutputRollout, declaration.Contract.Pagination != nil, declaration.Validate != nil, declaration.Constraints)
+		}
+		dataSchema := string(declaration.Contract.Result.DataSchema)
+		for _, leaked := range []string{`"pagesRead"`, `"complete"`, `"truncated"`, `"hasMore"`, `"nextCursor"`, `"stopReason"`} {
+			if strings.Contains(dataSchema, leaked) {
+				t.Fatalf("%s data_schema leaked pagination field %s: %s", declaration.Command, leaked, dataSchema)
+			}
+		}
+
+		baseArgs := []string{}
+		if declaration.Command == "+search" {
+			baseArgs = []string{"--query", "synthetic"}
+		}
+		for _, invalid := range [][]string{
+			{"--max-pages", "2"},
+			{"--max-items", "2"},
+			{"--page-all", "--max-pages", "0"},
+			{"--page-all", "--max-pages", "-1"},
+			{"--page-all", "--max-items", "0"},
+			{"--page-all", "--max-items", "-1"},
+		} {
+			caller := &driveCoverageCaller{}
+			args := append(append([]string{}, baseArgs...), invalid...)
+			if err := runDriveCoverage(t, declaration, caller, args...); err == nil || len(caller.history) != 0 {
+				t.Fatalf("%s accepted invalid pagination args %v: err=%v calls=%#v", declaration.Command, args, err, caller.history)
+			}
+		}
+	}
+}
+
+func TestCrossPlatformCoverageDrivePaginationRejectsContradictionsWithoutUnsafeCursor(t *testing.T) {
+	contradictory := &driveCoverageCaller{responses: map[string][]string{
+		"list_files": {`{"success":true,"items":[],"hasMore":false,"nextToken":"stale"}`},
+	}}
+	err := runDriveCoverage(t, List, contradictory, "--page-all")
+	var typed *apperrors.Error
+	if err == nil || !errors.As(err, &typed) || typed.Reason != "drive_pagination_inconsistent_state" {
+		t.Fatalf("contradictory pagination error=%#v", err)
+	}
+	if typed.Details["nextCursor"] != nil || strings.Contains(strings.Join(typed.Actions, " "), "nextCursor") {
+		t.Fatalf("contradictory pagination exposed unsafe continuation: details=%#v actions=%#v", typed.Details, typed.Actions)
+	}
+
+	failedSecondPage := &driveCoverageCaller{responses: map[string][]string{
+		"list_files": {
+			`{"success":true,"items":[{"fileId":"first"}],"hasMore":true,"nextToken":"retry-c2"}`,
+			`__ERROR__`,
+		},
+	}}
+	err = runDriveCoverage(t, List, failedSecondPage, "--limit", "1", "--page-all")
+	typed = nil
+	if err == nil || !errors.As(err, &typed) || typed.Reason != "drive_pagination_page_read_failed" {
+		t.Fatalf("second page failure=%#v", err)
+	}
+	if typed.Details["retryCursor"] != "retry-c2" || typed.Details["nextCursor"] != nil || !strings.Contains(strings.Join(typed.Actions, " "), "retryCursor") {
+		t.Fatalf("retry cursor semantics=%#v actions=%#v", typed.Details, typed.Actions)
+	}
+	if typed.ExecutionStarted == nil || !*typed.ExecutionStarted {
+		t.Fatalf("pagination failure execution state=%#v", typed.ExecutionStarted)
+	}
+
+	cmd := &cobra.Command{Use: "unified"}
+	ctx, _ := output.WithResultStore(context.Background())
+	cmd.SetContext(ctx)
+	output.SetCommandRollout(cmd, output.RolloutUnifiedActive)
+	rt := shortcut.RuntimeContextForTest(cmd, List)
+	if err := outputDrivePageResult(rt, drivePageResult{Business: map[string]any{"files": []any{}}, EndpointExhausted: true, NextToken: "contradictory"}); err == nil {
+		t.Fatal("output accepted exhausted pagination with a continuation token")
 	}
 }
 

--- a/internal/shortcut/drive/drive_shortcuts_test.go
+++ b/internal/shortcut/drive/drive_shortcuts_test.go
@@ -411,7 +411,10 @@ func TestCrossPlatformCoverageDriveUnifiedPaginationContract(t *testing.T) {
 			if len(rows) != 2 {
 				t.Fatalf("business data=%#v", data)
 			}
-			for _, leaked := range []string{"count", "pagesRead", "complete", "truncated", "hasMore", "nextCursor", "stopReason"} {
+			if data["count"] != float64(2) || data["hasMore"] != false || data["nextCursor"] != nil {
+				t.Fatalf("legacy data paths=%#v", data)
+			}
+			for _, leaked := range []string{"pagesRead", "complete", "truncated", "stopReason"} {
 				if _, found := data[leaked]; found {
 					t.Fatalf("business data leaked pagination field %q: %#v", leaked, data)
 				}
@@ -440,6 +443,122 @@ func TestCrossPlatformCoverageDriveUnifiedPaginationContract(t *testing.T) {
 	if pagination["endpoint_exhausted"] != false || pagination["next_token"] != "limited-c2" {
 		t.Fatalf("bounded pagination=%#v", pagination)
 	}
+	data, _ := envelope["data"].(map[string]any)
+	if data["count"] != float64(1) || data["hasMore"] != true || data["nextCursor"] != pagination["next_token"] {
+		t.Fatalf("bounded legacy data paths=%#v", data)
+	}
+}
+
+func TestCrossPlatformCoverageDriveCollectionWireCompatibility(t *testing.T) {
+	for _, tc := range []struct {
+		declaration shortcut.Shortcut
+		tool        string
+		inputKey    string
+		outputKey   string
+		args        []string
+		autoPage    bool
+	}{
+		{List, "list_files", "items", "files", nil, true},
+		{Search, "search_files", "items", "files", []string{"--query", "synthetic"}, true},
+		{Recent, "get_recent_list", "recentItems", "items", nil, true},
+		{RecycleList, "list_recycle_items", "recycleItems", "items", nil, false},
+		{StarList, "get_star_list", "starList", "items", nil, false},
+		{VersionHistory, "list_file_versions", "versions", "versions", []string{"--node", "test-node"}, false},
+		{SearchDocs, "search_documents", "documents", "docs", []string{"--query", "synthetic"}, false},
+	} {
+		t.Run(tc.declaration.Command, func(t *testing.T) {
+			var schema struct {
+				Properties           map[string]json.RawMessage `json:"properties"`
+				Required             []string                   `json:"required"`
+				AdditionalProperties bool                       `json:"additionalProperties"`
+			}
+			if err := json.Unmarshal(tc.declaration.Contract.Result.DataSchema, &schema); err != nil {
+				t.Fatal(err)
+			}
+			if !schema.AdditionalProperties || fmt.Sprint(schema.Required) != fmt.Sprint([]string{"count", tc.outputKey}) {
+				t.Fatalf("shared schema narrowed the legacy contract: %#v", schema)
+			}
+			for _, field := range []string{"count", tc.outputKey, "hasMore", "nextCursor"} {
+				if _, ok := schema.Properties[field]; !ok {
+					t.Fatalf("schema lost legacy property %q", field)
+				}
+			}
+			modes := []string{"single-page"}
+			if tc.autoPage {
+				modes = append(modes, "bounded-auto-page")
+			}
+			for _, mode := range modes {
+				t.Run(mode, func(t *testing.T) {
+					for _, hasMore := range []bool{false, true} {
+						payload := map[string]any{"success": true, tc.inputKey: []any{}, "hasMore": hasMore}
+						if hasMore {
+							payload["nextCursor"] = "test-next-page"
+						}
+						caller := &driveCoverageCaller{responses: map[string][]string{tc.tool: {driveJSON(payload)}}}
+						args := append([]string{}, tc.args...)
+						if mode == "bounded-auto-page" {
+							args = append(args, "--page-all", "--max-pages", "1")
+						}
+						raw, err := runDriveCoverageRaw(t, tc.declaration, caller, args...)
+						if err != nil {
+							t.Fatal(err)
+						}
+						var envelope map[string]any
+						if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+							t.Fatal(err)
+						}
+						data, _ := envelope["data"].(map[string]any)
+						if data["count"] != float64(0) || data["hasMore"] != hasMore || data[tc.outputKey] == nil || len(caller.calls) != 1 {
+							t.Fatalf("legacy output/call count drift: data=%#v calls=%#v", data, caller.calls)
+						}
+						if hasMore && data["nextCursor"] != "test-next-page" || !hasMore && data["nextCursor"] != nil {
+							t.Fatalf("legacy cursor drift: %#v", data)
+						}
+						if tc.autoPage {
+							meta, _ := envelope["meta"].(map[string]any)
+							pagination, _ := meta["pagination"].(map[string]any)
+							if meta["count"] != data["count"] || pagination["endpoint_exhausted"] != !hasMore || pagination["next_token"] != data["nextCursor"] {
+								t.Fatalf("data/meta disagree: %#v", envelope)
+							}
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageDrivePaginationErrorOperation(t *testing.T) {
+	for _, tc := range []struct {
+		declaration shortcut.Shortcut
+		server      string
+		tool        string
+		inputKey    string
+		args        []string
+	}{
+		{List, "drive", "list_files", "items", nil},
+		{Search, "drive", "search_files", "items", []string{"--query", "synthetic"}},
+		{Recent, "doc", "get_recent_list", "recentItems", nil},
+	} {
+		t.Run(tc.declaration.Command, func(t *testing.T) {
+			for _, payload := range []string{"__ERROR__", driveJSON(map[string]any{"success": true, tc.inputKey: []any{}, "hasMore": true})} {
+				caller := &driveCoverageCaller{responses: map[string][]string{tc.tool: {payload}}}
+				err := runDriveCoverage(t, tc.declaration, caller, tc.args...)
+				var typed *apperrors.Error
+				if !errors.As(err, &typed) || typed.Operation != tc.server+"/"+tc.tool {
+					t.Fatalf("pagination error operation: %#v", err)
+				}
+				for _, field := range []string{"contractVersion", "contract_version"} {
+					if _, found := typed.Details[field]; found {
+						t.Fatalf("pagination error published undeclared protocol %q: %#v", field, typed.Details)
+					}
+				}
+				if typed.FailureStage != "pagination" || !strings.HasPrefix(typed.Reason, "drive_pagination_") {
+					t.Fatalf("pagination error lost recovery facts: %#v", typed)
+				}
+			}
+		})
+	}
 }
 
 func TestCrossPlatformCoverageDrivePaginationValidationAndSchema(t *testing.T) {
@@ -448,7 +567,7 @@ func TestCrossPlatformCoverageDrivePaginationValidationAndSchema(t *testing.T) {
 			t.Fatalf("%s pagination declaration is incomplete: rollout=%q pagination=%v validate=%v constraints=%#v", declaration.Command, declaration.OutputRollout, declaration.Contract.Pagination != nil, declaration.Validate != nil, declaration.Constraints)
 		}
 		dataSchema := string(declaration.Contract.Result.DataSchema)
-		for _, leaked := range []string{`"pagesRead"`, `"complete"`, `"truncated"`, `"hasMore"`, `"nextCursor"`, `"stopReason"`} {
+		for _, leaked := range []string{`"pagesRead"`, `"complete"`, `"truncated"`, `"stopReason"`} {
 			if strings.Contains(dataSchema, leaked) {
 				t.Fatalf("%s data_schema leaked pagination field %s: %s", declaration.Command, leaked, dataSchema)
 			}

--- a/internal/shortcut/drive/drive_shortcuts_test.go
+++ b/internal/shortcut/drive/drive_shortcuts_test.go
@@ -475,6 +475,46 @@ func TestCrossPlatformCoverageDrivePaginationValidationAndSchema(t *testing.T) {
 	}
 }
 
+func TestCrossPlatformCoverageDrivePaginationDefensiveDefaultsAndRecentFilters(t *testing.T) {
+	caller := &driveCoverageCaller{responses: map[string][]string{
+		"list_files": {`{"success":true,"items":[{"name":"anonymous"}],"hasMore":false}`},
+	}}
+	helpers.InitDeps(caller)
+	cmd := &cobra.Command{Use: "list"}
+	result, err := collectDrivePages(shortcut.RuntimeContextForTest(cmd, List), nil, drivePageOptions{
+		PageSize:      1,
+		MaxPages:      0,
+		MaxItems:      0,
+		Server:        "drive",
+		Tool:          "list_files",
+		OutputKey:     "files",
+		PageSizeParam: "maxResults",
+		CursorParam:   "nextToken",
+		CollectionKeys: []string{
+			"items",
+		},
+		Project: func(items []any) []map[string]any {
+			return projectDriveRows(items, map[string][]string{"name": {"name"}})
+		},
+	})
+	if err != nil || result.Items != 1 || !result.EndpointExhausted {
+		t.Fatalf("defensive defaults result=%#v err=%v", result, err)
+	}
+	if key := drivePageItemKey(map[string]any{"name": "anonymous"}); key != "" {
+		t.Fatalf("anonymous item key=%q", key)
+	}
+
+	recent := &driveCoverageCaller{responses: map[string][]string{
+		"get_recent_list": {`{"success":true,"recentItems":[],"hasMore":false}`},
+	}}
+	if err := runDriveCoverage(t, Recent, recent, "--operate-type", "1", "--creator-type", "2"); err != nil {
+		t.Fatal(err)
+	}
+	if len(recent.calls) != 1 || fmt.Sprint(recent.calls[0].args["operateTypes"]) != "[1]" || recent.calls[0].args["creatorType"] != 2 {
+		t.Fatalf("recent filter params=%#v", recent.calls)
+	}
+}
+
 func TestCrossPlatformCoverageDrivePaginationRejectsContradictionsWithoutUnsafeCursor(t *testing.T) {
 	contradictory := &driveCoverageCaller{responses: map[string][]string{
 		"list_files": {`{"success":true,"items":[],"hasMore":false,"nextToken":"stale"}`},

--- a/internal/shortcut/drive/drive_shortcuts_test.go
+++ b/internal/shortcut/drive/drive_shortcuts_test.go
@@ -175,6 +175,23 @@ func TestCrossPlatformCoverageDriveCreateAndInspectReadback(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "部分读取") {
 		t.Fatalf("metadata-only stats error = %v", err)
 	}
+
+	nestedStats := &driveCoverageCaller{responses: map[string][]string{
+		"get_file_info":  {`{"success":true,"result":{"fileId":"n3","name":"x"}}`},
+		"get_node_stats": {`{"success":true,"stats":{"views":1}}`},
+	}}
+	if err := runDriveCoverage(t, Inspect, nestedStats, "--node", "n3", "--include-stats"); err != nil {
+		t.Fatalf("nested stats error = %v", err)
+	}
+
+	invalidStats := &driveCoverageCaller{responses: map[string][]string{
+		"get_file_info":  {`{"success":true,"result":{"fileId":"n4","name":"x"}}`},
+		"get_node_stats": {`{"success":true}`},
+	}}
+	err = runDriveCoverage(t, Inspect, invalidStats, "--node", "n4", "--include-stats")
+	if err == nil || !strings.Contains(err.Error(), "部分读取") {
+		t.Fatalf("invalid stats error = %v", err)
+	}
 }
 
 func TestCrossPlatformCoverageDriveBoundedAutoPagination(t *testing.T) {
@@ -256,6 +273,66 @@ func TestCrossPlatformCoverageDriveBoundedAutoPagination(t *testing.T) {
 	}
 	if len(maxPages.calls) != 2 {
 		t.Fatalf("max-pages calls = %#v", maxPages.calls)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		args      []string
+		responses []string
+		want      string
+	}{
+		{
+			name: "non-positive bounds use defensive defaults",
+			args: []string{"--limit", "1", "--page-all", "--max-pages", "0", "--max-items", "0"},
+			responses: []string{
+				`{"success":true,"items":[{"name":"anonymous"}],"hasMore":false}`,
+			},
+		},
+		{
+			name: "server exceeds requested page size",
+			args: []string{"--limit", "2", "--page-all", "--max-items", "1"},
+			responses: []string{
+				`{"success":true,"items":[{"fileId":"n1"},{"fileId":"n2"}],"hasMore":false}`,
+			},
+			want: "drive_pagination_page_size_exceeded",
+		},
+		{
+			name: "pagination cannot be proven",
+			args: []string{"--limit", "1", "--page-all"},
+			responses: []string{
+				`{"success":true,"items":[{"fileId":"n1"}]}`,
+			},
+			want: "drive_pagination_pagination_unproven",
+		},
+		{
+			name: "max items returns a bounded partial result",
+			args: []string{"--limit", "1", "--page-all", "--max-items", "1"},
+			responses: []string{
+				`{"success":true,"items":[{"fileId":"n1"}],"hasMore":true,"nextToken":"c2"}`,
+			},
+		},
+		{
+			name: "missing continuation cursor",
+			args: []string{"--limit", "1", "--page-all"},
+			responses: []string{
+				`{"success":true,"items":[],"hasMore":true}`,
+			},
+			want: "drive_pagination_missing_next_cursor",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &driveCoverageCaller{responses: map[string][]string{"list_files": tc.responses}}
+			err := runDriveCoverage(t, List, caller, tc.args...)
+			if tc.want == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.want != "" {
+				var typed *apperrors.Error
+				if err == nil || !errors.As(err, &typed) || typed.Reason != tc.want {
+					t.Fatalf("error = %#v, want reason %q", err, tc.want)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/shortcut/drive/drive_shortcuts_test.go
+++ b/internal/shortcut/drive/drive_shortcuts_test.go
@@ -259,6 +259,38 @@ func TestCrossPlatformCoverageDriveBoundedAutoPagination(t *testing.T) {
 	}
 }
 
+func TestCrossPlatformCoverageDrivePaginationPreservesImplicitPageSizes(t *testing.T) {
+	tests := []struct {
+		name        string
+		declaration shortcut.Shortcut
+		tool        string
+		args        []string
+		sizeParam   string
+		wantSize    int
+	}{
+		{name: "search", declaration: Search, tool: "search_files", args: []string{"--query", "x"}, sizeParam: "pageSize", wantSize: 10},
+		{name: "recent", declaration: Recent, tool: "get_recent_list", sizeParam: "maxResults", wantSize: 20},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, flag := range tc.declaration.Flags {
+				if flag.Name == "limit" && flag.Default != "" {
+					t.Fatalf("limit default = %q, want existing implicit default", flag.Default)
+				}
+			}
+			caller := &driveCoverageCaller{responses: map[string][]string{
+				tc.tool: {`{"success":true,"items":[],"recentItems":[],"hasMore":false}`},
+			}}
+			if err := runDriveCoverage(t, tc.declaration, caller, tc.args...); err != nil {
+				t.Fatal(err)
+			}
+			if len(caller.calls) != 1 || caller.calls[0].args[tc.sizeParam] != tc.wantSize {
+				t.Fatalf("calls = %#v, want %s=%d", caller.calls, tc.sizeParam, tc.wantSize)
+			}
+		})
+	}
+}
+
 func TestCrossPlatformCoverageDriveDownloadAndUploadRequireArtifactsAndReadback(t *testing.T) {
 	var outputFlag *shortcut.Flag
 	for i := range Download.Flags {

--- a/internal/shortcut/drive/drive_shortcuts_test.go
+++ b/internal/shortcut/drive/drive_shortcuts_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/localio"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
@@ -31,12 +32,19 @@ type driveCoverageCaller struct {
 	mu        sync.Mutex
 	responses map[string][]string
 	history   []string
+	calls     []driveCoverageCall
 }
 
-func (caller *driveCoverageCaller) CallTool(_ context.Context, _, tool string, _ map[string]any) (*edition.ToolResult, error) {
+type driveCoverageCall struct {
+	tool string
+	args map[string]any
+}
+
+func (caller *driveCoverageCaller) CallTool(_ context.Context, _, tool string, args map[string]any) (*edition.ToolResult, error) {
 	caller.mu.Lock()
 	defer caller.mu.Unlock()
 	caller.history = append(caller.history, tool)
+	caller.calls = append(caller.calls, driveCoverageCall{tool: tool, args: cloneDriveMap(args)})
 	queue := caller.responses[tool]
 	if len(queue) == 0 {
 		return nil, errors.New("missing fake response for " + tool)
@@ -136,6 +144,17 @@ func TestCrossPlatformCoverageDriveCreateAndInspectReadback(t *testing.T) {
 	}}
 	if err := runDriveCoverage(t, CreateFolder, mismatch, "--name", "wanted"); err == nil || !strings.Contains(err.Error(), "读回名称") {
 		t.Fatalf("readback mismatch error = %v", err)
+	} else {
+		var typed *apperrors.Error
+		if !errors.As(err, &typed) {
+			t.Fatalf("readback mismatch type = %T", err)
+		}
+		if typed.ExecutionStarted == nil || !*typed.ExecutionStarted || typed.Retryable || typed.Reason != "readback_mismatch" {
+			t.Fatalf("readback mismatch metadata = %#v", typed)
+		}
+		if typed.Details["nodeId"] != "folder-2" || typed.Details["retrySafe"] != false {
+			t.Fatalf("readback mismatch details = %#v", typed.Details)
+		}
 	}
 
 	partial := &driveCoverageCaller{responses: map[string][]string{
@@ -146,6 +165,97 @@ func TestCrossPlatformCoverageDriveCreateAndInspectReadback(t *testing.T) {
 	err := runDriveCoverage(t, Inspect, partial, "--node", "n1", "--include-stats", "--include-publish")
 	if err == nil || !strings.Contains(err.Error(), "部分读取") {
 		t.Fatalf("inspect partial error = %v", err)
+	}
+
+	metadataOnlyStats := &driveCoverageCaller{responses: map[string][]string{
+		"get_file_info":  {`{"success":true,"result":{"fileId":"n2","name":"x"}}`},
+		"get_node_stats": {`{"success":true,"contentType":"document","name":"x","message":"no statistics"}`},
+	}}
+	err = runDriveCoverage(t, Inspect, metadataOnlyStats, "--node", "n2", "--include-stats")
+	if err == nil || !strings.Contains(err.Error(), "部分读取") {
+		t.Fatalf("metadata-only stats error = %v", err)
+	}
+}
+
+func TestCrossPlatformCoverageDriveBoundedAutoPagination(t *testing.T) {
+	tests := []struct {
+		name        string
+		declaration shortcut.Shortcut
+		tool        string
+		args        []string
+		responses   []string
+		cursorParam string
+		sizeParam   string
+	}{
+		{
+			name: "list", declaration: List, tool: "list_files",
+			args: []string{"--limit", "2", "--page-all", "--max-pages", "3", "--max-items", "3"},
+			responses: []string{
+				`{"success":true,"items":[{"fileId":"n1"},{"fileId":"n2"}],"hasMore":true,"nextToken":"c2"}`,
+				`{"success":true,"items":[{"fileId":"n2"},{"fileId":"n3"}],"hasMore":false}`,
+			},
+			cursorParam: "nextToken", sizeParam: "maxResults",
+		},
+		{
+			name: "search", declaration: Search, tool: "search_files",
+			args: []string{"--query", "x", "--limit", "2", "--page-all", "--max-pages", "3", "--max-items", "3"},
+			responses: []string{
+				`{"success":true,"items":[{"fileId":"n1"},{"fileId":"n2"}],"hasMore":true,"nextPageToken":"c2"}`,
+				`{"success":true,"items":[{"fileId":"n3"}],"hasMore":false}`,
+			},
+			cursorParam: "pageToken", sizeParam: "pageSize",
+		},
+		{
+			name: "recent", declaration: Recent, tool: "get_recent_list",
+			args: []string{"--limit", "2", "--page-all", "--max-pages", "3", "--max-items", "3"},
+			responses: []string{
+				`{"success":true,"recentItems":[{"nodeId":"n1"},{"nodeId":"n2"}],"hasMore":true,"nextCursor":"c2"}`,
+				`{"success":true,"recentItems":[{"nodeId":"n3"}],"hasMore":false}`,
+			},
+			cursorParam: "nextToken", sizeParam: "maxResults",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &driveCoverageCaller{responses: map[string][]string{tc.tool: tc.responses}}
+			if err := runDriveCoverage(t, tc.declaration, caller, tc.args...); err != nil {
+				t.Fatal(err)
+			}
+			if len(caller.calls) != 2 {
+				t.Fatalf("calls = %#v", caller.calls)
+			}
+			if caller.calls[0].args[tc.sizeParam] != 2 || caller.calls[1].args[tc.sizeParam] != 1 {
+				t.Fatalf("page sizes = %#v, %#v", caller.calls[0].args, caller.calls[1].args)
+			}
+			if caller.calls[1].args[tc.cursorParam] != "c2" {
+				t.Fatalf("second page args = %#v", caller.calls[1].args)
+			}
+		})
+	}
+
+	stalled := &driveCoverageCaller{responses: map[string][]string{
+		"list_files": {
+			`{"success":true,"items":[{"fileId":"n1"}],"hasMore":true,"nextToken":"same"}`,
+			`{"success":true,"items":[{"fileId":"n2"}],"hasMore":true,"nextToken":"same"}`,
+		},
+	}}
+	err := runDriveCoverage(t, List, stalled, "--limit", "1", "--page-all", "--cursor", "start")
+	var typed *apperrors.Error
+	if err == nil || !errors.As(err, &typed) || typed.Reason != "drive_pagination_stalled_cursor" {
+		t.Fatalf("stalled cursor error = %#v", err)
+	}
+
+	maxPages := &driveCoverageCaller{responses: map[string][]string{
+		"list_files": {
+			`{"success":true,"items":[{"fileId":"n1"}],"hasMore":true,"nextToken":"c2"}`,
+			`{"success":true,"items":[{"fileId":"n2"}],"hasMore":true,"nextToken":"c3"}`,
+		},
+	}}
+	if err := runDriveCoverage(t, List, maxPages, "--limit", "1", "--page-all", "--max-pages", "2", "--max-items", "10"); err != nil {
+		t.Fatal(err)
+	}
+	if len(maxPages.calls) != 2 {
+		t.Fatalf("max-pages calls = %#v", maxPages.calls)
 	}
 }
 
@@ -197,6 +307,15 @@ func TestCrossPlatformCoverageDriveDownloadAndUploadRequireArtifactsAndReadback(
 			err := runDriveCoverage(t, Upload, caller, "--file", "input.bin", "--yes")
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+			if tc.name == "prefix-only remote name" {
+				var typed *apperrors.Error
+				if !errors.As(err, &typed) || typed.ExecutionStarted == nil || !*typed.ExecutionStarted || typed.Retryable {
+					t.Fatalf("upload mismatch metadata = %#v", err)
+				}
+				if typed.Details["nodeId"] != "uploaded-4" || typed.Details["requestedName"] != "input.bin" {
+					t.Fatalf("upload mismatch details = %#v", typed.Details)
+				}
 			}
 		})
 	}

--- a/internal/shortcut/drive/operations.go
+++ b/internal/shortcut/drive/operations.go
@@ -65,7 +65,11 @@ var Inspect = shortcut.Shortcut{
 			}
 			value, callErr := rt.CallMCPReadData("drive", read.tool, read.params)
 			if callErr == nil {
-				value, callErr = requireDriveObject(value, "drive/"+read.tool)
+				if read.tool == "get_node_stats" {
+					value, callErr = requireDriveStats(value, "drive/"+read.tool)
+				} else {
+					value, callErr = requireDriveObject(value, "drive/"+read.tool)
+				}
 			}
 			if callErr != nil {
 				steps = append(steps, map[string]any{"tool": read.tool, "status": "failed"})
@@ -138,18 +142,20 @@ var CreateFolder = shortcut.Shortcut{
 			return err
 		}
 		if name := firstString(verified, "name", "fileName"); name != rt.Str("name") {
-			return driveResponseErrorWithDetails(
+			return driveCommittedWriteMismatch(
 				"drive/create_folder",
 				"readback_mismatch",
 				fmt.Sprintf("创建后读回名称 %q 与请求 %q 不一致", name, rt.Str("name")),
+				nodeID,
+				rt.Str("name"),
+				name,
 				map[string]any{
-					"resource": map[string]any{
-						"resourceType":  "folder",
-						"nodeId":        nodeID,
-						"requestedName": rt.Str("name"),
-						"observedName":  name,
-						"ownership":     "owned",
-					},
+					"resourceType":  "folder",
+					"nodeId":        nodeID,
+					"requestedName": rt.Str("name"),
+					"observedName":  name,
+					"ownership":     "owned",
+					"readback":      verified,
 				},
 			)
 		}

--- a/internal/shortcut/drive/pagination.go
+++ b/internal/shortcut/drive/pagination.go
@@ -188,7 +188,15 @@ func outputDrivePageResult(rt *shortcut.RuntimeContext, result drivePageResult) 
 		Count:      output.NewCount(result.Items),
 		Pagination: pagination,
 	}
-	return output.StoreResult(rt.Command().Context(), output.Success(result.Business, output.WithMeta(meta)))
+	// Keep the existing data paths for consumers of the already-unified commands.
+	// Both projections derive from the same validated pagination state.
+	data := cloneDriveMap(result.Business)
+	data["count"] = result.Items
+	data["hasMore"] = !result.EndpointExhausted
+	if result.NextToken != "" {
+		data["nextCursor"] = result.NextToken
+	}
+	return output.StoreResult(rt.Command().Context(), output.Success(data, output.WithMeta(meta)))
 }
 
 func drivePaginationError(options drivePageOptions, reason string, cause error, page int, items []map[string]any, cursors drivePaginationErrorCursors) error {
@@ -197,7 +205,6 @@ func drivePaginationError(options drivePageOptions, reason string, cause error, 
 		message += ": " + cause.Error()
 	}
 	details := map[string]any{
-		"contractVersion": "drive.list.v1",
 		"status":          "partial_success",
 		"complete":        false,
 		"reason":          reason,

--- a/internal/shortcut/drive/pagination.go
+++ b/internal/shortcut/drive/pagination.go
@@ -26,6 +26,13 @@ type drivePageOptions struct {
 	Project        func([]any) []map[string]any
 }
 
+func drivePageSize(rt *shortcut.RuntimeContext, flag string, fallback int) int {
+	if rt.Changed(flag) {
+		return rt.Int(flag)
+	}
+	return fallback
+}
+
 func collectDrivePages(rt *shortcut.RuntimeContext, base map[string]any, options drivePageOptions) (map[string]any, error) {
 	if options.MaxPages <= 0 {
 		options.MaxPages = 20

--- a/internal/shortcut/drive/pagination.go
+++ b/internal/shortcut/drive/pagination.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0
+
+package drive
+
+import (
+	"fmt"
+	"strings"
+
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
+)
+
+type drivePageOptions struct {
+	PageAll        bool
+	PageSize       int
+	MaxPages       int
+	MaxItems       int
+	Cursor         string
+	Server         string
+	Tool           string
+	OutputKey      string
+	PageSizeParam  string
+	CursorParam    string
+	CollectionKeys []string
+	Project        func([]any) []map[string]any
+}
+
+func collectDrivePages(rt *shortcut.RuntimeContext, base map[string]any, options drivePageOptions) (map[string]any, error) {
+	if options.MaxPages <= 0 {
+		options.MaxPages = 20
+	}
+	if options.MaxItems <= 0 {
+		options.MaxItems = 500
+	}
+	pageLimit := 1
+	if options.PageAll {
+		pageLimit = options.MaxPages
+	}
+
+	items := make([]map[string]any, 0)
+	seenItems := map[string]bool{}
+	seenCursors := map[string]bool{}
+	cursor := strings.TrimSpace(options.Cursor)
+	if cursor != "" {
+		seenCursors[cursor] = true
+	}
+	complete := false
+	truncated := false
+	stopReason := ""
+	nextCursor := ""
+	hasMore := false
+	pagesRead := 0
+
+	for page := 1; page <= pageLimit; page++ {
+		remaining := options.MaxItems - len(items)
+		requestPageSize := options.PageSize
+		if requestPageSize > remaining {
+			requestPageSize = remaining
+		}
+		params := cloneDriveMap(base)
+		params[options.PageSizeParam] = requestPageSize
+		if cursor != "" {
+			params[options.CursorParam] = cursor
+		}
+		data, err := rt.CallMCPData(options.Server, options.Tool, params)
+		if err != nil {
+			return nil, drivePaginationError(options, "page_read_failed", err, page, items, cursor)
+		}
+		pagesRead++
+		rawItems, pageState, err := requireDriveCollection(data, options.Server+"/"+options.Tool, options.CollectionKeys...)
+		if err != nil {
+			return nil, drivePaginationError(options, "invalid_page", err, page, items, cursor)
+		}
+		projected := options.Project(rawItems)
+		pageItems := make([]map[string]any, 0, len(projected))
+		pageSeen := map[string]bool{}
+		for _, item := range projected {
+			key := drivePageItemKey(item)
+			if key != "" && (seenItems[key] || pageSeen[key]) {
+				continue
+			}
+			if key != "" {
+				pageSeen[key] = true
+			}
+			pageItems = append(pageItems, item)
+		}
+		if len(pageItems) > remaining {
+			return nil, drivePaginationError(options, "page_size_exceeded", nil, page, items, cursor)
+		}
+		for _, item := range pageItems {
+			if key := drivePageItemKey(item); key != "" {
+				seenItems[key] = true
+			}
+			items = append(items, item)
+		}
+
+		pageHasMore, hasMoreKnown, next := drivePageState(pageState)
+		nextCursor = strings.TrimSpace(next)
+		switch {
+		case hasMoreKnown:
+			hasMore = pageHasMore
+			complete = !pageHasMore
+		case nextCursor != "":
+			hasMore = true
+		case len(projected) < requestPageSize:
+			complete = true
+		default:
+			hasMore = true
+			stopReason = "pagination_unproven"
+		}
+		if len(items) >= options.MaxItems && hasMore {
+			truncated = true
+			stopReason = "max_items"
+		}
+		if truncated {
+			complete = false
+			hasMore = true
+		}
+
+		if truncated || complete || !options.PageAll {
+			break
+		}
+		if stopReason == "pagination_unproven" {
+			return nil, drivePaginationError(options, stopReason, nil, page, items, cursor)
+		}
+		if nextCursor == "" {
+			return nil, drivePaginationError(options, "missing_next_cursor", nil, page, items, cursor)
+		}
+		if seenCursors[nextCursor] {
+			return nil, drivePaginationError(options, "stalled_cursor", nil, page, items, nextCursor)
+		}
+		seenCursors[nextCursor] = true
+		cursor = nextCursor
+		if page == pageLimit {
+			truncated = true
+			stopReason = "max_pages"
+		}
+	}
+
+	return map[string]any{
+		"contractVersion": "drive.list.v1",
+		"status":          "success",
+		"count":           len(items),
+		options.OutputKey: items,
+		"pagesRead":       pagesRead,
+		"complete":        complete,
+		"truncated":       truncated,
+		"hasMore":         hasMore,
+		"nextCursor":      nextCursor,
+		"stopReason":      stopReason,
+		"failures":        []map[string]any{},
+	}, nil
+}
+
+func drivePaginationError(options drivePageOptions, reason string, cause error, page int, items []map[string]any, cursor string) error {
+	message := fmt.Sprintf("%s 分页未完成，已在第 %d 页停止", options.Tool, page)
+	if cause != nil {
+		message += ": " + cause.Error()
+	}
+	return apperrors.NewAPI(
+		message,
+		apperrors.WithOperation(options.Server+"/"+options.Tool),
+		apperrors.WithReason("drive_pagination_"+reason),
+		apperrors.WithFailureStage("pagination"),
+		apperrors.WithExecutionStarted(false),
+		apperrors.WithRetryable(cause != nil),
+		apperrors.WithActions("保留 nextCursor 后继续读取", "缩小查询范围后重试"),
+		apperrors.WithDetails(map[string]any{
+			"contractVersion": "drive.list.v1",
+			"status":          "partial_success",
+			"complete":        false,
+			"reason":          reason,
+			"page":            page,
+			"nextCursor":      cursor,
+			"count":           len(items),
+			options.OutputKey: items,
+		}),
+		apperrors.WithCause(cause),
+	)
+}
+
+func cloneDriveMap(source map[string]any) map[string]any {
+	out := make(map[string]any, len(source)+2)
+	for key, value := range source {
+		out[key] = value
+	}
+	return out
+}
+
+func drivePageItemKey(item map[string]any) string {
+	for _, key := range []string{"nodeId", "dentryId", "id", "docUrl", "url"} {
+		if value, ok := item[key].(string); ok && strings.TrimSpace(value) != "" {
+			return key + ":" + strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func drivePageState(data map[string]any) (bool, bool, string) {
+	hasMore, known := boolField(data, "hasMore", "has_more")
+	next := firstString(data, "nextCursor", "nextToken", "nextPageToken", "next_page_token")
+	return hasMore, known, next
+}

--- a/internal/shortcut/drive/pagination.go
+++ b/internal/shortcut/drive/pagination.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
 )
 
@@ -26,6 +27,19 @@ type drivePageOptions struct {
 	Project        func([]any) []map[string]any
 }
 
+type drivePageResult struct {
+	Business          map[string]any
+	EndpointExhausted bool
+	NextToken         string
+	Pages             int
+	Items             int
+}
+
+type drivePaginationErrorCursors struct {
+	Request string
+	Retry   string
+}
+
 func drivePageSize(rt *shortcut.RuntimeContext, flag string, fallback int) int {
 	if rt.Changed(flag) {
 		return rt.Int(flag)
@@ -33,7 +47,31 @@ func drivePageSize(rt *shortcut.RuntimeContext, flag string, fallback int) int {
 	return fallback
 }
 
-func collectDrivePages(rt *shortcut.RuntimeContext, base map[string]any, options drivePageOptions) (map[string]any, error) {
+func validateDriveAutoPagination(rt *shortcut.RuntimeContext) error {
+	if !rt.Bool("page-all") {
+		if rt.Changed("max-pages") || rt.Changed("max-items") {
+			return fmt.Errorf("--max-pages/--max-items 仅与 --page-all 一起使用")
+		}
+		return nil
+	}
+	if rt.Int("max-pages") <= 0 {
+		return fmt.Errorf("--max-pages 必须大于 0")
+	}
+	if rt.Int("max-items") <= 0 {
+		return fmt.Errorf("--max-items 必须大于 0")
+	}
+	return nil
+}
+
+func driveAutoPaginationConstraints() []shortcut.Constraint {
+	return []shortcut.Constraint{{
+		Kind:        shortcut.ConstraintCustom,
+		Flags:       []string{"page-all", "max-pages", "max-items"},
+		Description: "--max-pages/--max-items 仅与 --page-all 一起使用，且必须大于 0",
+	}}
+}
+
+func collectDrivePages(rt *shortcut.RuntimeContext, base map[string]any, options drivePageOptions) (drivePageResult, error) {
 	if options.MaxPages <= 0 {
 		options.MaxPages = 20
 	}
@@ -52,14 +90,9 @@ func collectDrivePages(rt *shortcut.RuntimeContext, base map[string]any, options
 	if cursor != "" {
 		seenCursors[cursor] = true
 	}
-	complete := false
-	truncated := false
-	stopReason := ""
-	nextCursor := ""
-	hasMore := false
 	pagesRead := 0
 
-	for page := 1; page <= pageLimit; page++ {
+	for page := 1; ; page++ {
 		remaining := options.MaxItems - len(items)
 		requestPageSize := options.PageSize
 		if requestPageSize > remaining {
@@ -72,12 +105,15 @@ func collectDrivePages(rt *shortcut.RuntimeContext, base map[string]any, options
 		}
 		data, err := rt.CallMCPData(options.Server, options.Tool, params)
 		if err != nil {
-			return nil, drivePaginationError(options, "page_read_failed", err, page, items, cursor)
+			return drivePageResult{}, drivePaginationError(options, "page_read_failed", err, page, items, drivePaginationErrorCursors{
+				Request: cursor,
+				Retry:   cursor,
+			})
 		}
 		pagesRead++
 		rawItems, pageState, err := requireDriveCollection(data, options.Server+"/"+options.Tool, options.CollectionKeys...)
 		if err != nil {
-			return nil, drivePaginationError(options, "invalid_page", err, page, items, cursor)
+			return drivePageResult{}, drivePaginationError(options, "invalid_page", err, page, items, drivePaginationErrorCursors{Request: cursor})
 		}
 		projected := options.Project(rawItems)
 		pageItems := make([]map[string]any, 0, len(projected))
@@ -93,7 +129,7 @@ func collectDrivePages(rt *shortcut.RuntimeContext, base map[string]any, options
 			pageItems = append(pageItems, item)
 		}
 		if len(pageItems) > remaining {
-			return nil, drivePaginationError(options, "page_size_exceeded", nil, page, items, cursor)
+			return drivePageResult{}, drivePaginationError(options, "page_size_exceeded", nil, page, items, drivePaginationErrorCursors{Request: cursor})
 		}
 		for _, item := range pageItems {
 			if key := drivePageItemKey(item); key != "" {
@@ -103,86 +139,89 @@ func collectDrivePages(rt *shortcut.RuntimeContext, base map[string]any, options
 		}
 
 		pageHasMore, hasMoreKnown, next := drivePageState(pageState)
-		nextCursor = strings.TrimSpace(next)
-		switch {
-		case hasMoreKnown:
-			hasMore = pageHasMore
-			complete = !pageHasMore
-		case nextCursor != "":
-			hasMore = true
-		case len(projected) < requestPageSize:
-			complete = true
-		default:
-			hasMore = true
-			stopReason = "pagination_unproven"
-		}
-		if len(items) >= options.MaxItems && hasMore {
-			truncated = true
-			stopReason = "max_items"
-		}
-		if truncated {
-			complete = false
-			hasMore = true
+		nextCursor := strings.TrimSpace(next)
+		if hasMoreKnown && !pageHasMore && nextCursor != "" {
+			return drivePageResult{}, drivePaginationError(options, "inconsistent_state", nil, page, items, drivePaginationErrorCursors{Request: cursor})
 		}
 
-		if truncated || complete || !options.PageAll {
-			break
+		endpointExhausted := false
+		switch {
+		case hasMoreKnown && !pageHasMore:
+			endpointExhausted = true
+		case hasMoreKnown && pageHasMore && nextCursor == "":
+			return drivePageResult{}, drivePaginationError(options, "missing_next_cursor", nil, page, items, drivePaginationErrorCursors{Request: cursor})
+		case nextCursor != "":
+		case len(projected) < requestPageSize:
+			endpointExhausted = true
+		default:
+			return drivePageResult{}, drivePaginationError(options, "pagination_unproven", nil, page, items, drivePaginationErrorCursors{Request: cursor})
 		}
-		if stopReason == "pagination_unproven" {
-			return nil, drivePaginationError(options, stopReason, nil, page, items, cursor)
+
+		if !endpointExhausted && seenCursors[nextCursor] {
+			return drivePageResult{}, drivePaginationError(options, "stalled_cursor", nil, page, items, drivePaginationErrorCursors{Request: cursor})
 		}
-		if nextCursor == "" {
-			return nil, drivePaginationError(options, "missing_next_cursor", nil, page, items, cursor)
+
+		result := drivePageResult{
+			Business:          map[string]any{options.OutputKey: items},
+			EndpointExhausted: endpointExhausted,
+			NextToken:         nextCursor,
+			Pages:             pagesRead,
+			Items:             len(items),
 		}
-		if seenCursors[nextCursor] {
-			return nil, drivePaginationError(options, "stalled_cursor", nil, page, items, nextCursor)
+		if endpointExhausted || !options.PageAll || len(items) >= options.MaxItems || page == pageLimit {
+			return result, nil
 		}
+
 		seenCursors[nextCursor] = true
 		cursor = nextCursor
-		if page == pageLimit {
-			truncated = true
-			stopReason = "max_pages"
-		}
 	}
-
-	return map[string]any{
-		"contractVersion": "drive.list.v1",
-		"status":          "success",
-		"count":           len(items),
-		options.OutputKey: items,
-		"pagesRead":       pagesRead,
-		"complete":        complete,
-		"truncated":       truncated,
-		"hasMore":         hasMore,
-		"nextCursor":      nextCursor,
-		"stopReason":      stopReason,
-		"failures":        []map[string]any{},
-	}, nil
 }
 
-func drivePaginationError(options drivePageOptions, reason string, cause error, page int, items []map[string]any, cursor string) error {
+func outputDrivePageResult(rt *shortcut.RuntimeContext, result drivePageResult) error {
+	pagination, err := output.NewPagination(result.EndpointExhausted, result.NextToken)
+	if err != nil {
+		return fmt.Errorf("drive pagination result is invalid: %w", err)
+	}
+	pagination.Pages = result.Pages
+	pagination.Items = result.Items
+	meta := &output.Meta{
+		Count:      output.NewCount(result.Items),
+		Pagination: pagination,
+	}
+	return output.StoreResult(rt.Command().Context(), output.Success(result.Business, output.WithMeta(meta)))
+}
+
+func drivePaginationError(options drivePageOptions, reason string, cause error, page int, items []map[string]any, cursors drivePaginationErrorCursors) error {
 	message := fmt.Sprintf("%s 分页未完成，已在第 %d 页停止", options.Tool, page)
 	if cause != nil {
 		message += ": " + cause.Error()
+	}
+	details := map[string]any{
+		"contractVersion": "drive.list.v1",
+		"status":          "partial_success",
+		"complete":        false,
+		"reason":          reason,
+		"page":            page,
+		"count":           len(items),
+		options.OutputKey: items,
+	}
+	if cursors.Request != "" {
+		details["requestCursor"] = cursors.Request
+	}
+	actions := []string{"缩小查询范围后重新执行"}
+	if cursors.Retry != "" {
+		details["retryCursor"] = cursors.Retry
+		actions = append([]string{"使用 retryCursor 重试当前页"}, actions...)
 	}
 	return apperrors.NewAPI(
 		message,
 		apperrors.WithOperation(options.Server+"/"+options.Tool),
 		apperrors.WithReason("drive_pagination_"+reason),
 		apperrors.WithFailureStage("pagination"),
-		apperrors.WithExecutionStarted(false),
+		apperrors.WithExecutionStarted(true),
 		apperrors.WithRetryable(cause != nil),
-		apperrors.WithActions("保留 nextCursor 后继续读取", "缩小查询范围后重试"),
-		apperrors.WithDetails(map[string]any{
-			"contractVersion": "drive.list.v1",
-			"status":          "partial_success",
-			"complete":        false,
-			"reason":          reason,
-			"page":            page,
-			"nextCursor":      cursor,
-			"count":           len(items),
-			options.OutputKey: items,
-		}),
+		apperrors.WithActions(actions...),
+		apperrors.WithDetails(details),
 		apperrors.WithCause(cause),
 	)
 }

--- a/skills/multi/dingtalk-drive/SKILL.md
+++ b/skills/multi/dingtalk-drive/SKILL.md
@@ -37,8 +37,8 @@ metadata:
 
 | 用户意图 | 唯一推荐入口 | 关键边界 |
 |---|---|---|
-| 全局按名称或关键词找文件 | `dws drive +search --query <关键词>` | 多候选停止；Drive 搜索没有 Doc 的 `--page-all`，按真实 nextCursor 翻页；在线文档正文搜索走 `doc +search` |
-| 浏览根目录或已知文件夹 | `dws drive +list [--folder <dentryUuid>]` | 默认一页，处理 nextCursor |
+| 全局按名称或关键词找文件 | `dws drive +search --query <关键词> --page-all --max-pages 20 --max-items 500` | 需要完整搜索时自动翻页；只需首批结果时可不加 `--page-all`；多候选停止；在线文档正文搜索走 `doc +search` |
+| 浏览根目录或已知文件夹 | `dws drive +list [--folder <dentryUuid>] --page-all --max-pages 20 --max-items 500` | 需要完整浏览时自动翻页；只需首批结果时可不加 `--page-all` |
 | 发现钉盘企业空间或“我的文件”空间 | `dws wiki space list --type <orgSpace\|mySpace> --format json` | Drive 只读前置；orgSpace 按 nextToken 续页，取 spaceId/rootFolderId 后回到 Drive |
 | 查看最近访问/编辑 | `dws drive +recent [--operate-type 1] --limit <N>` | 1=最近编辑；默认最近访问 |
 | 查看节点类型和元数据 | `dws drive +inspect --node <dentryUuid>` | 按需加 stats/publish/cover，不为普通列表强制调用 |
@@ -80,7 +80,7 @@ metadata:
 
 ## 关键结果语义
 
-- `+list/+search/+recent` 检查集合、hasMore 和 nextCursor；缺少集合不能当空结果，多候选禁止默认第一项。
+- `+list/+search/+recent` 的完整查询统一使用 `--page-all --max-pages <N> --max-items <N>`，并检查集合、完整性和截断状态；只需首批结果时可不加 `--page-all`。缺少集合不能当空结果，多候选禁止默认第一项。
 - `+download` 验证相对路径存在且 sizeBytes > 0；`+upload` 检查最终 nodeId、名称、类型和大小。只有源端与结果都提供可比哈希时才核对 checksum；缺失时保留现有证据，不虚构端到端校验和。
 - copy/move/rename/create-folder 检查 `ok/outcome` 和读回；`partial_success` 不是完成。
 - status 检查分类集合；pull/push/sync 检查 summary 和逐项结果，failed/unknown 必须保留。


### PR DESCRIPTION
## Summary

- Add bounded automatic pagination to `dws drive +list`, `+search`, and `+recent` through optional `--page-all`, `--max-pages`, and `--max-items`; preserve default one-page behavior and implicit page sizes.
- Publish validated `meta.count` / `meta.pagination` while retaining legacy `data.count`, `data.hasMore`, and optional `data.nextCursor`, derived from the same validated state.
- Reject contradictory, missing, unprovable, and stalled pagination evidence; distinguish a failed-page `retryCursor` from a safe continuation token.
- Reject metadata-only statistics and retain committed-resource evidence when create/upload read-back names differ, avoiding blind duplicate writes.
- Teach complete list/search pagination in the Drive Skill Golden Route.

## Latest review fixes and synchronization

Candidate `9b0ff06f66944969984ab2ba7ca648c651c15af3`, branch `drive_opt`, rebased onto `main` at `29fbcb40a4d123b5e282912a3736ac1788c706bc`.
All seven pre-rebase patches are unchanged according to `git range-diff`; no extra product edits were introduced by this synchronization. The new upstream includes shared upload/delegation and app/Schema changes, so affected validation is rerun rather than assumed unaffected.

- **P2 — error identity:** remove fixed `error.details.contractVersion=drive.list.v1`. Typed `operation` correctly identifies `drive/list_files`, `drive/search_files`, or `doc/get_recent_list`; no secondary version protocol is introduced. Tests cover transport and pagination-state errors on all three commands.
- **P1 — shared Result compatibility:** preserve the legacy collection Schema properties, required fields, and `additionalProperties:true`, including recycle/star/version-history/search-docs.
- **P1 — wire compatibility:** preserve the existing collection data paths beside framework metadata. Unified-envelope tests cover all seven collection commands, including exhausted/bounded states on automatic-pagination routes.

## Risk tier

- [ ] Documentation-only
- [x] Standard: scoped Drive behavior, optional controls, tests, Skill guidance, and release fragment; stable package graph
- [ ] High-risk

## Compatibility and governance

- Existing command paths, aliases, flag types, defaults, requiredness, and legacy collection data paths are preserved.
- Nine optional flags are added across three commands. Explicit new `--max-pages` / `--max-items` controls require `--page-all` and positive values.
- Current-candidate Interface Integrity is compatible with zero blocking changes against main and stable `v1.0.60`; complete Schema compatibility passes both. No separate migration-ledger PR is required for these optional additions.
- The pre-existing metadata emitters of recycle/star/version-history/search-docs are not migrated; this PR preserves their shared business-data Schema.

## Verification

Local results below belong to `9b0ff06f`; GitHub CI is separate and must rerun after the head push.

- [x] Release fragment `.changes/drive-shortcut-pagination-verification.md`; `check-release-fragments.sh origin/main HEAD` — PASS
- [x] `git diff --check origin/main...HEAD` — PASS
- [x] `make build` — PASS
- [ ] `DWS_PACKAGE_VERSION=0.0.0-test go test -race -count=1 ./internal/shortcut/drive ./internal/helpers ./internal/app` — Drive PASS; helpers/app running
- [x] Eight focused Drive regression groups — PASS; exact current-SHA log captured
- [x] Changed-code coverage via `TestCrossPlatformCoverage*` and `check-coverage-gate.sh --base-ref origin/main --changed-only --diff-profile <profile>` — 141/141 executable statements, 100.0000%
- [x] `check-generated-drift.sh` including assembly determinism — PASS
- [x] `check-schema-catalog.sh` — PASS, 29 products / 1298 tools; `check-command-surface.sh --strict` — PASS
- [x] Built CLI `drive +list --help` and compact Schema — pagination controls and framework metadata paths present
- [x] `make authoritative-interface-integrity BASE_REF=origin/main CANDIDATE_REF=9b0ff06f66944969984ab2ba7ca648c651c15af3` — compatible, blocking 0
- [x] `make schema-compatibility BASE_REF=origin/main CANDIDATE_REF=9b0ff06f66944969984ab2ba7ca648c651c15af3` — PASS against main and stable
- [x] `make skill-command-integrity` and `make skill-context-budget` — PASS
- [x] `check-open-source-assets.sh` — PASS; evidence is limited to aggregates and synthetic tests
- Full-repository tests/lint are not claimed locally; Actions owns those results.

## Agent 测试报告

The existing report evaluates historical **`42406bf6`**, not this current PR head. Its Judge decisions, source files, and denominator have not been changed. These are the previously audited report values, not a new evaluation run:

| Historical series | Business success | Average Total (Token) | Average seconds/Attempt | Average Agent rounds/Attempt |
|---|---:|---:|---:|---:|
| Drive `42406bf6` | 299/318 (94.03%) | 267,796 | 88.722 | 14.198 |
| V1 `62d72ad8` | 196/212 (92.45%) | 276,649 | 96.526 | 15.156 |
| Baseline `ea18feb0` | 170/212 (80.19%) | 384,892 | 102.587 | 14.750 |
| Lark CLI 1.0.87 | 459/555 (82.70%) | 552,053 | 108.971 | 16.182 |

106 cases × 3 runs = 318: targeted reruns replace original positions rather than increasing the denominator. Current/V1 use the report's normalized business rules; baseline/Lark retain historical Judges and are qualified comparisons. Confirmation-framework retests are not attributed to Drive Shortcut code. Historical execution excludes later Golden Route, pagination-envelope, and latest review changes; it is **not current-HEAD Agent validation**.

## 指令回归截图

The historical Agent report screenshot and a freshly captured `9b0ff06f` focused-test screenshot are prepared and privacy-checked. **Upload remains blocked by Chrome's local-file permission; no image is claimed attached.** The current-head screenshot proves synthetic command regression tests, not live Agent execution.

## Notes

- Bounded pagination remains opt-in; rollback is a normal revert of this PR.
- This is the same Open/Ready PR. Existing auto-merge settings are unchanged; no manual merge was performed.
- Current-head evidence is synthetic; no new business evaluation or Judge run was started by this rebase.
