### PR TITLE
fix(chat): allow quote replies when conversation omits topic state

### DIFF
--- a/internal/helpers/chat_thread.go
+++ b/internal/helpers/chat_thread.go
@@ -1116,7 +1116,7 @@ func guardTopicQuoteReply(cmd *cobra.Command, openConversationID, openMessageID 
 	case topicContainerTopic:
 		return topicQuoteReplyDisabledError()
 	case topicContainerUnknown:
-		return topicQuoteGuardUnavailable("chat/get_conversation_info", "会话信息未明确返回 convThreadEnabled，无法确认引用回复目标是否属于话题圈，已阻止发送")
+		return topicQuoteGuardUnavailable("chat/get_conversation_info", "会话信息返回的 convThreadEnabled 取值无法解析，无法确认引用回复目标是否属于话题圈，已阻止发送")
 	}
 	return nil
 }
@@ -1148,7 +1148,6 @@ const (
 )
 
 func detectTopicContainerState(value any) topicContainerState {
-	sawFalse := false
 	sawInvalid := false
 	var visit func(any) bool
 	visit = func(current any) bool {
@@ -1166,13 +1165,11 @@ func detectTopicContainerState(value any) topicContainerState {
 					if enabled {
 						return true
 					}
-					sawFalse = true
 				case string:
 					switch strings.ToLower(strings.TrimSpace(enabled)) {
 					case "true", "1":
 						return true
 					case "false", "0":
-						sawFalse = true
 					default:
 						sawInvalid = true
 					}
@@ -1192,10 +1189,12 @@ func detectTopicContainerState(value any) topicContainerState {
 	if visit(value) {
 		return topicContainerTopic
 	}
-	if sawFalse && !sawInvalid {
-		return topicContainerNonTopic
+	if sawInvalid {
+		return topicContainerUnknown
 	}
-	return topicContainerUnknown
+	// 网关仅对开启话题圈的会话返回 convThreadEnabled / topicGroup / isTopicGroup，
+	// 普通会话整个字段缺失：缺失按非话题处理，只有取值存在但无法解析时才视为无法判定。
+	return topicContainerNonTopic
 }
 
 func topicQuoteGuardUnavailable(operation, message string) error {

--- a/internal/helpers/chat_thread_test.go
+++ b/internal/helpers/chat_thread_test.go
@@ -1102,6 +1102,7 @@ func TestCrossPlatformCoverageAtomicThreadQuoteGuardRejectsConversationFailuresA
 		wantReason string
 	}{
 		{name: "invalid response", response: `<html>bad gateway</html>`, wantReason: "topic_quote_guard_unavailable"},
+		{name: "unparseable convThreadEnabled", response: `{"result":{"convThreadEnabled":"maybe"}}`, wantReason: "topic_quote_guard_unavailable"},
 		{name: "topic conversation", response: `{"result":{"convThreadEnabled":true}}`, wantReason: "topic_quote_reply_disabled"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -1123,20 +1124,21 @@ func TestCrossPlatformCoverageAtomicThreadQuoteGuardRejectsConversationFailuresA
 	}
 }
 
-func TestCrossPlatformCoverageAtomicThreadQuoteGuardFailsClosedWithoutConversationState(t *testing.T) {
+func TestCrossPlatformCoverageAtomicThreadQuoteGuardAllowsWhenConversationOmitsTopicState(t *testing.T) {
+	// 网关对普通会话不返回 convThreadEnabled（字段仅话题圈会话才有），
+	// 字段缺失应按非话题放行，否则普通群的引用回复会被整体误拦。
 	caller := &chatThreadCaller{responses: map[string]string{
 		"im/list_messages_by_ids":    `{"result":{"messages":[{"openMessageId":"message-1","openConversationId":"cid"}]}}`,
 		"chat/get_conversation_info": `{"result":{"openConversationId":"cid"}}`,
 	}}
-	err := executeAtomicThreadCommand(t, caller,
+	if err := executeAtomicThreadCommand(t, caller,
 		"message", "reply", "--conversation-id", "cid", "--ref-msg-id", "message-1",
-		"--ref-sender", "DAAAAAAAAAAAiE", "--text", "普通引用")
-	var typed *apperrors.Error
-	if err == nil || !errors.As(err, &typed) || typed.Reason != "topic_quote_guard_unavailable" {
-		t.Fatalf("error = %v", err)
+		"--ref-sender", "DAAAAAAAAAAAiE", "--text", "普通引用"); err != nil {
+		t.Fatal(err)
 	}
-	if len(caller.calls) != 2 || caller.calls[1].tool != "get_conversation_info" {
-		t.Fatalf("quote guard reached write: %#v", caller.calls)
+	if len(caller.calls) != 3 || caller.calls[0].tool != "list_messages_by_ids" ||
+		caller.calls[1].tool != "get_conversation_info" || caller.calls[2].tool != "send_personal_message" {
+		t.Fatalf("quote guard calls = %#v", caller.calls)
 	}
 }
 
@@ -1449,6 +1451,9 @@ func TestCrossPlatformCoverageDetectTopicContainerState(t *testing.T) {
 		{name: "nested array", value: []any{map[string]any{"convThreadEnabled": true}}, want: topicContainerTopic},
 		{name: "topic group", value: map[string]any{"topicGroup": "1"}, want: topicContainerTopic},
 		{name: "is topic group false", value: map[string]any{"isTopicGroup": false}, want: topicContainerNonTopic},
+		{name: "no topic fields", value: map[string]any{"openConversationId": "cid"}, want: topicContainerNonTopic},
+		{name: "empty object", value: map[string]any{}, want: topicContainerNonTopic},
+		{name: "nil", value: nil, want: topicContainerNonTopic},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if got := detectTopicContainerState(test.value); got != test.want {


### PR DESCRIPTION
## 问题

`chat message reply` 对所有普通群（非话题圈）一律失败，错误为 `topic_quote_guard_unavailable`：

​```
dws chat message reply --conversation-id <普通群cid> --ref-msg-id <msgId> ...
→ 会话信息未明确返回 convThreadEnabled，无法确认引用回复目标是否属于话题圈，已阻止发送
​```

真机复现：对普通群发起引用回复，100% 失败，功能整体不可用。

## 根因

`guardTopicQuoteReply` 依赖 `chat/get_conversation_info` 显式返回 `convThreadEnabled=false` 才放行。但真实网关**只对开启话题圈的会话返回该字段**，普通会话的响应里根本没有这个字段（真机抽样 6 个普通会话均无）。于是 `detectTopicContainerState` 把「字段缺失」判为 `topicContainerUnknown`，fail-closed 拦截——把所有普通群的引用回复全部误杀。

guard 引入（67342e3f / c76bad4a）时的意图是拦截「话题圈内引用回复」（话题圈应走 `chat thread reply`），而不是拦截普通群；字段缺失被并入 Unknown 是实现层面的过度保守。

## 修复

`detectTopicContainerState` 区分两种情况：

- 字段**缺失** → 按非话题处理，放行（网关契约：字段仅话题圈会话才有）
- 字段存在但**取值无法解析**（如 `"maybe"`、数字类型）→ 仍 fail-closed 拦截

话题圈会话（字段为 true）依旧被拒（`topic_quote_reply_disabled`），防护语义不变。同时更新了 guard 的报错文案，明确其现在只对应「取值无法解析」。

## 测试

- 原 fail-closed 用例 `FailsClosedWithoutConversationState` 改写为 `AllowsWhenConversationOmitsTopicState`：字段缺失时断言放行并到达 `send_personal_message`
- 失败路径新增「取值无法解析」用例（`convThreadEnabled: "maybe"` → 仍拦截）
- `DetectTopicContainerState` 单测补充字段缺失场景（无话题字段 / 空对象 / nil）
- 既有 mock 均 payload 显式带 `convThreadEnabled:false`，不受影响；`internal/helpers` 全量套件通过

## 真机验证

修复构建的二进制对普通群发起引用回复成功（返回 openTaskId，消息真实送达）；话题圈拒绝路径行为不变。

## 权衡说明

这会轻微放宽 guard：若某个话题圈会话的 `get_conversation_info` 响应恰好缺失该字段，引用回复将被放行。但真机证据表明网关对话题圈会话稳定返回该字段，此场景仅为理论风险；相比「所有普通群引用回复全部不可用」的实际影响，放行缺失字段是正确取舍。