### PR TITLE
fix(ci): focus Multi-profile E2E on the isolated chain

### DIFF
--- a/.changes/main-integration-e2e-runtime.md
+++ b/.changes/main-integration-e2e-runtime.md
@@ -1,0 +1,8 @@
+---
+category: Fixed
+---
+
+- **Main integration reliability** — keeps main and release multi-profile E2E
+  validation focused on the isolated profile chain while existing CI shards own
+  the complete Go regressions, avoiding the long-lived runner shutdown window
+  without adding CI jobs.

--- a/.github/workflows/multi-profile-e2e.yml
+++ b/.github/workflows/multi-profile-e2e.yml
@@ -35,11 +35,12 @@ jobs:
         run: |
           set -o pipefail
           mkdir -p .tmp-bin
-          bash scripts/dev/test-multi-profile-e2e.sh --keep-workdir | tee "$MULTI_PROFILE_E2E_LOG"
+          bash scripts/dev/test-multi-profile-e2e.sh --skip-go-tests --keep-workdir | tee "$MULTI_PROFILE_E2E_LOG"
           {
             echo "### Multi-profile E2E"
-            echo "- Command: \`bash scripts/dev/test-multi-profile-e2e.sh --keep-workdir\`"
+            echo "- Command: \`bash scripts/dev/test-multi-profile-e2e.sh --skip-go-tests --keep-workdir\`"
             echo "- Scope: isolated auth/profile storage, profile switch/use, one-shot profile override, CSV multi-profile aggregation, legacy migration"
+            echo "- Go regressions: delegated to the protected-main CI test and coverage shards"
             echo "- Result: passed"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2936,7 +2936,7 @@ jobs:
                 --candidate-ref HEAD
               ;;
             e2e)
-              bash scripts/dev/test-multi-profile-e2e.sh
+              bash scripts/dev/test-multi-profile-e2e.sh --skip-go-tests
               ;;
             *)
               echo "unsupported release validation check: $VALIDATION_CHECK" >&2

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -147,7 +147,12 @@ Complete `Multi-profile E2E` is not a PR admission context. It belongs to the
 `Main Integration — 主干集成` workflow and runs only after a push to `main` (or
 an explicit manual dispatch). A failing downstream run remains a real
 regression and must be repaired, but it must not be represented by a synthetic
-successful PR check.
+successful PR check. The workflow executes the isolated profile storage,
+routing, migration, and aggregation chain without repeating the complete
+`internal/auth`, `internal/app`, and `test/cli` package suites. Those Go
+regressions remain owned by the protected-main test and coverage shards. The
+release E2E validation uses the same boundary so release verification does not
+duplicate an already admitted commit's complete Go suite.
 
 ```mermaid
 flowchart TB

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -1509,10 +1509,22 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 	if !strings.Contains(integration, "include-hidden-files: true") {
 		t.Error("main integration must upload diagnostics stored below the hidden .tmp-bin directory")
 	}
+	const focusedIntegrationCommand = "bash scripts/dev/test-multi-profile-e2e.sh --skip-go-tests --keep-workdir"
+	if count := strings.Count(integration, focusedIntegrationCommand); count != 2 {
+		t.Errorf("main integration must execute and report the focused E2E command exactly twice, got %d", count)
+	}
 
 	integrationScript := readWorkflow("scripts/dev/test-multi-profile-e2e.sh")
+	for _, want := range []string{
+		"--skip-go-tests)",
+		"RUN_GO_TESTS=0",
+	} {
+		if !strings.Contains(integrationScript, want) {
+			t.Errorf("multi-profile E2E script missing focused-CI boundary %q", want)
+		}
+	}
 	if !strings.Contains(integrationScript, `GO_TEST_TIMEOUT="${MULTI_PROFILE_GO_TEST_TIMEOUT:-10m}"`) {
-		t.Error("multi-profile E2E must allow enough time for the complete internal/app regression suite")
+		t.Error("multi-profile E2E must allow enough time when complete Go regressions are explicitly requested")
 	}
 	if strings.Contains(integrationScript, "go test -timeout 180s") {
 		t.Error("multi-profile E2E must not retain the obsolete three-minute Go test budget")

--- a/test/scripts/package_script_test.go
+++ b/test/scripts/package_script_test.go
@@ -1668,7 +1668,7 @@ func TestReleaseWorkflowParallelizesSealedValidationWithoutWeakeningPublication(
 		`--base-ref HEAD`,
 		`--stable-ref "$PREVIOUS_STABLE"`,
 		`--candidate-ref HEAD`,
-		"test-multi-profile-e2e.sh",
+		"bash scripts/dev/test-multi-profile-e2e.sh --skip-go-tests",
 	} {
 		if !strings.Contains(validation, required) {
 			t.Errorf("parallel release validation is missing %q", required)


### PR DESCRIPTION
## 目标

Fixes #1276

治理 `Main Integration — 主干集成` 连续在完整 `internal/app` 回归阶段收到 Hosted Runner shutdown、以 143 退出的问题。保持单 Job，不新增矩阵或排队节点。

## 实现摘要

- 主干 `Multi-profile E2E` 使用脚本已有的 `--skip-go-tests`，直接执行真实 CLI 构建及隔离 profile E2E。
- Release 的 sealed-candidate E2E 使用相同边界，避免发布验证重复运行已通过 Code Admission 的完整 Go package suite。
- 完整 `internal/auth`、`internal/app`、`test/cli` 回归继续由现有 test/race/coverage 门禁负责。
- 增加主干及 Release 工作流契约断言，防止未聚焦的整包回归重新进入云端 E2E。
- 更新 CI 治理文档和 Unreleased change note。

## 失败证据

- https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/33710322437
- https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/33738885261
- https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/33746512237/job/100620110023

三个主干 SHA 均在真正 E2E 开始前、完整 Go 回归仍运行时收到 SIGTERM/Runner shutdown。最后一次成功样本中，Go 回归约 293 秒，后续构建及真实 E2E 约 47 秒。

## 验证

| 验证 | 结果 |
|---|---|
| `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run "^(TestChangelogPRFastPathWorkflowContract\|TestReleaseWorkflowParallelizesSealedValidationWithoutWeakeningPublication)$" -count=1` | PASS，0.732s |
| `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts/... -count=1` | PASS，333.886s |
| `DWS_PACKAGE_VERSION=0.0.0-test bash scripts/dev/test-multi-profile-e2e.sh --skip-go-tests` | PASS，完整隔离链路约 87s |
| `git diff --check` | PASS |
| `make lint` | 已执行；在主干既有、未修改文件的 staticcheck 问题上失败，本 PR 修改文件未出现在错误列表 |
| `actionlint` | NOT VERIFIED：本机未安装；由 PR Lint 门禁验证 |

环境：macOS 26.5.1 arm64，Go 1.26.5；Go 构建与测试临时目录限制在该隔离 worktree 的 `.tmp-bin`。

## 风险与边界

- 云端 E2E 不再重复完整 package suite；安全边界依赖同一 SHA 的现有 Code Admission、protected-main test/race/coverage 门禁。
- profile 存储、profile use/switch、单次 override、多账号聚合、logout/reset、legacy migration 等真实 E2E 检查均未删减。
- 不调整 required contexts、并发策略、Job 数量或 15 分钟 Job timeout。

## 回滚

如需恢复重复整包回归，可回滚本 PR，使主干和 Release 调用重新省略 `--skip-go-tests`。