### PR TITLE
ci: consolidate app race partitions into three lanes

### DIFF
--- a/.changes/1278-ci-app-race-lanes.md
+++ b/.changes/1278-ci-app-race-lanes.md
@@ -1,0 +1,9 @@
+---
+category: Changed
+---
+
+- **Bounded CI app race fan-out** (#1278) — keeps all nine reviewed
+  `internal/app` race-test partitions process-isolated while balancing them
+  across three physical jobs, reducing focused and full-suite runner demand by
+  six jobs without weakening partition coverage or increasing the 20-minute
+  job limit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,27 +581,19 @@ jobs:
     # shards at full-suite scope; release-scripts is included because its
     # dedicated job only runs at full-suite or release-sensitive scope, and
     # dropping it here would stop testing test/scripts changes entirely.
-    # internal/app is carried by one shard per bounded partition rather than a
-    # single app shard: the partitions used to run end to end inside one job,
-    # where the Schema partition alone owned most of the wall clock. The
-    # app-<partition> names are pinned to the helper's partition set by
-    # TestCIAppRacePartitionMatrixMatchesHelper, so a partition can never lose
-    # its job silently. The CrossPlatformCoverage-heavy C range is split again
-    # to retain headroom on runners reclaimed near the five-minute mark.
+    # internal/app keeps nine process-isolated logical partitions, balanced
+    # across three physical app lanes. The lane names and their exact partition
+    # union are pinned to the helper by TestCIAppRaceLaneMatrixMatchesHelper.
+    # This preserves memory release between Go test processes while reducing
+    # hosted-runner fan-out by six jobs per focused run.
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         shard:
-          - app-schema
-          - app-a-b
-          - app-c-a-l
-          - app-c-m-o
-          - app-c-p-r
-          - app-c-s-z
-          - app-c-other
-          - app-d-r
-          - app-s-z-example-fuzz
+          - app-lane-1
+          - app-lane-2
+          - app-lane-3
           - generators
           - helpers
           - cli
@@ -643,12 +635,12 @@ jobs:
           TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
-          # Every app partition shard tests the same single internal/app
-          # package, so the impacted-package query uses the base shard name and
-          # the partition only selects which tests run.
+          # Every app lane tests the same single internal/app package, so the
+          # impacted-package query uses the base shard name and the lane only
+          # selects which process-isolated test partitions run.
           package_shard="$TEST_SHARD"
           case "$TEST_SHARD" in
-            app-*) package_shard=app ;;
+            app-lane-*) package_shard=app ;;
           esac
           package_output="$(
             ./scripts/ci/changed-test-packages.sh \
@@ -699,15 +691,13 @@ jobs:
             }
           done
           case "$TEST_SHARD" in
-            app-*)
-              # A single long-lived app test process retains every constructed
-              # command tree in framework registries. Each partition is its own
-              # job, so that state is released when the process exits and the
-              # partitions run concurrently instead of end to end. The helper
-              # still verifies that the partition patterns cover every top-level
-              # test exactly once before running the one it was asked for.
+            app-lane-*)
+              # Each lane invokes several logical partitions sequentially, and
+              # every partition remains a fresh Go test process so framework
+              # registries are released between partitions. The helper verifies
+              # that all lanes cover every logical partition exactly once.
               test "${#packages[@]}" -eq 1
-              ./scripts/ci/run-app-race-tests.sh run "${packages[0]}" "${TEST_SHARD#app-}"
+              ./scripts/ci/run-app-race-tests.sh run-lane "${packages[0]}" "${TEST_SHARD#app-}"
               exit 0
               ;;
           esac
@@ -731,26 +721,19 @@ jobs:
     needs: lint
     if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.full_suite == 'true' }}
     runs-on: ubuntu-latest
-    # internal/app is split across one shard per bounded partition so the
-    # partitions run concurrently and each releases its framework registries
-    # when the process exits; cli/smoke need headroom beyond go test -timeout for
-    # setup + assembly. The app-<partition> names are pinned to the helper's
-    # partition set by TestCIAppRacePartitionMatrixMatchesHelper. The
-    # CrossPlatformCoverage-heavy C range is split again for runner headroom.
+    # internal/app keeps nine process-isolated logical partitions, balanced
+    # across three physical app lanes. The lane names and exact partition union
+    # are pinned to the helper by TestCIAppRaceLaneMatrixMatchesHelper. This
+    # preserves registry release while reducing hosted-runner fan-out by six
+    # jobs. cli/smoke retain extra timeout headroom for setup + assembly.
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         shard:
-          - app-schema
-          - app-a-b
-          - app-c-a-l
-          - app-c-m-o
-          - app-c-p-r
-          - app-c-s-z
-          - app-c-other
-          - app-d-r
-          - app-s-z-example-fuzz
+          - app-lane-1
+          - app-lane-2
+          - app-lane-3
           - generators
           - helpers
           - cli
