### PR TITLE
fix(ci): approve mail contact confirmation hardening

### DIFF
--- a/scripts/policy/schema-compat/main.go
+++ b/scripts/policy/schema-compat/main.go
@@ -104,6 +104,12 @@ var reviewedCompatibilityExceptions = map[string][]reviewedCompatibilityExceptio
 	"wiki/wiki.remove_member": {
 		{Field: "confirmation", Old: "not_required", New: "user_required"},
 	},
+	// PR #1193: personal mail contact batch deletion bypasses interactive CLI
+	// confirmation, so its published Agent contract must require the same
+	// explicit user approval enforced by the runtime guard.
+	"mail/mail.batch_delete_user_mail_contacts": {
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+	},
 	// PR #1097 (issue #1096): 6 commands that affect other users and are
 	// irreversible were incorrectly marked not_required / medium. Tightened
 	// to user_required / high; calendar event delete and minutes replace-text

--- a/scripts/policy/schema-compat/main_test.go
+++ b/scripts/policy/schema-compat/main_test.go
@@ -423,6 +423,7 @@ func TestSchemaCompatibilityAcceptsReviewedRemoveConfirmationHardening(t *testin
 	for _, toolPath := range []string{
 		"doc/doc.remove_permission",
 		"drive/drive.permission_remove",
+		"mail/mail.batch_delete_user_mail_contacts",
 		"wiki/wiki.remove_member",
 	} {
 		if failures := checkToolCompatibility(toolPath, oldTool, newTool); len(failures) != 0 {


### PR DESCRIPTION
## Summary

- Approve the exact Schema compatibility transition for `mail/mail.batch_delete_user_mail_contacts` from `not_required` to `user_required`.
- Keep every unrelated tool, field, and reverse transition fail-closed.
- This is the base-owned prerequisite for #1193.

## Risk tier

- [ ] Documentation-only
- [ ] Standard
- [x] High-risk: policy compatibility allowlist

## Verification

- [x] Release fragment: N/A; no user-visible implementation or interface is shipped by this governance-only PR.
- [x] Targeted tests: `go test ./scripts/policy/schema-compat -count=1`
- [x] Authority integration: `go test ./scripts/policy/schemacompat -count=1`
- [x] Behavior evidence: the reviewed tool accepts only the exact `confirmation: not_required -> user_required` transition; existing tests continue rejecting unreviewed tools and reverse weakening.
- [x] Documentation: N/A
- [ ] Full local suite: delegated to required high-risk CI

## Notes

After this lands on `main`, #1193 must merge/rebase the new main authority and rerun CI.