### PR TITLE
fix(cli): classify validation errors and unify outputs

### DIFF
--- a/internal/app/param_alias_e2e_test.go
+++ b/internal/app/param_alias_e2e_test.go
@@ -299,7 +299,11 @@ func executeParamAliasDryRunE2E(t *testing.T, args ...string) (*pipeline.Context
 	}
 	root := NewRootCommand()
 	rootNewCommandRunnerWithFlags = originalRunnerFactory
-	root.SetOut(io.Discard)
+	// Unified-result leaves emit through Cobra's output writer, while legacy
+	// dry-run leaves still write through the process stdout formatter. Point
+	// both surfaces at the same capture file so this protocol-agnostic alias
+	// probe keeps observing the one preview produced by either rollout state.
+	root.SetOut(captureFile)
 	root.SetErr(io.Discard)
 	root.SetArgs(args)
 
@@ -320,7 +324,15 @@ func executeParamAliasDryRunE2E(t *testing.T, args ...string) (*pipeline.Context
 	}
 	var preview paramAliasDryRunPreview
 	if executeErr == nil {
-		if err := json.Unmarshal(output, &preview); err != nil {
+		previewJSON := output
+		var envelope struct {
+			OK   *bool           `json:"ok"`
+			Data json.RawMessage `json:"data"`
+		}
+		if err := json.Unmarshal(output, &envelope); err == nil && envelope.OK != nil && len(envelope.Data) > 0 {
+			previewJSON = envelope.Data
+		}
+		if err := json.Unmarshal(previewJSON, &preview); err != nil {
 			t.Fatalf("decode dry-run preview: %v\noutput=%s", err, output)
 		}
 	}

--- a/internal/corecmd/corecmd.go
+++ b/internal/corecmd/corecmd.go
@@ -750,7 +750,10 @@ func ValidateRequired(cmd *cobra.Command, flags []FlagSpec) error {
 		}
 	}
 	if err := cmdutil.MissingRequiredFlagsError(cmd, plain...); err != nil {
-		return err
+		return apperrors.NewValidation(
+			err.Error(),
+			apperrors.WithReason("missing_required_flags"),
+		)
 	}
 	for _, flag := range flags {
 		if !flag.Required || flag.ValidationMode == ValidationShortcut ||

--- a/internal/corecmd/corecmd_test.go
+++ b/internal/corecmd/corecmd_test.go
@@ -294,8 +294,16 @@ func TestCrossPlatformCoverageValidateRequired(t *testing.T) {
 	plain := []FlagSpec{{Name: "content", Usage: "C", Required: true}}
 	cmd := newTestCommand()
 	RegisterFlags(cmd, plain)
-	if err := ValidateRequired(cmd, plain); err == nil || !strings.Contains(err.Error(), "content") {
+	err := ValidateRequired(cmd, plain)
+	if err == nil || !strings.Contains(err.Error(), "content") {
 		t.Fatalf("missing plain required err = %v", err)
+	}
+	if got := apperrors.ExitCode(err); got != apperrors.ExitCodeValidation {
+		t.Fatalf("missing plain required exit code = %d, want %d", got, apperrors.ExitCodeValidation)
+	}
+	var typed *apperrors.Error
+	if !errors.As(err, &typed) || typed.Reason != "missing_required_flags" {
+		t.Fatalf("missing plain required error = %#v, want validation/missing_required_flags", err)
 	}
 	_ = cmd.Flags().Set("content", "x")
 	if err := ValidateRequired(cmd, plain); err != nil {

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -3102,10 +3102,16 @@ func newChatCommand() *cobra.Command {
 				specified++
 			}
 			if specified > 1 {
-				return fmt.Errorf("--conversation-id, --user and --open-dingtalk-id are mutually exclusive, specify exactly one")
+				return apperrors.NewValidation(
+					"--conversation-id, --user and --open-dingtalk-id are mutually exclusive, specify exactly one",
+					apperrors.WithReason("mutually_exclusive"),
+				)
 			}
 			if specified == 0 {
-				return fmt.Errorf("--conversation-id, --user or --open-dingtalk-id is required")
+				return apperrors.NewValidation(
+					"--conversation-id, --user or --open-dingtalk-id is required",
+					apperrors.WithReason("require_one_of"),
+				)
 			}
 			if openDingTalkID != "" {
 				if err := targetresolver.ValidateExplicitOpenDingTalkID("--open-dingtalk-id", openDingTalkID); err != nil {
@@ -3333,10 +3339,16 @@ func newChatCommand() *cobra.Command {
 				specified++
 			}
 			if specified > 1 {
-				return fmt.Errorf("--conversation-id, --user and --open-dingtalk-id are mutually exclusive, specify exactly one")
+				return apperrors.NewValidation(
+					"--conversation-id, --user and --open-dingtalk-id are mutually exclusive, specify exactly one",
+					apperrors.WithReason("mutually_exclusive"),
+				)
 			}
 			if specified == 0 {
-				return fmt.Errorf("--conversation-id, --user or --open-dingtalk-id is required")
+				return apperrors.NewValidation(
+					"--conversation-id, --user or --open-dingtalk-id is required",
+					apperrors.WithReason("require_one_of"),
+				)
 			}
 			if openDingTalkID != "" {
 				if err := targetresolver.ValidateExplicitOpenDingTalkID("--open-dingtalk-id", openDingTalkID); err != nil {
@@ -3385,7 +3397,10 @@ func newChatCommand() *cobra.Command {
 				switch msgType {
 				case "image":
 					if mediaId == "" {
-						return fmt.Errorf("--media-id is required for msgType=image")
+						return apperrors.NewValidation(
+							"--media-id is required for msgType=image",
+							apperrors.WithReason("missing_required_flag"),
+						)
 					}
 					contentJSON = fmt.Sprintf(`{"mediaId":"%s"}`, mediaId)
 				case "file", "audio", "video":
@@ -3394,7 +3409,10 @@ func newChatCommand() *cobra.Command {
 					dentryId, _ := cmd.Flags().GetInt64("dentry-id")
 					spaceId, _ := cmd.Flags().GetInt64("space-id")
 					if (dentryId == 0) != (spaceId == 0) {
-						return fmt.Errorf("--dentry-id and --space-id must be specified together")
+						return apperrors.NewValidation(
+							"--dentry-id and --space-id must be specified together",
+							apperrors.WithReason("require_together"),
+						)
 					}
 					if filePath != "" {
 						meta, err := buildConversationLocalFileMeta(filePath, "", "")
@@ -3433,7 +3451,11 @@ func newChatCommand() *cobra.Command {
 							}
 							contentJSON, _ = buildConversationFileContent(dentryId, spaceId, meta)
 						} else if dentryId == 0 || spaceId == 0 {
-							return fmt.Errorf("--file must be a readable local file, or pass legacy --dentry-id and --space-id: %w", err)
+							return apperrors.NewValidation(
+								"--file must be a readable local file, or pass legacy --dentry-id and --space-id: "+err.Error(),
+								apperrors.WithReason("invalid_file"),
+								apperrors.WithCause(err),
+							)
 						}
 					}
 					if contentJSON == "" {
@@ -3441,7 +3463,10 @@ func newChatCommand() *cobra.Command {
 						fileType, _ := cmd.Flags().GetString("file-type")
 						fileSize, _ := cmd.Flags().GetInt64("file-size")
 						if dentryId == 0 || spaceId == 0 || fileName == "" {
-							return fmt.Errorf("readable local --file is required for msgType=file; legacy flags --dentry-id, --space-id, --file-name are still supported")
+							return apperrors.NewValidation(
+								"readable local --file is required for msgType=file; legacy flags --dentry-id, --space-id, --file-name are still supported",
+								apperrors.WithReason("missing_required_flags"),
+							)
 						}
 						contentJSON = fmt.Sprintf(`{"dentryId":%d,"spaceId":%d,"fileName":"%s","fileType":"%s","filePath":"%s","fileSize":%d}`,
 							dentryId, spaceId, fileName, fileType, filePath, fileSize)
@@ -3452,17 +3477,26 @@ func newChatCommand() *cobra.Command {
 					locationName, _ := cmd.Flags().GetString("location-name")
 					mapThumbnailUrl, _ := cmd.Flags().GetString("map-thumbnail-url")
 					if latitude == "" || longitude == "" || locationName == "" || mapThumbnailUrl == "" {
-						return fmt.Errorf("--latitude, --longitude, --location-name, --map-thumbnail-url are all required for msgType=location")
+						return apperrors.NewValidation(
+							"--latitude, --longitude, --location-name, --map-thumbnail-url are all required for msgType=location",
+							apperrors.WithReason("missing_required_flags"),
+						)
 					}
 					contentJSON = fmt.Sprintf(`{"locationName":"%s","longitude":"%s","latitude":"%s","mapThumbnailUrl":"%s"}`, locationName, longitude, latitude, mapThumbnailUrl)
 				case "profile":
 					contactID, _ := cmd.Flags().GetString("contact-id")
 					if contactID == "" {
-						return fmt.Errorf("--contact-id is required for msgType=profile")
+						return apperrors.NewValidation(
+							"--contact-id is required for msgType=profile",
+							apperrors.WithReason("missing_required_flag"),
+						)
 					}
 					contentJSON = fmt.Sprintf(`{"openDingTalkId":"%s"}`, contactID)
 				default:
-					return fmt.Errorf("unsupported --msg-type: %s (supported: image, file, audio, video, location, profile)", msgType)
+					return apperrors.NewValidation(
+						fmt.Sprintf("unsupported --msg-type: %s (supported: image, file, audio, video, location, profile)", msgType),
+						apperrors.WithReason("invalid_enum"),
+					)
 				}
 
 				params := map[string]any{
@@ -3487,7 +3521,10 @@ func newChatCommand() *cobra.Command {
 				text = args[0]
 			}
 			if text == "" {
-				return fmt.Errorf("message content required (use --content or positional arg, or --media-id for image)")
+				return apperrors.NewValidation(
+					"message content required (use --content or positional arg, or --media-id for image)",
+					apperrors.WithReason("require_one_of"),
+				)
 			}
 			title, _ := cmd.Flags().GetString("title")
 			if title == "" {
@@ -3526,6 +3563,7 @@ func newChatCommand() *cobra.Command {
 	}
 	chatMessageSendRunE := chatMessageSendCmd.RunE
 	DeclareLeafMetadata(chatMessageSendCmd, LeafSpec{
+		OutputRollout: output.RolloutUnifiedActive,
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "medium",
 			Confirmation: "not_required", Idempotency: "unknown",
@@ -3556,6 +3594,25 @@ func newChatCommand() *cobra.Command {
 				{Name: "group", Property: "openConversationId", Required: boolPtr(false)},
 				{Name: "idempotency-key", Property: "uuid"},
 				{Name: "open-dingtalk-id", Property: "receiverOpenDingTalkId"},
+			},
+			Result: &contract.ResultSpec{
+				Outcomes: []contract.ResultOutcome{
+					contract.ResultOutcomeSuccess,
+					contract.ResultOutcomePending,
+					contract.ResultOutcomeFailure,
+				},
+				DataSchema: json.RawMessage(`{
+					"type":"object",
+					"description":"个人消息发送的下游响应；标识可能位于顶层或 result 对象中",
+					"properties":{
+						"success":{"type":"boolean","description":"下游是否接受发送请求"},
+						"result":{"type":"object","description":"下游返回的发送结果对象","additionalProperties":true},
+						"openTaskId":{"type":"string","description":"异步发送任务 ID"},
+						"openMessageId":{"type":"string","description":"发送成功后的消息 ID"},
+						"openConversationId":{"type":"string","description":"消息所在会话 ID"}
+					},
+					"additionalProperties":true
+				}`),
 			},
 		},
 	})

--- a/internal/helpers/chat_command_edges_test.go
+++ b/internal/helpers/chat_command_edges_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,13 @@ func runChatCoverageCommand(t *testing.T, caller edition.ToolCaller, args ...str
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)
 	root.SetArgs(append(append([]string(nil), args...), "--yes"))
-	return root.ExecuteContext(context.Background())
+	ctx, _ := output.WithResultStore(context.Background())
+	executed, err := root.ExecuteContextC(ctx)
+	if err != nil {
+		return err
+	}
+	_, _, err = output.EmitStoredResult(executed)
+	return err
 }
 
 func runChatCoverageDirect(t *testing.T, path []string, flags map[string]string) error {
@@ -57,6 +64,20 @@ func runChatCoverageDirect(t *testing.T, path []string, flags map[string]string)
 		flag.Changed = true
 	}
 	return command.RunE(command, nil)
+}
+
+func TestCrossPlatformCoverageChatMessageSendValidationErrorsAreTyped(t *testing.T) {
+	err := runChatCoverageDirect(t, []string{"message", "send"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "--conversation-id") {
+		t.Fatalf("missing target error = %v", err)
+	}
+	if got := apperrors.ExitCode(err); got != apperrors.ExitCodeValidation {
+		t.Fatalf("missing target exit code = %d, want validation/%d", got, apperrors.ExitCodeValidation)
+	}
+	var typed *apperrors.Error
+	if !errors.As(err, &typed) || typed.Reason != "require_one_of" {
+		t.Fatalf("missing target error = %#v, want validation/require_one_of", err)
+	}
 }
 
 func TestCrossPlatformCoverageEvaluationRegressionChatSearchSpellingsAndNaturalBotTarget(t *testing.T) {

--- a/internal/helpers/chat_message_search_test.go
+++ b/internal/helpers/chat_message_search_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/agentproduct"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/spf13/cobra"
@@ -722,7 +723,13 @@ func executeChatChangedContract(t *testing.T, caller *chatChangedContractCaller,
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
 	cmd.SetArgs(append(append([]string(nil), args...), "--yes"))
-	return cmd.Execute()
+	ctx, _ := output.WithResultStore(context.Background())
+	executed, err := cmd.ExecuteContextC(ctx)
+	if err != nil {
+		return err
+	}
+	_, _, err = output.EmitStoredResult(executed)
+	return err
 }
 
 func TestCrossPlatformCoverageChatMessageListUsesMCPMetadataGroupKey(t *testing.T) {

--- a/internal/helpers/destructive_confirmation_test.go
+++ b/internal/helpers/destructive_confirmation_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/spf13/cobra"
@@ -64,7 +65,13 @@ func executeGuardedMutationCommand(t *testing.T, caller *guardedMutationCaller, 
 		root.SetIn(strings.NewReader(""))
 	}
 	root.SetArgs(args)
-	return root.Execute()
+	ctx, _ := output.WithResultStore(context.Background())
+	executed, err := root.ExecuteContextC(ctx)
+	if err != nil {
+		return err
+	}
+	_, _, err = output.EmitStoredResult(executed)
+	return err
 }
 
 func requireTypedConfirmationError(t *testing.T, err error) {

--- a/internal/helpers/drive.go
+++ b/internal/helpers/drive.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 )
 
 // ──────────────────────────────────────────────────────────
@@ -2180,14 +2182,17 @@ func newDriveCommand() *cobra.Command {
 			switch taskType {
 			case "export", "import", "copy", "move":
 			default:
-				return fmt.Errorf("不支持的任务类型: %s，当前支持: export|import|copy|move", taskType)
+				return apperrors.NewValidation(
+					fmt.Sprintf("不支持的任务类型: %s，当前支持: export|import|copy|move", taskType),
+					apperrors.WithReason("invalid_enum"),
+				)
 			}
 
 			if deps.Caller.DryRun() {
-				deps.Out.PrintKeyValue("操作", "查询异步任务")
-				deps.Out.PrintKeyValue("类型", taskType)
-				deps.Out.PrintKeyValue("ID", taskID)
-				return nil
+				return output.StoreResult(cmd.Context(), output.Success(map[string]any{
+					"id":   taskID,
+					"type": taskType,
+				}, output.WithDryRun()))
 			}
 
 			// query_task 工具注册在 drive (dingpan) MCP server 上，需显式路由。
@@ -2195,12 +2200,13 @@ func newDriveCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return deps.Out.PrintJSON(result)
+			return output.StoreResult(cmd.Context(), output.Success(result))
 		},
 	}
 	taskGetCmd.Flags().String("type", "", "任务类型: export|import|copy|move (必填)")
 	taskGetCmd.Flags().String("id", "", "任务 ID (必填)")
 	DeclareLeafMetadata(taskGetCmd, LeafSpec{
+		OutputRollout: output.RolloutUnifiedActive,
 		Safety: contract.SafetySpec{
 			Effect: "read", Risk: "low",
 			Confirmation: "not_required", Idempotency: "idempotent",
@@ -2237,6 +2243,27 @@ func newDriveCommand() *cobra.Command {
 			Parameters: []contract.ParamDecl{
 				{Name: "id", Property: "taskId", Required: boolPtr(true)},
 				{Name: "type", Property: "taskType", Required: boolPtr(true)},
+			},
+			Result: &contract.ResultSpec{
+				Outcomes: []contract.ResultOutcome{
+					contract.ResultOutcomeSuccess,
+					contract.ResultOutcomeFailure,
+				},
+				DataSchema: json.RawMessage(`{
+					"type":"object",
+					"description":"归一化后的异步任务状态和结果",
+					"properties":{
+						"id":{"type":"string","description":"任务 ID"},
+						"type":{"type":"string","description":"任务类型","enum":["export","import","copy","move"]},
+						"status":{"type":"string","description":"归一化任务状态","enum":["PENDING","PROCESSING","SUCCESS","FAILED","PARTIAL_FAILED","TIMEOUT"]},
+						"resultUrl":{"type":"string","description":"任务产出的下载地址"},
+						"resultName":{"type":"string","description":"任务产出的文件名称"},
+						"message":{"type":"string","description":"任务状态说明或失败原因"},
+						"createTime":{"type":"string","description":"任务创建时间"}
+					},
+					"required":["id","type"],
+					"additionalProperties":false
+				}`),
 			},
 		},
 	})

--- a/internal/helpers/drive_coverage_more_test.go
+++ b/internal/helpers/drive_coverage_more_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +33,13 @@ func executeDriveEdge(t *testing.T, caller *scriptedToolCaller, args ...string) 
 	root.SetErr(io.Discard)
 	root.SetArgs(args)
 	os.Args = append([]string{"dws", "drive"}, args...)
-	return root.Execute()
+	ctx, _ := output.WithResultStore(context.Background())
+	executed, err := root.ExecuteContextC(ctx)
+	if err != nil {
+		return err
+	}
+	_, _, err = output.EmitStoredResult(executed)
+	return err
 }
 
 func TestCrossPlatformCoverageParseDriveUploadInfoRemainingCoverage(t *testing.T) {

--- a/internal/helpers/drive_task_test.go
+++ b/internal/helpers/drive_task_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 )
 
 // ── NormalizeStatus 枚举映射 ──
@@ -362,8 +364,12 @@ func TestCrossPlatformCoverageRunNodeTransferWithAsyncPoll(t *testing.T) {
 
 func TestCrossPlatformCoverageDriveTaskGetCommand(t *testing.T) {
 	t.Run("missing required flags", func(t *testing.T) {
-		if err := executeDriveEdge(t, &scriptedToolCaller{}, "task", "get"); err == nil {
+		err := executeDriveEdge(t, &scriptedToolCaller{}, "task", "get")
+		if err == nil {
 			t.Fatal("missing flags returned nil")
+		}
+		if got := apperrors.ExitCode(err); got != apperrors.ExitCodeValidation {
+			t.Fatalf("exit code = %d, want validation/%d: %v", got, apperrors.ExitCodeValidation, err)
 		}
 	})
 
@@ -371,6 +377,9 @@ func TestCrossPlatformCoverageDriveTaskGetCommand(t *testing.T) {
 		err := executeDriveEdge(t, &scriptedToolCaller{}, "task", "get", "--type", "sync", "--id", "t1")
 		if err == nil || !strings.Contains(err.Error(), "不支持的任务类型") {
 			t.Fatalf("error = %v", err)
+		}
+		if got := apperrors.ExitCode(err); got != apperrors.ExitCodeValidation {
+			t.Fatalf("exit code = %d, want validation/%d", got, apperrors.ExitCodeValidation)
 		}
 	})
 

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -26,18 +26,38 @@ import (
 // avoids a mass-rename while keeping reusable command-resolution and flag
 // utilities in cmdutil.
 var (
-	groupRunE                       = cmdutil.GroupRunE
-	hintSubCmd                      = cmdutil.HintSubCmd
-	mustGetFlag                     = cmdutil.MustGetFlag
-	flagOrFallback                  = cmdutil.FlagOrFallback
-	mustFlagOrFallback              = cmdutil.MustFlagOrFallback
-	validateRequiredFlags           = cmdutil.ValidateRequiredFlags
-	validateRequiredFlagWithAliases = cmdutil.ValidateRequiredFlagWithAliases
-	parseISOTimeToMillis            = cmdutil.ParseISOTimeToMillis
-	validateTimeRange               = cmdutil.ValidateTimeRange
-	helperSleep                     = time.Sleep
-	helperAfter                     = time.After
+	groupRunE            = cmdutil.GroupRunE
+	hintSubCmd           = cmdutil.HintSubCmd
+	mustGetFlag          = cmdutil.MustGetFlag
+	flagOrFallback       = cmdutil.FlagOrFallback
+	mustFlagOrFallback   = cmdutil.MustFlagOrFallback
+	parseISOTimeToMillis = cmdutil.ParseISOTimeToMillis
+	validateTimeRange    = cmdutil.ValidateTimeRange
+	helperSleep          = time.Sleep
+	helperAfter          = time.After
 )
+
+func validateRequiredFlags(cmd *cobra.Command, names ...string) error {
+	err := cmdutil.ValidateRequiredFlags(cmd, names...)
+	if err == nil {
+		return nil
+	}
+	return apperrors.NewValidation(
+		err.Error(),
+		apperrors.WithReason("missing_required_flags"),
+	)
+}
+
+func validateRequiredFlagWithAliases(cmd *cobra.Command, primary string, aliases ...string) error {
+	err := cmdutil.ValidateRequiredFlagWithAliases(cmd, primary, aliases...)
+	if err == nil {
+		return nil
+	}
+	return apperrors.NewValidation(
+		err.Error(),
+		apperrors.WithReason("missing_required_flag"),
+	)
+}
 
 // newGroupCommand declares the ordinary navigation policy used by helper
 // command containers. The unified framework compiles this declaration into

--- a/internal/helpers/validation_output_regression_test.go
+++ b/internal/helpers/validation_output_regression_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package helpers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contractfinal"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
+	"github.com/spf13/cobra"
+)
+
+func executeUnifiedProductCommand(t *testing.T, root *cobra.Command, caller *scriptedToolCaller, args ...string) []byte {
+	t.Helper()
+	testseam.Protect(t, &deps)
+	InitDeps(caller)
+
+	var stdout, stderr bytes.Buffer
+	deps.Out.w = &stdout
+	deps.Out.errW = &stderr
+	installExampleGlobalFlags(root)
+	if root.PersistentFlags().Lookup("debug") == nil {
+		root.PersistentFlags().Bool("debug", false, "")
+	}
+	if root.PersistentFlags().Lookup("verbose") == nil {
+		root.PersistentFlags().Bool("verbose", false, "")
+	}
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(args)
+
+	ctx, _ := output.WithResultStore(context.Background())
+	executed, err := root.ExecuteContextC(ctx)
+	if err != nil {
+		t.Fatalf("ExecuteContextC(%v): %v\nstderr:\n%s", args, err, stderr.String())
+	}
+	_, emitted, err := output.EmitStoredResult(executed)
+	if err != nil {
+		t.Fatalf("EmitStoredResult(%v): %v", args, err)
+	}
+	if !emitted {
+		t.Fatalf("command %v returned without a unified result", args)
+	}
+	return stdout.Bytes()
+}
+
+func assertUnifiedSuccessEnvelope(t *testing.T, raw []byte) {
+	t.Helper()
+	var envelope map[string]any
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("output is not one JSON envelope: %v\n%s", err, raw)
+	}
+	if envelope["ok"] != true || envelope["outcome"] != "success" {
+		t.Fatalf("envelope = %#v, want ok=true outcome=success", envelope)
+	}
+	if _, ok := envelope["data"]; !ok {
+		t.Fatalf("envelope has no data: %#v", envelope)
+	}
+}
+
+func TestCrossPlatformCoverageChatAndDriveUseUnifiedResultEnvelope(t *testing.T) {
+	t.Run("chat message send", func(t *testing.T) {
+		out := executeUnifiedProductCommand(t, newChatCommand(), &scriptedToolCaller{
+			format: "json",
+			steps:  []scriptedToolStep{{text: `{"success":true,"result":{"openMessageId":"msg-1","openConversationId":"cid-1"}}`}},
+		}, "message", "send", "--conversation-id", "cid-1", "--content", "hello", "--format", "json")
+		assertUnifiedSuccessEnvelope(t, out)
+	})
+
+	t.Run("drive task get", func(t *testing.T) {
+		out := executeUnifiedProductCommand(t, newDriveCommand(), &scriptedToolCaller{
+			format: "json",
+			steps:  []scriptedToolStep{{text: `{"status":"SUCCESS","resultUrl":"https://example.invalid/result"}`}},
+		}, "task", "get", "--type", "export", "--id", "task-1", "--format", "json")
+		assertUnifiedSuccessEnvelope(t, out)
+	})
+}
+
+func TestCrossPlatformCoverageChatAndDriveUnifiedResultDeclarations(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		root *cobra.Command
+		path []string
+	}{
+		{name: "chat message send", root: newChatCommand(), path: []string{"message", "send"}},
+		{name: "drive task get", root: newDriveCommand(), path: []string{"task", "get"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			leaf, _, err := test.root.Find(test.path)
+			if err != nil || leaf == nil {
+				t.Fatalf("Find(%v): command=%v err=%v", test.path, leaf, err)
+			}
+			if !output.UsesUnifiedResult(leaf) {
+				t.Fatalf("%s rollout = %q, want unified", test.name, output.CommandRollout(leaf))
+			}
+			final, ok := contractfinal.RuntimeContractFinal(leaf)
+			if !ok || final.Result == nil || len(final.Result.Outcomes) == 0 || len(final.Result.DataSchema) == 0 {
+				t.Fatalf("%s result declaration = %#v, found=%v", test.name, final.Result, ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- classify framework and helper required-flag failures as typed validation errors instead of internal failures
- classify Chat and Drive local argument checks with stable validation reasons
- migrate chat message send and drive task get to the unified result envelope and publish reviewed result contracts
- add regression coverage for exit-code classification and single-envelope success output

## Verification

- DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/corecmd ./internal/helpers ./internal/app
- make build
- ./scripts/policy/check-generated-drift.sh
- ./scripts/policy/check-schema-catalog.sh