@@ -776,27 +759,25 @@ jobs:
           TEST_SHARD: ${{ matrix.shard }}
         run: |
           set -euo pipefail
-          # Every app partition shard tests the same single internal/app
-          # package, so the package query uses the base shard name and the
-          # partition only selects which tests run.
+          # Every app lane tests the same single internal/app package, so the
+          # package query uses the base shard name and the lane only selects
+          # which process-isolated test partitions run.
           package_shard="$TEST_SHARD"
           case "$TEST_SHARD" in
-            app-*) package_shard=app ;;
+            app-lane-*) package_shard=app ;;
           esac
           package_output="$(./scripts/ci/test-packages.sh list "$package_shard")"
           test -n "$package_output"
           mapfile -t packages <<< "$package_output"
           test "${#packages[@]}" -gt 0
           case "$TEST_SHARD" in
-            app-*)
-              # A single long-lived app test process retains every constructed
-              # command tree in framework registries. Each partition is its own
-              # job, so that state is released when the process exits and the
-              # partitions run concurrently instead of end to end. The helper
-              # still verifies that the partition patterns cover every top-level
-              # test exactly once before running the one it was asked for.
+            app-lane-*)
+              # Each lane invokes several logical partitions sequentially, and
+              # every partition remains a fresh Go test process so framework
+              # registries are released between partitions. The helper verifies
+              # that all lanes cover every logical partition exactly once.
               test "${#packages[@]}" -eq 1
-              ./scripts/ci/run-app-race-tests.sh run "${packages[0]}" "${TEST_SHARD#app-}"
+              ./scripts/ci/run-app-race-tests.sh run-lane "${packages[0]}" "${TEST_SHARD#app-}"
               exit 0
               ;;
           esac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,6 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
-### Changed
-
-- **Bounded CI app race fan-out** — keeps all nine reviewed `internal/app`
-  race-test partitions process-isolated while balancing them across three
-  physical jobs, reducing focused and full-suite runner demand by six jobs
-  without weakening partition coverage or increasing the 20-minute job limit.
-
 ## [1.0.62-beta.2] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/) and th
 
 ## [Unreleased]
 
+### Changed
+
+- **Bounded CI app race fan-out** — keeps all nine reviewed `internal/app`
+  race-test partitions process-isolated while balancing them across three
+  physical jobs, reducing focused and full-suite runner demand by six jobs
+  without weakening partition coverage or increasing the 20-minute job limit.
+
 ## [1.0.62-beta.2] - 2026-09-02
 
 ### Added

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -336,6 +336,26 @@ candidate SHA。
 `check-interface-baseline.sh` 不再作为本地或 CI 的兼容性审批入口，也不能用于批准
 flag 迁移。
 
+The race suite keeps nine reviewed `internal/app` test-name partitions but
+dispatches them through three balanced physical lanes. Each partition remains
+an independent Go test process, so process-global command registries are
+released between partitions; the lane is only the hosted-runner scheduling
+unit. `scripts/ci/run-app-race-tests.sh` owns both the partition set and the
+lane map, and the workflow contract proves that each focused/full-suite matrix
+contains exactly those three lanes and that their union contains every
+partition exactly once.
+
+The initial lane balance is evidence-based rather than alphabetical by job.
+Across 11 successful full-suite runs sampled on 2026-09-03, replaying the
+recorded partition step durations produced a slowest-lane median of 8m53s,
+p90 of 9m02s, and maximum of 9m08s. The 20-minute job timeout remains unchanged
+as regression headroom. The scheduling model predicts 33 to 27 successful jobs
+per ordinary full-suite PR and about 40-50 seconds lower completion time for the
+last PR when two to four full suites arrive two minutes apart. These are rollout
+targets, not post-change measurements; maintainers must validate them against
+live overlapping runs and rebalance the helper-owned lane map if the slowest
+lane p95 exceeds 12 minutes.
+
 Schema compatibility 使用同一组 base、stable、candidate refs，以及 base-owned flag
 与 command migration ledgers。merge-base-owned checker 分别规范化 merge-base 与
 stable 的完整 Schema，并让 candidate 对两份历史 contract 独立执行检查；它只把已通过

