### PR TITLE
ci(interface): review update-card flow status type

### DIFF
--- a/internal/interfacesnapshot/reviewed.go
+++ b/internal/interfacesnapshot/reviewed.go
@@ -48,9 +48,9 @@ type flagTypeChange struct {
 //
 // Entries are direction-sensitive by construction: "string" → "int" is a
 // separate key from "int" → "string" and only the reviewed direction is
-// accepted. The reverse is not a candidate for this table — widening an int
-// flag back to string lets values the parser used to reject reach RunE, which
-// is a genuine loosening of validation rather than a type migration.
+// accepted. An int → string migration is not automatically safe: it must keep
+// accepting every historically successful numeric spelling and constrain any
+// newly accepted strings in RunE.
 //
 // The table alone does not admit a change: reviewedFlagTypeChange is consulted
 // only when nothing else about the flag moved. See compareEffectiveFlags.
@@ -80,6 +80,14 @@ var reviewedFlagTypeChanges = map[flagTypeChange]struct{}{
 	// not reachable by a caller here because RunE requires the flag to be
 	// explicitly set, so this is not a contract change.
 	{CommandPath: "dws minutes permission apply", Flag: "policy", From: "string", To: "int"}: {},
+
+	// "dws chat message update-card --flow-status" moves from a native Int flag
+	// to String so the new A2UI engine can accept its reviewed status names. The
+	// default streaming path still parses with base 0 and enforces [1,5], which
+	// preserves every numeric spelling accepted by the historical pflag Int.
+	// A2UI additionally accepts the decimal compatibility values 1-9 and maps
+	// them to the corresponding enum names before transport.
+	{CommandPath: "dws chat message update-card", Flag: "flow-status", From: "int", To: "string"}: {},
 }
 
 // reviewedFlagTypeChange reports whether this exact command, flag and direction

--- a/scripts/policy/interface-baseline/reviewed.go
+++ b/scripts/policy/interface-baseline/reviewed.go
@@ -39,9 +39,9 @@ type flagTypeChange struct {
 //
 // Entries are direction-sensitive by construction: "string" → "int" is a
 // separate key from "int" → "string" and only the reviewed direction is
-// accepted. The reverse is not a candidate for this table — widening an int
-// flag back to string lets values the parser used to reject reach RunE, which
-// is a genuine loosening of validation rather than a type migration.
+// accepted. An int → string migration is not automatically safe: it must keep
+// accepting every historically successful numeric spelling and constrain any
+// newly accepted strings in RunE.
 //
 // The table alone does not admit a change: reviewedFlagTypeChange is consulted
 // only when nothing else about the flag moved. See the callers in
@@ -72,6 +72,14 @@ var reviewedFlagTypeChanges = map[flagTypeChange]struct{}{
 	// not reachable by a caller here because RunE requires the flag to be
 	// explicitly set, so this is not a contract change.
 	{CommandPath: "dws minutes permission apply", Flag: "policy", From: "string", To: "int"}: {},
+
+	// "dws chat message update-card --flow-status" moves from a native Int flag
+	// to String so the new A2UI engine can accept its reviewed status names. The
+	// default streaming path still parses with base 0 and enforces [1,5], which
+	// preserves every numeric spelling accepted by the historical pflag Int.
+	// A2UI additionally accepts the decimal compatibility values 1-9 and maps
+	// them to the corresponding enum names before transport.
+	{CommandPath: "dws chat message update-card", Flag: "flow-status", From: "int", To: "string"}: {},
 }
 
 // reviewedFlagTypeChange reports whether this exact command, flag and direction


### PR DESCRIPTION
## Summary

Review one exact CLI contract migration:

- command: `dws chat message update-card`
- flag: `--flow-status`
- direction: `int` → `string`
- downstream implementation: #1231

This PR changes only the two mirrored reviewed-type tables. It does not modify the command tree or consume its own approval. After this PR lands on `main`, #1231 can sync that base-owned authorization and rerun Interface Integrity.

## Why the migration is compatible

The historical command uses pflag `Int`, whose successful spellings are parsed with base 0. The downstream implementation at `38d8391b` preserves that behavior on the default streaming path with `strconv.ParseInt(..., 0, 64)` and the existing `[1,5]` range check. Therefore decimal values and historical spellings such as `0x3` continue to reach the same integer payload.

The new string domain is reachable only when callers explicitly select `--card-engine a2ui`. That path accepts the reviewed A2UI enum names and maps numeric values `1`-`9` to those enum names before transport. Streaming does not forward arbitrary strings.

No other historical flag contract changes: name, visibility, requiredness, shorthand, no-opt behavior, and scope remain unchanged. The approval is keyed by canonical command path, so accepted command aliases do not require duplicate entries.

## Trust boundary

The compatibility checker and reviewed table are owned by the PR merge-base. A candidate cannot add this entry and use it to approve a surface change in the same PR. This PR lands the reviewed decision first; #1231 consumes it only after it becomes part of `main`.

## Validation

- `go test ./internal/interfacesnapshot ./scripts/policy/interface-baseline`
- `make interface-integrity BASE_REF=upstream/main CANDIDATE_REF=HEAD`
- downstream focused test: `go test ./internal/helpers -run UpdateCard -count=1`

The downstream test covers A2UI enum input, numeric mapping `1`-`9`, the streaming `[1,5]` guard, and the historical `0x3` spelling.