### PR TITLE
policy(schema): review OA pending approval RPC redirect

### DIFF
--- a/scripts/policy/schema-compat/main.go
+++ b/scripts/policy/schema-compat/main.go
@@ -863,6 +863,13 @@ func isReviewedCompatibilityException(toolPath, field, oldValue, newValue string
 // canonicalRawJSON) — not a bare RPC name. Adding an entry is a contract
 // decision and belongs in review, not in a feature change.
 var reviewedInterfaceRefRedirect = map[string]map[string]string{
+	// The public pending-approval command keeps its stable canonical identity,
+	// while the OA backend moved from the legacy list endpoint to the dedicated
+	// current-user todo-task endpoint. The CLI-facing contract remains
+	// compatible; only the audited backing RPC changes.
+	"oa/oa.list_pending_approvals": {
+		`{"product_id":"oa","rpc_name":"list_pending_approvals"}`: `{"product_id":"oa","rpc_name":"get_todo_tasks"}`,
+	},
 	// The style surface moved from update_range (which writes values) to
 	// set_cell_range's cellStyles payload (style-only, preserving values). This
 	// is the only channel that can express italic / underline / strike-through /

--- a/scripts/policy/schema-compat/main_test.go
+++ b/scripts/policy/schema-compat/main_test.go
@@ -1259,6 +1259,20 @@ func TestCrossPlatformCoverageReviewedRedirectKeysAreCanonicalJSON(t *testing.T)
 	}
 }
 
+func TestCrossPlatformCoverageOAPendingApprovalRedirectIsReviewed(t *testing.T) {
+	const toolPath = "oa/oa.list_pending_approvals"
+	const oldRef = `{"product_id":"oa","rpc_name":"list_pending_approvals"}`
+	const newRef = `{"product_id":"oa","rpc_name":"get_todo_tasks"}`
+
+	redirects, ok := reviewedInterfaceRefRedirect[toolPath]
+	if !ok {
+		t.Fatalf("missing reviewed interface_ref redirect for %s", toolPath)
+	}
+	if got := redirects[oldRef]; got != newRef {
+		t.Fatalf("reviewed redirect = %q, want %q", got, newRef)
+	}
+}
+
 func TestCrossPlatformCoverageSchemaCompatInterfaceRefRedirect(t *testing.T) {
 	// The redirect carve-out only accepts an explicitly reviewed tool + old→new
 	// ref pair. Register the fixture's path for the duration of this test so the


### PR DESCRIPTION
## Summary

- Add an explicitly reviewed Schema `interface_ref` redirect for
  `oa/oa.list_pending_approvals`:
  - From `oa.list_pending_approvals`
  - To `oa.get_todo_tasks`
- Add regression coverage for the exact tool and old-to-new RPC mapping.
- Preserve the public canonical identity `oa.list_pending_approvals`.

This is a governance prerequisite for #1223. The feature PR changes the backing
MCP RPC while preserving the existing public CLI and Schema identity. Because
Schema compatibility policy is owned by the merge-base, this redirect must be
reviewed and merged independently before #1223 can pass compatibility checks.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [ ] Standard: ordinary implementation change with a stable package graph
- [x] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

- [x] Release fragment added for a user-visible behavior/interface change
  (otherwise `N/A`): N/A — this PR changes compatibility governance only.
- [x] Release-seal validation: N/A
- [x] Targeted test/check commands and results:
  - `DWS_PACKAGE_VERSION=0.0.0-test go test ./scripts/policy/schema-compat -count=1`
    — passed.
  - `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath
    GIT_CONFIG_VALUE_0=/dev/null DWS_PACKAGE_VERSION=0.0.0-test
    go test ./scripts/policy/... -count=1`
    — passed.
  - `git diff --check` — passed.
- [x] Behavior evidence:
  - The regression test fails when the OA redirect is absent.
  - After registering the exact redirect, the test passes.
  - Simulated the required merge order by applying this governance change to
    the merge-base and replaying all three commits from #1223.
  - Schema compatibility passed against both the updated merge-base and
    `v1.0.61` for all 29 historical products.
- [x] Documentation links/content/rendering checked: N/A
- [ ] Full local suite run because the change is high-risk:
  - Not run; the complete policy package suite and end-to-end Schema
    compatibility gate were run locally. Full repository coverage remains CI.
- [x] `./scripts/policy/check-generated-drift.sh`: N/A — no generator inputs or
  generated artifacts changed.
- [x] `./scripts/policy/check-command-surface.sh --strict`: N/A — no command
  surface changed.
- [x] `./scripts/release/verify-package-managers.sh`: N/A — no packaging or
  installer surface changed.

## Notes

- This PR does not change runtime command behavior, CLI flags, canonical
  identity, or user-visible output.
- The exception is intentionally limited to one canonical Schema tool and one
  exact old-to-new `interface_ref` pair.
- Merge this PR before rebasing and rerunning CI for #1223.