### PR TITLE
fix(release): preserve uploaded draft identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,10 @@ on:
         description: "Failed attempt number within the exact-tag Release workflow run"
         required: false
         type: string
+      recover_draft_release_id:
+        description: "Optional exact draft GitHub Release database ID left by the failed run"
+        required: false
+        type: string
       recover_release_nonce:
         description: "Unique identifier for this machine-verified recovery request"
         required: false
@@ -110,6 +114,7 @@ jobs:
           RECOVER_COMMIT: ${{ inputs.recover_release_commit }}
           RECOVER_FAILED_RUN_ID: ${{ inputs.recover_failed_run_id }}
           RECOVER_FAILED_RUN_ATTEMPT: ${{ inputs.recover_failed_run_attempt }}
+          RECOVER_DRAFT_RELEASE_ID: ${{ inputs.recover_draft_release_id }}
           RECOVER_NONCE: ${{ inputs.recover_release_nonce }}
           RECOVER_CONFIRMATION: ${{ inputs.recover_release_confirmation }}
           RELEASE_OPERATION: ${{ inputs.release_operation }}
@@ -133,6 +138,7 @@ jobs:
           if test -n "$RECOVER_VERSION" || test -n "$RECOVER_TAG_OBJECT" || \
              test -n "$RECOVER_COMMIT" || test -n "$RECOVER_FAILED_RUN_ID" || \
              test -n "$RECOVER_FAILED_RUN_ATTEMPT" || \
+             test -n "$RECOVER_DRAFT_RELEASE_ID" || \
              test -n "$RECOVER_NONCE" || \
              test -n "$RECOVER_CONFIRMATION"; then recovery=1; fi
           test $((release_flow + npm_repair + gitee_repair + oss_repair + governance + recovery)) -eq 1 || {
@@ -196,6 +202,12 @@ jobs:
               echo "recover_failed_run_attempt must be a positive attempt number" >&2
               exit 1
             }
+            if test -n "$RECOVER_DRAFT_RELEASE_ID"; then
+              printf '%s\n' "$RECOVER_DRAFT_RELEASE_ID" | grep -Eq '^[1-9][0-9]*$' || {
+                echo "recover_draft_release_id must be a positive release database ID" >&2
+                exit 1
+              }
+            fi
             printf '%s\n' "$RECOVER_NONCE" | grep -Eq "^${RECOVER_COMMIT}-[0-9]+-[0-9]+$" || {
               echo "recover_release_nonce must be bound to the release commit" >&2
               exit 1
@@ -1249,6 +1261,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.release-publisher-token.outputs.token }}
           RELEASE_CHANNEL: ${{ needs.release-contract.outputs.channel }}
+          RECOVER_DRAFT_RELEASE_ID: ${{ inputs.recover_draft_release_id }}
         run: |
           set -eu
           expected_prerelease=false
@@ -1365,7 +1378,9 @@ jobs:
               exit 0
             fi
           elif [ "$IS_RECOVERY" = "true" ]; then
-            if release_id="$(find_recovery_draft_release_id)"; then
+            if [ -n "$RECOVER_DRAFT_RELEASE_ID" ]; then
+              release_id="$RECOVER_DRAFT_RELEASE_ID"
+            elif release_id="$(find_recovery_draft_release_id)"; then
               :
             else
               find_status=$?
@@ -1461,7 +1476,7 @@ jobs:
               "repos/$GITHUB_REPOSITORY/releases/$release_id" \
               --jq '[.id, .tag_name] | @tsv'
           )"
-          test "$uploaded_release_state" = "$(printf '%s\\t%s' "$release_id" "$RELEASE_VERSION")" || {
+          test "$uploaded_release_state" = "$(printf '%s\t%s' "$release_id" "$RELEASE_VERSION")" || {
             echo "GitHub Release identity changed during upload: $release_id -> $uploaded_release_state" >&2
             exit 1
           }

--- a/scripts/release/recover-release.sh
+++ b/scripts/release/recover-release.sh
@@ -10,11 +10,12 @@ VERSION="${1:-}"
 REMOTE=""
 FAILED_RUN_ID=""
 FAILED_RUN_ATTEMPT=""
+DRAFT_RELEASE_ID=""
 EXPECTED_REPOSITORY="DingTalk-Real-AI/dingtalk-workspace-cli"
 
 usage() {
   cat >&2 <<'EOF'
-usage: recover-release.sh <version> --remote <name> [--failed-run <run-id>] [--failed-attempt <attempt>]
+usage: recover-release.sh <version> --remote <name> [--failed-run <run-id>] [--failed-attempt <attempt>] [--draft-release-id <release-id>]
 
 Recovers one failed existing release tag through the protected default-branch
 Release workflow. It never creates, moves, or deletes a tag.
@@ -28,6 +29,7 @@ while [ "$#" -gt 0 ]; do
     --remote) [ "$#" -ge 2 ] || { usage; exit 2; }; REMOTE="$2"; shift 2 ;;
     --failed-run) [ "$#" -ge 2 ] || { usage; exit 2; }; FAILED_RUN_ID="$2"; shift 2 ;;
     --failed-attempt) [ "$#" -ge 2 ] || { usage; exit 2; }; FAILED_RUN_ATTEMPT="$2"; shift 2 ;;
