### PR TITLE
fix(release): make runtime doctor diagnostic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1127,22 +1127,17 @@ jobs:
             test -n "$binary_team"
             test "$binary_team" = "$library_team"
             if [ "$arch" = "$host_arch" ]; then
-              runtime_context_ready=0
-              for doctor_attempt in 1 2 3; do
-                doctor_home="$stage/doctor-home-$doctor_attempt"
-                doctor_json="$stage/doctor-$doctor_attempt.json"
-                rm -rf "$doctor_home"
-                mkdir -p "$doctor_home"
-                HOME="$doctor_home" "$stage/dws" doctor --json --timeout 2 > "$doctor_json"
-                if jq -e '.checks[] | select(.name == "runtime_context") | .status == "pass" and .detail.token_length > 0 and (.detail.token_fingerprint | length) == 12' \
-                  "$doctor_json" >/dev/null; then
-                  runtime_context_ready=1
-                  break
-                fi
-                echo "runtime_context verification attempt $doctor_attempt failed" >&2
-                cat "$doctor_json" >&2
-              done
-              test "$runtime_context_ready" -eq 1
+              # Runtime context initialization obtains a host-scoped native token.
+              # It is diagnostic-only here: the signed binary and embedded dylib
+              # above are the release artifacts this job is authorized to verify.
+              doctor_home="$stage/doctor-home"
+              doctor_json="$stage/doctor.json"
+              rm -rf "$doctor_home"
+              mkdir -p "$doctor_home"
+              if ! HOME="$doctor_home" "$stage/dws" doctor --json --timeout 2 > "$doctor_json"; then
+                echo "runtime_context diagnostic command failed" >&2
+              fi
+              cat "$doctor_json" >&2
             fi
           done
 

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -2671,11 +2671,9 @@ func TestReleaseWorkflowUsesAppleCodesignBeforePublication(t *testing.T) {
 		"runtime-payload materialize",
 		`test "$binary_team" = "$library_team"`,
 		`doctor --json --timeout 2`,
-		"for doctor_attempt in 1 2 3",
-		`doctor-home-$doctor_attempt`,
-		`doctor-$doctor_attempt.json`,
-		"runtime_context verification attempt $doctor_attempt failed",
-		`.detail.token_fingerprint | length`,
+		`doctor-home`,
+		`doctor.json`,
+		"runtime_context diagnostic command failed",
 	} {
 		if !strings.Contains(verifySection, required) {
 			t.Errorf("Apple verification stage is missing %q", required)


### PR DESCRIPTION
## 根因

已封存 v1.0.62-beta.1 的 runtime-context 具有固定 3 秒原生初始化上限。官方 recovery run 33532413111 中，Apple 签名、runtime dylib 签名、Team ID、网络和版本检查均通过，但三次冷启动都在约 3.2–3.4 秒因 initialization_timeout 失败。

## 变更

- 保持 Darwin 二进制与 runtime dylib 的 codesign strict 校验及 Team ID 一致性硬门禁。
- 保留 dws doctor JSON 的红脱敏输出，供 runner 原生上下文异常排查。
- 不再将 host-scoped runtime token 初始化作为不可变发布工件的硬发布条件。

## 验证

- DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run TestReleaseWorkflowUsesAppleCodesignBeforePublication -count=1
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
- git diff --check

该调整已获 Raph 明确授权，用于恢复已封存 beta。