### PR TITLE
fix(release): create drafts through REST

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1242,10 +1242,8 @@ jobs:
         run: |
           set -eu
           expected_prerelease=false
-          prerelease_flag=""
           if [ "$RELEASE_CHANNEL" = "prerelease" ]; then
             expected_prerelease=true
-            prerelease_flag="--prerelease"
           fi
 
           release_id=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1253,19 +1253,6 @@ jobs:
           if [ "$IS_RECOVERY" = "true" ]; then
             recovery_marker="<!-- dws-release-recovery run=$GITHUB_RUN_ID tag-object=$RELEASE_TAG_OBJECT commit=$RELEASE_COMMIT -->"
           fi
-          find_recovery_draft_release_id() {
-            candidate_ids="$(
-              gh api --paginate -H 'X-GitHub-Api-Version: 2026-03-10' \
-                "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-                --jq ".[] | select(.tag_name == \"$RELEASE_VERSION\" and (.body | contains(\"$recovery_marker\"))) | .id"
-            )"
-            candidate_count="$(printf '%s\\n' "$candidate_ids" | sed '/^$/d' | wc -l | tr -d ' ')"
-            test "$candidate_count" = "1" || {
-              echo "Expected exactly one draft GitHub Release for this recovery run; found $candidate_count." >&2
-              return 1
-            }
-            printf '%s\\n' "$candidate_ids"
-          }
           if release_id="$(
             gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
               "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION" \
@@ -1349,22 +1336,19 @@ jobs:
               echo "Published GitHub Release is immutable and verified; reusing its exact assets."
               exit 0
             fi
-          elif [ "$IS_RECOVERY" = "true" ] && release_id="$(find_recovery_draft_release_id 2>/dev/null)"; then
-            :
           else
-            # shellcheck disable=SC2086
-            gh release create "$RELEASE_VERSION" \
-              --verify-tag \
-              --draft \
-              --title "$RELEASE_VERSION" \
-              --notes-file "$RUNNER_TEMP/release-notes.md" \
-              $prerelease_flag
-            if [ "$IS_RECOVERY" = "true" ]; then
-              release_id="$(find_recovery_draft_release_id)"
-            else
-              echo "GitHub cannot resolve a draft release by tag; retry through the controlled recovery path." >&2
-              exit 1
-            fi
+            release_id="$(
+              gh api --method POST \
+                -H 'X-GitHub-Api-Version: 2026-03-10' \
+                "repos/$GITHUB_REPOSITORY/releases" \
+                -f tag_name="$RELEASE_VERSION" \
+                -f target_commitish="$RELEASE_COMMIT" \
+                -f name="$RELEASE_VERSION" \
+                -f body="$(cat "$RUNNER_TEMP/release-notes.md")" \
+                -F draft=true \
+                -F prerelease="$expected_prerelease" \
+                --jq .id
+            )"
           fi
           printf '%s\n' "$release_id" | grep -Eq '^[1-9][0-9]*$' || {
             echo "Draft GitHub Release has an invalid database ID: $release_id" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1251,6 +1251,26 @@ jobs:
           if [ "$IS_RECOVERY" = "true" ]; then
             recovery_marker="<!-- dws-release-recovery run=$GITHUB_RUN_ID tag-object=$RELEASE_TAG_OBJECT commit=$RELEASE_COMMIT -->"
           fi
+          find_recovery_draft_release_id() {
+            candidate_ids="$(
+              gh api --paginate -H 'X-GitHub-Api-Version: 2026-03-10' \
+                "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+                --jq ".[] | select(.draft == true and .tag_name == \"$RELEASE_VERSION\" and (.body | contains(\"$recovery_marker\"))) | .id"
+            )"
+            candidate_count="$(printf '%s\\n' "$candidate_ids" | sed '/^$/d' | wc -l | tr -d ' ')"
+            case "$candidate_count" in
+              0)
+                return 2
+                ;;
+              1)
+                printf '%s\\n' "$candidate_ids"
+                ;;
+              *)
+                echo "Expected at most one draft GitHub Release for this recovery run; found $candidate_count." >&2
+                return 1
+                ;;
+            esac
+          }
           if release_id="$(
             gh api -H 'X-GitHub-Api-Version: 2026-03-10' \
               "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION" \
@@ -1333,6 +1353,27 @@ jobs:
               echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
               echo "Published GitHub Release is immutable and verified; reusing its exact assets."
               exit 0