+    --draft-release-id) [ "$#" -ge 2 ] || { usage; exit 2; }; DRAFT_RELEASE_ID="$2"; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) printf 'unknown recovery argument: %s\n' "$1" >&2; usage; exit 2 ;;
   esac
@@ -49,6 +51,12 @@ if [ -n "$FAILED_RUN_ATTEMPT" ]; then
   }
   printf '%s\n' "$FAILED_RUN_ATTEMPT" | grep -Eq '^[1-9][0-9]*$' || {
     printf 'invalid failed Release run attempt: %s\n' "$FAILED_RUN_ATTEMPT" >&2
+    exit 2
+  }
+fi
+if [ -n "$DRAFT_RELEASE_ID" ]; then
+  printf '%s\n' "$DRAFT_RELEASE_ID" | grep -Eq '^[1-9][0-9]*$' || {
+    printf 'invalid draft GitHub Release ID: %s\n' "$DRAFT_RELEASE_ID" >&2
     exit 2
   }
 fi
@@ -247,6 +255,9 @@ printf '  tag object: %s\n' "$tag_object"
 printf '  commit:     %s\n' "$commit"
 printf '  failed run: https://github.com/%s/actions/runs/%s/attempts/%s\n' \
   "$EXPECTED_REPOSITORY" "$FAILED_RUN_ID" "$FAILED_RUN_ATTEMPT"
+if [ -n "$DRAFT_RELEASE_ID" ]; then
+  printf '  draft ID:   %s\n' "$DRAFT_RELEASE_ID"
+fi
 [ -t 0 ] || { printf '%s\n' 'interactive recovery confirmation is required' >&2; exit 1; }
 printf 'Type %s to request machine-verified recovery: ' "$VERSION"
 IFS= read -r confirmation
@@ -254,7 +265,7 @@ IFS= read -r confirmation
 
 nonce="${commit}-$(date +%s)-$$"
 workflow_sha="$(git rev-parse "refs/remotes/$REMOTE/main")"
-gh workflow run release.yml \
+set -- \
   --repo "$EXPECTED_REPOSITORY" \
   --ref main \
   -f "recover_release_version=$VERSION" \
@@ -264,6 +275,10 @@ gh workflow run release.yml \
   -f "recover_failed_run_attempt=$FAILED_RUN_ATTEMPT" \
   -f "recover_release_nonce=$nonce" \
   -f "recover_release_confirmation=$VERSION"
