### PR TITLE
fix(connect): support Qoder typed stream content

### DIFF
--- a/.changes/qoder-stream-content-blocks.md
+++ b/.changes/qoder-stream-content-blocks.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Qoder Stream replies** (#1217) — sends Qoder CLI user messages as typed text-content blocks and surfaces `errors[]` from failed stream results, preventing successful DingTalk delivery from degrading into “本地 agent 无文本输出”.

--- a/internal/helpers/connect_qoder_stream.go
+++ b/internal/helpers/connect_qoder_stream.go
@@ -153,8 +153,13 @@ func (f *qoderStreamForwarder) forwardStream(ctx context.Context, convID, text s
 		sessionID = f.sessions.id(convID)
 	}
 	msg := map[string]any{
-		"type":               "user",
-		"message":            map[string]any{"role": "user", "content": text},
+		"type": "user",
+		"message": map[string]any{
+			"role": "user",
+			"content": []map[string]string{
+				{"type": "text", "text": text},
+			},
+		},
 		"parent_tool_use_id": nil,
 		"session_id":         sessionID,
 	}
@@ -471,10 +476,11 @@ func qoderControlResponse(line, requestID string) (bool, error) {
 
 func parseQoderPersistentLine(line string) (delta, final string, done bool) {
 	var ev struct {
-		Type    string `json:"type"`
-		Subtype string `json:"subtype"`
-		Error   string `json:"error"`
-		Result  string `json:"result"`
+		Type    string   `json:"type"`
+		Subtype string   `json:"subtype"`
+		Error   string   `json:"error"`
+		Errors  []string `json:"errors"`
+		Result  string   `json:"result"`
 		Message struct {
 			Content []struct {
 				Type string `json:"type"`
@@ -503,6 +509,9 @@ func parseQoderPersistentLine(line string) (delta, final string, done bool) {
 		if ev.Subtype != "" && ev.Subtype != "success" {
 			if ev.Error != "" {
 				return "", ev.Error, true
+			}
+			if len(ev.Errors) > 0 {
+				return "", strings.Join(ev.Errors, "\n"), true
 			}
 		}
 		if t := text(); t != "" {

--- a/internal/helpers/connect_qoder_stream_test.go
+++ b/internal/helpers/connect_qoder_stream_test.go
@@ -53,15 +53,34 @@ if "--input-format" in sys.argv:
             }), flush=True)
             continue
         if msg.get("type") == "user":
-            content = msg.get("message", {}).get("content", "")
+            content = msg.get("message", {}).get("content", [])
+            if not isinstance(content, list):
+                print(json.dumps({
+                    "type": "result",
+                    "subtype": "error_during_execution",
+                    "errors": ["message.content must be an array"],
+                }), flush=True)
+                continue
+            text = "".join(
+                part.get("text", "")
+                for part in content
+                if isinstance(part, dict) and part.get("type") == "text"
+            )
+            if text == "trigger backend failure":
+                print(json.dumps({
+                    "type": "result",
+                    "subtype": "error_during_execution",
+                    "errors": ["API Error: rejected request"],
+                }), flush=True)
+                continue
             print(json.dumps({
                 "type": "assistant",
-                "message": {"content": [{"type": "text", "text": "seen " + content}]},
+                "message": {"content": [{"type": "text", "text": "seen " + text}]},
             }), flush=True)
             print(json.dumps({
                 "type": "result",
                 "subtype": "success",
-                "message": {"content": [{"type": "text", "text": "done " + content}]},
+                "message": {"content": [{"type": "text", "text": "done " + text}]},
             }), flush=True)
 else:
     prompt = sys.argv[-1] if len(sys.argv) > 1 else ""
@@ -155,6 +174,33 @@ func TestQoderForwarderKeepsStreamJSONProcessAlive(t *testing.T) {
 	}
 	if !strings.Contains(lines[0], "--input-format") || !strings.Contains(lines[0], "stream-json") {
 		t.Fatalf("qodercli should start in stream-json input mode, log:\n%s", raw)
+	}
+}
+
+func TestQoderForwarderSurfacesResultErrors(t *testing.T) {
+	t.Setenv("DWS_CONNECT_NO_INSTALL", "1")
+	t.Setenv("DWS_AGENT_CMD", "")
+	t.Setenv("DWS_CONFIG_DIR", t.TempDir())
+	t.Setenv("DWS_AGENT_TIMEOUT_MS", "3000")
+	stubDir := t.TempDir()
+	_, logPath := writeQoderStreamStub(t, stubDir)
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("DWS_QODER_STUB_LOG", logPath)
+
+	fwd, err := forwarderForChannel("qoder", "qoder-client", connectAgentOptions{Memory: true})
+	if err != nil {
+		t.Fatalf("forwarderForChannel(qoder): %v", err)
+	}
+	if closer, ok := fwd.(forwarderCloser); ok {
+		defer closer.close()
+	}
+
+	reply, err := fwd.forward(context.Background(), "conv", "trigger backend failure")
+	if err != nil {
+		t.Fatalf("forward returned error: %v", err)
+	}
+	if !strings.Contains(reply, "AI 后端调用失败") || !strings.Contains(reply, "rejected request") {
+		t.Fatalf("reply = %q, want actionable Qoder backend error", reply)
 	}
 }
 


### PR DESCRIPTION
## Summary

- encode persistent Qoder user turns as typed text-content blocks required by Qoder CLI 1.1.32 protocol 1.3.0
- surface `result.errors[]` through the existing actionable backend-error reply path instead of returning `（本地 agent 无文本输出）`
- extend the persistent subprocess fixture to enforce the real wire shape and cover failed result events

Fixes #1217

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow, packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: transport behavior changes in the DingTalk-to-Qoder stream bridge

## Verification

- [x] Release fragment added: `.changes/qoder-stream-content-blocks.md`
- [x] TDD red evidence: `TestQoderForwarderKeepsStreamJSONProcessAlive` returned `（本地 agent 无文本输出）` for both turns before the payload fix
- [x] TDD red evidence: `TestQoderForwarderSurfacesResultErrors` returned `（本地 agent 无文本输出）` before `errors[]` parsing
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/helpers -run "^TestQoderForwarder(KeepsStreamJSONProcessAlive|SurfacesResultErrors)$" -count=1`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/helpers -count=1`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test -race ./internal/helpers -count=1`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go vet ./internal/helpers`
- [x] `make build`
- [x] `./scripts/release/render-release-fragments.sh .changes`
- [x] `./scripts/policy/check-release-fragments.sh origin/main HEAD`
- [x] `git diff --check origin/main...HEAD`
- [x] Clean detached-worktree full suite: `DWS_PACKAGE_VERSION=0.0.0-test go test ./... -count=1`
- [x] Live behavior evidence with Qoder CLI 1.1.32: string `message.content` reproduced `message.content.map is not a function`; the equivalent typed block returned a normal assistant/result response
- [x] Documentation links/content/rendering: N/A, behavior is covered by release fragment and tests
- [x] Generated drift: N/A, no generator inputs or generated artifacts changed
- [x] Command surface check: N/A, no command path or flag changed
- [x] Package-manager verification: N/A, no packaging or installer change

## Notes

- Persistent per-conversation session IDs and successful assistant/result parsing are unchanged.
- The full suite was run in a clean detached worktree because the primary checkout contains unrelated ignored artifacts; the clean run passed.
- Rollback is a single revert of this commit. No migration or stored-data change is involved.