### PR TITLE
fix(release): use job token for release REST API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1237,7 +1237,9 @@ jobs:
       - name: Publish or reuse immutable GitHub Release
         id: publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the job-scoped token so this REST client receives the
+          # contents: write permission declared by publish-release.
+          GITHUB_TOKEN: ${{ github.token }}
           RELEASE_CHANNEL: ${{ needs.release-contract.outputs.channel }}
         run: |
           set -eu
@@ -1485,7 +1487,7 @@ jobs:
 
       - name: Require immutable published GitHub Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ steps.publish.outputs.release_id }}
           RELEASE_CHANNEL: ${{ needs.release-contract.outputs.channel }}
         run: |

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -2252,6 +2252,7 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 
 	for _, required := range []string{
 		"id: publish",
+		`GITHUB_TOKEN: ${{ github.token }}`,
 		`"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION"`,
 		`"repos/$GITHUB_REPOSITORY/releases"`,
 		"find_recovery_draft_release_id()",
@@ -2317,6 +2318,7 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 
 	terminalStep := publishJob[strings.Index(publishJob, "      - name: Require immutable published GitHub Release\n"):]
 	for _, required := range []string{
+		`GITHUB_TOKEN: ${{ github.token }}`,
 		`RELEASE_ID: ${{ steps.publish.outputs.release_id }}`,
 		`RELEASE_CHANNEL: ${{ needs.release-contract.outputs.channel }}`,
 		`"repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"`,


### PR DESCRIPTION
Fix the v1.0.62-beta.1 recovery 403 by binding Release REST calls to the publish job scoped GitHub token. Add workflow contract coverage for both mutable and immutable release verification steps.