+if [ -n "$DRAFT_RELEASE_ID" ]; then
+  set -- "$@" -f "recover_draft_release_id=$DRAFT_RELEASE_ID"
+fi
+gh workflow run release.yml "$@"
 
 expected_title="Release recovery $VERSION at $commit $nonce"
 started_at="$(date +%s)"

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -2122,12 +2122,14 @@ func TestReleaseWorkflowRecoveryReusesGuardedJobs(t *testing.T) {
 		"recover_release_commit:",
 		"recover_failed_run_id:",
 		"recover_failed_run_attempt:",
+		"recover_draft_release_id:",
 		"recover_release_nonce:",
 		"recover_release_confirmation:",
 		`format('Release recovery {0} at {1} {2}', inputs.recover_release_version, inputs.recover_release_commit, inputs.recover_release_nonce)`,
 		"workflow_dispatch must select exactly one release mode",
 		"release recovery confirmation must equal the exact version",
 		"recover_release_nonce must be bound to the release commit",
+		"recover_draft_release_id must be a positive release database ID",
 		`run.path !== ".github/workflows/release.yml"`,
 		`const expectedEvent = failedByCloud ? "workflow_dispatch" : "push"`,
 		`run.event !== expectedEvent`,
@@ -2288,12 +2290,14 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 		"find_recovery_draft_release_id()",
 		`select(.draft == true and .tag_name == \"$RELEASE_VERSION\"`,
 		`release_id="$(find_recovery_draft_release_id)"`,
+		`RECOVER_DRAFT_RELEASE_ID: ${{ inputs.recover_draft_release_id }}`,
+		`release_id="$RECOVER_DRAFT_RELEASE_ID"`,
 		`if [ "$find_status" -ne 2 ]; then`,
 		"Expected at most one draft GitHub Release for this recovery run",
 		"gh api --method POST",
 		`"repos/$GITHUB_REPOSITORY/releases/$release_id"`,
 		`uploaded_release_state="$(`,
-		`test "$uploaded_release_state" = "$(printf '%s\\t%s' "$release_id" "$RELEASE_VERSION")"`,
+		`test "$uploaded_release_state" = "$(printf '%s\t%s' "$release_id" "$RELEASE_VERSION")"`,
 		"Draft GitHub Release ID $release_id targets",
 		"Draft GitHub Release notes differ from the sealed CHANGELOG.",
 		"Draft GitHub Release is not bound to this exact recovery run.",
@@ -2330,7 +2334,7 @@ func TestReleaseWorkflowDraftLifecycleUsesOneReleaseID(t *testing.T) {
 	bodyVerify := strings.Index(publishStep, "Draft GitHub Release notes differ from the sealed CHANGELOG.")
 	markerVerify := strings.Index(publishStep, "Draft GitHub Release is not bound to this exact recovery run.")
 	upload := strings.Index(publishStep, `gh release upload "$RELEASE_VERSION"`)
-	idRecheck := strings.Index(publishStep, `test "$uploaded_release_state" = "$(printf '%s\\t%s' "$release_id" "$RELEASE_VERSION")"`)
+	idRecheck := strings.Index(publishStep, `test "$uploaded_release_state" = "$(printf '%s\t%s' "$release_id" "$RELEASE_VERSION")"`)
 	verify := strings.Index(publishStep, "tmp/trusted-release-tooling/scripts/release/verify-github-release-assets.sh")
 	download := strings.LastIndex(publishStep, "tmp/trusted-release-tooling/scripts/release/download-github-release-assets.sh")
 	byteCompare := strings.Index(publishStep, `cmp -s "$local_asset" "$remote_asset"`)
@@ -2391,6 +2395,7 @@ func TestRecoverReleaseBindsOneFailedRunAttempt(t *testing.T) {
 
 	for _, required := range []string{
 		"--failed-attempt <attempt>",
+		"--draft-release-id <release-id>",
 		"--failed-attempt requires --failed-run",
 		"find_latest_failed_attempt",
 		`while [ "$find_attempt" -ge 1 ]`,
@@ -2404,6 +2409,7 @@ func TestRecoverReleaseBindsOneFailedRunAttempt(t *testing.T) {
 		`is not bound by the cloud seal`,
 		"actions/runs/%s/attempts/%s",
 		`-f "recover_failed_run_attempt=$FAILED_RUN_ATTEMPT"`,
+		`-f "recover_draft_release_id=$DRAFT_RELEASE_ID"`,
 	} {
 		if !strings.Contains(script, required) {
 			t.Errorf("release recovery script is missing attempt binding %q", required)


### PR DESCRIPTION
## Summary

- compare the uploaded Release ID and tag with a real TSV separator instead of a literal backslash-t
- allow protected recovery to bind an exact draft Release database ID left by the failed run
- plumb the optional draft ID through the recovery helper and contract tests

## Incident evidence

- failed Release run: 33580339205
- failed job: 100094385441
- sealed version: v1.0.62-beta.2
- sealed commit: a7942ce546015c4c0bb49be0eae97acdef815e24
- annotated tag object: 103b20b4b570ad8fea7b2f5b5572b5d97ce5da43
- retained draft Release ID: 380928262
- failure: the API returned a real tab from jq @tsv, while the expected value used a literal backslash-t

## Validation

- go test ./test/scripts -run TestReleaseWorkflowRecoveryReusesGuardedJobs\|TestReleaseWorkflowDraftLifecycleUsesOneReleaseID\|TestRecoverReleaseBindsOneFailedRunAttempt -count=1
- go test ./test/scripts -run ^TestReleaseCommandReusesExactPreflightProof$ -count=1 -timeout=2m
- bash -n scripts/release/recover-release.sh
- git diff --check

The full test/scripts package reached its existing 10-minute package timeout in TestReleaseCommandReusesExactPreflightProof; that test passed independently in 6.4 seconds. No tag or draft is deleted or recreated.