### PR TITLE
ci: stabilize coverage recovery without more jobs

### DIFF
--- a/.changes/coverage-app-partition-cache.md
+++ b/.changes/coverage-app-partition-cache.md
@@ -1,0 +1,8 @@
+---
+category: Fixed
+---
+
+- **Coverage baseline reliability** — balances the existing app test
+  partitions across the current coverage runners and reuses the same bounded
+  path for trusted cold-cache recovery, avoiding the long-lived app test
+  process without adding CI matrix jobs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1518,10 +1518,9 @@ jobs:
       - name: Build
         run: make build
 
-      # Each shard keeps -p 1 so the authoritative measurement stays serial
-      # inside one instrumented process group; shards run on isolated runners,
-      # and scripts/ci/test-packages.sh verify proves the shard union equals
-      # the previous single full-suite package set exactly once.
+      # Keep the matrix at five hosted runners. The shared runner balances the
+      # existing internal/app test partitions across those jobs, bounds package
+      # parallelism inside each runner, and preserves exact package ownership.
       - name: Run current shard tests with coverage
         shell: bash
         env:
@@ -1529,14 +1528,8 @@ jobs:
           COVERAGE_SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
-          package_output="$(./scripts/ci/test-packages.sh list-coverage "$COVERAGE_SHARD")"
-          test -n "$package_output"
-          mapfile -t packages <<< "$package_output"
-          test "${#packages[@]}" -gt 0
-          go test -count=1 -p 1 \
-            -coverprofile="coverage-shard-$COVERAGE_SHARD.txt" \
-            -covermode=atomic \
-            "${packages[@]}"
+          ./scripts/ci/run-coverage-shard.sh run \
+            "$COVERAGE_SHARD" "coverage-shard-$COVERAGE_SHARD.txt"
           go tool cover -func="coverage-shard-$COVERAGE_SHARD.txt" | tail -n 1
 
       - name: Upload current shard coverage profile