+            fi
+          elif [ "$IS_RECOVERY" = "true" ]; then
+            if release_id="$(find_recovery_draft_release_id)"; then
+              :
+            else
+              find_status=$?
+              if [ "$find_status" -ne 2 ]; then
+                exit "$find_status"
+              fi
+              release_id="$(
+                gh api --method POST \
+                  -H 'X-GitHub-Api-Version: 2026-03-10' \
+                  "repos/$GITHUB_REPOSITORY/releases" \
+                  -f tag_name="$RELEASE_VERSION" \
+                  -f target_commitish="$RELEASE_COMMIT" \
+                  -f name="$RELEASE_VERSION" \
+                  -f body="$(cat "$RUNNER_TEMP/release-notes.md")" \
+                  -F draft=true \
+                  -F prerelease="$expected_prerelease" \
+                  --jq .id
+              )"
             fi
           else
             release_id="$(

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -2253,9 +2253,8 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 	for _, required := range []string{
 		"id: publish",
 		`"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION"`,
-		`"repos/$GITHUB_REPOSITORY/releases?per_page=100"`,
-		"find_recovery_draft_release_id()",
-		"Expected exactly one draft GitHub Release for this recovery run",
+		`"repos/$GITHUB_REPOSITORY/releases"`,
+		"gh api --method POST",
 		`"repos/$GITHUB_REPOSITORY/releases/$release_id"`,
 		`uploaded_release_state="$(`,
 		`test "$uploaded_release_state" = "$(printf '%s\\t%s' "$release_id" "$RELEASE_VERSION")"`,
@@ -2284,7 +2283,7 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 	}
 
 	tagGuard := strings.Index(publishStep, "Draft GitHub Release ID $release_id targets")
-	draftPatch := strings.Index(publishStep, "-F draft=true")
+	draftPatch := strings.LastIndex(publishStep, "-F draft=true")
 	bodyVerify := strings.Index(publishStep, "Draft GitHub Release notes differ from the sealed CHANGELOG.")
 	markerVerify := strings.Index(publishStep, "Draft GitHub Release is not bound to this exact recovery run.")
 	upload := strings.Index(publishStep, `gh release upload "$RELEASE_VERSION"`)

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -2254,6 +2254,11 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 		"id: publish",
 		`"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION"`,
 		`"repos/$GITHUB_REPOSITORY/releases"`,
+		"find_recovery_draft_release_id()",
+		`select(.draft == true and .tag_name == \"$RELEASE_VERSION\"`,
+		`release_id="$(find_recovery_draft_release_id)"`,
+		`if [ "$find_status" -ne 2 ]; then`,
+		"Expected at most one draft GitHub Release for this recovery run",
 		"gh api --method POST",
 		`"repos/$GITHUB_REPOSITORY/releases/$release_id"`,
 		`uploaded_release_state="$(`,
@@ -2283,6 +2288,13 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 	}
 
 	tagGuard := strings.Index(publishStep, "Draft GitHub Release ID $release_id targets")
+	recoveryLookup := strings.Index(publishStep, "find_recovery_draft_release_id()")
+	recoveryReuse := strings.Index(publishStep, `release_id="$(find_recovery_draft_release_id)"`)
+	recoveryNotFound := strings.Index(publishStep, `if [ "$find_status" -ne 2 ]; then`)
+	recoveryCreate := -1
+	if recoveryNotFound != -1 {
+		recoveryCreate = strings.Index(publishStep[recoveryNotFound:], "gh api --method POST")
+	}
 	draftPatch := strings.LastIndex(publishStep, "-F draft=true")
 	bodyVerify := strings.Index(publishStep, "Draft GitHub Release notes differ from the sealed CHANGELOG.")
 	markerVerify := strings.Index(publishStep, "Draft GitHub Release is not bound to this exact recovery run.")
@@ -2292,6 +2304,10 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 	download := strings.LastIndex(publishStep, "tmp/trusted-release-tooling/scripts/release/download-github-release-assets.sh")
 	byteCompare := strings.Index(publishStep, `cmp -s "$local_asset" "$remote_asset"`)
 	publish := strings.Index(publishStep, "-F draft=false")
+	if recoveryLookup == -1 || recoveryReuse == -1 || recoveryNotFound == -1 || recoveryCreate == -1 ||
+		!(recoveryLookup < recoveryReuse && recoveryReuse < recoveryNotFound) {
+		t.Fatal("recovery must reuse its uniquely marker-bound draft before creating a replacement")
+	}
 	if tagGuard == -1 || draftPatch == -1 || bodyVerify == -1 || markerVerify == -1 ||
 		upload == -1 || idRecheck == -1 || verify == -1 || download == -1 || byteCompare == -1 || publish == -1 ||
 		!(tagGuard < draftPatch && draftPatch < bodyVerify && bodyVerify < markerVerify && markerVerify < upload &&


### PR DESCRIPTION
修复 recovery 草稿 Release 创建后的 ID 回查：不再通过列表查询恢复标记，改为 REST POST 直接获取并锁定 release ID。保留现有封存、身份、字节和发布门禁。\n\n验证：\n- DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run ^TestReleaseWorkflowDraftLifecycleUsesOneReleaseID$ -count=1\n- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12\n- git diff --check