### PR TITLE
fix(chat): preserve AI send flags in message reads

### DIFF
--- a/.changes/chat-message-ai-send-flag.md
+++ b/.changes/chat-message-ai-send-flag.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **IM message AI provenance** — preserves the lower `messageAiSendFlag` value across message search, list, mget, @-mention, Pin, quoted-message, forwarded-message, and thread-reply projections.

--- a/internal/shortcut/chat/chat_message.go
+++ b/internal/shortcut/chat/chat_message.go
@@ -2101,6 +2101,9 @@ func listPinProject(data map[string]any) []map[string]any {
 		if threadID := chatmsg.ThreadID(m); threadID != nil {
 			row["threadId"] = threadID
 		}
+		if aiSendFlag := chatmsg.MessageAISendFlag(m); aiSendFlag != nil {
+			row["messageAiSendFlag"] = aiSendFlag
+		}
 		if len(row) > 0 {
 			out = append(out, row)
 		}

--- a/internal/shortcut/chat/chat_message_project_test.go
+++ b/internal/shortcut/chat/chat_message_project_test.go
@@ -27,6 +27,7 @@ func TestCrossPlatformCoverageListMessageProjectOne(t *testing.T) {
 		"openMessageId":        "mid",
 		"senderOpenDingTalkId": "DXYZ",
 		"msgType":              "text",
+		"messageAiSendFlag":    "DWS",
 		"createTime":           "2026-07-19 13:37:03",
 		"updateTime":           "2026-07-19 14:00:00",
 		"content":              testCipher,
@@ -34,12 +35,15 @@ func TestCrossPlatformCoverageListMessageProjectOne(t *testing.T) {
 			map[string]any{"emoji": "赞", "replyUsers": []any{"D1", "D2"}},
 		},
 		"forwardMessages": []any{
-			map[string]any{"openMessageId": "c1", "senderOpenDingTalkId": "DA", "content": "子消息", "createTime": "t"},
+			map[string]any{"openMessageId": "c1", "senderOpenDingTalkId": "DA", "content": "子消息", "createTime": "t", "messageAiSendFlag": "DWS"},
 		},
 	})
 
 	if row["messageId"] != "mid" || row["senderId"] != "DXYZ" || row["msgType"] != "text" {
 		t.Fatalf("field mapping = %#v", row)
+	}
+	if row["messageAiSendFlag"] != "DWS" {
+		t.Fatalf("AI send flag = %#v", row)
 	}
 	if row["createTime"] != "2026-07-19 13:37:03" {
 		t.Errorf("createTime = %v", row["createTime"])
@@ -54,7 +58,7 @@ func TestCrossPlatformCoverageListMessageProjectOne(t *testing.T) {
 		t.Errorf("encrypted text = %v, want marker", row["text"])
 	}
 	fwd, ok := row["forwarded"].([]map[string]any)
-	if !ok || len(fwd) != 1 || fwd[0]["messageId"] != "c1" || fwd[0]["text"] != "子消息" {
+	if !ok || len(fwd) != 1 || fwd[0]["messageId"] != "c1" || fwd[0]["text"] != "子消息" || fwd[0]["messageAiSendFlag"] != "DWS" {
 		t.Errorf("forwarded = %#v", row["forwarded"])
 	}
 
@@ -111,6 +115,7 @@ func TestCrossPlatformCoverageListPinProjectPreservesThreadIdentity(t *testing.T
 					"openMessageId":      "msg-1",
 					"openConversationId": "cid-1",
 					"openConvThreadId":   "thread-1",
+					"messageAiSendFlag":  "DWS",
 				},
 			},
 		},