@@ -1691,11 +1684,9 @@ jobs:
           (
             cd "$base_worktree"
             if [ "$FULL_SUITE" = true ]; then
-              go test -count=1 \
-                -p 1 \
-                -coverprofile="$GITHUB_WORKSPACE/coverage-base.txt" \
-                -covermode=atomic \
-                ./ ./cmd/... ./internal/... ./skills/...
+              DWS_COVERAGE_ROOT="$base_worktree" \
+                "$GITHUB_WORKSPACE/scripts/ci/run-full-coverage.sh" \
+                "$GITHUB_WORKSPACE/coverage-base.txt"
             elif [ -z "$changed_output" ] || [ -z "$impacted_output" ]; then
               printf 'mode: atomic\n' > "$GITHUB_WORKSPACE/coverage-base.txt"
             else
@@ -1840,10 +1831,7 @@ jobs:
           DWS_PACKAGE_VERSION: 0.0.0-test
         run: |
           set -euo pipefail
-          go test -count=1 -p 1 \
-            -coverprofile=coverage-cache.txt \
-            -covermode=atomic \
-            ./ ./cmd/... ./internal/... ./skills/...
+          ./scripts/ci/run-full-coverage.sh coverage-cache.txt
           test -s coverage-cache.txt
           test "$(head -n 1 coverage-cache.txt)" = "mode: atomic"
 
@@ -2008,25 +1996,24 @@ jobs:
           name: coverage-baseline-profile
           path: .
 
-      # Shard profiles cover disjoint package sets, so their block-level
-      # concatenation is the same candidate profile one serial run produced.
-      # Every expected shard must be present; a missing shard would silently
-      # shrink the scope-matched overall comparison.
+      # Each package belongs to one shard, while internal/app test partitions
+      # are balanced across the same five jobs. Union duplicate app source
+      # blocks by their greatest atomic count. Every expected shard must be
+      # present; a missing shard would silently shrink the comparison.
       - name: Assemble full-suite coverage profile
         if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.full_suite == 'true'
         shell: bash
         run: |
           set -euo pipefail
           test ! -f coverage.txt
+          profiles=()
           for shard in app cli generators helpers remaining; do
             profile="coverage-shard-$shard.txt"
             test -f "$profile"
             test "$(head -n 1 "$profile")" = "mode: atomic"
+            profiles+=("$profile")
           done
-          printf 'mode: atomic\n' > coverage.txt
-          for shard in app cli generators helpers remaining; do
-            tail -n +2 "coverage-shard-$shard.txt" >> coverage.txt
-          done
+          ./scripts/ci/merge-coverage-profiles.sh coverage.txt "${profiles[@]}"
 
       - name: Enforce coverage gate
         if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true'

--- a/.github/workflows/coverage-baseline-promotion.yml
+++ b/.github/workflows/coverage-baseline-promotion.yml
@@ -254,10 +254,7 @@ jobs:
           DWS_PACKAGE_VERSION: 0.0.0-test
         run: |
           set -euo pipefail
-          go test -count=1 -p 1 \
-            -coverprofile=coverage-cache.txt \
-            -covermode=atomic \
-            ./ ./cmd/... ./internal/... ./skills/...
+          ./scripts/ci/run-full-coverage.sh coverage-cache.txt
           test -s coverage-cache.txt
           test "$(head -n 1 coverage-cache.txt)" = "mode: atomic"
 

--- a/.github/workflows/coverage-baseline-repair.yml
+++ b/.github/workflows/coverage-baseline-repair.yml
@@ -529,10 +529,7 @@ jobs:
           DWS_PACKAGE_VERSION: 0.0.0-test
         run: |
           set -euo pipefail
-          go test -count=1 -p 1 \
-            -coverprofile=coverage-cache.txt \
-            -covermode=atomic \
-            ./ ./cmd/... ./internal/... ./skills/...
+          ./scripts/ci/run-full-coverage.sh coverage-cache.txt
           test -s coverage-cache.txt
           test "$(head -n 1 coverage-cache.txt)" = "mode: atomic"
 

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -348,11 +348,22 @@ base_ref=$(git merge-base HEAD origin/main)
 standard PR, CI derives changed packages and their reverse-dependency test
 closure, then generates candidate and merge-base profiles with the same test
 scope and `coverpkg`. High-risk and protected-main runs use the complete
-profiles. The complete candidate profile is produced by disjoint per-shard
-helper jobs (`scripts/ci/test-packages.sh list-coverage`, kept serial with
-`-p 1` inside each shard; `verify` proves the shard union equals the
-full-suite scope exactly once) and concatenated in the aggregate job before
-enforcement. The complete merge-base profile is restored from an exact-key
+profiles. The complete candidate profile is produced by five fixed per-shard
+helper jobs (`scripts/ci/test-packages.sh list-coverage`; `verify`
+proves the shard union equals the full-suite scope exactly once). Packages
+remain serial within each runner except for the large `remaining` shard, which
+uses fixed package parallelism `-p 2` to overlap its two independent long tails
+without requesting another runner. The `internal/app` package is handled
+separately: it reuses the existing reviewed test-name partitions and balances
+them across the same five coverage jobs, so each partition gets a fresh Go test
+process and releases process-global command registries. The assignment is
+validated in both directions and reduces the long tail without requesting
+another hosted runner. The partition and final shard profiles are
+deterministically unioned by source block before enforcement. This does not add
+matrix jobs. The same bounded in-job runner owns every trusted cold full-profile
+fallback, so PR baseline, metadata promotion, Formula promotion, and repair do
+not reintroduce the long-lived app process. The complete merge-base profile is
+restored from an exact-key
 cache written by the last green `main` push of that same commit (key:
 merge-base SHA plus resolved Go version); any miss falls back to recomputing
 it in a merge-base worktree. The trusted `main` producer and PR consumer use

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,7 +17,9 @@ Script groups:
 
 - Root installers: `./scripts/install.sh`, `./scripts/install.ps1`, `./scripts/install-skills.sh`
 - Product convenience installers: `./scripts/install-devapp.sh`, `./scripts/install-devapp.ps1`, `./scripts/install-event.sh`
-- CI package plan: `./scripts/ci/test-packages.sh`
+- CI package and coverage plan: `./scripts/ci/test-packages.sh`,
+  `./scripts/ci/run-coverage-shard.sh`, `./scripts/ci/run-full-coverage.sh`,
+  `./scripts/ci/merge-coverage-profiles.sh`
 - Dev helpers: `./scripts/dev/build.sh`, `./scripts/dev/lint.sh`, `./scripts/dev/ci-local.sh`, `./scripts/dev/run-mock-e2e.sh`, `./scripts/dev/coverage.sh`
 - Policy checks: `./scripts/policy/check-generated-drift.sh`, `./scripts/policy/check-command-surface.sh`, `./scripts/policy/check-command-compatibility.sh --base-ref <main-ref> --stable-ref <latest-GA-tag> --candidate-ref <candidate-sha>`, `./scripts/policy/check-schema-catalog.sh`, `./scripts/policy/check-schema-binary.sh`, `./scripts/policy/check-open-source-assets.sh`
 - Policy runtime files: set `DWS_POLICY_TMPDIR` to override the default `.worktrees/policy-tmp` workspace

--- a/scripts/ci/merge-coverage-profiles.sh
+++ b/scripts/ci/merge-coverage-profiles.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+set -eu
+
+usage() {
+	printf 'usage: %s <output-profile> <input-profile>...\n' "$0" >&2
+	exit 2
+}
+
+[ "$#" -ge 2 ] || usage
+
+output="$1"
+shift
+
+for profile in "$@"; do
+	[ "$profile" != "$output" ] || {
+		printf 'coverage merge output must not also be an input: %s\n' "$output" >&2
+		exit 2
+	}
+	[ -s "$profile" ] || {
+		printf 'coverage profile is missing or empty: %s\n' "$profile" >&2
+		exit 1
+	}
+done
+
+scratch_root="${RUNNER_TEMP:-${TMPDIR:-.}}"
+workdir="$(mktemp -d "$scratch_root/dws-merge-coverage.XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+blocks="$workdir/blocks"
+sorted="$workdir/sorted"
+
+# App coverage is collected from multiple fresh test processes so framework
+# registries are released between partitions. Every process emits the same
+# source blocks; keep each block once and retain the greatest atomic count.
+# Coverage policy uses the same union rule when it reads multiple profiles.
+awk '
+	FNR == 1 {
+		if ($0 != "mode: atomic") {
+			printf "%s: expected mode: atomic\n", FILENAME > "/dev/stderr"
+			invalid = 1
+		}
+		next
+	}
+	NF != 3 || $2 !~ /^[0-9]+$/ || $3 !~ /^[0-9]+$/ {
+		printf "%s:%d: invalid coverage profile line\n", FILENAME, FNR > "/dev/stderr"
+		invalid = 1
+		next
+	}
+	{
+		key = $1 " " $2
+		if (!(key in counts) || $3 + 0 > counts[key]) {
+			counts[key] = $3 + 0
+		}
+	}
+	END {
+		if (invalid) {
+			exit 1
+		}
+		for (key in counts) {
+			print key " " counts[key]
+		}
+	}
+' "$@" > "$blocks"
+
+LC_ALL=C sort "$blocks" > "$sorted"
+{
+	printf 'mode: atomic\n'
+	cat "$sorted"
+} > "$output"
+
+test -s "$output"
+test "$(head -n 1 "$output")" = "mode: atomic"

--- a/scripts/ci/run-app-race-tests.sh
+++ b/scripts/ci/run-app-race-tests.sh
@@ -7,6 +7,7 @@ usage() {
 	printf '%s\n' \
 		"usage: $0 verify <app-package>" \
 		"       $0 run <app-package> [partition]" \
+		"       $0 coverage <app-package> <output-profile> [partition]" \
 		"       $0 list-partitions" >&2
 	exit 2
 }
@@ -18,6 +19,7 @@ APP_PARTITIONS='schema a-b c-a-l c-m-o c-p-r c-s-z c-other d-r s-z-example-fuzz'
 
 mode="${1:-}"
 partition=""
+coverage_output=""
 case "$mode" in
 	list-partitions)
 		[ "$#" -eq 1 ] || usage