--- a/scripts/ci/run-app-race-tests.sh
+++ b/scripts/ci/run-app-race-tests.sh
@@ -7,18 +7,70 @@ usage() {
 	printf '%s\n' \
 		"usage: $0 verify <app-package>" \
 		"       $0 run <app-package> [partition]" \
+		"       $0 run-lane <app-package> <lane>" \
 		"       $0 coverage <app-package> <output-profile> [partition]" \
-		"       $0 list-partitions" >&2
+		"       $0 list-partitions" \
+		"       $0 list-lanes" \
+		"       $0 list-lane-partitions <lane>" >&2
 	exit 2
 }
 
-# Single source of truth for the partition set. CI runs one job per partition and
-# pins its shard names to this list, so a name that appears here without a
-# dispatch entry below fails closed rather than silently skipping tests.
+# Single source of truth for the logical partition set. CI keeps each partition
+# in a fresh Go test process, but balances them across three physical jobs so a
+# full-suite PR does not reserve nine hosted-runner slots for internal/app.
 APP_PARTITIONS='schema a-b c-a-l c-m-o c-p-r c-s-z c-other d-r s-z-example-fuzz'
+APP_LANES='lane-1 lane-2 lane-3'
+
+app_lane_partitions() {
+	case "$1" in
+		lane-1) printf '%s\n' 'c-a-l schema' ;;
+		lane-2) printf '%s\n' 'c-p-r c-m-o c-s-z' ;;
+		lane-3) printf '%s\n' 'd-r a-b c-other s-z-example-fuzz' ;;
+		*)
+			printf 'unknown app race lane: %s\n' "$1" >&2
+			return 1
+			;;
+	esac
+}
+
+# Fail closed if the lane map drops, duplicates, or invents a logical
+# partition. The Go workflow contract independently pins both matrices to the
+# same lane list.
+assigned_lane_partitions=''
+for lane_name in $APP_LANES; do
+	for lane_partition in $(app_lane_partitions "$lane_name"); do
+		case " $APP_PARTITIONS " in
+			*" $lane_partition "*) ;;
+			*)
+				printf 'app race lane %s references unknown partition %s\n' \
+					"$lane_name" "$lane_partition" >&2
+				exit 1
+				;;
+		esac
+		case " $assigned_lane_partitions " in
+			*" $lane_partition "*)
+				printf 'app race partition %s is assigned to more than one lane\n' \
+					"$lane_partition" >&2
+				exit 1
+				;;
+		esac
+		assigned_lane_partitions="$assigned_lane_partitions $lane_partition"
+	done
+done
+for lane_partition in $APP_PARTITIONS; do
+	case " $assigned_lane_partitions " in
+		*" $lane_partition "*) ;;
+		*)
+			printf 'app race partition %s is not assigned to a lane\n' \
+				"$lane_partition" >&2
+			exit 1
+			;;
+	esac
+done
 
 mode="${1:-}"
 partition=""
+lane=""
 coverage_output=""
 case "$mode" in
 	list-partitions)
@@ -26,6 +78,18 @@ case "$mode" in
 		for name in $APP_PARTITIONS; do
 			printf '%s\n' "$name"
 		done
+		exit 0
+		;;
+	list-lanes)
+		[ "$#" -eq 1 ] || usage
+		for name in $APP_LANES; do
+			printf '%s\n' "$name"
+		done
+		exit 0
+		;;
+	list-lane-partitions)
+		[ "$#" -eq 2 ] || usage
+		app_lane_partitions "$2"
 		exit 0
 		;;
 	verify)
@@ -36,6 +100,11 @@ case "$mode" in
 		[ "$#" -eq 2 ] || [ "$#" -eq 3 ] || usage
 		app_package="$2"
 		partition="${3:-}"
+		;;
+	run-lane)
+		[ "$#" -eq 3 ] || usage
+		app_package="$2"
+		lane="$3"
 		;;
 	coverage)
 		[ "$#" -eq 3 ] || [ "$#" -eq 4 ] || usage