@@ -118,7 +123,7 @@ func TestCrossPlatformCoverageListPinProjectPreservesThreadIdentity(t *testing.T
 	if len(got) != 1 {
 		t.Fatalf("pins = %#v", got)
 	}
-	if got[0]["messageId"] != "msg-1" || got[0]["threadId"] != "thread-1" {
+	if got[0]["messageId"] != "msg-1" || got[0]["threadId"] != "thread-1" || got[0]["messageAiSendFlag"] != "DWS" {
 		t.Fatalf("pin identity = %#v", got[0])
 	}
 }

--- a/internal/shortcut/chatmsg/chatmsg.go
+++ b/internal/shortcut/chatmsg/chatmsg.go
@@ -66,6 +66,7 @@ var messageResultContractV1 = MessageResultContract{
 		"senderId",
 		"senderType",
 		"messageType",
+		"messageAiSendFlag",
 		"text",
 		"createTime",
 		"updateTime",
@@ -300,6 +301,14 @@ func MessageType(m map[string]any) any {
 	return firstMessageValue(m, "msgType", "messageType", "message_type", "type")
 }
 
+// MessageAISendFlag preserves the lower IM marker that identifies a message
+// sent through an AI client. The service currently publishes the exact
+// messageAiSendFlag field (for example "DWS"); readers must not infer it from
+// sender type, robot status, clawType request metadata, or message content.
+func MessageAISendFlag(m map[string]any) any {
+	return firstMessageValue(m, "messageAiSendFlag")
+}
+
 // SenderID preserves the stable sender identity without replacing the legacy
 // scalar sender display field. Nested sender records and both userId families
 // are accepted because list/search/mget currently expose different shapes.
@@ -359,6 +368,9 @@ func ProjectMessageV1(m map[string]any, includeReactions bool) map[string]any {
 	}
 	if value := MessageType(m); value != nil {
 		row["messageType"] = value
+	}
+	if value := MessageAISendFlag(m); value != nil {
+		row["messageAiSendFlag"] = value
 	}
 	if value := UpdateTime(m); value != nil {
 		row["updateTime"] = value
@@ -420,6 +432,9 @@ func QuotedMessage(m map[string]any) map[string]any {
 	}
 	if value := MessageType(quoted); value != nil {
 		out["messageType"] = value
+	}
+	if value := MessageAISendFlag(quoted); value != nil {
+		out["messageAiSendFlag"] = value
 	}
 	if len(resources) > 0 {
 		out["resourceRefs"] = resources

--- a/internal/shortcut/chatmsg/chatmsg_test.go
+++ b/internal/shortcut/chatmsg/chatmsg_test.go
@@ -59,19 +59,21 @@ func TestCrossPlatformCoverageProjectMessageV1PublishesSharedIdentityAndContext(
 			"openDingTalkId": "D1",
 			"senderType":     "user",
 		},
-		"msgType":    "text",
-		"content":    "你好",
-		"createTime": "2026-08-03 10:00:00",
+		"msgType":           "text",
+		"messageAiSendFlag": "DWS",
+		"content":           "你好",
+		"createTime":        "2026-08-03 10:00:00",
 	}, true)
 	for key, want := range map[string]any{
-		"messageId":      "msg-1",
-		"conversationId": "cid-1",
-		"threadId":       "thread-1",
-		"sender":         "张三",
-		"senderId":       "D1",
-		"senderType":     "user",
-		"messageType":    "text",
-		"text":           "你好",
+		"messageId":         "msg-1",
+		"conversationId":    "cid-1",
+		"threadId":          "thread-1",
+		"sender":            "张三",
+		"senderId":          "D1",
+		"senderType":        "user",
+		"messageType":       "text",
+		"messageAiSendFlag": "DWS",
+		"text":              "你好",
 	} {
 		if row[key] != want {
 			t.Errorf("%s = %#v, want %#v; row=%#v", key, row[key], want, row)
@@ -208,6 +210,16 @@ func TestCrossPlatformCoverageMessageLedgerNilAndCursorOnlyBoundaries(t *testing
 	if second.MessageFields[0] == "mutated" || second.EnvelopeFields[0] == "mutated" {
 		t.Fatal("message result contract leaked mutable storage")
 	}
+	foundAISendFlag := false
+	for _, field := range second.MessageFields {
+		if field == "messageAiSendFlag" {
+			foundAISendFlag = true
+			break
+		}
+	}
+	if !foundAISendFlag {
+		t.Fatalf("message result contract omits messageAiSendFlag: %#v", second.MessageFields)
+	}
 	payload := NewMessageListPayload(nil)
 	if payload["count"] != 0 || payload["messages"] == nil {
 		t.Fatalf("nil message ledger = %#v", payload)
@@ -270,6 +282,7 @@ func TestCrossPlatformCoverageQuotedMessageIsBoundedAndSemantic(t *testing.T) {
 			"sender":             "Alice",
 			"content":            "原消息",
 			"createTime":         "2026-07-28 10:00:00",
+			"messageAiSendFlag":  "DWS",
 			"quotedMessage":      map[string]any{"openMessageId": "nested-must-not-expand"},
 		},
 	})
@@ -278,6 +291,9 @@ func TestCrossPlatformCoverageQuotedMessageIsBoundedAndSemantic(t *testing.T) {
 	}
 	if got["threadId"] != "thread-1" {
 		t.Fatalf("quoted thread identity = %#v", got)
+	}
+	if got["messageAiSendFlag"] != "DWS" {
+		t.Fatalf("quoted AI send flag = %#v", got)
 	}
 	if _, recursive := got["quotedMessage"]; recursive {
 		t.Fatalf("quoted message expanded recursively: %#v", got)

--- a/internal/shortcut/smart/at_me.go
+++ b/internal/shortcut/smart/at_me.go
@@ -524,6 +524,9 @@ func atMeProjectWithReactions(m map[string]any, includeReactions bool) map[strin
 	if messageType := chatmsg.MessageType(m); messageType != nil {
 		row["messageType"] = messageType
 	}
+	if aiSendFlag := chatmsg.MessageAISendFlag(m); aiSendFlag != nil {
+		row["messageAiSendFlag"] = aiSendFlag
+	}
 	if updateTime := chatmsg.UpdateTime(m); updateTime != nil {
 		row["updateTime"] = updateTime
 	}

--- a/internal/shortcut/smart/at_me_search_msg_test.go
+++ b/internal/shortcut/smart/at_me_search_msg_test.go
@@ -28,6 +28,7 @@ func TestCrossPlatformCoverageAtMeProject(t *testing.T) {
 		"content":            "普通消息",
 		"openMessageId":      "msg-1",
 		"msgType":            "text",
+		"messageAiSendFlag":  "DWS",
 		"conversationTitle":  "群A",
 		"openConversationId": "cid1",
 		"emotionReplyList": []any{
@@ -39,6 +40,9 @@ func TestCrossPlatformCoverageAtMeProject(t *testing.T) {
 	}
 	if row["messageId"] != "msg-1" || row["conversationId"] != "cid1" || row["messageType"] != "text" {
 		t.Errorf("atMeProject stable identity = %#v", row)
+	}
+	if row["messageAiSendFlag"] != "DWS" {
+		t.Errorf("atMeProject AI send flag = %#v", row)
 	}
 	if reactions, ok := row["reactions"].(map[string]any); !ok || len(reactions) == 0 {
 		t.Errorf("atMeProject reactions = %#v", row["reactions"])
@@ -90,13 +94,17 @@ func TestCrossPlatformCoverageAtMeProject(t *testing.T) {
 func TestCrossPlatformCoverageSearchMsgProject(t *testing.T) {
 	// nested sender + plain text + messageId
 	row := searchMsgProject(map[string]any{
-		"sender":     map[string]any{"nick": "千启"},
-		"createTime": "2026-07-19 13:37:03",
-		"content":    "命中关键词的消息",
-		"msgId":      "mid1",
+		"sender":            map[string]any{"nick": "千启"},
+		"createTime":        "2026-07-19 13:37:03",
+		"content":           "命中关键词的消息",
+		"msgId":             "mid1",
+		"messageAiSendFlag": "DWS",
 	})
 	if row["sender"] != "千启" || row["text"] != "命中关键词的消息" {
 		t.Fatalf("searchMsgProject = %#v", row)
+	}
+	if row["messageAiSendFlag"] != "DWS" {
+		t.Fatalf("searchMsgProject AI send flag = %#v", row)
 	}
 
 	// Canonical ID precedence and rich-text extraction must match typed search.

--- a/internal/shortcut/smart/search_msg_execution_test.go
+++ b/internal/shortcut/smart/search_msg_execution_test.go
@@ -414,7 +414,7 @@ func TestCrossPlatformCoverageSearchMsgGroupNameAndDefaultWindowMetadata(t *test
 }
 
 func TestCrossPlatformCoverageSearchMsgPagesAndEnrichesWithAdvancedFilters(t *testing.T) {
-	caller := &searchMsgExecutionCaller{}
+	caller := &searchMsgExecutionCaller{mgetResponse: `{"result":[{"openMessageId":"m1","content":"detail-1","messageAiSendFlag":"DWS"},{"openMessageId":"m2","content":"detail-2"}]}`}
 	payload := executeSearchMsg(t, caller,
 		"--query", "周报",
 		"--chat-id", "cid-1,cid-2",
@@ -472,6 +472,9 @@ func TestCrossPlatformCoverageSearchMsgPagesAndEnrichesWithAdvancedFilters(t *te
 	firstMessage, _ := messages[0].(map[string]any)
 	if firstMessage["text"] != "detail-1" {
 		t.Fatalf("enriched message = %#v", firstMessage)
+	}
+	if firstMessage["messageAiSendFlag"] != "DWS" {
+		t.Fatalf("enriched AI send flag = %#v", firstMessage)
 	}
 	scope, _ := payload["scope"].(map[string]any)
 	if scope["targetsValidated"] != true || scope["filterMode"] != "client" || scope["resultsWithinScope"] != true {

--- a/skills/multi/dingtalk-chat/SKILL.md
+++ b/skills/multi/dingtalk-chat/SKILL.md
@@ -79,12 +79,12 @@ metadata:
 - `+messages-send`：文件、Bot、Webhook、复杂 @ 或幂等控制。user 已知 ID 可直接传，也可用 `--user-query` / `--chat-query` 运行同一只读解析链；Bot 多群使用 `--groups/--groups-file`，返回 `im.batch-write.v1`；bot/webhook 只使用下层真实支持的文本/Markdown 能力。
 - 发文件消息用 `+messages-send --file <路径>`；只存会话空间、不发消息才用 `chat conversation-file upload`，返回 `dentryId`/`spaceId`。
 - Webhook 使用 `+messages-send --as webhook --webhook-token <token>`；不要退回原子 Webhook 命令。
-- 流式卡片用 `+messages-send-card`；群聊@传 ID/`--at-all`，Runtime 把 create 返回前缀加到 `--content`；禁写占位符；仅 text。
+- 流式卡片用 `+messages-send-card`；群聊 @ 传 ID/`--at-all`，Runtime 拼接 create 前缀；禁占位符，仅 text。
 
 ## 关键结果语义
 
 - `openTaskId` 是发送任务 ID，不是回复或撤回所需的消息 ID；消息 ID 必须来自真实查询结果。
-- 消息查询默认保留稳定 ID、会话/thread、发送者、文本、时间、reaction、引用、转发和 `resourceRefs`；`--no-reactions` 可关闭 reaction。
+- 消息查询默认保留稳定 ID、会话/thread、发送者、文本、时间、`messageAiSendFlag`、reaction、引用、转发和 `resourceRefs`；`--no-reactions` 可关闭 reaction。
 - 查询结果必须检查 `complete`、`hasMore`、`failures` 和资源下载 ledger；partial result 不得表述为完整成功。
 - 子消息使用自己的 `messageId`；仅缺会话 ID 时继承父消息的 `conversationId`。
 - 下载只允许工作目录内安全相对路径，默认不覆盖并原子落盘；覆盖必须由用户显式传 `--overwrite`。读取和下载不需要 `--yes`。

--- a/skills/multi/dingtalk-chat/references/contracts.md
+++ b/skills/multi/dingtalk-chat/references/contracts.md
@@ -11,7 +11,7 @@
 
 <!-- DWS_MESSAGE_RESULT_CONTRACT_START -->
 - `version`: `im.message-list.v1`
-- `message_fields`: `messageId`, `conversationId`, `threadId`, `sender`, `senderId`, `senderType`, `messageType`, `text`, `createTime`, `updateTime`, `reactions`, `quotedMessage`, `forwarded`, `resourceRefs`
+- `message_fields`: `messageId`, `conversationId`, `threadId`, `sender`, `senderId`, `senderType`, `messageType`, `messageAiSendFlag`, `text`, `createTime`, `updateTime`, `reactions`, `quotedMessage`, `forwarded`, `resourceRefs`
 - `envelope_fields`: `contractVersion`, `messages`, `count`, `resolvedFilters`, `queryRange`, `pagesFetched`, `paginationKnown`, `complete`, `hasMore`, `nextPage`, `stopReason`, `truncated`, `truncatedByPageLimit`, `truncatedByResultLimit`, `failedCount`, `failures`, `partial`, `scope`, `resourceDownloads`
 <!-- DWS_MESSAGE_RESULT_CONTRACT_END -->
 


### PR DESCRIPTION
## Summary

- Preserve the lower `messageAiSendFlag` value in the shared IM message contract and projections.
- Cover search, conversation reads, mget enrichment, @-mention reads, Pin rows, quoted messages, forwarded messages, and thread replies.
- Synchronize the DingTalk Chat Skill contract and add a release fragment.

This fixes a projection gap: live Chat/IM MCP reads already return values such as `messageAiSendFlag: "DWS"`, but semantic Shortcuts previously dropped the field.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [x] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

- [x] Release fragment added: `.changes/chat-message-ai-send-flag.md`
- [x] Release-seal validation: N/A (ordinary PR; `CHANGELOG.md` unchanged)
- [x] Targeted tests:
  - `go test ./internal/shortcut/chatmsg ./internal/shortcut/chat ./internal/shortcut/smart -count=1`
  - `make build`
  - `make multi-im-skill-chain-integrity`
- [x] Behavior evidence:
  - Exact live `+search-msg`, `+messages-mget`, `+chat-messages`, `+messages-list`, `+messages-list-direct`, `+at-me`, `+messages-list-pin`, and `+thread-replies` checks preserved the AI-send flag.
  - A disposable two-member Thread lifecycle verified AI-tagged root/reply mget, conversation read, Pin readback, and exact `+thread-replies` projection.
  - Pin/unpin, message recall, group dismissal, and marker/group absence were verified after cleanup.
  - Known-nonempty and guaranteed-empty search/list cases were exercised with sanitized output.
- [x] Documentation contract checked: Runtime marker and `skills/multi/dingtalk-chat/references/contracts.md` agree.
- [x] Full local suite: the default 10-minute umbrella timeout expired in existing macOS Keychain/package-script slow tests; every other package passed, and the two timed-out packages passed when rerun separately with `-timeout 20m`.
- [x] `./scripts/policy/check-release-fragments.sh $(git merge-base HEAD origin/main) HEAD`
- [x] `./scripts/policy/check-generated-drift.sh`
- [x] `./scripts/policy/check-schema-catalog.sh`
- [x] Command-surface check: N/A (no command or flag changes)
- [x] Package-manager verification: N/A (no packaging or installer changes)

## Notes

- The field remains optional and is emitted only when the lower response publishes it; Runtime does not infer AI provenance from sender type, robot status, request `clawType`, or message content.
- Live evidence and PR text are sanitized: no account, tenant, conversation, message, trace, or token values are included.
