### PR TITLE
fix(release): use REST release ID lookup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1249,12 +1249,11 @@ jobs:
           fi
 
           release_id=""
-          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
-            release_id="$(
-              gh release view "$RELEASE_VERSION" \
-                --json databaseId \
-                --jq .databaseId
-            )"
+          if release_id="$(
+            gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION" \
+              --jq .id 2>/dev/null
+          )"; then
             printf '%s\n' "$release_id" | grep -Eq '^[1-9][0-9]*$' || {
               echo "Existing GitHub Release has an invalid database ID: $release_id" >&2
               exit 1
@@ -1342,9 +1341,9 @@ jobs:
               --notes-file "$RUNNER_TEMP/release-notes.md" \
               $prerelease_flag
             release_id="$(
-              gh release view "$RELEASE_VERSION" \
-                --json databaseId \
-                --jq .databaseId
+              gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+                "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION" \
+                --jq .id
             )"
           fi
           printf '%s\n' "$release_id" | grep -Eq '^[1-9][0-9]*$' || {
@@ -1406,9 +1405,9 @@ jobs:
             dist/checksums.txt \
             --clobber
           uploaded_release_id="$(
-            gh release view "$RELEASE_VERSION" \
-              --json databaseId \
-              --jq .databaseId
+            gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION" \
+              --jq .id
           )"
           test "$uploaded_release_id" = "$release_id" || {
             echo "GitHub Release identity changed during upload: $release_id -> $uploaded_release_id" >&2

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -2252,7 +2252,7 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 
 	for _, required := range []string{
 		"id: publish",
-		"--json databaseId",
+		`"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION"`,
 		`"repos/$GITHUB_REPOSITORY/releases/$release_id"`,
 		`uploaded_release_id="$(`,
 		`test "$uploaded_release_id" = "$release_id"`,
@@ -2273,7 +2273,7 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 	for _, forbidden := range []string{
 		`gh release download "$RELEASE_VERSION"`,
 		`gh release edit "$RELEASE_VERSION" --draft=false`,
-		`"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION"`,
+		`gh release view "$RELEASE_VERSION"`,
 	} {
 		if strings.Contains(publishStep, forbidden) {
 			t.Errorf("Draft release lifecycle must not switch back from the locked release ID via %q", forbidden)


### PR DESCRIPTION
## 根因

Recovery run 33537222269 已通过签名与 sealed e2e，但在 GitHub Release 草稿创建后，gh release view 返回 HTTP 403 Resource not accessible by integration。

## 变更

所有按 tag 获取 GitHub Release ID 的位置统一使用 GitHub REST endpoint repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION。保留创建、上传、不可变性、字节一致性和发布门禁。

## 验证

- DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run TestReleaseWorkflowDraftLifecycleUsesOneReleaseID -count=1
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
- git diff --check

用于恢复已封存 v1.0.62-beta.1。