### PR TITLE
fix(release): locate recovery draft by marker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1249,6 +1249,23 @@ jobs:
           fi
 
           release_id=""
+          recovery_marker=""
+          if [ "$IS_RECOVERY" = "true" ]; then
+            recovery_marker="<!-- dws-release-recovery run=$GITHUB_RUN_ID tag-object=$RELEASE_TAG_OBJECT commit=$RELEASE_COMMIT -->"
+          fi
+          find_recovery_draft_release_id() {
+            candidate_ids="$(
+              gh api --paginate -H 'X-GitHub-Api-Version: 2026-03-10' \
+                "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+                --jq ".[] | select(.tag_name == \"$RELEASE_VERSION\" and (.body | contains(\"$recovery_marker\"))) | .id"
+            )"
+            candidate_count="$(printf '%s\\n' "$candidate_ids" | sed '/^$/d' | wc -l | tr -d ' ')"
+            test "$candidate_count" = "1" || {
+              echo "Expected exactly one draft GitHub Release for this recovery run; found $candidate_count." >&2
+              return 1
+            }
+            printf '%s\\n' "$candidate_ids"
+          }
           if release_id="$(
             gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
               "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION" \
@@ -1332,6 +1349,8 @@ jobs:
               echo "Published GitHub Release is immutable and verified; reusing its exact assets."
               exit 0
             fi
+          elif [ "$IS_RECOVERY" = "true" ] && release_id="$(find_recovery_draft_release_id 2>/dev/null)"; then
+            :
           else
             # shellcheck disable=SC2086
             gh release create "$RELEASE_VERSION" \
@@ -1340,11 +1359,12 @@ jobs:
               --title "$RELEASE_VERSION" \
               --notes-file "$RUNNER_TEMP/release-notes.md" \
               $prerelease_flag
-            release_id="$(
-              gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-                "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION" \
-                --jq .id
-            )"
+            if [ "$IS_RECOVERY" = "true" ]; then
+              release_id="$(find_recovery_draft_release_id)"
+            else
+              echo "GitHub cannot resolve a draft release by tag; retry through the controlled recovery path." >&2
+              exit 1
+            fi
           fi
           printf '%s\n' "$release_id" | grep -Eq '^[1-9][0-9]*$' || {
             echo "Draft GitHub Release has an invalid database ID: $release_id" >&2
@@ -1389,7 +1409,6 @@ jobs:
             exit 1
           }
           if [ "$IS_RECOVERY" = "true" ]; then
-            recovery_marker="<!-- dws-release-recovery run=$GITHUB_RUN_ID tag-object=$RELEASE_TAG_OBJECT commit=$RELEASE_COMMIT -->"
             case "$draft_body" in
               *"$recovery_marker"*) ;;
               *)
@@ -1404,13 +1423,13 @@ jobs:
             dist/dws-skills.zip \
             dist/checksums.txt \
             --clobber
-          uploaded_release_id="$(
+          uploaded_release_state="$(
             gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
-              "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION" \
-              --jq .id
+              "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+              --jq '[.id, .tag_name] | @tsv'
           )"
-          test "$uploaded_release_id" = "$release_id" || {
-            echo "GitHub Release identity changed during upload: $release_id -> $uploaded_release_id" >&2
+          test "$uploaded_release_state" = "$(printf '%s\\t%s' "$release_id" "$RELEASE_VERSION")" || {
+            echo "GitHub Release identity changed during upload: $release_id -> $uploaded_release_state" >&2
             exit 1
           }
           DWS_GITHUB_RELEASE_ID="$release_id" \

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -2253,9 +2253,12 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 	for _, required := range []string{
 		"id: publish",
 		`"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION"`,
+		`"repos/$GITHUB_REPOSITORY/releases?per_page=100"`,
+		"find_recovery_draft_release_id()",
+		"Expected exactly one draft GitHub Release for this recovery run",
 		`"repos/$GITHUB_REPOSITORY/releases/$release_id"`,
-		`uploaded_release_id="$(`,
-		`test "$uploaded_release_id" = "$release_id"`,
+		`uploaded_release_state="$(`,
+		`test "$uploaded_release_state" = "$(printf '%s\\t%s' "$release_id" "$RELEASE_VERSION")"`,
 		"Draft GitHub Release ID $release_id targets",
 		"Draft GitHub Release notes differ from the sealed CHANGELOG.",
 		"Draft GitHub Release is not bound to this exact recovery run.",
@@ -2285,7 +2288,7 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 	bodyVerify := strings.Index(publishStep, "Draft GitHub Release notes differ from the sealed CHANGELOG.")
 	markerVerify := strings.Index(publishStep, "Draft GitHub Release is not bound to this exact recovery run.")
 	upload := strings.Index(publishStep, `gh release upload "$RELEASE_VERSION"`)
-	idRecheck := strings.Index(publishStep, `test "$uploaded_release_id" = "$release_id"`)
+	idRecheck := strings.Index(publishStep, `test "$uploaded_release_state" = "$(printf '%s\\t%s' "$release_id" "$RELEASE_VERSION")"`)
 	verify := strings.Index(publishStep, "tmp/trusted-release-tooling/scripts/release/verify-github-release-assets.sh")
 	download := strings.LastIndex(publishStep, "tmp/trusted-release-tooling/scripts/release/download-github-release-assets.sh")
 	byteCompare := strings.Index(publishStep, `cmp -s "$local_asset" "$remote_asset"`)


### PR DESCRIPTION
修复 beta recovery 中 GitHub 草稿 Release 无法通过按 tag REST 查询定位的问题。仅在 recovery 模式下按当前 run 的精确恢复标记定位草稿；多匹配时失败，避免选择错误草稿。上传后继续通过锁定 release ID 验证身份。\n\n验证：\n- DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run ^TestReleaseWorkflowDraftLifecycleUsesOneReleaseID$ -count=1\n- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12\n- git diff --check