@@ -223,10 +292,11 @@ run_partition() {
 # (26s -> 291s locally, 357s in CI) without being able to report anything.
 schema_pattern='^Test.*Schema'
 
-# Dispatch table for the partition set declared in APP_PARTITIONS. CI passes one
-# partition per job so they run concurrently; running without a partition keeps
-# the original end-to-end behaviour for local use and for any caller that wants
-# the whole package in one invocation.
+# Dispatch table for the partition set declared in APP_PARTITIONS. Every call
+# starts a fresh Go test process. CI runs several calls sequentially inside one
+# balanced lane, preserving process isolation while bounding physical fan-out.
+# Running without a partition keeps the original end-to-end behaviour for local
+# use and for any caller that wants the whole package in one invocation.
 run_named_partition() {
 	case "$1" in
 		schema) run_partition schema no-race "$schema_pattern" ;;
@@ -253,6 +323,13 @@ if [ -n "$partition" ]; then
 		"$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/merge-coverage-profiles.sh" \
 			"$coverage_output" "$workdir/coverage-app-$partition.txt"
 	fi
+	exit 0
+fi
+
+if [ -n "$lane" ]; then
+	for name in $(app_lane_partitions "$lane"); do
+		run_named_partition "$name"
+	done
 	exit 0
 fi
 

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -1345,19 +1345,17 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 	// The focused path fans the impacted set across the same shards as test-race
 	// and runs each shard the way test-race runs it, so no single job carries
 	// internal/app together with its reverse dependencies. internal/app is split
-	// further into one shard per bounded partition, which keeps its package-level
-	// headroom through the process-isolating helper instead of one long -timeout
-	// and is strictly stronger than a single app job: every partition process
-	// releases the framework registries it populated, and the partitions run
-	// concurrently rather than end to end. Each partition shard still selects the
-	// same single internal/app package, so the impacted-package query maps the
-	// shard name back to app. release-scripts is asserted because its dedicated
+	// further into three balanced physical lanes. Every logical partition remains
+	// a fresh process, so it releases the framework registries it populated, while
+	// the workflow consumes six fewer hosted-runner slots. Each lane still selects
+	// the same single internal/app package, so the impacted-package query maps the
+	// lane name back to app. release-scripts is asserted because its dedicated
 	// job only runs at full-suite or release-sensitive scope, so losing it here
 	// would silently stop testing test/scripts changes.
 	for _, want := range []string{
-		`app-*) package_shard=app ;;`,
+		`app-lane-*) package_shard=app ;;`,
 		`test "${#packages[@]}" -eq 1`,
-		`./scripts/ci/run-app-race-tests.sh run "${packages[0]}" "${TEST_SHARD#app-}"`,
+		`./scripts/ci/run-app-race-tests.sh run-lane "${packages[0]}" "${TEST_SHARD#app-}"`,
 		`if [ "$TEST_SHARD" = "release-scripts" ]; then`,
 		`go test -v -count=1 -timeout=10m "${packages[@]}"`,
 		"timeout_budget=12m",
@@ -1379,16 +1377,15 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 		t.Fatal("Code Admission workflow missing race test job boundaries")
 	}
 	raceJob := admission[raceStart:raceEnd]
-	// internal/app is carried by one shard per bounded partition, so process-global
-	// command registries are released with each partition process and the Schema
-	// assembly peak no longer sits in front of the other partitions. Each
-	// partition shard resolves back to the same single internal/app package.
+	// internal/app is carried by three balanced lanes. Process-global command
+	// registries are still released with each logical partition process, and each
+	// lane resolves back to the same single internal/app package.
 	// Other full race shards retain the dynamic package timeout: default/floor
 	// 12m, with cli/smoke raised to 15m on slower hosted runners.
 	for _, want := range []string{
-		`app-*) package_shard=app ;;`,
+		`app-lane-*) package_shard=app ;;`,
 		`test "${#packages[@]}" -eq 1`,
-		`./scripts/ci/run-app-race-tests.sh run "${packages[0]}" "${TEST_SHARD#app-}"`,
+		`./scripts/ci/run-app-race-tests.sh run-lane "${packages[0]}" "${TEST_SHARD#app-}"`,
 		"timeout_budget=12m",
 		`if [ "$TEST_SHARD" = "cli" ] ||`,
 		`[ "$TEST_SHARD" = "smoke" ]; then`,

--- a/test/scripts/ci_test_package_plan_test.go
+++ b/test/scripts/ci_test_package_plan_test.go
@@ -104,24 +104,51 @@ func TestCIAppRacePartitionsCoverTopLevelTestsExactlyOnce(t *testing.T) {
 	}
 }
 
-// TestCIAppRacePartitionMatrixMatchesHelper pins the workflow's app partition
-// shards to the partition set the helper actually runs. The partitions are
-// separate CI jobs now, so the helper's own "covered exactly once" check can no
-// longer prove the whole package ran: a partition the helper knows about but no
-// matrix shard dispatches would silently stop running while every job stays
-// green. Both directions are asserted so a stale matrix shard fails too.
-func TestCIAppRacePartitionMatrixMatchesHelper(t *testing.T) {
+// TestCIAppRaceLaneMatrixMatchesHelper pins both workflow matrices to the three
+// physical lanes declared by the helper and proves that those lanes contain
+// every logical partition exactly once. A stale lane, dropped partition, or
+// duplicate assignment must fail rather than silently weakening the race suite.
+func TestCIAppRaceLaneMatrixMatchesHelper(t *testing.T) {
 	root := testPackagePlanRoot(t)
 	script := filepath.Join(root, "scripts", "ci", "run-app-race-tests.sh")
-	cmd := exec.Command("sh", script, "list-partitions")
-	cmd.Dir = root
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("%s list-partitions failed: %v\n%s", script, err, output)
-	}
-	partitions := strings.Fields(string(output))
+	partitionsOutput := runAppRaceHelper(t, root, script, "list-partitions")
+	partitions := strings.Fields(partitionsOutput)
 	if len(partitions) == 0 {
-		t.Fatalf("list-partitions returned no partitions: %q", output)
+		t.Fatalf("list-partitions returned no partitions: %q", partitionsOutput)
+	}
+	partitionSet := make(map[string]struct{}, len(partitions))
+	for _, partition := range partitions {
+		partitionSet[partition] = struct{}{}
+	}
+
+	lanesOutput := runAppRaceHelper(t, root, script, "list-lanes")
+	lanes := strings.Fields(lanesOutput)
+	if len(lanes) != 3 {
+		t.Fatalf("list-lanes returned %d lanes, want 3: %q", len(lanes), lanesOutput)
+	}
+	assigned := make(map[string]string, len(partitions))
+	for _, lane := range lanes {
+		laneOutput := runAppRaceHelper(t, root, script, "list-lane-partitions", lane)
+		lanePartitions := strings.Fields(laneOutput)
+		if len(lanePartitions) == 0 {
+			t.Fatalf("lane %q returned no partitions", lane)
+		}
+		for _, partition := range lanePartitions {
+			if _, ok := partitionSet[partition]; !ok {
+				t.Errorf("lane %q contains unknown partition %q", lane, partition)
+				continue
+			}
+			if previous, ok := assigned[partition]; ok {
+				t.Errorf("partition %q appears in lanes %q and %q", partition, previous, lane)
+				continue
+			}
+			assigned[partition] = lane
+		}
+	}
+	for _, partition := range partitions {
+		if _, ok := assigned[partition]; !ok {
+			t.Errorf("partition %q is not assigned to an app race lane", partition)
+		}
 	}
 
 	workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
@@ -145,10 +172,10 @@ func TestCIAppRacePartitionMatrixMatchesHelper(t *testing.T) {
 		}
 		body := admission[start:end]
 
-		for _, partition := range partitions {
-			want := "- app-" + partition
+		for _, lane := range lanes {
+			want := "- app-" + lane
 			if !strings.Contains(body, want) {
-				t.Errorf("%s matrix is missing shard %q for a partition the helper runs", job.name, want)
+				t.Errorf("%s matrix is missing helper lane shard %q", job.name, want)
 			}
 		}
 
@@ -159,17 +186,84 @@ func TestCIAppRacePartitionMatrixMatchesHelper(t *testing.T) {
 			}
 			name := strings.TrimPrefix(shard, "- app-")
 			matched := false
-			for _, partition := range partitions {
-				if partition == name {
+			for _, lane := range lanes {
+				if lane == name {
 					matched = true
 					break
 				}
 			}
 			if !matched {
-				t.Errorf("%s matrix shard %q has no matching helper partition", job.name, shard)
+				t.Errorf("%s matrix shard %q has no matching helper lane", job.name, shard)
 			}
 		}
 	}
+}
+
+func TestCIAppRaceLaneRunsEachPartitionInFreshGoTestProcess(t *testing.T) {
+	root := testPackagePlanRoot(t)
+	fakeBin := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "go-test.log")
+	fakeGo := filepath.Join(fakeBin, "go")
+	const fakeGoScript = `#!/bin/sh
+case " $* " in
+  *" -list "*)
+    printf '%s\n' \
+      TestAgentSchema \
+      TestAlpha \
+      TestCrossPlatformCoverageApple \
+      TestCrossPlatformCoverageMail \
+      TestCrossPlatformCoveragePolicy \
+      TestCrossPlatformCoverageSheet \
+      TestCreate \
+      TestDownload \
+      TestSend
+    exit 0
+    ;;
+esac
+printf '%s\n' "$*" >> "$FAKE_GO_LOG"
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatalf("write fake go: %v", err)
+	}
+
+	script := filepath.Join(root, "scripts", "ci", "run-app-race-tests.sh")
+	cmd := exec.Command("sh", script, "run-lane", "./internal/app", "lane-2")
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"FAKE_GO_LOG="+logPath,
+		"TMPDIR="+t.TempDir(),
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run lane-2 failed: %v\n%s", err, output)
+	}
+	for _, partition := range []string{"c-p-r", "c-m-o", "c-s-z"} {
+		want := "running internal/app race partition " + partition
+		if !strings.Contains(string(output), want) {
+			t.Errorf("run-lane output missing %q:\n%s", want, output)
+		}
+	}
+
+	invocations, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake go invocation log: %v", err)
+	}
+	lines := strings.FieldsFunc(strings.TrimSpace(string(invocations)), func(r rune) bool { return r == '\n' })
+	if len(lines) != 3 {
+		t.Fatalf("lane-2 launched %d go test processes, want 3:\n%s", len(lines), invocations)
+	}
+}
+
+func runAppRaceHelper(t *testing.T, root, script string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("sh", append([]string{script}, args...)...)
+	cmd.Dir = root
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", script, strings.Join(args, " "), err, output)
+	}
+	return string(output)
 }
 
 func TestCIMergeCoverageProfilesUnionsDuplicateBlocks(t *testing.T) {


### PR DESCRIPTION
## 目标

降低多个 PR 同时执行 full-suite 时，internal/app race 矩阵对 GitHub-hosted runner 并发槽的占用，同时保持现有测试覆盖、race instrumentation 和进程隔离语义。

关联 Issue：无；本次为直接授权的 CI 治理改动。

## 实现

- 保留全部 9 个已评审逻辑 partition，将它们平衡到 3 个物理 lane。
- 每个 partition 仍由独立 go test 进程执行，避免重新引入 framework registry 的进程内累积。
- focused 和 full-suite 两套矩阵同步从 9 个 app jobs 收敛为 3 个。
- helper 新增 list-lanes、list-lane-partitions 和 run-lane，并对 lane/partition 的遗漏、重复和未知项 fail closed。
- 契约测试双向验证两套 workflow matrix 与 helper lane 映射完全一致。
- 保持 Actions job timeout 为 20 分钟，每个 partition 的 Go timeout 为 15 分钟。

## 量化基线与目标

2026-09-03 对 11 个成功 full-suite run 的 partition step 耗时回放：

- 最慢 3-lane p50：8m53s
- p90：9m02s
- 样本最大：9m08s
- 普通 full-suite 成功 jobs：预计 33 → 27，每个 PR 减少 6 个
- 多个 full-suite 每隔 2 分钟进入时：最后一个 PR 的模拟完成时间预计降低约 40–50 秒

以上是上线目标，不作为事后效果结论；合入后需用真实重叠 PR run 继续验收。

## 验证

| 检查 | 结果 |
|---|---|
| 聚焦 CI lane/partition/workflow 契约测试 | PASS |
| DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -count=1 | PASS，349.772s |
| actionlint v1.7.12 .github/workflows/ci.yml | PASS |
| make format-check | PASS |
| git diff --check | PASS |

环境：macOS 26.5.1，Go 1.26.5 darwin/arm64。临时构建目录固定在隔离 worktree 内。

## 风险与回滚

主要风险是 partition 耗时随测试增长而失衡。当前 20 分钟 job timeout 保留为回退边界；合入后若最慢 lane p95 超过 12 分钟，应重新平衡 helper 中的 lane map。若出现覆盖或稳定性回归，可整体回滚本提交，恢复一 partition 一 job；required contexts、coverage gate 和其他 workflow 均未改变。

## 局限

本改动只降低 app race 的物理 fan-out，不处理当前更长的 Test race cli 关键路径，也不改变 full_suite 分类命中率。