@@ -35,6 +37,15 @@ case "$mode" in
 		app_package="$2"
 		partition="${3:-}"
 		;;
+	coverage)
+		[ "$#" -eq 3 ] || [ "$#" -eq 4 ] || usage
+		app_package="$2"
+		case "$3" in
+			/*) coverage_output="$3" ;;
+			*) coverage_output="$(pwd)/$3" ;;
+		esac
+		partition="${4:-}"
+		;;
 	*) usage ;;
 esac
 
@@ -45,6 +56,7 @@ tests="$workdir/tests"
 duplicates="$workdir/duplicates"
 list_output="$workdir/list-output"
 
+ROOT="${DWS_APP_TEST_ROOT:-$ROOT}"
 cd "$ROOT"
 if ! go test "$app_package" -list '^(Test|Example|Fuzz)' > "$list_output"; then
 	printf 'app race partition discovery failed for %s\n' "$app_package" >&2
@@ -175,6 +187,12 @@ run_partition() {
 			;;
 	esac
 
+	coverage_profile=""
+	if [ "$mode" = coverage ]; then
+		instrumentation=no-race
+		coverage_profile="$workdir/coverage-app-$name.txt"
+	fi
+
 	printf 'running internal/app %s partition %s\n' "$instrumentation" "$name"
 	set -- -v -count=1 -timeout=15m -run "$run_pattern"
 	if [ -n "$skip_pattern" ]; then
@@ -182,6 +200,9 @@ run_partition() {
 	fi
 	if [ "$instrumentation" = race ]; then
 		set -- -race "$@"
+	fi
+	if [ -n "$coverage_profile" ]; then
+		set -- "$@" -coverprofile="$coverage_profile" -covermode=atomic
 	fi
 	go test "$@" "$app_package"
 }
@@ -228,6 +249,20 @@ run_named_partition() {
 
 if [ -n "$partition" ]; then
 	run_named_partition "$partition"
+	if [ "$mode" = coverage ]; then
+		"$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/merge-coverage-profiles.sh" \
+			"$coverage_output" "$workdir/coverage-app-$partition.txt"
+	fi
+	exit 0
+fi
+
+if [ "$mode" = coverage ]; then
+	for name in $APP_PARTITIONS; do
+		run_named_partition "$name"
+	done
+	# shellcheck disable=SC2086
+	"$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/merge-coverage-profiles.sh" \
+		"$coverage_output" "$workdir"/coverage-app-*.txt
 	exit 0
 fi
 

--- a/scripts/ci/run-coverage-shard.sh
+++ b/scripts/ci/run-coverage-shard.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+set -eu
+set -f
+
+usage() {
+	printf '%s\n' \
+		"usage: $0 run <app|cli|generators|helpers|remaining> <output-profile>" \
+		"       $0 list-app-partitions <app|cli|generators|helpers|remaining>" >&2
+	exit 2
+}
+
+TOOLS_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+ROOT="${DWS_COVERAGE_ROOT:-$TOOLS_ROOT}"
+
+app_partitions_for_shard() {
+	case "$1" in
+		app) printf '%s\n' 'c-p-r a-b c-other s-z-example-fuzz' ;;
+		generators) printf '%s\n' 'd-r c-m-o' ;;
+		helpers) printf '%s\n' 'c-a-l schema' ;;
+		cli) printf '%s\n' 'c-s-z' ;;
+		remaining) printf '%s\n' '' ;;
+		*)
+			printf 'unknown coverage shard: %s\n' "$1" >&2
+			exit 2
+			;;
+	esac
+}
+
+mode="${1:-}"
+shard="${2:-}"
+[ -n "$shard" ] || usage
+app_partitions="$(app_partitions_for_shard "$shard")"
+
+case "$mode" in
+	list-app-partitions)
+		[ "$#" -eq 2 ] || usage
+		printf '%s\n' "$app_partitions"
+		exit 0
+		;;
+	run)
+		[ "$#" -eq 3 ] || usage
+		case "$3" in
+			/*) output="$3" ;;
+			*) output="$(pwd)/$3" ;;
+		esac
+		;;
+	*) usage ;;
+esac
+
+scratch_root="${RUNNER_TEMP:-${TMPDIR:-.}}"
+workdir="$(mktemp -d "$scratch_root/dws-coverage-shard.XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+package_output="$(
+	DWS_TEST_PACKAGES_ROOT="$ROOT" \
+		"$TOOLS_ROOT/scripts/ci/test-packages.sh" list-coverage "$shard"
+)"
+[ -n "$package_output" ] || {
+	printf 'coverage package shard is empty: %s\n' "$shard" >&2
+	exit 1
+}
+
+app_package="$(
+	DWS_TEST_PACKAGES_ROOT="$ROOT" \
+		"$TOOLS_ROOT/scripts/ci/test-packages.sh" list-coverage app
+)"
+app_package_count="$(printf '%s\n' "$app_package" | wc -l | tr -d ' ')"
+[ "$app_package_count" -eq 1 ] || {
+	printf 'app coverage shard must contain exactly one package\n' >&2
+	exit 1
+}
+
+profiles=''
+if [ "$shard" != app ]; then
+	package_profile="$workdir/coverage-packages-$shard.txt"
+	package_parallelism=1
+	if [ "$shard" = remaining ]; then
+		# The remaining set contains independent long-running packages. Let two
+		# package test binaries overlap on this runner instead of serializing
+		# both long tails; this does not request another Actions runner.
+		package_parallelism=2
+	fi
+	cd "$ROOT"
+	# Package paths cannot contain shell whitespace. Parallelism stays bounded
+	# inside this hosted runner to control CPU and memory pressure.
+	# shellcheck disable=SC2086
+	go test -count=1 -p "$package_parallelism" \
+		-coverprofile="$package_profile" \
+		-covermode=atomic \
+		$package_output
+	profiles="$profiles $package_profile"
+fi
+
+for partition in $app_partitions; do
+	partition_profile="$workdir/coverage-app-$partition.txt"
+	DWS_APP_TEST_ROOT="$ROOT" \
+		"$TOOLS_ROOT/scripts/ci/run-app-race-tests.sh" \
+		coverage "$app_package" "$partition_profile" "$partition"
+	profiles="$profiles $partition_profile"
+done
+
+# shellcheck disable=SC2086
+"$TOOLS_ROOT/scripts/ci/merge-coverage-profiles.sh" "$output" $profiles

--- a/scripts/ci/run-full-coverage.sh
+++ b/scripts/ci/run-full-coverage.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+set -f
+
+usage() {
+	printf 'usage: %s <output-profile>\n' "$0" >&2
+	exit 2
+}
+
+[ "$#" -eq 1 ] || usage
+
+TOOLS_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+ROOT="${DWS_COVERAGE_ROOT:-$TOOLS_ROOT}"
+case "$1" in
+	/*) output="$1" ;;
+	*) output="$(pwd)/$1" ;;
+esac
+
+git -C "$ROOT" rev-parse --show-toplevel >/dev/null
+
+scratch_root="${RUNNER_TEMP:-${TMPDIR:-.}}"
+workdir="$(mktemp -d "$scratch_root/dws-full-coverage.XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT HUP INT TERM
+
+profiles=''
+for shard in app cli generators helpers remaining; do
+	profile="$workdir/coverage-$shard.txt"
+	DWS_COVERAGE_ROOT="$ROOT" \
+		"$TOOLS_ROOT/scripts/ci/run-coverage-shard.sh" run "$shard" "$profile"
+	profiles="$profiles $profile"
+done
+
+# shellcheck disable=SC2086
+"$TOOLS_ROOT/scripts/ci/merge-coverage-profiles.sh" "$output" $profiles

--- a/scripts/ci/test-packages.sh
+++ b/scripts/ci/test-packages.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -eu
 
-ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+DEFAULT_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+ROOT="${DWS_TEST_PACKAGES_ROOT:-$DEFAULT_ROOT}"
 MODULE="$(cd "$ROOT" && go list -m)"
 
 usage() {

--- a/test/scripts/ci_test_package_plan_test.go
+++ b/test/scripts/ci_test_package_plan_test.go
@@ -172,6 +172,124 @@ func TestCIAppRacePartitionMatrixMatchesHelper(t *testing.T) {
 	}
 }
 
+func TestCIMergeCoverageProfilesUnionsDuplicateBlocks(t *testing.T) {
+	root := testPackagePlanRoot(t)
+	workdir := t.TempDir()
+	first := filepath.Join(workdir, "first.txt")
+	second := filepath.Join(workdir, "second.txt")
+	output := filepath.Join(workdir, "merged.txt")
+
+	const blockA = "example.com/project/a.go:10.2,12.3 2"
+	const blockB = "example.com/project/b.go:20.1,20.8 1"
+	if err := os.WriteFile(first, []byte("mode: atomic\n"+blockA+" 0\n"+blockB+" 3\n"), 0o600); err != nil {
+		t.Fatalf("write first coverage profile: %v", err)
+	}
+	if err := os.WriteFile(second, []byte("mode: atomic\n"+blockA+" 7\n"+blockB+" 1\n"), 0o600); err != nil {
+		t.Fatalf("write second coverage profile: %v", err)
+	}
+
+	script := filepath.Join(root, "scripts", "ci", "merge-coverage-profiles.sh")
+	cmd := exec.Command("sh", script, output, first, second)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "TMPDIR="+t.TempDir())
+	combined, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("merge coverage profiles failed: %v\n%s", err, combined)
+	}
+	merged, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read merged coverage profile: %v", err)
+	}
+	want := "mode: atomic\n" + blockA + " 7\n" + blockB + " 3\n"
+	if string(merged) != want {
+		t.Fatalf("merged profile = %q, want %q", merged, want)
+	}
+}
+
+func TestCIFullCoverageRunnerKeepsOneJobAndPartitionsApp(t *testing.T) {
+	root := testPackagePlanRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "scripts", "ci", "run-full-coverage.sh"))
+	if err != nil {
+		t.Fatalf("read full coverage runner: %v", err)
+	}
+	script := string(data)
+	for _, want := range []string{
+		"for shard in app cli generators helpers remaining; do",
+		`"$TOOLS_ROOT/scripts/ci/run-coverage-shard.sh" run "$shard" "$profile"`,
+		`"$TOOLS_ROOT/scripts/ci/merge-coverage-profiles.sh"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("full coverage runner missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{"xargs -P", "parallel "} {
+		if strings.Contains(script, forbidden) {
+			t.Errorf("full coverage runner unexpectedly adds in-job fan-out %q", forbidden)
+		}
+	}
+}
+
+func TestCICoverageShardRunnerBoundsPackageParallelism(t *testing.T) {
+	root := testPackagePlanRoot(t)
+	data, err := os.ReadFile(filepath.Join(root, "scripts", "ci", "run-coverage-shard.sh"))
+	if err != nil {
+		t.Fatalf("read coverage shard runner: %v", err)
+	}
+	script := string(data)
+	for _, want := range []string{
+		"package_parallelism=1",
+		`if [ "$shard" = remaining ]; then`,
+		"package_parallelism=2",
+		`go test -count=1 -p "$package_parallelism"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("coverage shard runner missing bounded parallelism contract %q", want)
+		}
+	}
+}
+
+func TestCICoverageShardsOwnEveryAppPartitionExactlyOnce(t *testing.T) {
+	root := testPackagePlanRoot(t)
+	appScript := filepath.Join(root, "scripts", "ci", "run-app-race-tests.sh")
+	list := exec.Command("sh", appScript, "list-partitions")
+	list.Dir = root
+	output, err := list.CombinedOutput()
+	if err != nil {
+		t.Fatalf("list app partitions failed: %v\n%s", err, output)
+	}
+	want := strings.Fields(string(output))
+	if len(want) == 0 {
+		t.Fatal("app partition list is empty")
+	}
+
+	shardScript := filepath.Join(root, "scripts", "ci", "run-coverage-shard.sh")
+	counts := map[string]int{}
+	for _, shard := range []string{"app", "cli", "generators", "helpers", "remaining"} {
+		cmd := exec.Command("sh", shardScript, "list-app-partitions", shard)
+		cmd.Dir = root
+		shardOutput, runErr := cmd.CombinedOutput()
+		if runErr != nil {
+			t.Fatalf("list app partitions for %s failed: %v\n%s", shard, runErr, shardOutput)
+		}
+		for _, partition := range strings.Fields(string(shardOutput)) {
+			counts[partition]++
+		}
+	}
+
+	wanted := map[string]bool{}
+	for _, partition := range want {
+		wanted[partition] = true
+		if counts[partition] != 1 {
+			t.Errorf("app partition %q assigned %d times, want exactly once", partition, counts[partition])
+		}
+	}
+	for partition := range counts {
+		if !wanted[partition] {
+			t.Errorf("coverage shard owns unknown app partition %q", partition)
+		}
+	}
+}
+
 func TestCITestPackagePlanFailsClosedWhenGoListFails(t *testing.T) {
 	root := testPackagePlanRoot(t)
 	fakeBin := t.TempDir()

--- a/test/scripts/coverage_workflow_contract_test.go
+++ b/test/scripts/coverage_workflow_contract_test.go
@@ -173,6 +173,17 @@ func TestCoverageWorkflowShardsAndBaselineCache(t *testing.T) {
 	}
 
 	fullJob := admission[fullStart:supportingStart]
+	const exactCoverageMatrix = `      matrix:
+        shard:
+          - app
+          - cli
+          - generators
+          - helpers
+          - remaining
+    steps:`
+	if !strings.Contains(fullJob, exactCoverageMatrix) {
+		t.Error("coverage-current-full must retain exactly five hosted-runner shards")
+	}
 	for _, want := range []string{
 		"needs.lint.outputs.full_suite == 'true'",
 		"fail-fast: false",
@@ -181,15 +192,16 @@ func TestCoverageWorkflowShardsAndBaselineCache(t *testing.T) {
 		"          - generators",
 		"          - helpers",
 		"          - remaining",
-		`./scripts/ci/test-packages.sh list-coverage "$COVERAGE_SHARD"`,
-		"go test -count=1 -p 1",
-		`-coverprofile="coverage-shard-$COVERAGE_SHARD.txt"`,
-		"-covermode=atomic",
+		`./scripts/ci/run-coverage-shard.sh run \`,
+		`"$COVERAGE_SHARD" "coverage-shard-$COVERAGE_SHARD.txt"`,
 		"name: coverage-current-shard-${{ matrix.shard }}",
 	} {
 		if !strings.Contains(fullJob, want) {
 			t.Errorf("coverage-current-full missing shard contract %q", want)
 		}
+	}
+	if strings.Contains(fullJob, "go test -count=1 -p 1") {
+		t.Error("coverage-current-full must delegate app partition balancing to the shared shard runner")
 	}
 
 	baselineJob := admission[baselineStart:metadataStart]
@@ -220,6 +232,13 @@ func TestCoverageWorkflowShardsAndBaselineCache(t *testing.T) {
 	if strings.Contains(baselineJob, "restore-keys") {
 		t.Error("coverage baseline cache must stay exact-key; prefix restore-keys can resurrect a wrong-commit baseline")
 	}
+	if !strings.Contains(baselineJob, `"$GITHUB_WORKSPACE/scripts/ci/run-full-coverage.sh"`) ||
+		!strings.Contains(baselineJob, `"$GITHUB_WORKSPACE/coverage-base.txt"`) {
+		t.Error("coverage-baseline cold fallback must reuse the bounded in-job partition runner")
+	}
+	if strings.Contains(baselineJob, "./ ./cmd/... ./internal/... ./skills/...") {
+		t.Error("coverage-baseline must not retain one long-lived full-suite go test process")
+	}
 
 	metadataJob := admission[metadataStart:gateStart]
 	for _, want := range []string{
@@ -239,8 +258,7 @@ func TestCoverageWorkflowShardsAndBaselineCache(t *testing.T) {
 		"id: metadata-current-cache",
 		"id: metadata-source-cache",
 		"key: dws-coverage-full-v2-${{ env.COVERAGE_SOURCE_REF }}-go${{ steps.setup-go-metadata.outputs.go-version }}",
-		"go test -count=1 -p 1",
-		"./ ./cmd/... ./internal/... ./skills/...",
+		"./scripts/ci/run-full-coverage.sh coverage-cache.txt",
 		"key: dws-coverage-full-v2-${{ github.sha }}-go${{ steps.setup-go-metadata.outputs.go-version }}",
 		"id: metadata-target-cache-verification",
 		"lookup-only: true",
@@ -270,6 +288,7 @@ func TestCoverageWorkflowShardsAndBaselineCache(t *testing.T) {
 		"for shard in app cli generators helpers remaining; do",
 		"test ! -f coverage.txt",
 		`test "$(head -n 1 "$profile")" = "mode: atomic"`,
+		`./scripts/ci/merge-coverage-profiles.sh coverage.txt "${profiles[@]}"`,
 		"github.event_name == 'push'",
 		"cp coverage.txt coverage-cache.txt",
 		"path: " + cachePath,
@@ -342,8 +361,7 @@ func TestFormulaCoverageBaselinePromotionContract(t *testing.T) {
 		"id: target-cache",
 		"id: parent-cache",
 		"key: dws-coverage-full-v2-${{ steps.validate-target.outputs.parent_sha }}-go${{ steps.setup-go.outputs.go-version }}",
-		"go test -count=1 -p 1",
-		"./ ./cmd/... ./internal/... ./skills/...",
+		"./scripts/ci/run-full-coverage.sh coverage-cache.txt",
 		"key: dws-coverage-full-v2-${{ steps.validate-target.outputs.target_sha }}-go${{ steps.setup-go.outputs.go-version }}",
 		"lookup-only: true",
 		"fail-on-cache-miss: true",
@@ -693,8 +711,7 @@ func TestCoverageBaselineRepairContract(t *testing.T) {
 		"id: target-cache",
 		"actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830",
 		"key: dws-coverage-full-v2-${{ steps.resolve-target.outputs.target_sha }}-go${{ steps.setup-go.outputs.go-version }}",
-		"go test -count=1 -p 1",
-		"./ ./cmd/... ./internal/... ./skills/...",
+		"./scripts/ci/run-full-coverage.sh coverage-cache.txt",
 		"actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830",
 		"id: target-cache-verification",
 		"lookup-only: true",


### PR DESCRIPTION
## 问题

高风险 PR 在 full coverage 路径上依赖 merge-base 精确 SHA 的缓存。缓存缺失时，PR、主干 metadata promotion、Formula promotion 和 repair 都会退化到一个长生命周期的 `go test -p 1` 全量进程；`internal/app` 又会在进程级 registry 中保留大量命令树。Runner 被回收后缓存始终无法补齐，重跑只会重复相同的冷启动失败。

关联现场：PR #1150 / Actions run `33712902849`。

## 修复

- 保持 `coverage-current-full` **恰好 5 个现有 matrix Job**，不新增 Runner。
- 将已有的 9 个 `internal/app` 测试名分区平衡到这 5 个 Job；每个分区使用独立 Go 测试进程，及时释放进程级 registry。
- `remaining` 仅在同一个 Runner 内固定使用 `-p 2`，覆盖两个独立长尾 package，不增加 Actions 排队量。
- 用确定性 block union 合并分区 coverage profile，并校验每个 app 分区恰好归属一次。
- PR cold baseline、main metadata promotion、Formula promotion 和 repair 统一复用同一个有界 full-coverage runner，避免修好候选分支后又在缓存修复路径退回旧的单进程实现。
- 保持精确 SHA + Go 版本的 `v2` 缓存 key 不变，避免错误复用邻近 commit 的基线。

## 验证

- `make test-plan`：132 个默认 package、103 个 full-suite coverage package 均恰好归属一次。
- `make format-check`
- `git diff --check`
- `sh -n` 检查全部修改的 shell 脚本。
- 定向 contract tests：profile union、固定 5 Job、package 并发上限、app 分区唯一归属、精确缓存合同均通过。
- `go vet ./test/scripts`
- `staticcheck ./test/scripts`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- 本地实跑 9 个 app 分区，976 个顶层测试恰好覆盖一次，合并 profile 可被 `go tool cover` 接受；最终 `remaining` shard 用时约 3 分钟。

完整 `go test ./test/scripts -count=1` 曾通过（约 329 秒）；最终复跑时 package 的既有 10 分钟超时只命中未修改的 `TestReleaseArtifactVerificationRequiresEveryChecksum`，该测试单独复跑通过（约 151 秒）。

## 风险与回滚

风险集中在 coverage profile 编排，不改变测试集合、覆盖率阈值或缓存身份。回滚此提交即可恢复旧的串行 full-coverage 路径。因为修改 GitHub workflow，本 PR 保持手动合并，不启用 auto-merge。
