### PR TITLE
fix(chat): align role and category routing

### DIFF
--- a/.changes/chat-role-category-routing.md
+++ b/.changes/chat-role-category-routing.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Chat role and category routing** — resolves natural group names before group-role operations, aligns role assignment guidance with required non-empty role IDs, and publishes a compact shortcut-first category workflow to reduce Help and Catalog discovery without dropping result, safety, or identity constraints.

--- a/internal/shortcut/chat/chat_group.go
+++ b/internal/shortcut/chat/chat_group.go
@@ -1892,6 +1892,23 @@ var ChatRoleRemove = shortcut.Shortcut{
 	},
 }
 
+func validateChatRoleIDs(values []string) error {
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return apperrors.NewValidation("--role-ids 不能包含空值或仅含空白的群身份 openRoleId")
+		}
+	}
+	return nil
+}
+
+func normalizeChatRoleIDs(values []string) []string {
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		normalized = append(normalized, strings.TrimSpace(value))
+	}
+	return normalized
+}
+
 // ChatRoleSetUser overwrites a user's group roles (set_custom_user_roles, im).
 var ChatRoleSetUser = shortcut.Shortcut{
 	Service:     "chat",
@@ -1930,8 +1947,15 @@ var ChatRoleSetUser = shortcut.Shortcut{
 		{Name: "user", Type: shortcut.FlagString, Desc: "用户 userId 或 openDingTalkId", Required: true},
 		{Name: "role-ids", Type: shortcut.FlagStringSlice, Desc: "要整体设置的群身份 openRoleId 列表，至少一个", Required: true},
 	},
+	Constraints: []shortcut.Constraint{
+		{Kind: shortcut.ConstraintCustom, Flags: []string{"role-ids"}, Description: "必须包含至少一个非空 openRoleId，且不能包含空值或仅含空白的元素"},
+	},
 	Tips: []string{`dws chat +chat-role-set-user --group <openConversationId> --user <userId> --role-ids roleId1,roleId2`},
+	Validate: func(rt *shortcut.RuntimeContext) error {
+		return validateChatRoleIDs(rt.StrSlice("role-ids"))
+	},
 	Execute: func(rt *shortcut.RuntimeContext) error {
+		roleIDs := normalizeChatRoleIDs(rt.StrSlice("role-ids"))
 		groupID, err := resolveStableOrNamedChat(rt)
 		if err != nil {
 			return err
@@ -1939,7 +1963,7 @@ var ChatRoleSetUser = shortcut.Shortcut{
 		user := rt.Str("user")
 		params := map[string]any{
 			"openConversationId": groupID,
-			"openRoleIds":        rt.StrSlice("role-ids"),
+			"openRoleIds":        roleIDs,
 		}
 		if isOpenID(user) {
 			params["openDingTalkId"] = user

--- a/internal/shortcut/chat/chat_group.go
+++ b/internal/shortcut/chat/chat_group.go
@@ -1352,9 +1352,9 @@ var ChatBots = shortcut.Shortcut{
 	},
 }
 
-// resolveStableOrNamedChat gives read-only group shortcuts one safe target
-// contract. Stable cid values bypass search; natural names always go through
-// the shared exact-match, full-pagination and ambiguity rules.
+// resolveStableOrNamedChat gives group shortcuts one safe target contract.
+// Stable cid values bypass search; natural names always go through the shared
+// exact-match, full-pagination and ambiguity rules before any business call.
 func resolveStableOrNamedChat(rt *shortcut.RuntimeContext) (string, error) {
 	resolved, err := targetresolver.ResolveChatTarget(
 		rt,
@@ -1693,7 +1693,7 @@ var ChatRoleList = shortcut.Shortcut{
 	Command:     "+chat-role-list",
 	Product:     "im",
 	Description: "拉取会话的群身份列表",
-	Intent:      "当你想查看某群自定义的群身份（如'班长''值日'）都有哪些时使用；需传群 openConversationId，只读返回群身份列表及 openRoleId。",
+	Intent:      "当你想查看某群自定义的群身份（如'班长''值日'）都有哪些时使用；--group 可传群名或 openConversationId，多命中会安全停止，只读返回群身份列表及 openRoleId。",
 	Risk:        shortcut.RiskRead,
 	Safety: contract.SafetySpec{
 		Effect: "read", Risk: "low",
@@ -1715,17 +1715,21 @@ var ChatRoleList = shortcut.Shortcut{
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "拉取会话的群身份列表",
-			UseWhen:      []string{"当你想查看某群自定义的群身份（如'班长''值日'）都有哪些时使用；需传群 openConversationId，只读返回群身份列表及 openRoleId。"},
+			UseWhen:      []string{"当你想查看某群自定义的群身份（如'班长''值日'）都有哪些时使用；--group 可传群名或 openConversationId，多命中会安全停止，只读返回群身份列表及 openRoleId。"},
 			AvoidWhen:    []string{"需要该 Shortcut 未公开的底层参数、原始响应或不同执行语义时，改用对应原子命令"},
 			Examples:     []string{"dws chat +chat-role-list --group <openConversationId>"},
 		},
 	},
 	Flags: []shortcut.Flag{
-		{Name: "group", Type: shortcut.FlagString, Desc: "群 openConversationId", Required: true},
+		{Name: "group", Type: shortcut.FlagString, Desc: "群名或 openConversationId；群名必须唯一匹配", Required: true},
 	},
 	Tips: []string{`dws chat +chat-role-list --group <openConversationId>`},
 	Execute: func(rt *shortcut.RuntimeContext) error {
-		data, err := rt.CallMCPData("im", "list_custom_group_roles", map[string]any{"openConversationId": rt.Str("group")})
+		groupID, err := resolveStableOrNamedChat(rt)
+		if err != nil {
+			return err
+		}
+		data, err := rt.CallMCPData("im", "list_custom_group_roles", map[string]any{"openConversationId": groupID})
 		if err != nil {
 			return err
 		}
@@ -1767,7 +1771,7 @@ var ChatRoleAdd = shortcut.Shortcut{
 	Command:     "+chat-role-add",
 	Product:     "im",
 	Description: "添加群身份",
-	Intent:      "当你想在群里新增一个自定义群身份/头衔时使用；会实际创建群身份，需传群 openConversationId 和身份名称。",
+	Intent:      "当你想在群里新增一个自定义群身份/头衔时使用；会实际创建群身份，--group 可传群名或 openConversationId，多命中时在写入前停止。",
 	Risk:        shortcut.RiskWrite,
 	Safety: contract.SafetySpec{
 		Effect: "write", Risk: "medium",
@@ -1789,19 +1793,23 @@ var ChatRoleAdd = shortcut.Shortcut{
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "添加群身份",
-			UseWhen:      []string{"当你想在群里新增一个自定义群身份/头衔时使用；会实际创建群身份，需传群 openConversationId 和身份名称。"},
+			UseWhen:      []string{"当你想在群里新增一个自定义群身份/头衔时使用；会实际创建群身份，--group 可传群名或 openConversationId，多命中时在写入前停止。"},
 			AvoidWhen:    []string{"需要该 Shortcut 未公开的底层参数、原始响应或不同执行语义时，改用对应原子命令"},
 			Examples:     []string{"dws chat +chat-role-add --group <openConversationId> --name \"管理员\""},
 		},
 	},
 	Flags: []shortcut.Flag{
-		{Name: "group", Type: shortcut.FlagString, Desc: "群 openConversationId", Required: true},
+		{Name: "group", Type: shortcut.FlagString, Desc: "群名或 openConversationId；群名必须唯一匹配", Required: true},
 		{Name: "name", Type: shortcut.FlagString, Desc: "群身份名称", Required: true},
 	},
 	Tips: []string{`dws chat +chat-role-add --group <openConversationId> --name "管理员"`},
 	Execute: func(rt *shortcut.RuntimeContext) error {
+		groupID, err := resolveStableOrNamedChat(rt)
+		if err != nil {
+			return err
+		}
 		return rt.CallMCP("add_custom_group_role", map[string]any{
-			"openConversationId": rt.Str("group"),
+			"openConversationId": groupID,
 			"name":               rt.Str("name"),
 		})
 	},
@@ -1813,7 +1821,7 @@ var ChatRoleUpdate = shortcut.Shortcut{
 	Command:     "+chat-role-update",
 	Product:     "im",
 	Description: "更新群身份名称",
-	Intent:      "当你想重命名已有的群身份时使用；会实际更新身份名称，需传群 openConversationId、身份 openRoleId 和新名称。",
+	Intent:      "当你想重命名已有的群身份时使用；会实际更新身份名称，--group 可传群名或 openConversationId，并需身份 openRoleId 和新名称。",
 	Risk:        shortcut.RiskWrite,
 	Safety: contract.SafetySpec{
 		Effect: "write", Risk: "medium",
@@ -1835,20 +1843,24 @@ var ChatRoleUpdate = shortcut.Shortcut{
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "更新群身份名称",
-			UseWhen:      []string{"当你想重命名已有的群身份时使用；会实际更新身份名称，需传群 openConversationId、身份 openRoleId 和新名称。"},
+			UseWhen:      []string{"当你想重命名已有的群身份时使用；会实际更新身份名称，--group 可传群名或 openConversationId，并需身份 openRoleId 和新名称。"},
 			AvoidWhen:    []string{"需要该 Shortcut 未公开的底层参数、原始响应或不同执行语义时，改用对应原子命令"},
 			Examples:     []string{"dws chat +chat-role-update --group <openConversationId> --role-id <openRoleId> --name \"新名称\""},
 		},
 	},
 	Flags: []shortcut.Flag{
-		{Name: "group", Type: shortcut.FlagString, Desc: "群 openConversationId", Required: true},
+		{Name: "group", Type: shortcut.FlagString, Desc: "群名或 openConversationId；群名必须唯一匹配", Required: true},
 		{Name: "role-id", Type: shortcut.FlagString, Desc: "群身份 openRoleId", Required: true},
 		{Name: "name", Type: shortcut.FlagString, Desc: "群身份新名称", Required: true},
 	},
 	Tips: []string{`dws chat +chat-role-update --group <openConversationId> --role-id <openRoleId> --name "新名称"`},
 	Execute: func(rt *shortcut.RuntimeContext) error {
+		groupID, err := resolveStableOrNamedChat(rt)
+		if err != nil {
+			return err
+		}
 		return rt.CallMCP("update_custom_group_role", map[string]any{
-			"openConversationId": rt.Str("group"),
+			"openConversationId": groupID,
 			"openRoleId":         rt.Str("role-id"),
 			"name":               rt.Str("name"),
 		})
@@ -1861,16 +1873,20 @@ var ChatRoleRemove = shortcut.Shortcut{
 	Command:     "+chat-role-remove",
 	Product:     "im",
 	Description: "删除群身份",
-	Intent:      "当你想删除某个自定义群身份时使用；会实际删除群身份，不可逆，需传群 openConversationId 和身份 openRoleId。",
+	Intent:      "当你想删除某个自定义群身份时使用；会实际删除群身份且不可逆，--group 可传群名或 openConversationId，并需身份 openRoleId。",
 	Risk:        shortcut.RiskHighWrite,
 	Flags: []shortcut.Flag{
-		{Name: "group", Type: shortcut.FlagString, Desc: "群 openConversationId", Required: true},
+		{Name: "group", Type: shortcut.FlagString, Desc: "群名或 openConversationId；群名必须唯一匹配", Required: true},
 		{Name: "role-id", Type: shortcut.FlagString, Desc: "群身份 openRoleId", Required: true},
 	},
 	Tips: []string{`dws chat +chat-role-remove --group <openConversationId> --role-id <openRoleId>`},
 	Execute: func(rt *shortcut.RuntimeContext) error {
+		groupID, err := resolveStableOrNamedChat(rt)
+		if err != nil {
+			return err
+		}
 		return rt.CallMCP("remove_custom_group_role", map[string]any{
-			"openConversationId": rt.Str("group"),
+			"openConversationId": groupID,
 			"openRoleId":         rt.Str("role-id"),
 		})
 	},
@@ -1882,7 +1898,7 @@ var ChatRoleSetUser = shortcut.Shortcut{
 	Command:     "+chat-role-set-user",
 	Product:     "im",
 	Description: "设置用户的群身份（覆盖该用户的全部群身份）",
-	Intent:      "当你想为某成员整体设定其在群内的身份时使用；会实际改写该用户的群身份集合（覆盖其原有全部身份），需传群、用户和 openRoleId 列表（传空则清除全部）。",
+	Intent:      "当你想为某成员整体设定其在群内的身份时使用；--group 可传群名或 openConversationId；会实际覆盖该用户的全部群身份，必须传至少一个 openRoleId；只撤销指定身份时使用 +chat-role-remove-user。",
 	Risk:        shortcut.RiskWrite,
 	Safety: contract.SafetySpec{
 		Effect: "write", Risk: "medium",
@@ -1904,21 +1920,25 @@ var ChatRoleSetUser = shortcut.Shortcut{
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "设置用户的群身份（覆盖该用户的全部群身份）",
-			UseWhen:      []string{"当你想为某成员整体设定其在群内的身份时使用；会实际改写该用户的群身份集合（覆盖其原有全部身份），需传群、用户和 openRoleId 列表（传空则清除全部）。"},
-			AvoidWhen:    []string{"需要该 Shortcut 未公开的底层参数、原始响应或不同执行语义时，改用对应原子命令"},
+			UseWhen:      []string{"当你想为某成员整体设定其在群内的身份时使用；--group 可传群名或 openConversationId；会实际覆盖该用户的全部群身份，必须传至少一个 openRoleId；只撤销指定身份时使用 +chat-role-remove-user。"},
+			AvoidWhen:    []string{"只撤销成员的指定群身份时使用 +chat-role-remove-user；需要未公开的底层参数或不同执行语义时才用对应原子命令。"},
 			Examples:     []string{"dws chat +chat-role-set-user --group <openConversationId> --user <userId> --role-ids roleId1,roleId2"},
 		},
 	},
 	Flags: []shortcut.Flag{
-		{Name: "group", Type: shortcut.FlagString, Desc: "群 openConversationId", Required: true},
+		{Name: "group", Type: shortcut.FlagString, Desc: "群名或 openConversationId；群名必须唯一匹配", Required: true},
 		{Name: "user", Type: shortcut.FlagString, Desc: "用户 userId 或 openDingTalkId", Required: true},
-		{Name: "role-ids", Type: shortcut.FlagStringSlice, Desc: "群身份 openRoleId 列表（空则清除全部）", Required: true},
+		{Name: "role-ids", Type: shortcut.FlagStringSlice, Desc: "要整体设置的群身份 openRoleId 列表，至少一个", Required: true},
 	},
 	Tips: []string{`dws chat +chat-role-set-user --group <openConversationId> --user <userId> --role-ids roleId1,roleId2`},
 	Execute: func(rt *shortcut.RuntimeContext) error {
+		groupID, err := resolveStableOrNamedChat(rt)
+		if err != nil {
+			return err
+		}
 		user := rt.Str("user")
 		params := map[string]any{
-			"openConversationId": rt.Str("group"),
+			"openConversationId": groupID,
 			"openRoleIds":        rt.StrSlice("role-ids"),
 		}
 		if isOpenID(user) {
@@ -1936,18 +1956,22 @@ var ChatRoleRemoveUser = shortcut.Shortcut{
 	Command:     "+chat-role-remove-user",
 	Product:     "im",
 	Description: "移除用户的指定群身份",
-	Intent:      "当你只想撤销某成员的部分群身份、保留其余时使用；会实际移除指定的群身份，需传群、用户和要移除的 openRoleId 列表。",
+	Intent:      "当你只想撤销某成员的部分群身份、保留其余时使用；--group 可传群名或 openConversationId；会实际移除指定的群身份，需传用户和 openRoleId 列表。",
 	Risk:        shortcut.RiskWrite,
 	Flags: []shortcut.Flag{
-		{Name: "group", Type: shortcut.FlagString, Desc: "群 openConversationId", Required: true},
+		{Name: "group", Type: shortcut.FlagString, Desc: "群名或 openConversationId；群名必须唯一匹配", Required: true},
 		{Name: "user", Type: shortcut.FlagString, Desc: "用户 userId 或 openDingTalkId", Required: true},
 		{Name: "role-ids", Type: shortcut.FlagStringSlice, Desc: "要移除的群身份 openRoleId 列表", Required: true},
 	},
 	Tips: []string{`dws chat +chat-role-remove-user --group <openConversationId> --user <userId> --role-ids roleId1`},
 	Execute: func(rt *shortcut.RuntimeContext) error {
+		groupID, err := resolveStableOrNamedChat(rt)
+		if err != nil {
+			return err
+		}
 		user := rt.Str("user")
 		params := map[string]any{
-			"openConversationId": rt.Str("group"),
+			"openConversationId": groupID,
 			"openRoleIds":        rt.StrSlice("role-ids"),
 		}
 		if isOpenID(user) {
@@ -1965,7 +1989,7 @@ var ChatRoleQueryUser = shortcut.Shortcut{
 	Command:     "+chat-role-query-user",
 	Product:     "im",
 	Description: "查询群成员的群身份",
-	Intent:      "当你想查看某个群成员当前拥有哪些群身份时使用；只读，需传群 openConversationId 和用户 userId 或 openDingTalkId。",
+	Intent:      "当你想查看某个群成员当前拥有哪些群身份时使用；只读，--group 可传群名或 openConversationId，用户可传 userId 或 openDingTalkId。",
 	Risk:        shortcut.RiskRead,
 	Safety: contract.SafetySpec{
 		Effect: "read", Risk: "low",
@@ -1987,19 +2011,23 @@ var ChatRoleQueryUser = shortcut.Shortcut{
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "查询群成员的群身份",
-			UseWhen:      []string{"当你想查看某个群成员当前拥有哪些群身份时使用；只读，需传群 openConversationId 和用户 userId 或 openDingTalkId。"},
+			UseWhen:      []string{"当你想查看某个群成员当前拥有哪些群身份时使用；只读，--group 可传群名或 openConversationId，用户可传 userId 或 openDingTalkId。"},
 			AvoidWhen:    []string{"需要该 Shortcut 未公开的底层参数、原始响应或不同执行语义时，改用对应原子命令"},
 			Examples:     []string{"dws chat +chat-role-query-user --group <openConversationId> --user <userId>"},
 		},
 	},
 	Flags: []shortcut.Flag{
-		{Name: "group", Type: shortcut.FlagString, Desc: "群 openConversationId", Required: true},
+		{Name: "group", Type: shortcut.FlagString, Desc: "群名或 openConversationId；群名必须唯一匹配", Required: true},
 		{Name: "user", Type: shortcut.FlagString, Desc: "用户 userId 或 openDingTalkId", Required: true},
 	},
 	Tips: []string{`dws chat +chat-role-query-user --group <openConversationId> --user <userId>`},
 	Execute: func(rt *shortcut.RuntimeContext) error {
+		groupID, err := resolveStableOrNamedChat(rt)
+		if err != nil {
+			return err
+		}
 		user := rt.Str("user")
-		params := map[string]any{"openConversationId": rt.Str("group")}
+		params := map[string]any{"openConversationId": groupID}
 		if isOpenID(user) {
 			params["openDingTalkId"] = user
 		} else {

--- a/internal/shortcut/chat/chat_group.go
+++ b/internal/shortcut/chat/chat_group.go
@@ -1893,6 +1893,9 @@ var ChatRoleRemove = shortcut.Shortcut{
 }
 
 func validateChatRoleIDs(values []string) error {
+	if len(values) == 0 {
+		return apperrors.NewValidation("--role-ids 必须包含至少一个非空的群身份 openRoleId")
+	}
 	for _, value := range values {
 		if strings.TrimSpace(value) == "" {
 			return apperrors.NewValidation("--role-ids 不能包含空值或仅含空白的群身份 openRoleId")

--- a/internal/shortcut/chat/chat_group.go
+++ b/internal/shortcut/chat/chat_group.go
@@ -1945,7 +1945,7 @@ var ChatRoleSetUser = shortcut.Shortcut{
 	Flags: []shortcut.Flag{
 		{Name: "group", Type: shortcut.FlagString, Desc: "群名或 openConversationId；群名必须唯一匹配", Required: true},
 		{Name: "user", Type: shortcut.FlagString, Desc: "用户 userId 或 openDingTalkId", Required: true},
-		{Name: "role-ids", Type: shortcut.FlagStringSlice, Desc: "要整体设置的群身份 openRoleId 列表，至少一个", Required: true},
+		{Name: "role-ids", Type: shortcut.FlagStringSlice, Desc: "要整体设置的群身份 openRoleId 列表；必须包含至少一个非空 openRoleId，且不能包含空值或仅含空白的元素", Required: true},
 	},
 	Constraints: []shortcut.Constraint{
 		{Kind: shortcut.ConstraintCustom, Flags: []string{"role-ids"}, Description: "必须包含至少一个非空 openRoleId，且不能包含空值或仅含空白的元素"},

--- a/internal/shortcut/chat/lark_alignment_test.go
+++ b/internal/shortcut/chat/lark_alignment_test.go
@@ -182,6 +182,160 @@ func TestCrossPlatformCoverageEvaluationRegressionNaturalGroupTargetsAndRecallIn
 	})
 }
 
+func TestCrossPlatformCoverageChatRoleSetUserRejectsEmptyRolesBeforeAnyCall(t *testing.T) {
+	tests := []struct {
+		name    string
+		roleIDs string
+		yes     bool
+	}{
+		{name: "before confirmation", roleIDs: ""},
+		{name: "after confirmation", roleIDs: "", yes: true},
+		{name: "blank element after confirmation", roleIDs: "role-1, ", yes: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &larkAlignmentCaller{}
+			helpers.InitDeps(fake)
+			root := newPlatformCoverageRoot()
+			args := []string{
+				"chat", "+chat-role-set-user",
+				"--group", "项目群",
+				"--user", "user-1",
+				"--role-ids", tt.roleIDs,
+			}
+			if tt.yes {
+				args = append(args, "--yes")
+			}
+			root.SetArgs(args)
+			if err := root.Execute(); err == nil {
+				t.Fatal("empty role IDs unexpectedly accepted")
+			}
+			if len(fake.calls) != 0 {
+				t.Fatalf("empty role IDs reached group resolution or write: %#v", fake.calls)
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageChatRoleSetUserConfirmedPassesExactParams(t *testing.T) {
+	fake := &larkAlignmentCaller{responses: map[string]string{
+		"im/search_groups": `{"result":[{"openConversationId":"cid-project","title":"项目群"}],"hasMore":false}`,
+	}}
+	helpers.InitDeps(fake)
+	root := newPlatformCoverageRoot()
+	root.SetArgs([]string{
+		"chat", "+chat-role-set-user",
+		"--group", "项目群",
+		"--user", "user-1",
+		"--role-ids", " role-1 ,role-2 ",
+		"--yes",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 2 || fake.calls[0].tool != "search_groups" || fake.calls[1].tool != "set_custom_user_roles" {
+		t.Fatalf("calls = %#v", fake.calls)
+	}
+	want := map[string]any{
+		"openConversationId": "cid-project",
+		"openRoleIds":        []string{"role-1", "role-2"},
+		"userId":             "user-1",
+	}
+	if !reflect.DeepEqual(fake.calls[1].args, want) {
+		t.Fatalf("write args = %#v, want %#v", fake.calls[1].args, want)
+	}
+}
+
+func TestCrossPlatformCoverageChatRoleCommandsResolveNamesToExactBusinessCalls(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		tool string
+		want map[string]any
+	}{
+		{
+			name: "add",
+			args: []string{"chat", "+chat-role-add", "--group", "项目群", "--name", "管理员", "--yes"},
+			tool: "add_custom_group_role",
+			want: map[string]any{"openConversationId": "cid-project", "name": "管理员"},
+		},
+		{
+			name: "update",
+			args: []string{"chat", "+chat-role-update", "--group", "项目群", "--role-id", "role-1", "--name", "新名称", "--yes"},
+			tool: "update_custom_group_role",
+			want: map[string]any{"openConversationId": "cid-project", "openRoleId": "role-1", "name": "新名称"},
+		},
+		{
+			name: "remove",
+			args: []string{"chat", "+chat-role-remove", "--group", "项目群", "--role-id", "role-1", "--yes"},
+			tool: "remove_custom_group_role",
+			want: map[string]any{"openConversationId": "cid-project", "openRoleId": "role-1"},
+		},
+		{
+			name: "remove user roles",
+			args: []string{"chat", "+chat-role-remove-user", "--group", "项目群", "--user", "user-1", "--role-ids", "role-1,role-2", "--yes"},
+			tool: "remove_custom_user_roles",
+			want: map[string]any{"openConversationId": "cid-project", "openRoleIds": []string{"role-1", "role-2"}, "userId": "user-1"},
+		},
+		{
+			name: "query user roles",
+			args: []string{"chat", "+chat-role-query-user", "--group", "项目群", "--user", "user-1"},
+			tool: "query_custom_user_roles",
+			want: map[string]any{"openConversationId": "cid-project", "userId": "user-1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &larkAlignmentCaller{responses: map[string]string{
+				"im/search_groups": `{"result":[{"openConversationId":"cid-project","title":"项目群"}],"hasMore":false}`,
+			}}
+			helpers.InitDeps(fake)
+			root := newPlatformCoverageRoot()
+			root.SetArgs(tt.args)
+			if err := root.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			if len(fake.calls) != 2 || fake.calls[0].tool != "search_groups" || fake.calls[1].tool != tt.tool {
+				t.Fatalf("calls = %#v", fake.calls)
+			}
+			if !reflect.DeepEqual(fake.calls[1].args, tt.want) {
+				t.Fatalf("business args = %#v, want %#v", fake.calls[1].args, tt.want)
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageChatRoleCommandsStopAmbiguousNamesBeforeBusinessCalls(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "list", args: []string{"chat", "+chat-role-list", "--group", "项目群"}},
+		{name: "add", args: []string{"chat", "+chat-role-add", "--group", "项目群", "--name", "管理员", "--yes"}},
+		{name: "update", args: []string{"chat", "+chat-role-update", "--group", "项目群", "--role-id", "role-1", "--name", "新名称", "--yes"}},
+		{name: "remove", args: []string{"chat", "+chat-role-remove", "--group", "项目群", "--role-id", "role-1", "--yes"}},
+		{name: "set user roles", args: []string{"chat", "+chat-role-set-user", "--group", "项目群", "--user", "user-1", "--role-ids", "role-1", "--yes"}},
+		{name: "remove user roles", args: []string{"chat", "+chat-role-remove-user", "--group", "项目群", "--user", "user-1", "--role-ids", "role-1", "--yes"}},
+		{name: "query user roles", args: []string{"chat", "+chat-role-query-user", "--group", "项目群", "--user", "user-1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &larkAlignmentCaller{responses: map[string]string{
+				"im/search_groups": `{"result":[{"openConversationId":"cid-a","title":"项目群"},{"openConversationId":"cid-b","title":"项目群"}],"hasMore":false}`,
+			}}
+			helpers.InitDeps(fake)
+			root := newPlatformCoverageRoot()
+			root.SetArgs(tt.args)
+			if err := root.Execute(); err == nil {
+				t.Fatal("ambiguous group name unexpectedly reached a role operation")
+			}
+			if len(fake.calls) != 1 || fake.calls[0].tool != "search_groups" {
+				t.Fatalf("ambiguous group reached a business call: %#v", fake.calls)
+			}
+		})
+	}
+}
+
 func TestCrossPlatformCoverageChatCreateAddsCurrentUserAndNormalizesResult(t *testing.T) {
 	fake := &larkAlignmentCaller{}
 	helpers.InitDeps(fake)

--- a/internal/shortcut/chat/lark_alignment_test.go
+++ b/internal/shortcut/chat/lark_alignment_test.go
@@ -122,6 +122,23 @@ func TestCrossPlatformCoverageEvaluationRegressionNaturalGroupTargetsAndRecallIn
 		}
 	})
 
+	t.Run("group name to role list", func(t *testing.T) {
+		fake := &larkAlignmentCaller{responses: map[string]string{
+			"im/search_groups":           `{"result":[{"openConversationId":"cid-project","title":"项目群"}],"hasMore":false}`,
+			"im/list_custom_group_roles": `{"result":{"roles":[]}}`,
+		}}
+		helpers.InitDeps(fake)
+		root := newPlatformCoverageRoot()
+		root.SetArgs([]string{"chat", "+chat-role-list", "--group", "项目群"})
+		if err := root.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		if len(fake.calls) != 2 || fake.calls[1].tool != "list_custom_group_roles" ||
+			fake.calls[1].args["openConversationId"] != "cid-project" {
+			t.Fatalf("calls = %#v", fake.calls)
+		}
+	})
+
 	t.Run("group query to invite url", func(t *testing.T) {
 		fake := &larkAlignmentCaller{responses: map[string]string{
 			"im/search_groups": `{"result":[{"openConversationId":"cid-project","title":"项目群"}],"hasMore":false}`,

--- a/internal/shortcut/chat/lark_alignment_test.go
+++ b/internal/shortcut/chat/lark_alignment_test.go
@@ -183,6 +183,10 @@ func TestCrossPlatformCoverageEvaluationRegressionNaturalGroupTargetsAndRecallIn
 }
 
 func TestCrossPlatformCoverageChatRoleSetUserRejectsEmptyRolesBeforeAnyCall(t *testing.T) {
+	if err := validateChatRoleIDs(nil); err == nil {
+		t.Fatal("zero-length role IDs unexpectedly accepted")
+	}
+
 	tests := []struct {
 		name    string
 		roleIDs string

--- a/skills/multi/dingtalk-chat/SKILL.md
+++ b/skills/multi/dingtalk-chat/SKILL.md
@@ -45,6 +45,7 @@ metadata:
 | <!-- dws-intent: chat.read.conversation -->读取指定会话、返回较多消息 | `dws chat +chat-messages` | 粗粒度读取；目标条件明确时优先 `+search-msg` |
 | <!-- dws-intent: chat.search.filtered -->多维度条件搜索（发送者/关键词/@/类型，单/跨会话） | `dws chat +search-msg` | 目标条件明确时使用 |
 | <!-- dws-intent: chat.create.group -->按成员 ID 或姓名创建群聊 | `dws chat +chat-create` | 姓名用 `--member-query` 由 CLI 唯一解析，不先手工搜索 |
+| <!-- dws-intent: chat.reply.quote -->引用回复一条已有消息 | `dws chat +messages-reply` | 使用真实消息与会话 ID；未知投递状态不得写成成功送达 |
 | 查看指定群成员（用户/机器人） | `dws chat +chat-members-list --group <群名或ID>` | 唯一解析并全量读取 |
 | 获取群邀请链接 | `dws chat +chat-invite-url --group <群名或ID>` | 多候选时停止 |
 | 查看群机器人 | `dws chat +chat-bots --group <群名或ID>` | 返回稳定 `bots[]` |
@@ -57,6 +58,8 @@ metadata:
 | 读取并下载消息资源 | 查询命令加 `--download-resources` | 不另起手工下载循环；下载失败项保留在结果中 |
 | <!-- dws-intent: chat.conversation.list-top -->查看置顶会话 | `dws chat +conversation-list-top` | 会话 Top 与消息 Pin、消息 Top、Favorite 不同 |
 | 监听未来 IM 事件 | [`dingtalk-event`](../dingtalk-event/SKILL.md) | 常规监听走 `+listen-im`；生命周期/高级控制走 `consume` |
+
+以下次级入口只按需使用；先选定意图，再读取一个精确 reference。
 
 ## 关键结果语义
 

--- a/skills/multi/dingtalk-chat/SKILL.md
+++ b/skills/multi/dingtalk-chat/SKILL.md
@@ -44,9 +44,12 @@ metadata:
 | <!-- dws-intent: chat.send.advanced -->文件、Bot、Webhook、复杂 @ 或高级发送 | `dws chat +messages-send` | Bot 多群用 `--groups/--groups-file` 并检查逐项 ledger |
 | <!-- dws-intent: chat.read.conversation -->读取指定会话、返回较多消息 | `dws chat +chat-messages` | 粗粒度读取；目标条件明确时优先 `+search-msg` |
 | <!-- dws-intent: chat.search.filtered -->多维度条件搜索（发送者/关键词/@/类型，单/跨会话） | `dws chat +search-msg` | 目标条件明确时使用 |
+| <!-- dws-intent: chat.create.group -->按成员 ID 或姓名创建群聊 | `dws chat +chat-create` | 姓名用 `--member-query` 由 CLI 唯一解析，不先手工搜索 |
 | 查看指定群成员（用户/机器人） | `dws chat +chat-members-list --group <群名或ID>` | 唯一解析并全量读取 |
 | 获取群邀请链接 | `dws chat +chat-invite-url --group <群名或ID>` | 多候选时停止 |
 | 查看群机器人 | `dws chat +chat-bots --group <群名或ID>` | 返回稳定 `bots[]` |
+| 管理群身份 | 按动作使用 `+chat-role-list` / `+chat-role-add` / `+chat-role-update` / `+chat-role-remove` / `+chat-role-set-user` / `+chat-role-remove-user` / `+chat-role-query-user` | `--group` 接受群名或 ID；定义删除用单数 `--role-id`，成员设置/移除用复数 `--role-ids` |
+| 管理个人会话分类 | `+category-create` → `+category-add-conversation` → `+category-list-conversations` → `+category-delete`；读取全部用 `+category-list` | 分类不是聊天群；高频生命周期直接走 shortcut，详情读 `chat-conversation.md` |
 | 个人收藏表情列表/发送/收藏 | `dws chat emotion list/send/favorite` | 约束见 leaf Schema |
 | 修改群名称 | `dws chat +chat-update --group <群名或openConversationId> --name <新名称>` | Shortcut 内统一解析群名或稳定 ID；多候选时停止，不直接调用 atomic `group rename` |
 | 查看指定群内 @我的消息 | `dws chat +at-me --group <群名> --page-all` | 检查 `complete`；空结果仍返回数组 |
@@ -55,46 +58,15 @@ metadata:
 | <!-- dws-intent: chat.conversation.list-top -->查看置顶会话 | `dws chat +conversation-list-top` | 会话 Top 与消息 Pin、消息 Top、Favorite 不同 |
 | 监听未来 IM 事件 | [`dingtalk-event`](../dingtalk-event/SKILL.md) | 常规监听走 `+listen-im`；生命周期/高级控制走 `consume` |
 
-以下次级入口在意图明确时直接使用，不需要先加载完整 Catalog：
-
-| 用户意图 | 入口 |
-|---|---|
-| 已知消息 ID 批量读取详情 | `dws chat +messages-mget` |
-| 已知资源引用单独下载 | `dws chat +messages-resource-download` |
-| 只上传会话文件，不发消息 | `dws chat conversation-file upload --conversation-id <cid> --file <路径>`；返回文件 ID，仅本地路径 |
-| 按关键词搜索群 | `dws chat +chat-search` |
-| 查看消息收藏 | `dws chat +flag-list` |
-| <!-- dws-intent: chat.reply.quote -->引用回复 | 人：`dws chat +messages-reply`；成功结果保留新消息/会话/投递与原消息来源上下文。Bot 群：`dws chat message send-by-bot --conversation-id <cid> --reply <mid> --ref-sender <sid>` |
-| 撤回当前用户消息 | `dws chat +messages-recall --msg-id <openMessageId>`；可省略会话 ID，由 CLI 只读补齐；兼容单值 `--message-ids` |
-| 已知话题主消息 ID 或 thread/topic ID 读取回复 | `dws chat +thread-replies` |
-| <!-- dws-intent: chat.create.group -->按成员 ID 或姓名创建群聊 | `dws chat +chat-create`；成员/群主均可自然解析，任一歧义都会在创建前整体停止 |
-| 跨全部会话查看 @我的消息 | `dws chat +at-me --page-all` |
-
-### 发送入口边界
-
-- `+dm`：姓名目标的简单文本/Markdown，参数空间最小。
-- `+send-to-group`：群名或稳定 ID 目标的简单文本/Markdown，避免暴露无关身份矩阵。
-- Markdown 中的公网图片必须写成 `![图片标题](https://example.com/image.png)` 才会内联展示；
-  省略开头的 `!` 时只会显示为链接。
-- `+messages-send`：文件、Bot、Webhook、复杂 @ 或幂等控制。user 已知 ID 可直接传，也可用 `--user-query` / `--chat-query` 运行同一只读解析链；Bot 多群使用 `--groups/--groups-file`，返回 `im.batch-write.v1`；bot/webhook 只使用下层真实支持的文本/Markdown 能力。
-- 发文件消息用 `+messages-send --file <路径>`；只存会话空间、不发消息才用 `chat conversation-file upload`，返回 `dentryId`/`spaceId`。
-- Webhook 使用 `+messages-send --as webhook --webhook-token <token>`；不要退回原子 Webhook 命令。
-- 流式卡片用 `+messages-send-card`；群聊 @ 传 ID/`--at-all`，Runtime 拼接 create 前缀；禁占位符，仅 text。
-
 ## 关键结果语义
 
-- `openTaskId` 是发送任务 ID，不是回复或撤回所需的消息 ID；消息 ID 必须来自真实查询结果。
-- 消息查询默认保留稳定 ID、会话/thread、发送者、文本、时间、`messageAiSendFlag`、reaction、引用、转发和 `resourceRefs`；`--no-reactions` 可关闭 reaction。
-- 查询结果必须检查 `complete`、`hasMore`、`failures` 和资源下载 ledger；partial result 不得表述为完整成功。
-- 子消息使用自己的 `messageId`；仅缺会话 ID 时继承父消息的 `conversationId`。
-- 下载只允许工作目录内安全相对路径，默认不覆盖并原子落盘；覆盖必须由用户显式传 `--overwrite`。读取和下载不需要 `--yes`。
-- Favorite、消息 Pin、消息 Top、会话 Top 是不同对象层级，不能互换。
+- `openTaskId` 是发送任务 ID，不是消息 ID；后续 ID 必须来自真实结果。
+- 查询检查 `complete/hasMore/failures` 和下载 ledger；partial 不得表述为完整成功，也不得丢失已取得业务数据。
+- Favorite、消息 Pin、消息 Top、会话 Top 是不同对象，不能互换；详细字段、子消息和下载规则只在对应 reference 中加载。
 
 ## 按需加载
 
-只在任务命中时读取一个精确 reference：
-
-[话题与话题圈](references/chat/thread.md)
+只在根路由不足且任务命中时读取一个精确 reference：
 
 | 场景 | Reference |
 |---|---|
@@ -106,6 +78,7 @@ metadata:
 | 建群、成员或已知机器人增删、管理员、公告与群设置 | [group-admin](references/chat/group-admin.md) |
 | 搜索未知机器人、机器人消息发送/撤回与 Webhook | [chat-bot.md](references/chat/chat-bot.md) |
 | 会话置顶、分类、红点、免打扰和隐藏 | [chat-conversation.md](references/chat/chat-conversation.md) |
+| 话题与话题圈 | [thread.md](references/chat/thread.md) |
 | 低频意图之间仍需消歧 | [intent-guide.md](references/intent-guide.md) |
 | 表情名称与 ID | [chat-emoji-list.md](references/chat-emoji-list.md) |
 | 稳定结果、身份矩阵与能力边界 | [contracts.md](references/contracts.md) |
@@ -115,13 +88,13 @@ metadata:
 | 卡片公开 Schema 边界 | [card/schema.md](references/card/schema.md) |
 | 只有上述 reference 仍无法定位的原子能力 | [chat.md](references/chat.md) 的对应章节 |
 
-不要预加载 reference。Shortcut Catalog 只在根路由和精确 reference 都无法定位低频能力时使用。
+不要预加载 reference；根路由参数充分时不读取。Catalog 只在根路由和精确 reference 都无法定位低频能力时使用。
 
 ## 错误最短路径
 
 1. resolution 返回零命中或多候选：停止写操作，展示候选并让用户消歧；禁止默认第一项。
 2. `unknown command` / `unknown flag`：读取精确 leaf Help，修正后最多重试一次。
-3. 参数约束或 confirmation 不清楚：读取精确 leaf Schema，以 Runtime gate 为准。
-4. 认证、权限、profile 或 confirmation 错误：读取 `dingtalk-shared` 的对应 reference；正常 IM 不读取完整 shared Skill。
+3. 参数约束或 confirmation 不清楚：首次业务调用前读取精确 leaf Schema；`confirmation_required` 后停止，不自动补 `--yes` 重试。
+4. 认证、权限或 profile 错误：只读取 `dingtalk-shared` 的对应 reference。
 5. `backend_dependency_unavailable`：保持原参数，对只读命令最多重试一次；不要改 flag、猜认证命令或切换同义原子命令，持续失败时保留 Trace ID。
 6. 其他错误：保留真实错误和已完成/失败项；不要连续尝试同义原子命令。

--- a/skills/multi/dingtalk-chat/references/01-messaging.md
+++ b/skills/multi/dingtalk-chat/references/01-messaging.md
@@ -53,6 +53,7 @@ dws chat +chat-messages --group <openConversationId> \
 - 群名 + 文件/高级控制：`+messages-send --as user --chat-query <群名> --file <相对路径>`。
 - Bot 多群文本/Markdown：`+messages-send --as bot --robot-code <code> --groups <cid1,cid2>`；
   Runtime 去重并返回 `im.batch-write.v1` 逐目标 ledger，最多 100 个稳定群 ID。
+- Markdown 中的公网图片必须写成 `![图片标题](https://example.com/image.png)` 才会内联；省略 `!` 只显示链接。
 
 `--user-query` 和 `--chat-query` 会在 CLI 内运行真实只读解析；零命中或多候选时在上传或发送前停止。Bot/Webhook 不接受这两个自然目标参数。
 

--- a/skills/multi/dingtalk-chat/references/chat/chat-conversation.md
+++ b/skills/multi/dingtalk-chat/references/chat/chat-conversation.md
@@ -96,29 +96,29 @@ dws chat clear-messages --conversation-id <openConversationId>
 
 ### 会话分组
 
+会话分组是当前用户的分类容器，不是聊天群。删除分类不会删除其中的真实会话。高频生命周期统一使用 Shortcut：
+
 | 命令 | 用途 | 必填参数 |
 |------|------|----------|
-| `category list` | 获取用户自定义会话分组 | 无 |
-| `category list-conversations` | 拉取指定分组下会话 | `--category-id`，可选 `--exclude-muted` |
-| `category list-by-conv` | 拉取指定会话所属的用户自定义会话分组 | `--group` |
-| `category batch-info` | 批量拉取用户自定义会话分组信息 | `--category-ids` |
-| `category create` | 创建会话分组 | `--title` |
-| `category create-smart` | 创建智能会话分组，可按群名称关键词和群内成员匹配 | `--name`，可选 `--keywords` `--members` |
-| `category delete` | 删除会话分组 | `--category-id` |
-| `category rename` | 修改分组名称 | `--category-id` `--title` |
-| `category add-conv` | 将会话加入分组 | `--group` `--category-ids` |
-| `category remove-conv` | 将会话移出分组 | `--group` `--category-ids` |
+| `+category-list` | 获取用户自定义会话分组 | 无 |
+| `+category-create` | 创建会话分组 | `--title` |
+| `+category-add-conversation` | 将会话加入分组 | `--group` `--category-ids` |
+| `+category-list-conversations` | 拉取指定分组下会话 | `--category-id`，可选 `--exclude-muted` |
+| `+category-remove-conversation` | 将会话移出分组 | `--group` `--category-ids` |
+| `+category-rename` | 修改分组名称 | `--category-id` `--title` |
+| `+category-delete` | 删除会话分组 | `--category-id` |
 
 ```bash
-dws chat category list
-dws chat category list-by-conv --group <openConversationId>
-dws chat category batch-info --category-ids 123,456
-dws chat category create --title "工作群"
-dws chat category create-smart --name "重点群" --keywords "重点,项目" --members openDingTalkId1,openDingTalkId2
-dws chat category add-conv --group <openConversationId> --category-ids 123,456
+dws chat +category-create --title "工作群" --format json
+dws chat +category-add-conversation --group <openConversationId> --category-ids 123,456 --format json
+dws chat +category-list-conversations --category-id 123 --format json
+dws chat +category-delete --category-id 123 --format json
 ```
 
-`create-smart` 中 `--keywords` 是群名称关键词列表，`--members` 是群内成员 openDingTalkId 列表；两者可单独使用，也可组合使用。
+只有 Shortcut 尚未覆盖的低频查询和智能规则才使用原子 `category list-by-conv`、
+`category batch-info`、`category create-smart`。`create-smart --keywords` 是群名关键词列表，
+`--members` 是群成员 openDingTalkId 列表，两者可单独或组合使用。写操作在首次调用前按
+Runtime gate 完成确认；上述示例不代表可以绕过确认。
 
 ## 常见工作流
 
@@ -140,11 +140,12 @@ dws chat +chat-messages --group <openConversationId> --time "2026-03-10 00:00:00
 ### 会话分组
 
 ```bash
-dws chat category create --title "重点项目" --format json
-dws chat category add-conv --group <openConversationId> --category-ids <categoryId> --format json
+dws chat +category-create --title "重点项目" --format json
+dws chat +category-add-conversation --group <openConversationId> --category-ids <categoryId> --format json
+dws chat +category-list-conversations --category-id <categoryId> --format json
 dws chat category list-by-conv --group <openConversationId> --format json
 dws chat category batch-info --category-ids <categoryId> --format json
-dws chat category list-conversations --category-id <categoryId> --format json
+dws chat +category-delete --category-id <categoryId> --format json
 ```
 
 ### 智能会话分组

--- a/skills/multi/dingtalk-chat/references/chat/group-admin.md
+++ b/skills/multi/dingtalk-chat/references/chat/group-admin.md
@@ -121,9 +121,11 @@ dws chat group user-settings set \
 
 - `list/add/update/remove` 管理身份定义；
 - `set-user/remove-user/query-user` 管理成员身份；
-- `openRoleId` 必须来自真实身份列表。
+- Shortcut 的 `--group` 可传群名或 `openConversationId`，群名多候选时在业务调用前停止；
+- 删除一个身份定义使用单数 `--role-id`；整体设置或移除成员身份使用复数 `--role-ids`；
+- `set-user --role-ids` 必须至少包含一个真实 `openRoleId`，只撤销指定身份使用 `remove-user`，不传空字符串猜“清空”。
 
-覆盖或清除成员身份前确认用户、群和完整角色集合，不能用展示名称猜 `openRoleId`。
+整体覆盖或撤销成员身份前确认用户、群和完整角色集合，不能用展示名称猜 `openRoleId`。
 
 ## 退出、解散与外部群升级
 


### PR DESCRIPTION
## Summary

- Resolve natural group names through the shared target resolver for every `+chat-role-*` shortcut, while stopping ambiguous matches before any business call.
- Align role assignment guidance with the runtime contract: `--role-ids` must be non-empty, and role removal uses `+chat-role-remove-user`.
- Publish a shortcut-first category lifecycle and move optional messaging details into references, reducing the root Chat Skill context without dropping business result, safety, or identity constraints.

## Risk tier

- [ ] Documentation-only
- [x] Standard — scoped Chat shortcut behavior, contract prose, tests, and Skill/reference changes; package graph remains stable.
- [ ] High-risk

## Verification

- [x] Release fragment added: `.changes/chat-role-category-routing.md`
- [x] `go test ./internal/shortcut/chat -count=1`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/app -run 'Test.*(ChatRole|Category|AgentSelection|Schema).*' -count=1`
- [x] Chat Skill `quick_validate.py`
- [x] `./scripts/policy/check-skill-context-budget.sh` (`chat_bytes=8972`, target `10000`)
- [x] `make build`
- [x] `./scripts/policy/check-generated-drift.sh`
- [x] `./scripts/policy/check-schema-catalog.sh` (29 products, 1308 tools)
- [x] `git diff --check upstream/main...HEAD`

## Behavioral evidence

- Added a cross-platform role-list case proving that a natural group name is resolved to the stable conversation ID before the role business call.
- Existing Chat shortcut and final Schema tests remain green after rebasing onto the latest `upstream/main`.

## Scope notes

- No harness changes.
- No new Help or full-Catalog discovery step was introduced.
- Category atomic commands remain documented only where no shortcut-equivalent lifecycle command exists.
