### PR TITLE
test: stabilize mock MCP CLI helper timeout

### DIFF
--- a/test/mock_mcp/mock_mcp_smoke_test.go
+++ b/test/mock_mcp/mock_mcp_smoke_test.go
@@ -35,6 +35,9 @@ const (
 	mockMCPSmokeCAEnv           = "DWS_MOCK_MCP_SMOKE_CA_FILE"
 	mockMCPSmokeDownloadDialEnv = "DWS_MOCK_MCP_SMOKE_DOWNLOAD_DIAL"
 	mockCurrentDOpenID          = "DAAAAAAAAAAAiE"
+	// helper 会启动第二个启用 race 的测试进程。保持有界，同时为 remaining
+	// shard 与其他 CI race 包并行时的调度抖动预留空间。
+	mockMCPCLIExecutionTimeout = 30 * time.Second
 )
 
 type recordedToolCall struct {
@@ -906,7 +909,7 @@ func runCLI(t *testing.T, env []string, args ...string) (string, string, error) 
 func runCLIInDir(t *testing.T, env []string, dir string, args ...string) (string, string, error) {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), mockMCPCLIExecutionTimeout)
 	defer cancel()
 	processArgs := append([]string{"-test.run=^TestCLIHelperProcess$", "--"}, args...)
 	cmd := exec.CommandContext(ctx, os.Args[0], processArgs...)


### PR DESCRIPTION
## 目标
紧急修复 protected main CI 中 `Test (race: remaining)` 的 mock MCP CLI 子进程偶发 10 秒超时。

## 实现
- 将 helper 子进程的有界执行预算从 10 秒提升至 30 秒。
- 保留外层测试与 CI 超时，真实阻塞仍会失败。

## 验证
| 命令 | 结果 |
| --- | --- |
| `DWS_PACKAGE_VERSION=0.0.0-test go test -race -count=3 -timeout=6m ./test/mock_mcp` | 通过，51.430s |
| `git diff --check` | 通过 |

## 风险与回滚
- 风险：仅延后 mock 测试对真正卡死的报错时间，仍被 30 秒边界及 CI 总超时限制。
- 回滚：还原该常量为 10 秒。

## 关联
当前没有对应的已建 Issue；该 PR 直接处理 main CI 失败。