### PR TITLE
fix(release): mint scoped app token for GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1234,12 +1234,20 @@ jobs:
           "$GITHUB_WORKSPACE/tmp/trusted-release-tooling/scripts/release/verify-github-tag-authority.sh" \
             "$RELEASE_VERSION" "$RELEASE_COMMIT" "$RELEASE_TAG_OBJECT"
 
+      - name: Mint repository-scoped Release publisher token
+        id: release-publisher-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.REVIEWER_ROUTER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.REVIEWER_ROUTER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: Publish or reuse immutable GitHub Release
         id: publish
         env:
-          # Use the job-scoped token so this REST client receives the
-          # contents: write permission declared by publish-release.
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.release-publisher-token.outputs.token }}
           RELEASE_CHANNEL: ${{ needs.release-contract.outputs.channel }}
         run: |
           set -eu
@@ -1487,7 +1495,7 @@ jobs:
 
       - name: Require immutable published GitHub Release
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.release-publisher-token.outputs.token }}
           RELEASE_ID: ${{ steps.publish.outputs.release_id }}
           RELEASE_CHANNEL: ${{ needs.release-contract.outputs.channel }}
         run: |

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -2243,6 +2243,36 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 	t.Parallel()
 	workflow := readReleaseWorkflow(t)
 	publishJob := releaseWorkflowSection(t, workflow, "  publish-release:\n", "\n  publish-channels:\n")
+	tokenStep := releaseWorkflowSection(
+		t,
+		publishJob,
+		"      - name: Mint repository-scoped Release publisher token\n",
+		"\n      - name: Publish or reuse immutable GitHub Release\n",
+	)
+	for _, required := range []string{
+		"id: release-publisher-token",
+		"actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+		`client-id: ${{ vars.REVIEWER_ROUTER_APP_CLIENT_ID }}`,
+		`private-key: ${{ secrets.REVIEWER_ROUTER_APP_PRIVATE_KEY }}`,
+		`owner: ${{ github.repository_owner }}`,
+		`repositories: ${{ github.event.repository.name }}`,
+		"permission-contents: write",
+	} {
+		if !strings.Contains(tokenStep, required) {
+			t.Errorf("Release publisher token step is missing %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"permission-actions:",
+		"permission-administration:",
+		"permission-checks:",
+		"permission-pull-requests:",
+		"skip-token-revoke:",
+	} {
+		if strings.Contains(tokenStep, forbidden) {
+			t.Errorf("Release publisher token must stay repository-scoped and contents-only: found %q", forbidden)
+		}
+	}
 	publishStep := releaseWorkflowSection(
 		t,
 		publishJob,
@@ -2252,7 +2282,7 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 
 	for _, required := range []string{
 		"id: publish",
-		`GITHUB_TOKEN: ${{ github.token }}`,
+		`GITHUB_TOKEN: ${{ steps.release-publisher-token.outputs.token }}`,
 		`"repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_VERSION"`,
 		`"repos/$GITHUB_REPOSITORY/releases"`,
 		"find_recovery_draft_release_id()",
@@ -2318,7 +2348,7 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 
 	terminalStep := publishJob[strings.Index(publishJob, "      - name: Require immutable published GitHub Release\n"):]
 	for _, required := range []string{
-		`GITHUB_TOKEN: ${{ github.token }}`,
+		`GITHUB_TOKEN: ${{ steps.release-publisher-token.outputs.token }}`,
 		`RELEASE_ID: ${{ steps.publish.outputs.release_id }}`,
 		`RELEASE_CHANNEL: ${{ needs.release-contract.outputs.channel }}`,
 		`"repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID"`,


### PR DESCRIPTION
## Summary

- mint a short-lived GitHub App token only after sealed release inputs and artifacts are verified
- scope the token to this repository and Contents write
- use the same token for Release publication and immutable delivery verification
- add workflow contract coverage for exact token scope and automatic revocation

## Why

Recovery run 33571018479 received HTTP 403 on its first Release REST read even though the built-in GITHUB_TOKEN job permissions reported Contents write. The existing Reviewer Router App is already installed for this repository with Contents write, so the release job now requests only that permission for the publication window.

## Verification

- DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run ^TestReleaseWorkflow -count=1 -timeout=10m
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml
- git diff --check

The complete test/scripts package also ran, but an unrelated existing external-script test TestReleaseArtifactVerificationRequiresEveryChecksum exceeded the package 10 minute timeout; all Release workflow contract tests pass independently.