### PR TITLE
fix(release): retry runtime context verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1127,9 +1127,22 @@ jobs:
             test -n "$binary_team"
             test "$binary_team" = "$library_team"
             if [ "$arch" = "$host_arch" ]; then
-              HOME="$stage/home" "$stage/dws" doctor --json --timeout 2 > "$stage/doctor.json"
-              jq -e '.checks[] | select(.name == "runtime_context") | .status == "pass" and .detail.token_length > 0 and (.detail.token_fingerprint | length) == 12' \
-                "$stage/doctor.json" >/dev/null
+              runtime_context_ready=0
+              for doctor_attempt in 1 2 3; do
+                doctor_home="$stage/doctor-home-$doctor_attempt"
+                doctor_json="$stage/doctor-$doctor_attempt.json"
+                rm -rf "$doctor_home"
+                mkdir -p "$doctor_home"
+                HOME="$doctor_home" "$stage/dws" doctor --json --timeout 2 > "$doctor_json"
+                if jq -e '.checks[] | select(.name == "runtime_context") | .status == "pass" and .detail.token_length > 0 and (.detail.token_fingerprint | length) == 12' \
+                  "$doctor_json" >/dev/null; then
+                  runtime_context_ready=1
+                  break
+                fi
+                echo "runtime_context verification attempt $doctor_attempt failed" >&2
+                cat "$doctor_json" >&2
+              done
+              test "$runtime_context_ready" -eq 1
             fi
           done
 

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -2671,6 +2671,10 @@ func TestReleaseWorkflowUsesAppleCodesignBeforePublication(t *testing.T) {
 		"runtime-payload materialize",
 		`test "$binary_team" = "$library_team"`,
 		`doctor --json --timeout 2`,
+		"for doctor_attempt in 1 2 3",
+		`doctor-home-$doctor_attempt`,
+		`doctor-$doctor_attempt.json`,
+		"runtime_context verification attempt $doctor_attempt failed",
 		`.detail.token_fingerprint | length`,
 	} {
 		if !strings.Contains(verifySection, required) {


### PR DESCRIPTION
## 目标
修复 `v1.0.62-beta.1` 已封 Release 在 Apple 签名后 runtime_context 自检的偶发失败。

## 实现
- 对 sealed host-arch 资产最多执行三次独立 HOME 的 `dws doctor --json --timeout 2`。
- 每次仍要求原有 runtime_context、token length 与 fingerprint 断言；三次均失败则 fail-closed。
- 输出失败尝试的脱敏 doctor JSON，便于精确恢复诊断。

## 验证
| 命令 | 结果 |
| --- | --- |
| `go test ./test/scripts -run ^TestReleaseWorkflowUsesAppleCodesignBeforePublication$ -count=1` | 通过 |
| `actionlint` | 通过 |
| `git diff --check` | 通过 |

## 风险与回滚
- 风险：极短暂初始化抖动最多增加两次自检。稳定异常仍会阻断发布。
- 回滚：还原该重试循环。

## 治理
Raph 已明确授权本 PR 使用 bypass 合入，以恢复同一已封版本。