### PR TITLE
feat(contact): add invite/apply/admin CLI commands

### DIFF
--- a/.changes/1279-apply-list-safety-effect.md
+++ b/.changes/1279-apply-list-safety-effect.md
@@ -1,0 +1,9 @@
+---
+category: Fixed
+---
+
+- **Contact apply-list safety semantics** — `dws contact org apply-list` marks
+  unread join applications as read on the server; its schema safety effect is
+  now declared as `write` (risk stays `low`, confirmation stays
+  `not_required`) and the selection guidance discloses the read-marking side
+  effect so Agents no longer treat it as a pure read.

--- a/.changes/1279-apply-remove-safety-effect.md
+++ b/.changes/1279-apply-remove-safety-effect.md
@@ -1,0 +1,9 @@
+---
+category: Fixed
+---
+
+- **Contact apply-remove safety semantics** — `dws contact org apply-remove`
+  deletes organization join application records irreversibly; its schema safety
+  effect is now declared as `destructive` (risk `high`, confirmation
+  `user_required`) and the selection guidance discloses that the deletion is
+  not recoverable so Agents no longer treat it as an ordinary write.

--- a/.changes/1279-contact-org-list-pagination.md
+++ b/.changes/1279-contact-org-list-pagination.md
@@ -1,0 +1,10 @@
+---
+category: Fixed
+---
+
+- **Contact org list pagination contract** — `dws contact org invite-list` and
+  `dws contact org apply-list` now declare the unified cursor Pagination contract
+  (`cursor` parameter, `meta.pagination` metadata) and their result data schemas
+  no longer leak `hasMore`/`nextCursor`. Runtime responses project the server-side
+  cursor fields into `meta.pagination` so Agents can resume paging from the
+  standard contract.

--- a/.changes/contact-invite-apply-admin.md
+++ b/.changes/contact-invite-apply-admin.md
@@ -1,0 +1,10 @@
+---
+category: Added
+---
+
+- **Contact invite/apply administration** — adds `dws contact exclusive-account
+  disable|enable` for enterprise-account status, a `dws contact org`
+  invite/apply group (`invite-switch`, `invite-audit`, `invite-info`,
+  `invite-list`, `apply-list`, `apply-approve`, `apply-reject`, `apply-block`,
+  `apply-remove`), and `dws contact dept invite-audit` for department-level
+  join-request auditing.

--- a/docs/command-index.md
+++ b/docs/command-index.md
@@ -182,14 +182,26 @@ _Group chats, conversations, messages, and robot/webhook integrations._
 
 _Users, departments, directory lookups, and enterprise onboarding._
 
-**9 commands**
+**21 commands**
 
 | Command | Description | When to use |
 |---|---|---|
 | `dws contact account create` | Create a dedicated login account in the current enterprise. | When the user explicitly asks for an enterprise account or login account, rather than a new enterprise organization. |
+| `dws contact dept invite-audit` | Set whether joining a specific department requires admin review (department-level auto-approval). | When the user explicitly asks to enable or disable per-department join-request auditing. |
 | `dws contact dept list-members` | List members of a specific department by department ID. | When the agent needs the roster of a department to target communication or build a team overview. |
 | `dws contact dept search` | Search departments in the organization's contact directory by keyword. | When the agent needs to resolve a department name to a department ID. |
+| `dws contact exclusive-account disable` | Disable a dedicated enterprise login account so it can no longer sign in. | When the user explicitly asks to suspend an enterprise account and has confirmed the staff user ID. |
+| `dws contact exclusive-account enable` | Re-enable a previously disabled dedicated enterprise login account. | When the user explicitly asks to restore an enterprise account's ability to sign in. |
+| `dws contact org apply-approve` | Approve a pending join-enterprise application by application ID. | When the user explicitly asks to accept an application after confirming it via `dws contact org apply-list`. |
+| `dws contact org apply-block` | Block (blacklist) a join-enterprise application and its applicant with a reason. | When the user explicitly asks to blacklist an applicant, understanding later applications are also rejected. |
+| `dws contact org apply-list` | List user-submitted applications to join the enterprise, filterable by status. | When the user asks to review pending or processed join requests, or needs application IDs for approval commands. |
+| `dws contact org apply-reject` | Reject a join-enterprise application by application ID with a reason. | When the user explicitly asks to decline an application and provide the rejection reason. |
+| `dws contact org apply-remove` | Delete a join-enterprise application record permanently. | When the user explicitly asks to remove an application record and accepts it cannot be recovered. |
 | `dws contact org create` | Create a new DingTalk enterprise organization. | When the user explicitly asks to create or initialize an enterprise and provides its name and creator display name. |
+| `dws contact org invite-audit` | Set whether joining the enterprise requires admin review (enterprise-level auto-approval). | When the user explicitly asks to enable or disable join-request auditing for the whole enterprise. |
+| `dws contact org invite-info` | Fetch the enterprise invite link, invite code, join switches, and audit type. | When the user asks for the invite link/QR code or wants to inspect current join settings. |
+| `dws contact org invite-list` | List join-enterprise invitations the administrators have sent, filterable by status. | When the user asks which invited members have not yet accepted. |
+| `dws contact org invite-switch` | Toggle who can apply to join the enterprise (master switch plus search/code/link channels). | When the user explicitly asks to open or close join-application channels. |
 | `dws contact user get` | Batch-fetch detailed profile information for one or more users by user ID. | When the agent needs names, titles, emails, or departments for a known set of user IDs. |
 | `dws contact user get-self` | Retrieve the profile of the currently authenticated user. | When the agent needs to identify who it is acting on behalf of (user ID, name, org). |
 | `dws contact user invite` | Invite one employee by mobile number into the current enterprise. | When the user explicitly asks to add an employee and has supplied the employee name and mobile number. |

--- a/internal/app/root_help_test.go
+++ b/internal/app/root_help_test.go
@@ -126,6 +126,7 @@ func TestLeafHelpRendersSelectionSafetyAndReferences(t *testing.T) {
 		{path: "dev app delete", wantEffect: "destructive", wantConfirm: "user_required", wantSkill: "dingtalk-misc", wantDocument: "references/devapp.md"},
 		{path: "contract record list", wantEffect: "read", wantConfirm: "not_required", wantSkill: "dingtalk-misc", wantDocument: "references/contract.md"},
 		{path: "contract subject delete", wantEffect: "destructive", wantConfirm: "user_required", wantSkill: "dingtalk-misc", wantDocument: "references/contract.md"},
+		{path: "contact org apply-list", wantEffect: "write", wantConfirm: "not_required", wantSkill: "dingtalk-contact", wantDocument: "references/contact.md"},
 	} {
 		t.Run(strings.ReplaceAll(tc.path, " ", "_"), func(t *testing.T) {
 			root := NewRootCommand()
@@ -955,6 +956,47 @@ func TestContactWriteOpsConfirmationGate(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestContactApplyListSchemaProjectionMatchesRuntimeBehavior 是 apply-list
+// 安全语义的回归：查询会把服务端未读申请标记为已读（Long 帮助明示），
+// 最终 Schema 投影必须声明 Effect=write，不能把有副作用的查询伪装成纯
+// 读取；同时副作用仅清除未读标记，Confirmation 应保持 not_required，
+// 运行时也不得出现确认 gate。投影与运行行为任一侧回归都会被本测试拦截。
+func TestContactApplyListSchemaProjectionMatchesRuntimeBehavior(t *testing.T) {
+	t.Run("schema projection discloses read-marking side effect", func(t *testing.T) {
+		meta, ok := cli.ResolveMeta("contact org apply-list")
+		if !ok {
+			t.Fatal("ResolveMeta(contact org apply-list) missing")
+		}
+		if meta.Safety.Effect != "write" {
+			t.Fatalf("apply-list effect = %q, want write (query marks unread applies as read)", meta.Safety.Effect)
+		}
+		if meta.Safety.Risk != "low" || meta.Safety.Confirmation != "not_required" || meta.Safety.Idempotency != "idempotent" {
+			t.Fatalf("apply-list safety = %+v, want low/not_required/idempotent", meta.Safety)
+		}
+		if !strings.Contains(meta.Selection.AgentSummary, "标记为已读") {
+			t.Fatalf("apply-list agent summary %q must disclose the read-marking side effect", meta.Selection.AgentSummary)
+		}
+	})
+
+	t.Run("not_required projection runs without confirmation gate", func(t *testing.T) {
+		recorder := &contactWriteOpsRecorder{}
+		err := executeContactWriteOp(t, recorder, []string{"contact", "org", "apply-list"})
+		if err != nil {
+			t.Fatalf("apply-list without --yes must not hit the confirmation gate: %v", err)
+		}
+		if len(recorder.calls) != 1 {
+			t.Fatalf("apply-list want exactly 1 MCP call, got %d: %+v", len(recorder.calls), recorder.calls)
+		}
+		call := recorder.calls[0]
+		if call.server != "contact" || call.tool != "query_org_apply_list" {
+			t.Fatalf("apply-list call = %s/%s, want contact/query_org_apply_list", call.server, call.tool)
+		}
+		if want := map[string]any{"status": int64(1), "size": int64(20)}; !reflect.DeepEqual(call.args, want) {
+			t.Fatalf("apply-list args = %#v, want %#v", call.args, want)
+		}
+	})
 }
 
 func TestChatConversationFileUploadUsesANewPath(t *testing.T) {

--- a/internal/app/root_help_test.go
+++ b/internal/app/root_help_test.go
@@ -15,11 +15,13 @@ package app
 
 import (
 	"bytes"
+	"context"
 	stderrors "errors"
 	"io"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/runtimeannotate"
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 	"github.com/spf13/cobra"
@@ -843,6 +846,114 @@ func TestRootKeepsContactOrgInviteApplyAdminCommands(t *testing.T) {
 	}
 	if got, err := executeRootCaptureStdout(t, []string{"--dry-run", "contact", "org", "apply-reject", "--id", "123"}); err == nil || !strings.Contains(err.Error(), "--reason") {
 		t.Fatalf("org apply-reject without --reason should fail with a reason hint, got err = %v\n%s", err, got)
+	}
+}
+
+// contactWriteOpsCall 记录一次 MCP 写调用的完整入参。
+type contactWriteOpsCall struct {
+	server string
+	tool   string
+	args   map[string]any
+}
+
+// contactWriteOpsRecorder 是记录型 ToolCaller，供确认门禁测试断言
+// 工具名与参数（区别于只验证参数组装的 --dry-run 用例）。
+type contactWriteOpsRecorder struct {
+	calls []contactWriteOpsCall
+}
+
+func (r *contactWriteOpsRecorder) CallTool(_ context.Context, server, tool string, args map[string]any) (*edition.ToolResult, error) {
+	r.calls = append(r.calls, contactWriteOpsCall{server: server, tool: tool, args: args})
+	return &edition.ToolResult{Content: []edition.ContentBlock{{Type: "text", Text: `{"success":true}`}}}, nil
+}
+
+func (*contactWriteOpsRecorder) Format() string { return "json" }
+func (*contactWriteOpsRecorder) DryRun() bool   { return false }
+func (*contactWriteOpsRecorder) Fields() string { return "" }
+func (*contactWriteOpsRecorder) JQ() string     { return "" }
+
+// executeContactWriteOp 走非 dry-run 真实执行路径：os.Args 需含产品名 contact
+// 供 resolveProductID 路由 MCP Server；stdin 传空 reader 模拟非交互环境
+// （EOF 时 ConfirmSafety 失败关闭）。
+func executeContactWriteOp(t *testing.T, recorder *contactWriteOpsRecorder, args []string) error {
+	t.Helper()
+	testseam.Swap(t, &os.Args, append([]string{"dws"}, args...))
+	root := NewRootCommand()
+	helpers.InitDepsForTest(t, recorder)
+	root.SetIn(strings.NewReader(""))
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(args)
+	return root.Execute()
+}
+
+// TestContactWriteOpsConfirmationGate 是 user_required 写操作的端到端回归：
+// 上方成功用例全部传 --dry-run（绕过确认 gate），无法证明真实执行路径上
+// 未确认会在 MCP 调用前被拒绝。这里覆盖三类高风险写操作：
+//   - apply-remove：删除申请记录，不可恢复；
+//   - apply-block：屏蔽会拉黑申请人；
+//   - disable：停用企业账号会阻止其登录钉钉。
+func TestContactWriteOpsConfirmationGate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		tool     string
+		wantArgs map[string]any
+	}{
+		{
+			name:     "apply remove is not recoverable",
+			args:     []string{"contact", "org", "apply-remove", "--id", "123"},
+			tool:     "remove_org_apply",
+			wantArgs: map[string]any{"id": int64(123)},
+		},
+		{
+			name:     "apply block blacklists the applicant",
+			args:     []string{"contact", "org", "apply-block", "--id", "123", "--reason", "恶意重复申请"},
+			tool:     "block_org_apply",
+			wantArgs: map[string]any{"id": int64(123), "reason": "恶意重复申请"},
+		},
+		{
+			name: "exclusive account disable blocks sign-in",
+			args: []string{"contact", "exclusive-account", "disable", "--staff-id", "user001"},
+			tool: "exclusive_account_set_status",
+			// uesrId 是 MCP 工具运行时入参的历史字段名（平台 inputMappings 笔误）。
+			wantArgs: map[string]any{"uesrId": "user001", "status": "disable"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("unconfirmed rejects before any MCP call", func(t *testing.T) {
+				recorder := &contactWriteOpsRecorder{}
+				err := executeContactWriteOp(t, recorder, tc.args)
+				if err == nil {
+					t.Fatalf("%s without confirmation must be rejected", tc.name)
+				}
+				if !apperrors.IsConfirmationRequired(err) {
+					t.Fatalf("%s error = %v, want reason confirmation_required", tc.name, err)
+				}
+				if len(recorder.calls) != 0 {
+					t.Fatalf("%s must not reach MCP before confirmation, got calls: %+v", tc.name, recorder.calls)
+				}
+			})
+
+			t.Run("explicit yes executes exactly the expected tool call", func(t *testing.T) {
+				recorder := &contactWriteOpsRecorder{}
+				err := executeContactWriteOp(t, recorder, append(tc.args, "--yes"))
+				if err != nil {
+					t.Fatalf("%s with --yes failed: %v", tc.name, err)
+				}
+				if len(recorder.calls) != 1 {
+					t.Fatalf("%s with --yes want exactly 1 MCP call, got %d: %+v", tc.name, len(recorder.calls), recorder.calls)
+				}
+				call := recorder.calls[0]
+				if call.server != "contact" || call.tool != tc.tool {
+					t.Fatalf("%s call = %s/%s, want contact/%s", tc.name, call.server, call.tool, tc.tool)
+				}
+				if !reflect.DeepEqual(call.args, tc.wantArgs) {
+					t.Fatalf("%s args = %#v, want %#v", tc.name, call.args, tc.wantArgs)
+				}
+			})
+		})
 	}
 }
 

--- a/internal/app/root_help_test.go
+++ b/internal/app/root_help_test.go
@@ -710,6 +710,142 @@ func TestRootKeepsContactWukongCompatibilityCommands(t *testing.T) {
 	}
 }
 
+func TestRootKeepsContactOrgInviteApplyAdminCommands(t *testing.T) {
+	root := NewRootCommand()
+
+	// 命令树结构：exclusive-account 新组、org 组 9 个新子命令、dept 组 invite-audit。
+	mustFindCommand(t, root, "contact", "exclusive-account")
+	mustFindCommand(t, root, "contact", "exclusive-account", "disable")
+	mustFindCommand(t, root, "contact", "exclusive-account", "enable")
+	mustFindCommand(t, root, "contact", "org", "invite-switch")
+	mustFindCommand(t, root, "contact", "org", "invite-audit")
+	mustFindCommand(t, root, "contact", "org", "invite-info")
+	mustFindCommand(t, root, "contact", "org", "invite-list")
+	mustFindCommand(t, root, "contact", "org", "apply-list")
+	mustFindCommand(t, root, "contact", "org", "apply-approve")
+	mustFindCommand(t, root, "contact", "org", "apply-reject")
+	mustFindCommand(t, root, "contact", "org", "apply-block")
+	mustFindCommand(t, root, "contact", "org", "apply-remove")
+	mustFindCommand(t, root, "contact", "dept", "invite-audit")
+
+	approve := mustFindCommand(t, root, "contact", "org", "apply-approve")
+	if !containsString(approve.Aliases, "approve") {
+		t.Fatal("contact org apply-approve missing approve alias")
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "exclusive account disable",
+			args: []string{"--dry-run", "contact", "exclusive-account", "disable", "--staff-id", "user001"},
+			want: []string{"exclusive_account_set_status", "uesrId", "user001", "disable"},
+		},
+		{
+			name: "exclusive account enable",
+			args: []string{"--dry-run", "contact", "exclusive-account", "enable", "--staff-id", "user001"},
+			want: []string{"exclusive_account_set_status", "uesrId", "user001", "enable"},
+		},
+		{
+			name: "org invite switch",
+			args: []string{"--dry-run", "contact", "org", "invite-switch", "--open", "true", "--search-invite", "false"},
+			want: []string{"set_org_invite_switch", `"open": true`, `"searchInviteSwitch": false`},
+		},
+		{
+			name: "org invite audit open",
+			args: []string{"--dry-run", "contact", "org", "invite-audit", "--no-audit"},
+			want: []string{"set_org_apply_audit", `"auditType": 0`},
+		},
+		{
+			name: "org invite audit close",
+			args: []string{"--dry-run", "contact", "org", "invite-audit", "--no-audit=false"},
+			want: []string{"set_org_apply_audit", `"auditType": 1`},
+		},
+		{
+			name: "org invite info",
+			args: []string{"--dry-run", "contact", "org", "invite-info"},
+			want: []string{"get_org_invite_info"},
+		},
+		{
+			name: "org invite list defaults",
+			args: []string{"--dry-run", "contact", "org", "invite-list"},
+			want: []string{"list_team_invite", `"status": 1`, `"size": 20`},
+		},
+		{
+			name: "org invite list paging",
+			args: []string{"--dry-run", "contact", "org", "invite-list", "--status", "2", "--cursor", "33", "--size", "50"},
+			want: []string{"list_team_invite", `"status": 2`, `"cursor": 33`, `"size": 50`},
+		},
+		{
+			name: "org apply list all",
+			args: []string{"--dry-run", "contact", "org", "apply-list", "--status", "0"},
+			want: []string{"query_org_apply_list", `"status": 0`},
+		},
+		{
+			name: "org apply approve",
+			args: []string{"--dry-run", "contact", "org", "apply-approve", "--id", "123"},
+			want: []string{"approve_org_apply", `"id": 123`},
+		},
+		{
+			name: "org apply reject",
+			args: []string{"--dry-run", "contact", "org", "apply-reject", "--id", "123", "--reason", "不符合入职条件"},
+			want: []string{"reject_org_apply", `"id": 123`, "reason", "不符合入职条件"},
+		},
+		{
+			name: "org apply block",
+			args: []string{"--dry-run", "contact", "org", "apply-block", "--id", "123", "--reason", "恶意重复申请"},
+			want: []string{"block_org_apply", `"id": 123`, "reason", "恶意重复申请"},
+		},
+		{
+			name: "org apply remove",
+			args: []string{"--dry-run", "contact", "org", "apply-remove", "--id", "123"},
+			want: []string{"remove_org_apply", `"id": 123`},
+		},
+		{
+			name: "dept invite audit",
+			args: []string{"--dry-run", "contact", "dept", "invite-audit", "--dept", "12345", "--no-audit"},
+			want: []string{"set_dept_apply_audit", `"deptId": 12345`, `"auditType": 0`},
+		},
+		{
+			name: "dept invite audit emp apply join",
+			args: []string{"--dry-run", "contact", "dept", "invite-audit", "--dept", "12345", "--no-audit", "--emp-apply-join-dept", "true"},
+			want: []string{"set_dept_apply_audit", `"deptId": 12345`, `"auditType": 0`, `"empApplyJoinDept": true`},
+		},
+		{
+			// pflag 布尔 flag 不吞并后置值：--no-audit true 中的 "true" 是位置参数，
+			// contactNoAuditArgs 需将其归并回 flag 值而不是拒绝。
+			name: "org invite audit positional bool tolerance",
+			args: []string{"--dry-run", "contact", "org", "invite-audit", "--no-audit", "false"},
+			want: []string{"set_org_apply_audit", `"auditType": 1`},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := executeRootCaptureStdout(t, tc.args)
+			if err != nil {
+				t.Fatalf("Execute(%v) error = %v\n%s", tc.args, err, got)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("Execute(%v) output missing %q:\n%s", tc.args, want, got)
+				}
+			}
+		})
+	}
+
+	// 负例：--no-audit 必须显式传值（dry-run 已绕过确认 gate，能命中参数校验）。
+	if got, err := executeRootCaptureStdout(t, []string{"--dry-run", "contact", "org", "invite-audit"}); err == nil || !strings.Contains(err.Error(), "--no-audit") {
+		t.Fatalf("org invite-audit without --no-audit should fail with a no-audit hint, got err = %v\n%s", err, got)
+	}
+	if got, err := executeRootCaptureStdout(t, []string{"--dry-run", "contact", "org", "invite-list", "--status", "9"}); err == nil || !strings.Contains(err.Error(), "--status") {
+		t.Fatalf("org invite-list --status 9 should fail with a status hint, got err = %v\n%s", err, got)
+	}
+	if got, err := executeRootCaptureStdout(t, []string{"--dry-run", "contact", "org", "apply-reject", "--id", "123"}); err == nil || !strings.Contains(err.Error(), "--reason") {
+		t.Fatalf("org apply-reject without --reason should fail with a reason hint, got err = %v\n%s", err, got)
+	}
+}
+
 func TestChatConversationFileUploadUsesANewPath(t *testing.T) {
 	root := NewRootCommand()
 	fileCmd := mustFindCommand(t, root, "chat", "file")

--- a/internal/app/root_help_test.go
+++ b/internal/app/root_help_test.go
@@ -127,6 +127,7 @@ func TestLeafHelpRendersSelectionSafetyAndReferences(t *testing.T) {
 		{path: "contract record list", wantEffect: "read", wantConfirm: "not_required", wantSkill: "dingtalk-misc", wantDocument: "references/contract.md"},
 		{path: "contract subject delete", wantEffect: "destructive", wantConfirm: "user_required", wantSkill: "dingtalk-misc", wantDocument: "references/contract.md"},
 		{path: "contact org apply-list", wantEffect: "write", wantConfirm: "not_required", wantSkill: "dingtalk-contact", wantDocument: "references/contact.md"},
+		{path: "contact org apply-remove", wantEffect: "destructive", wantConfirm: "user_required", wantSkill: "dingtalk-contact", wantDocument: "references/contact.md"},
 	} {
 		t.Run(strings.ReplaceAll(tc.path, " ", "_"), func(t *testing.T) {
 			root := NewRootCommand()
@@ -995,6 +996,60 @@ func TestContactApplyListSchemaProjectionMatchesRuntimeBehavior(t *testing.T) {
 		}
 		if want := map[string]any{"status": int64(1), "size": int64(20)}; !reflect.DeepEqual(call.args, want) {
 			t.Fatalf("apply-list args = %#v, want %#v", call.args, want)
+		}
+	})
+}
+
+// TestContactApplyRemoveSchemaProjectionMatchesRuntimeBehavior 是 apply-remove
+// 安全语义的回归：删除申请记录不可恢复，最终 Schema 投影必须声明
+// Effect=destructive；必须保留 user_required 确认门禁，未确认不得调用 MCP，
+// 确认后精确调用 remove_org_apply。投影与运行行为任一侧回归都会被拦截。
+func TestContactApplyRemoveSchemaProjectionMatchesRuntimeBehavior(t *testing.T) {
+	t.Run("schema projection discloses non-recoverable deletion", func(t *testing.T) {
+		meta, ok := cli.ResolveMeta("contact org apply-remove")
+		if !ok {
+			t.Fatal("ResolveMeta(contact org apply-remove) missing")
+		}
+		if meta.Safety.Effect != "destructive" {
+			t.Fatalf("apply-remove effect = %q, want destructive (record deletion is not recoverable)", meta.Safety.Effect)
+		}
+		if meta.Safety.Risk != "high" || meta.Safety.Confirmation != "user_required" || meta.Safety.Idempotency != "non_idempotent" {
+			t.Fatalf("apply-remove safety = %+v, want high/user_required/non_idempotent", meta.Safety)
+		}
+		if !strings.Contains(meta.Selection.AgentSummary, "不可恢复") {
+			t.Fatalf("apply-remove agent summary %q must disclose non-recoverable deletion", meta.Selection.AgentSummary)
+		}
+	})
+
+	t.Run("user_required projection rejects until explicitly confirmed", func(t *testing.T) {
+		recorder := &contactWriteOpsRecorder{}
+		err := executeContactWriteOp(t, recorder, []string{"contact", "org", "apply-remove", "--id", "123"})
+		if err == nil {
+			t.Fatal("apply-remove without --yes must be rejected")
+		}
+		if !apperrors.IsConfirmationRequired(err) {
+			t.Fatalf("apply-remove error = %v, want reason confirmation_required", err)
+		}
+		if len(recorder.calls) != 0 {
+			t.Fatalf("apply-remove must not reach MCP before confirmation, got calls: %+v", recorder.calls)
+		}
+	})
+
+	t.Run("explicit yes executes exactly remove_org_apply", func(t *testing.T) {
+		recorder := &contactWriteOpsRecorder{}
+		err := executeContactWriteOp(t, recorder, []string{"contact", "org", "apply-remove", "--id", "123", "--yes"})
+		if err != nil {
+			t.Fatalf("apply-remove with --yes failed: %v", err)
+		}
+		if len(recorder.calls) != 1 {
+			t.Fatalf("apply-remove with --yes want exactly 1 MCP call, got %d: %+v", len(recorder.calls), recorder.calls)
+		}
+		call := recorder.calls[0]
+		if call.server != "contact" || call.tool != "remove_org_apply" {
+			t.Fatalf("apply-remove call = %s/%s, want contact/remove_org_apply", call.server, call.tool)
+		}
+		if want := map[string]any{"id": int64(123)}; !reflect.DeepEqual(call.args, want) {
+			t.Fatalf("apply-remove args = %#v, want %#v", call.args, want)
 		}
 	})
 }

--- a/internal/app/schema_contact_org_list_contract_test.go
+++ b/internal/app/schema_contact_org_list_contract_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
+)
+
+// schemaString normalizes a schema payload value to string for assertions.
+func schemaString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func contactOrgListSchemaLeaf(t *testing.T, canonical string, compact bool) map[string]any {
+	t.Helper()
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	args := []string{"schema", canonical, "--format", "json"}
+	if compact {
+		args = append(args, "--compact")
+	}
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute schema %s compact=%v: %v; stderr=%s", canonical, compact, err, stderr.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode schema %s compact=%v: %v", canonical, compact, err)
+	}
+	return payload
+}
+
+// TestContactOrgListSchemaPublishesPaginationAndStripsCursorFields 验证
+// contact.list_team_invite 与 contact.query_org_apply_list 的 full/compact
+// 最终投影都发布统一 Pagination 契约，且业务 Result.DataSchema 不再包含
+// hasMore/nextCursor 等内部分页字段。
+func TestContactOrgListSchemaPublishesPaginationAndStripsCursorFields(t *testing.T) {
+	for _, canonical := range []string{"contact.list_team_invite", "contact.query_org_apply_list"} {
+		t.Run(canonical, func(t *testing.T) {
+			full := contactOrgListSchemaLeaf(t, canonical, false)
+			compact := contactOrgListSchemaLeaf(t, canonical, true)
+
+			if full["result"] == nil || compact["result"] == nil {
+				t.Fatalf("result missing: full=%#v compact=%#v", full["result"], compact["result"])
+			}
+			if !strings.EqualFold(schemaString(full["result"].(map[string]any)["data_schema"].(map[string]any)["type"]), "object") {
+				t.Fatalf("full result data_schema is not object: %#v", full["result"])
+			}
+			if !strings.EqualFold(schemaString(compact["result"].(map[string]any)["data_schema"].(map[string]any)["type"]), "object") {
+				t.Fatalf("compact result data_schema is not object: %#v", compact["result"])
+			}
+
+			fullResult := full["result"].(map[string]any)
+			compactResult := compact["result"].(map[string]any)
+			fullDataSchema, _ := json.Marshal(fullResult["data_schema"])
+			compactDataSchema, _ := json.Marshal(compactResult["data_schema"])
+			for _, s := range []string{string(fullDataSchema), string(compactDataSchema)} {
+				if strings.Contains(s, "hasMore") || strings.Contains(s, "nextCursor") {
+					t.Fatalf("%s data_schema must not contain pagination fields: %s", canonical, s)
+				}
+			}
+
+			if full["pagination"] == nil || compact["pagination"] == nil {
+				t.Fatalf("pagination missing: full=%#v compact=%#v", full["pagination"], compact["pagination"])
+			}
+			if !reflect.DeepEqual(full["pagination"], compact["pagination"]) {
+				t.Fatalf("full/compact pagination mismatch\nfull=%#v\ncompact=%#v", full["pagination"], compact["pagination"])
+			}
+			pg := full["pagination"].(map[string]any)
+			if schemaString(pg["kind"]) != contract.PaginationKindCursor {
+				t.Fatalf("%s pagination.kind = %v, want %s", canonical, pg["kind"], contract.PaginationKindCursor)
+			}
+			if schemaString(pg["cursor_parameter"]) != "cursor" {
+				t.Fatalf("%s pagination.cursor_parameter = %v, want cursor", canonical, pg["cursor_parameter"])
+			}
+			if schemaString(pg["meta_path"]) != contract.PaginationMetaPath {
+				t.Fatalf("%s pagination.meta_path = %v, want %s", canonical, pg["meta_path"], contract.PaginationMetaPath)
+			}
+		})
+	}
+}

--- a/internal/helpers/contact.go
+++ b/internal/helpers/contact.go
@@ -3017,9 +3017,12 @@ contact user profile fields 获取可用字段列表。
 	})
 
 	contactOrgApplyListCmd := newContactOrgApplyListCommand()
+	// Safety：查询会把服务端未读申请标记为已读（见 Long 帮助），因此 Effect
+	// 如实声明为 write（对齐 chat mark-read 先例）；副作用仅清除未读标记，
+	// Risk 仍为 low 且无需用户确认，重复查询幂等。
 	DeclareLeafMetadata(contactOrgApplyListCmd, LeafSpec{
 		Safety: contract.SafetySpec{
-			Effect: "read", Risk: "low",
+			Effect: "write", Risk: "low",
 			Confirmation: "not_required", Idempotency: "idempotent",
 		},
 		Contract: LeafContract{
@@ -3030,7 +3033,7 @@ contact user profile fields 获取可用字段列表。
 				CLIPath:        "contact org apply-list",
 				PrimaryCLIPath: "contact org apply-list",
 			},
-			Description: "分页查询用户主动申请加入企业的记录（可按状态筛选），返回申请 ID 供后续审批命令使用",
+			Description: "分页查询用户主动申请加入企业的记录（可按状态筛选），返回申请 ID 供后续审批命令使用；查询后服务端会把未读申请标记为已读",
 			Result: &contract.ResultSpec{
 				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
 				DataSchema: json.RawMessage(`{"type":"object","description":"加入企业申请列表","properties":{"result":{"type":"object","description":"申请记录列表","properties":{"values":{"type":"array","description":"申请记录","items":{"type":"object","properties":{"id":{"type":"number","description":"申请记录ID，供 apply-approve/reject/block/remove 使用"},"status":{"type":"number","description":"申请状态：1=未处理，2=已通过，3=已拒绝，4=已屏蔽"},"content":{"type":"string","description":"申请人姓名"},"gmtCreate":{"type":"number","description":"申请时间（毫秒时间戳）"},"dept":{"type":"object","description":"申请加入的部门","properties":{"deptId":{"type":"number","description":"部门ID"},"deptName":{"type":"string","description":"部门名称"},"deptPathName":{"type":"string","description":"部门名称全路径"}}},"inviterEmployeeModel":{"type":"object","description":"邀请人信息","properties":{"nick":{"type":"string","description":"邀请人昵称"},"name":{"type":"string","description":"邀请人姓名"}}},"optEmployeeModel":{"type":"object","description":"操作人信息","properties":{"nick":{"type":"string","description":"操作人昵称"},"name":{"type":"string","description":"操作人姓名"}}}}}},"hasMore":{"type":"boolean","description":"是否还有更多数据"},"nextCursor":{"type":"number","description":"下一页游标，hasMore=true 时传回继续翻页"}}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
@@ -3041,9 +3044,9 @@ contact user profile fields 获取可用字段列表。
 				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "query_org_apply_list"},
 			},
 			Selection: contract.SelectionSpec{
-				AgentSummary: "查询用户申请加入企业的记录列表",
-				UseWhen:      []string{"用户需要查看待处理/已处理的企业加入申请，或需要获取申请 ID 以便审批（同意/拒绝/屏蔽/删除）"},
-				AvoidWhen:    []string{"查询管理员发出的邀请记录用 contact org invite-list；直接审批时仍应先读本命令确认申请人与状态"},
+				AgentSummary: "查询用户申请加入企业的记录列表（查询会把未读申请标记为已读）",
+				UseWhen:      []string{"用户需要查看待处理/已处理的企业加入申请，或需要获取申请 ID 以便审批（同意/拒绝/屏蔽/删除）；注意查询会把服务端未读申请标记为已读，属有副作用的查询"},
+				AvoidWhen:    []string{"查询管理员发出的邀请记录用 contact org invite-list；直接审批时仍应先读本命令确认申请人与状态，注意本命令会清除未读标记"},
 				Examples: []string{
 					"dws contact org apply-list",
 					"dws contact org apply-list --status 0 --size 50",

--- a/internal/helpers/contact.go
+++ b/internal/helpers/contact.go
@@ -899,6 +899,411 @@ func newContactAccountUpdateCommand() *cobra.Command {
 	return cmd
 }
 
+// ── 企业申请/邀请与账号状态辅助解析 ──────────────────────────
+
+// contactParseStatusWithAliases 解析必填的整型状态 flag 并校验枚举取值。
+// allowedDesc 用于报错文案（如 "1（未处理）/ 2（已同意）"）。
+func contactParseStatusWithAliases(cmd *cobra.Command, primary, allowedDesc string, allowedValues ...int64) (int64, error) {
+	if err := validateRequiredFlagWithAliases(cmd, primary); err != nil {
+		return 0, err
+	}
+	raw := strings.TrimSpace(flagOrFallback(cmd, primary))
+	setName := contactFirstSetFlagName(cmd, primary)
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("--%s 必须是整数: %w", setName, err)
+	}
+	for _, allowed := range allowedValues {
+		if v == allowed {
+			return v, nil
+		}
+	}
+	return 0, fmt.Errorf("--%s 取值必须是 %s，当前值 %d", setName, allowedDesc, v)
+}
+
+// contactParsePageSizeWithAliases 解析每页条数 flag（默认值在注册时给出），校验 1..max 区间。
+func contactParsePageSizeWithAliases(cmd *cobra.Command, primary string, max int64, aliases ...string) (int64, error) {
+	raw := strings.TrimSpace(flagOrFallback(cmd, primary, aliases...))
+	setName := contactFirstSetFlagName(cmd, append([]string{primary}, aliases...)...)
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("--%s 必须是整数: %w", setName, err)
+	}
+	if v < 1 || v > max {
+		return 0, fmt.Errorf("--%s 取值范围 1-%d，当前值 %d", setName, max, v)
+	}
+	return v, nil
+}
+
+// contactParseOptionalInt64WithAliases 解析可选整型 flag；未传或传空返回 (0, false)。
+func contactParseOptionalInt64WithAliases(cmd *cobra.Command, primary string, aliases ...string) (int64, bool, error) {
+	if !contactAnyFlagChanged(cmd, append([]string{primary}, aliases...)...) {
+		return 0, false, nil
+	}
+	raw := strings.TrimSpace(flagOrFallback(cmd, primary, aliases...))
+	if raw == "" {
+		return 0, false, nil
+	}
+	setName := contactFirstSetFlagName(cmd, append([]string{primary}, aliases...)...)
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("--%s 必须是整数: %w", setName, err)
+	}
+	return v, true, nil
+}
+
+// contactOptionalBoolFlag 读取可选布尔 flag（String 注册，值 true/false）；
+// 未传或传空返回 nil，传入但解析失败时报错。
+func contactOptionalBoolFlag(cmd *cobra.Command, name string) (*bool, error) {
+	if !cmd.Flags().Changed(name) {
+		return nil, nil
+	}
+	raw := strings.TrimSpace(mustGetFlag(cmd, name))
+	if raw == "" {
+		return nil, nil
+	}
+	v, err := strconv.ParseBool(raw)
+	if err != nil {
+		return nil, fmt.Errorf("--%s 必须是 boolean（true/false）: %w", name, err)
+	}
+	return &v, nil
+}
+
+// contactRequireNoAuditFlag 读取 --no-audit 布尔 flag（必须显式传值），
+// 返回对应 auditType：true→0（免审核），false→1（需管理员审核）。
+func contactRequireNoAuditFlag(cmd *cobra.Command) (int64, error) {
+	if !cmd.Flags().Changed("no-audit") {
+		return 0, fmt.Errorf("必须显式传 --no-audit true/false：true=免审核（申请自动通过），false=需管理员审核")
+	}
+	noAudit, err := cmd.Flags().GetBool("no-audit")
+	if err != nil {
+		return 0, fmt.Errorf("--no-audit 解析失败: %w", err)
+	}
+	if noAudit {
+		return 0, nil
+	}
+	return 1, nil
+}
+
+// contactParseOrgApplyID 解析成员申请记录 ID（来自 org apply-list 返回的 id 字段）。
+func contactParseOrgApplyID(cmd *cobra.Command, primary string, aliases ...string) (int64, error) {
+	if err := validateRequiredFlagWithAliases(cmd, primary, aliases...); err != nil {
+		return 0, err
+	}
+	raw := strings.TrimSpace(flagOrFallback(cmd, primary, aliases...))
+	setName := contactFirstSetFlagName(cmd, append([]string{primary}, aliases...)...)
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("--%s 必须是整数（申请记录 ID 来自 dws contact org apply-list 的 id 字段）: %w", setName, err)
+	}
+	return v, nil
+}
+
+// contactNoAuditArgs 是 org/dept invite-audit 的 Args 校验：正常拒绝位置参数，
+// 但将 pflag 布尔 flag 不吞并的后置值（--no-audit true / --no-audit false）
+// 归并回 flag 值，避免用户/LLM 的常见写法被当作位置参数拒绝。
+func contactNoAuditArgs(cmd *cobra.Command, args []string) error {
+	if len(args) == 1 && cmd.Flags().Changed("no-audit") {
+		switch strings.ToLower(strings.TrimSpace(args[0])) {
+		case "true", "false":
+			_ = cmd.Flags().Set("no-audit", args[0])
+			args = nil
+		}
+	}
+	if len(args) > 0 {
+		return fmt.Errorf("unknown command %q（--no-audit 为布尔 flag：裸传 --no-audit 即 true，显式取值用 --no-audit=false）", args[0])
+	}
+	return nil
+}
+
+// newContactExclusiveAccountSetStatusCommand 构造 exclusive-account disable/enable 命令。
+// 两者共用 exclusive_account_set_status MCP 工具，目标状态由 statusValue 固定。
+func newContactExclusiveAccountSetStatusCommand(verb, verbLabel, statusValue string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   verb,
+		Short: verbLabel + "企业账号",
+		Long:  verbLabel + "当前企业的专属登录账号（停用后该账号无法登录钉钉，启用后恢复登录）。需要企业管理员权限，执行前需要确认。",
+		Example: `  dws contact exclusive-account ` + verb + ` --staff-id user001
+
+  # 查询 userId: dws contact user search --keyword "姓名"`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := validateRequiredFlagWithAliases(cmd, "staff-id", "user-id", "userid", "staffId"); err != nil {
+				return err
+			}
+			staffID := strings.TrimSpace(flagOrFallback(cmd, "staff-id", "user-id", "userid", "staffId"))
+			if staffID == "" {
+				return fmt.Errorf("--%s 不能为空", contactFirstSetFlagName(cmd, "staff-id", "user-id", "userid", "staffId"))
+			}
+			return callMCPTool("exclusive_account_set_status", map[string]any{
+				// MCP 工具运行时入参字段名为 uesrId（平台 inputMappings 的历史笔误，
+				// 已发布版本不可改名），CLI 传参必须与其保持一致，勿"修正"为 userId。
+				"uesrId": staffID,
+				"status": statusValue,
+			})
+		},
+	}
+	cmd.Flags().String("staff-id", "", "企业账号的员工 userid (必填)")
+	cmd.Flags().String("user-id", "", "--staff-id 的别名")
+	cmd.Flags().String("userid", "", "--staff-id 的别名")
+	_ = cmd.Flags().MarkHidden("user-id")
+	_ = cmd.Flags().MarkHidden("userid")
+	cli.AnnotateRuntimeRequiredFlags(cmd, "staff-id")
+	return cmd
+}
+
+// newContactOrgInviteSwitchCommand 构造 contact org invite-switch 命令。
+func newContactOrgInviteSwitchCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "invite-switch",
+		Short: "设置加入企业申请开关",
+		Long: `设置用户申请加入企业的开关：总开关 --open（是否允许用户申请加入企业），以及三个子开关
+--search-invite（搜索团队名称申请）、--apply-code-invite（填写团队号申请）、--link-invite（链接和二维码申请）。
+子开关不传表示保持当前值不变。返回更新后的企业邀请信息。需要超级管理员权限，执行前需要确认。
+
+【相关命令】
+  - 只查看当前开关状态（不修改）→ contact org invite-info`,
+		Example: `  dws contact org invite-switch --open true
+  dws contact org invite-switch --open true --search-invite false --link-invite true`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			open, err := contactParseBoolWithAliases(cmd, "open")
+			if err != nil {
+				return err
+			}
+			toolArgs := map[string]any{"open": open}
+			if v, err := contactOptionalBoolFlag(cmd, "search-invite"); err != nil {
+				return err
+			} else if v != nil {
+				toolArgs["searchInviteSwitch"] = *v
+			}
+			if v, err := contactOptionalBoolFlag(cmd, "apply-code-invite"); err != nil {
+				return err
+			} else if v != nil {
+				toolArgs["orgApplyCodeInviteSwitch"] = *v
+			}
+			if v, err := contactOptionalBoolFlag(cmd, "link-invite"); err != nil {
+				return err
+			} else if v != nil {
+				toolArgs["linkInviteSwitch"] = *v
+			}
+			return callMCPTool("set_org_invite_switch", toolArgs)
+		},
+	}
+	cmd.Flags().String("open", "", "申请加入企业总开关：true=允许用户申请加入企业 (必填)")
+	cmd.Flags().String("search-invite", "", "搜索团队名称申请加入开关：true/false（可选，不传保持不变）")
+	cmd.Flags().String("apply-code-invite", "", "填写团队号申请加入开关：true/false（可选，不传保持不变）")
+	cmd.Flags().String("link-invite", "", "链接和二维码申请加入开关：true/false（可选，不传保持不变）")
+	cli.AnnotateRuntimeRequiredFlags(cmd, "open")
+	return cmd
+}
+
+// newContactOrgInviteAuditCommand 构造 contact org invite-audit 命令（企业级免审核）。
+func newContactOrgInviteAuditCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "invite-audit",
+		Short: "设置加入企业申请免审核（企业级）",
+		Long: `设置【企业级】申请加入企业的审核策略：--no-audit 开启免审核（auditType=0，申请自动通过、无需管理员审核），
+--no-audit=false 恢复需管理员审核（auditType=1）。执行前需要确认。
+
+【相关命令】
+  - 只设置某个部门的免审核 → contact dept invite-audit --dept <deptId> --no-audit
+  - 查看当前审核类型      → contact org invite-info`,
+		Example: `  dws contact org invite-audit --no-audit            # 开启免审核（申请自动通过）
+  dws contact org invite-audit --no-audit=false      # 恢复需管理员审核`,
+		Args: contactNoAuditArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			auditType, err := contactRequireNoAuditFlag(cmd)
+			if err != nil {
+				return err
+			}
+			return callMCPTool("set_org_apply_audit", map[string]any{"auditType": auditType})
+		},
+	}
+	cmd.Flags().Bool("no-audit", false, "裸传 --no-audit 即开启免审核（auditType=0，申请自动通过），--no-audit=false 恢复需管理员审核（auditType=1）(必填)")
+	cli.AnnotateRuntimeRequiredFlags(cmd, "no-audit")
+	return cmd
+}
+
+// newContactDeptInviteAuditCommand 构造 contact dept invite-audit 命令（部门级免审核）。
+func newContactDeptInviteAuditCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "invite-audit",
+		Short: "设置加入部门申请免审核（部门级）",
+		Long: `设置指定部门的申请加入免审核策略：--no-audit 开启免审核（auditType=0，非组织内成员申请加入该部门时自动通过），
+--no-audit=false 恢复需管理员审核（auditType=1）。执行前需要确认。
+
+免审核开启时可传 --emp-apply-join-dept 控制【组织内成员】能否直接申请加入该部门
+（true=允许，false=不允许；仅免审核开启时生效，不传默认 false）。
+
+【相关命令】
+  - 企业级免审核 → contact org invite-audit --no-audit`,
+		Example: `  dws contact dept invite-audit --dept 12345 --no-audit
+  dws contact dept invite-audit --dept 12345 --no-audit --emp-apply-join-dept true`,
+		Args: contactNoAuditArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			deptID, err := contactParseInt64WithAliases(cmd, "dept", "dept-id", "deptId", "id")
+			if err != nil {
+				return err
+			}
+			auditType, err := contactRequireNoAuditFlag(cmd)
+			if err != nil {
+				return err
+			}
+			toolArgs := map[string]any{"deptId": deptID, "auditType": auditType}
+			if v, err := contactOptionalBoolFlag(cmd, "emp-apply-join-dept"); err != nil {
+				return err
+			} else if v != nil {
+				toolArgs["empApplyJoinDept"] = *v
+			}
+			return callMCPTool("set_dept_apply_audit", toolArgs)
+		},
+	}
+	cmd.Flags().String("dept", "", "部门 ID (必填)；根部门传 1")
+	cmd.Flags().String("dept-id", "", "--dept 的别名")
+	_ = cmd.Flags().MarkHidden("dept-id")
+	cmd.Flags().Bool("no-audit", false, "裸传 --no-audit 即开启免审核（auditType=0，申请自动通过），--no-audit=false 恢复需管理员审核（auditType=1）(必填)")
+	cmd.Flags().String("emp-apply-join-dept", "", "免审核开启时是否允许组织内成员申请加入该部门：true/false（可选，默认 false）")
+	cli.AnnotateRuntimeRequiredFlags(cmd, "dept", "no-audit")
+	return cmd
+}
+
+// newContactOrgInviteListCommand 构造 contact org invite-list 命令。
+func newContactOrgInviteListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "invite-list",
+		Short: "查询企业邀请记录列表",
+		Long: `分页查询企业已发出的成员邀请记录（管理员邀请加入企业的记录），按创建时间倒序。
+--status 筛选：1=未处理（默认），2=已同意，3=已忽略或失效。
+主管理员/创建者/超级管理员可查看所有邀请记录，子管理员仅能查看自己邀请的成员。`,
+		Example: `  dws contact org invite-list
+  dws contact org invite-list --status 2 --size 50
+  dws contact org invite-list --cursor 20   # 翻页：cursor 传上一页返回的 nextCursor`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			status, err := contactParseStatusWithAliases(cmd, "status", "1（未处理）/ 2（已同意）/ 3（已忽略）", 1, 2, 3)
+			if err != nil {
+				return err
+			}
+			size, err := contactParsePageSizeWithAliases(cmd, "size", 100)
+			if err != nil {
+				return err
+			}
+			toolArgs := map[string]any{"status": status, "size": size}
+			if cursor, ok, err := contactParseOptionalInt64WithAliases(cmd, "cursor"); err != nil {
+				return err
+			} else if ok {
+				toolArgs["cursor"] = cursor
+			}
+			return callMCPTool("list_team_invite", toolArgs)
+		},
+	}
+	cmd.Flags().String("status", "1", "邀请状态：1=未处理，2=已同意，3=已忽略或失效（默认 1）")
+	cmd.Flags().String("size", "20", "每页条数，1-100（默认 20）")
+	cmd.Flags().String("cursor", "", "分页游标；首页不传，翻页时传上一页返回的 nextCursor（可选）")
+	return cmd
+}
+
+// newContactOrgApplyListCommand 构造 contact org apply-list 命令。
+func newContactOrgApplyListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apply-list",
+		Short: "查询加入企业申请列表",
+		Long: `分页查询用户主动申请加入企业的记录，供管理员审批处理。
+--status 筛选：0=全部，1=未处理（默认），2=已通过，3=已拒绝，4=已屏蔽。
+返回申请 ID（id）、申请人姓名（content）、申请说明、状态、申请时间、申请加入的部门、邀请人/操作人信息；
+hasMore=true 时用 nextCursor 翻页。
+
+注意：查询后未读申请会被标记为已读。
+后续审批：contact org apply-approve / apply-reject / apply-block / apply-remove（均传本命令返回的 id）。`,
+		Example: `  dws contact org apply-list
+  dws contact org apply-list --status 0 --size 50
+  dws contact org apply-list --cursor 20   # 翻页：cursor 传上一页返回的 nextCursor`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			status, err := contactParseStatusWithAliases(cmd, "status", "0（全部）/ 1（未处理）/ 2（已通过）/ 3（已拒绝）/ 4（已屏蔽）", 0, 1, 2, 3, 4)
+			if err != nil {
+				return err
+			}
+			size, err := contactParsePageSizeWithAliases(cmd, "size", 100)
+			if err != nil {
+				return err
+			}
+			toolArgs := map[string]any{"status": status, "size": size}
+			if cursor, ok, err := contactParseOptionalInt64WithAliases(cmd, "cursor"); err != nil {
+				return err
+			} else if ok {
+				toolArgs["cursor"] = cursor
+			}
+			return callMCPTool("query_org_apply_list", toolArgs)
+		},
+	}
+	cmd.Flags().String("status", "1", "申请状态：0=全部，1=未处理，2=已通过，3=已拒绝，4=已屏蔽（默认 1）")
+	cmd.Flags().String("size", "20", "每页条数，1-100（默认 20）")
+	cmd.Flags().String("cursor", "", "分页游标；首页不传，翻页时传上一页返回的 nextCursor（可选）")
+	return cmd
+}
+
+// contactOrgApplyDecisionSpec 描述 apply-approve / apply-reject / apply-block / apply-remove
+// 四个成员申请审批命令的差异，共用 newContactOrgApplyDecisionCommand 构造。
+type contactOrgApplyDecisionSpec struct {
+	use        string   // 子命令名
+	verbLabel  string   // 中文动词（同意/拒绝/屏蔽/删除）
+	toolName   string   // MCP 工具名
+	risk       string   // Safety 风险级别
+	withReason bool     // 是否需要 --reason
+	aliases    []string // 子命令别名
+}
+
+// newContactOrgApplyDecisionCommand 构造成员申请审批命令（approve/reject/block/remove）。
+func newContactOrgApplyDecisionCommand(spec contactOrgApplyDecisionSpec) *cobra.Command {
+	long := spec.verbLabel + "指定的「申请加入企业」记录，申请记录 ID 来自 contact org apply-list 返回的 id 字段。执行前需要确认。"
+	if spec.withReason {
+		long += "\n--reason 为" + spec.verbLabel + "原因，会记录在申请处理记录中 (必填)。"
+	}
+	example := fmt.Sprintf("  dws contact org %s --id 12345", spec.use)
+	if spec.withReason {
+		example += ` --reason "不符合入职条件"`
+	}
+	example += "\n\n  # 查询申请 ID: dws contact org apply-list"
+	cmd := &cobra.Command{
+		Use:     spec.use,
+		Aliases: spec.aliases,
+		Short:   spec.verbLabel + "加入企业申请",
+		Long:    long,
+		Example: example,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			applyID, err := contactParseOrgApplyID(cmd, "id", "apply-id", "applyId")
+			if err != nil {
+				return err
+			}
+			toolArgs := map[string]any{"id": applyID}
+			if spec.withReason {
+				if err := validateRequiredFlagWithAliases(cmd, "reason"); err != nil {
+					return err
+				}
+				reason := strings.TrimSpace(flagOrFallback(cmd, "reason"))
+				if reason == "" {
+					return fmt.Errorf("--reason 不能为空")
+				}
+				toolArgs["reason"] = reason
+			}
+			return callMCPTool(spec.toolName, toolArgs)
+		},
+	}
+	cmd.Flags().String("id", "", "申请记录 ID (必填)，来自 contact org apply-list 的 id 字段")
+	cmd.Flags().String("apply-id", "", "--id 的别名")
+	_ = cmd.Flags().MarkHidden("apply-id")
+	required := []string{"id"}
+	if spec.withReason {
+		cmd.Flags().String("reason", "", spec.verbLabel+"原因 (必填)")
+		required = append(required, "reason")
+	}
+	cli.AnnotateRuntimeRequiredFlags(cmd, required...)
+	return cmd
+}
+
 func newContactCommand() *cobra.Command {
 	// Product-level Agent routing Decl (migrated from selection/contact.json
 	// products.contact). Catalog assembly stamps provenance contract_final.
@@ -1536,7 +1941,21 @@ func newContactCommand() *cobra.Command {
 		contactLabelListMembersCmd,
 	)
 
-	contactDeptCmd := newGroupCommand(&cobra.Command{Use: "dept", Short: "部门查询", RunE: groupRunE})
+	contactDeptCmd := newGroupCommand(&cobra.Command{
+		Use:   "dept",
+		Short: "部门管理",
+		Long: `部门管理：部门查询（搜索、详情、子部门、成员列表）、创建/更新部门，以及部门级申请免审核设置。
+
+【何时用哪个命令】
+  - 搜索部门                           → contact dept search
+  - 查询部门详情                       → contact dept get-info
+  - 查询子部门列表                     → contact dept list-children
+  - 查询部门成员列表                   → contact dept list-members
+  - 创建部门                           → contact dept create
+  - 更新部门名称/父部门                → contact dept update
+  - 设置部门级申请免审核                → contact dept invite-audit`,
+		RunE: groupRunE,
+	})
 
 	contactDeptSearchCmd := &cobra.Command{
 		Use:     "search",
@@ -2297,6 +2716,46 @@ contact user profile fields 获取可用字段列表。
 			_ = s.cmd.Flags().MarkHidden(name)
 		}
 	}
+	contactDeptInviteAuditCmd := newContactDeptInviteAuditCommand()
+	DeclareLeafMetadata(contactDeptInviteAuditCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "write", Risk: "medium",
+			Confirmation: "user_required", Idempotency: "idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "set_dept_apply_audit",
+				CanonicalPath:  "contact.set_dept_apply_audit",
+				CLIPath:        "contact dept invite-audit",
+				PrimaryCLIPath: "contact dept invite-audit",
+			},
+			Description: "设置指定部门的申请加入免审核策略：--no-audit true 免审核（auditType=0），false 需管理员审核（auditType=1）",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"部门免审核设置结果","properties":{"result":{"type":"object","description":"调用结果","properties":{}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "set_dept_apply_audit"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "设置指定部门的申请加入免审核策略",
+				UseWhen:      []string{"用户明确要求设置某个部门的申请免审核（部门 ID 已确认）"},
+				AvoidWhen:    []string{"企业级免审核用 contact org invite-audit；未确认部门 ID 时先用 contact dept search / get-info 查询"},
+				Examples: []string{
+					"dws contact dept invite-audit --dept 12345 --no-audit",
+					"dws contact dept invite-audit --dept 12345 --no-audit --emp-apply-join-dept true",
+				},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "dept", Property: "deptId", Required: boolPtr(true), InterfaceType: "integer", Description: "部门 ID；根部门传 1（服务端自动映射）"},
+				{Name: "no-audit", Property: "auditType", Required: boolPtr(true), InterfaceType: "boolean", Description: "true=免审核（auditType=0），false=需管理员审核（auditType=1）"},
+				{Name: "emp-apply-join-dept", Property: "empApplyJoinDept", Required: boolPtr(false), InterfaceType: "boolean", Description: "免审核开启时是否允许组织内成员申请加入该部门；默认 false"},
+			},
+		},
+	})
 	contactDeptCmd.AddCommand(
 		contactDeptSearchCmd,
 		contactDeptGetInfoCmd,
@@ -2304,6 +2763,7 @@ contact user profile fields 获取可用字段列表。
 		contactDeptListMembersCmd,
 		contactDeptCreateCmd,
 		contactDeptUpdateCmd,
+		contactDeptInviteAuditCmd,
 	)
 
 	// ── org 企业管理 ──────────────────────────────────────────────────
@@ -2311,12 +2771,19 @@ contact user profile fields 获取可用字段列表。
 	contactOrgCmd := newGroupCommand(&cobra.Command{
 		Use:   "org",
 		Short: "企业管理",
-		Long: `企业管理：创建企业。
+		Long: `企业管理：创建企业，以及企业申请/邀请管理（申请开关、免审核、邀请信息、邀请与申请记录查询、申请审批）。
 
 【何时用哪个命令】
   - 创建新企业                         → contact org create
+  - 设置申请加入企业开关                → contact org invite-switch
+  - 设置企业级申请免审核                → contact org invite-audit
+  - 获取邀请链接/团队码/开关状态        → contact org invite-info
+  - 查询已发出的邀请记录                → contact org invite-list
+  - 查询用户申请记录                    → contact org apply-list
+  - 同意/拒绝/屏蔽/删除申请             → contact org apply-approve / apply-reject / apply-block / apply-remove
   - 创建企业专属账号                   → contact account create
-  - 邀请员工加入企业                   → contact user invite`,
+  - 邀请员工加入企业                   → contact user invite
+  - 部门级申请免审核                    → contact dept invite-audit`,
 		RunE: groupRunE,
 	})
 
@@ -2376,6 +2843,389 @@ contact user profile fields 获取可用字段列表。
 	contactOrgCreateCmd.Flags().String("org-name", "", "企业名称 (必填)")
 	contactOrgCreateCmd.Flags().String("creator-username", "", "创建者在企业内的名称，对应 creatorUsername (必填)")
 	contactOrgCmd.AddCommand(contactOrgCreateCmd)
+
+	// org 企业申请/邀请管理（MCP 工具：set_org_invite_switch / set_org_apply_audit /
+	// get_org_invite_info / list_team_invite / query_org_apply_list / *_org_apply）。
+	contactOrgInviteSwitchCmd := newContactOrgInviteSwitchCommand()
+	DeclareLeafMetadata(contactOrgInviteSwitchCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "write", Risk: "medium",
+			Confirmation: "user_required", Idempotency: "idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "set_org_invite_switch",
+				CanonicalPath:  "contact.set_org_invite_switch",
+				CLIPath:        "contact org invite-switch",
+				PrimaryCLIPath: "contact org invite-switch",
+			},
+			Description: "设置用户申请加入企业的开关（总开关与搜索/团队号/链接三个子开关），子开关不传保持不变",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"申请开关设置结果","properties":{"result":{"type":"object","description":"更新后的企业邀请信息","properties":{"url":{"type":"string","description":"邀请链接"},"inviteSwitch":{"type":"boolean","description":"邀请开关，true=开启了邀请"},"searchInviteSwitch":{"type":"boolean","description":"搜索团队名称申请加入开关"},"orgApplyCodeInviteSwitch":{"type":"boolean","description":"填写团队号申请加入开关"},"linkInviteSwitch":{"type":"boolean","description":"链接和二维码申请加入开关"},"auditType":{"type":"number","description":"审核类型，0=申请无需审核，1=申请需管理员审核"}}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "set_org_invite_switch"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "设置用户申请加入企业的开关",
+				UseWhen:      []string{"用户明确要求开启/关闭申请加入企业，或调整搜索团队名/团队号/链接二维码等申请渠道"},
+				AvoidWhen:    []string{"仅查看开关状态用 contact org invite-info；调整审核策略用 contact org invite-audit；部门级开关用 contact dept invite-audit"},
+				Examples: []string{
+					"dws contact org invite-switch --open true",
+					"dws contact org invite-switch --open true --search-invite false --link-invite true",
+				},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "open", Property: "open", Required: boolPtr(true), InterfaceType: "boolean", Description: "申请加入企业总开关：true=允许用户申请加入"},
+				{Name: "search-invite", Property: "searchInviteSwitch", Required: boolPtr(false), InterfaceType: "boolean", Description: "搜索团队名称申请加入开关；不传保持不变"},
+				{Name: "apply-code-invite", Property: "orgApplyCodeInviteSwitch", Required: boolPtr(false), InterfaceType: "boolean", Description: "填写团队号申请加入开关；不传保持不变"},
+				{Name: "link-invite", Property: "linkInviteSwitch", Required: boolPtr(false), InterfaceType: "boolean", Description: "链接和二维码申请加入开关；不传保持不变"},
+			},
+		},
+	})
+
+	contactOrgInviteAuditCmd := newContactOrgInviteAuditCommand()
+	DeclareLeafMetadata(contactOrgInviteAuditCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "write", Risk: "medium",
+			Confirmation: "user_required", Idempotency: "idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "set_org_apply_audit",
+				CanonicalPath:  "contact.set_org_apply_audit",
+				CLIPath:        "contact org invite-audit",
+				PrimaryCLIPath: "contact org invite-audit",
+			},
+			Description: "设置企业级申请加入免审核策略：--no-audit true 免审核（auditType=0），false 需管理员审核（auditType=1）",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"企业级免审核设置结果","properties":{"result":{"type":"object","description":"调用结果","properties":{}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "set_org_apply_audit"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "设置企业级申请加入免审核策略",
+				UseWhen:      []string{"用户明确要求开启/关闭「申请加入企业免审核」，影响整个企业的申请审核策略"},
+				AvoidWhen:    []string{"仅设置某个部门的免审核用 contact dept invite-audit；查看当前审核类型用 contact org invite-info"},
+				Examples: []string{
+					"dws contact org invite-audit --no-audit",
+					"dws contact org invite-audit --no-audit=false",
+				},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "no-audit", Property: "auditType", Required: boolPtr(true), InterfaceType: "boolean", Description: "true=免审核（auditType=0，申请自动通过），false=需管理员审核（auditType=1）"},
+			},
+		},
+	})
+
+	contactOrgInviteInfoCmd := &cobra.Command{
+		Use:   "invite-info",
+		Short: "获取企业邀请信息",
+		Long: `获取当前企业的邀请信息：邀请链接（url）、微信邀请链接、邀请码、邀请有效期，
+以及申请加入相关开关状态（inviteSwitch、searchInviteSwitch、orgApplyCodeInviteSwitch、linkInviteSwitch）、
+审核类型（auditType：0=免审核，1=需审核）等。无需参数。
+
+【相关命令】
+  - 修改申请开关      → contact org invite-switch
+  - 修改审核类型      → contact org invite-audit`,
+		Example: `  dws contact org invite-info`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return callMCPTool("get_org_invite_info", nil)
+		},
+	}
+	DeclareLeafMetadata(contactOrgInviteInfoCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "read", Risk: "low",
+			Confirmation: "not_required", Idempotency: "idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "get_org_invite_info",
+				CanonicalPath:  "contact.get_org_invite_info",
+				CLIPath:        "contact org invite-info",
+				PrimaryCLIPath: "contact org invite-info",
+			},
+			Description: "获取企业邀请信息：邀请链接、邀请码、申请开关状态与审核类型",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"企业邀请信息","properties":{"result":{"type":"object","description":"企业邀请信息","properties":{"url":{"type":"string","description":"邀请链接"},"inviteSwitch":{"type":"boolean","description":"邀请开关，true=开启了邀请"},"orgAuthLevel":{"type":"number","description":"企业认证等级，0=未认证，1=高级认证，2=中级认证，3=初级认证，4=普通认证，6=年检认证"},"searchInviteSwitch":{"type":"boolean","description":"搜索团队名称申请加入开关"},"orgApplyCodeInviteSwitch":{"type":"boolean","description":"填写团队号申请加入开关"},"linkInviteSwitch":{"type":"boolean","description":"链接和二维码申请加入开关"},"auditType":{"type":"number","description":"审核类型，0=申请无需审核，1=申请需管理员审核"},"allowEmpApplyJoinDept":{"type":"boolean","description":"是否允许员工申请加入部门（仅免审核时有效）"},"antWxUrl":{"type":"string","description":"微信邀请链接"},"expireTime":{"type":"number","description":"邀请链接过期时间（毫秒时间戳）"},"validPeriod":{"type":"number","description":"邀请有效期（天），空为永久有效"},"inviteCode":{"type":"string","description":"邀请码"}}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "get_org_invite_info"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "获取企业邀请信息（邀请链接、邀请码、申请开关与审核类型）",
+				UseWhen:      []string{"用户需要获取企业邀请链接/邀请码，或查看申请加入相关开关与审核策略的当前状态"},
+				AvoidWhen:    []string{"修改开关用 contact org invite-switch；修改审核类型用 contact org invite-audit；查询邀请/申请记录用 contact org invite-list / apply-list"},
+				Examples:     []string{"dws contact org invite-info"},
+			},
+		},
+	})
+
+	contactOrgInviteListCmd := newContactOrgInviteListCommand()
+	DeclareLeafMetadata(contactOrgInviteListCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "read", Risk: "low",
+			Confirmation: "not_required", Idempotency: "idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "list_team_invite",
+				CanonicalPath:  "contact.list_team_invite",
+				CLIPath:        "contact org invite-list",
+				PrimaryCLIPath: "contact org invite-list",
+			},
+			Description: "分页查询企业已发出的成员邀请记录（管理员邀请加入企业的记录），按创建时间倒序，可按状态筛选",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"企业邀请记录列表","properties":{"result":{"type":"object","description":"邀请记录列表","properties":{"values":{"type":"array","description":"邀请记录","items":{"type":"object","properties":{"id":{"type":"number","description":"邀请记录ID"},"status":{"type":"number","description":"邀请状态：1=未处理，2=已同意，3=已忽略或失效"},"empName":{"type":"string","description":"被邀请人姓名"},"optUserProfileModel":{"type":"object","description":"邀请人信息","properties":{"nick":{"type":"string","description":"邀请人昵称"}}}}}},"hasMore":{"type":"boolean","description":"是否还有更多数据"},"nextCursor":{"type":"number","description":"下一页游标，hasMore=true 时传回继续翻页"}}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "list_team_invite"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "查询企业已发出的成员邀请记录列表",
+				UseWhen:      []string{"用户需要查看管理员邀请加入企业的记录（如待处理邀请、邀请后未加入的成员）"},
+				AvoidWhen:    []string{"查询用户主动申请加入的记录用 contact org apply-list；获取邀请链接用 contact org invite-info"},
+				Examples: []string{
+					"dws contact org invite-list",
+					"dws contact org invite-list --status 2 --size 50",
+				},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "status", Property: "status", Required: boolPtr(false), InterfaceType: "integer", Description: "邀请状态：1=未处理（默认），2=已同意，3=已忽略或失效"},
+				{Name: "size", Property: "size", Required: boolPtr(false), InterfaceType: "integer", Description: "每页条数 1-100，默认 20"},
+				{Name: "cursor", Property: "cursor", Required: boolPtr(false), InterfaceType: "integer", Description: "分页游标；翻页时传上一页返回的 nextCursor"},
+			},
+		},
+	})
+
+	contactOrgApplyListCmd := newContactOrgApplyListCommand()
+	DeclareLeafMetadata(contactOrgApplyListCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "read", Risk: "low",
+			Confirmation: "not_required", Idempotency: "idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "query_org_apply_list",
+				CanonicalPath:  "contact.query_org_apply_list",
+				CLIPath:        "contact org apply-list",
+				PrimaryCLIPath: "contact org apply-list",
+			},
+			Description: "分页查询用户主动申请加入企业的记录（可按状态筛选），返回申请 ID 供后续审批命令使用",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"加入企业申请列表","properties":{"result":{"type":"object","description":"申请记录列表","properties":{"values":{"type":"array","description":"申请记录","items":{"type":"object","properties":{"id":{"type":"number","description":"申请记录ID，供 apply-approve/reject/block/remove 使用"},"status":{"type":"number","description":"申请状态：1=未处理，2=已通过，3=已拒绝，4=已屏蔽"},"content":{"type":"string","description":"申请人姓名"},"gmtCreate":{"type":"number","description":"申请时间（毫秒时间戳）"},"dept":{"type":"object","description":"申请加入的部门","properties":{"deptId":{"type":"number","description":"部门ID"},"deptName":{"type":"string","description":"部门名称"},"deptPathName":{"type":"string","description":"部门名称全路径"}}},"inviterEmployeeModel":{"type":"object","description":"邀请人信息","properties":{"nick":{"type":"string","description":"邀请人昵称"},"name":{"type":"string","description":"邀请人姓名"}}},"optEmployeeModel":{"type":"object","description":"操作人信息","properties":{"nick":{"type":"string","description":"操作人昵称"},"name":{"type":"string","description":"操作人姓名"}}}}}},"hasMore":{"type":"boolean","description":"是否还有更多数据"},"nextCursor":{"type":"number","description":"下一页游标，hasMore=true 时传回继续翻页"}}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "query_org_apply_list"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "查询用户申请加入企业的记录列表",
+				UseWhen:      []string{"用户需要查看待处理/已处理的企业加入申请，或需要获取申请 ID 以便审批（同意/拒绝/屏蔽/删除）"},
+				AvoidWhen:    []string{"查询管理员发出的邀请记录用 contact org invite-list；直接审批时仍应先读本命令确认申请人与状态"},
+				Examples: []string{
+					"dws contact org apply-list",
+					"dws contact org apply-list --status 0 --size 50",
+				},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "status", Property: "status", Required: boolPtr(false), InterfaceType: "integer", Description: "申请状态：0=全部，1=未处理（默认），2=已通过，3=已拒绝，4=已屏蔽"},
+				{Name: "size", Property: "size", Required: boolPtr(false), InterfaceType: "integer", Description: "每页条数 1-100，默认 20"},
+				{Name: "cursor", Property: "cursor", Required: boolPtr(false), InterfaceType: "integer", Description: "分页游标；翻页时传上一页返回的 nextCursor"},
+			},
+		},
+	})
+
+	contactOrgApplyApproveCmd := newContactOrgApplyDecisionCommand(contactOrgApplyDecisionSpec{
+		use: "apply-approve", verbLabel: "同意", toolName: "approve_org_apply",
+		risk: "medium", aliases: []string{"approve"},
+	})
+	DeclareLeafMetadata(contactOrgApplyApproveCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "write", Risk: "medium",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "approve_org_apply",
+				CanonicalPath:  "contact.approve_org_apply",
+				CLIPath:        "contact org apply-approve",
+				PrimaryCLIPath: "contact org apply-approve",
+			},
+			Description: "同意指定的「申请加入企业」记录，申请人将加入企业",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"同意申请结果","properties":{"result":{"type":"object","description":"调用结果","properties":{}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "approve_org_apply"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "同意指定的「申请加入企业」记录",
+				UseWhen:      []string{"用户明确要求同意某条加入企业申请，且已通过 contact org apply-list 确认申请 ID 与申请人"},
+				AvoidWhen:    []string{"拒绝用 contact org apply-reject；屏蔽申请人用 contact org apply-block；未确认申请内容前不要执行"},
+				Examples:     []string{"dws contact org apply-approve --id 12345"},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "id", Property: "id", Required: boolPtr(true), InterfaceType: "integer", Description: "申请记录 ID，来自 contact org apply-list 的 id 字段"},
+			},
+		},
+	})
+
+	contactOrgApplyRejectCmd := newContactOrgApplyDecisionCommand(contactOrgApplyDecisionSpec{
+		use: "apply-reject", verbLabel: "拒绝", toolName: "reject_org_apply",
+		risk: "medium", withReason: true, aliases: []string{"reject"},
+	})
+	DeclareLeafMetadata(contactOrgApplyRejectCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "write", Risk: "medium",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "reject_org_apply",
+				CanonicalPath:  "contact.reject_org_apply",
+				CLIPath:        "contact org apply-reject",
+				PrimaryCLIPath: "contact org apply-reject",
+			},
+			Description: "拒绝指定的「申请加入企业」记录，需填写拒绝原因",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"拒绝申请结果","properties":{"result":{"type":"object","description":"调用结果","properties":{}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "reject_org_apply"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "拒绝指定的「申请加入企业」记录",
+				UseWhen:      []string{"用户明确要求拒绝某条加入企业申请并说明了拒绝原因"},
+				AvoidWhen:    []string{"同意用 contact org apply-approve；屏蔽申请人用 contact org apply-block；删除记录用 contact org apply-remove"},
+				Examples:     []string{"dws contact org apply-reject --id 12345 --reason \"不符合入职条件\""},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "id", Property: "id", Required: boolPtr(true), InterfaceType: "integer", Description: "申请记录 ID，来自 contact org apply-list 的 id 字段"},
+				{Name: "reason", Property: "reason", Required: boolPtr(true), Description: "拒绝原因，会记录在申请处理记录中"},
+			},
+		},
+	})
+
+	contactOrgApplyBlockCmd := newContactOrgApplyDecisionCommand(contactOrgApplyDecisionSpec{
+		use: "apply-block", verbLabel: "屏蔽", toolName: "block_org_apply",
+		risk: "high", withReason: true, aliases: []string{"block"},
+	})
+	DeclareLeafMetadata(contactOrgApplyBlockCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "write", Risk: "high",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "block_org_apply",
+				CanonicalPath:  "contact.block_org_apply",
+				CLIPath:        "contact org apply-block",
+				PrimaryCLIPath: "contact org apply-block",
+			},
+			Description: "屏蔽指定的「申请加入企业」记录（拉黑该申请人），需填写屏蔽原因",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"屏蔽申请结果","properties":{"result":{"type":"object","description":"调用结果","properties":{}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "block_org_apply"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "屏蔽指定的「申请加入企业」记录（拉黑申请人）",
+				UseWhen:      []string{"用户明确要求屏蔽/拉黑某申请人及其申请记录，并说明屏蔽原因"},
+				AvoidWhen:    []string{"仅拒绝单次申请用 contact org apply-reject；屏蔽后申请人后续申请也会被拦截，非明确要求不要使用"},
+				Examples:     []string{"dws contact org apply-block --id 12345 --reason \"恶意重复申请\""},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "id", Property: "id", Required: boolPtr(true), InterfaceType: "integer", Description: "申请记录 ID，来自 contact org apply-list 的 id 字段"},
+				{Name: "reason", Property: "reason", Required: boolPtr(true), Description: "屏蔽原因，会记录在申请处理记录中"},
+			},
+		},
+	})
+
+	contactOrgApplyRemoveCmd := newContactOrgApplyDecisionCommand(contactOrgApplyDecisionSpec{
+		use: "apply-remove", verbLabel: "删除", toolName: "remove_org_apply",
+		risk: "high", aliases: []string{"remove", "apply-delete"},
+	})
+	DeclareLeafMetadata(contactOrgApplyRemoveCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "write", Risk: "high",
+			Confirmation: "user_required", Idempotency: "non_idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "remove_org_apply",
+				CanonicalPath:  "contact.remove_org_apply",
+				CLIPath:        "contact org apply-remove",
+				PrimaryCLIPath: "contact org apply-remove",
+			},
+			Description: "删除指定的「申请加入企业」记录（记录删除后不可恢复）",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"删除申请结果","properties":{"result":{"type":"object","description":"调用结果","properties":{}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "remove_org_apply"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "删除指定的「申请加入企业」记录",
+				UseWhen:      []string{"用户明确要求删除某条申请记录且已理解删除后不可恢复"},
+				AvoidWhen:    []string{"正常审批用 apply-approve / apply-reject；删除不可恢复，优先考虑拒绝或屏蔽"},
+				Examples:     []string{"dws contact org apply-remove --id 12345"},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "id", Property: "id", Required: boolPtr(true), InterfaceType: "integer", Description: "申请记录 ID，来自 contact org apply-list 的 id 字段"},
+			},
+		},
+	})
+
+	contactOrgCmd.AddCommand(
+		contactOrgInviteSwitchCmd,
+		contactOrgInviteAuditCmd,
+		contactOrgInviteInfoCmd,
+		contactOrgInviteListCmd,
+		contactOrgApplyListCmd,
+		contactOrgApplyApproveCmd,
+		contactOrgApplyRejectCmd,
+		contactOrgApplyBlockCmd,
+		contactOrgApplyRemoveCmd,
+	)
 
 	// ── account 企业账号管理 ──────────────────────────────────────────
 
@@ -2513,6 +3363,93 @@ contact user profile fields 获取可用字段列表。
 		},
 	})
 	contactAccountCmd.AddCommand(contactAccountCreateCmd, contactAccountUpdateCmd)
+
+	// ── exclusive-account 企业账号状态 ──────────────────────────
+
+	contactExclusiveAccountCmd := newGroupCommand(&cobra.Command{
+		Use:   "exclusive-account",
+		Short: "企业账号状态管理",
+		Long: `企业专属账号状态管理：停用或启用企业账号。
+
+【何时用哪个命令】
+  - 停用企业账号（无法登录）           → contact exclusive-account disable
+  - 重新启用已停用的企业账号           → contact exclusive-account enable
+  - 创建企业专属账号                   → contact account create
+  - 更新企业账号资料                   → contact account update`,
+		RunE: groupRunE,
+	})
+
+	contactExclusiveAccountDisableCmd := newContactExclusiveAccountSetStatusCommand("disable", "停用", "disable")
+	DeclareLeafMetadata(contactExclusiveAccountDisableCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "write", Risk: "medium",
+			Confirmation: "user_required", Idempotency: "idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "exclusive_account_disable",
+				CanonicalPath:  "contact.exclusive_account_disable",
+				CLIPath:        "contact exclusive-account disable",
+				PrimaryCLIPath: "contact exclusive-account disable",
+			},
+			Description: "停用指定的企业专属账号，停用后该账号无法登录钉钉",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"停用企业账号结果","properties":{"result":{"type":"object","description":"调用结果","properties":{}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "exclusive_account_set_status"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "停用指定的企业专属账号",
+				UseWhen:      []string{"用户明确要求停用/禁用某个企业专属账号（员工 userid 已确认）"},
+				AvoidWhen:    []string{"恢复登录用 contact exclusive-account enable；更新账号资料用 contact account update；不确定 userid 时先通过 contact user search 确认"},
+				Examples:     []string{"dws contact exclusive-account disable --staff-id user001"},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "staff-id", Property: "uesrId", Required: boolPtr(true), Description: "企业账号的员工 userid（映射到 MCP 工具入参 uesrId，平台侧历史字段名）"},
+			},
+		},
+	})
+	contactExclusiveAccountEnableCmd := newContactExclusiveAccountSetStatusCommand("enable", "启用", "enable")
+	DeclareLeafMetadata(contactExclusiveAccountEnableCmd, LeafSpec{
+		Safety: contract.SafetySpec{
+			Effect: "write", Risk: "medium",
+			Confirmation: "user_required", Idempotency: "idempotent",
+		},
+		Contract: LeafContract{
+			Identity: contract.ToolIdentitySpec{
+				ProductID:      "contact",
+				Name:           "exclusive_account_enable",
+				CanonicalPath:  "contact.exclusive_account_enable",
+				CLIPath:        "contact exclusive-account enable",
+				PrimaryCLIPath: "contact exclusive-account enable",
+			},
+			Description: "重新启用已停用的企业专属账号，启用后该账号恢复登录",
+			Result: &contract.ResultSpec{
+				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+				DataSchema: json.RawMessage(`{"type":"object","description":"启用企业账号结果","properties":{"result":{"type":"object","description":"调用结果","properties":{}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+			},
+			Interface: &contract.InterfaceSpec{
+				Mode:         "mcp",
+				Availability: "available",
+				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "exclusive_account_set_status"},
+			},
+			Selection: contract.SelectionSpec{
+				AgentSummary: "重新启用已停用的企业专属账号",
+				UseWhen:      []string{"用户明确要求启用/恢复某个已停用的企业专属账号"},
+				AvoidWhen:    []string{"停用账号用 contact exclusive-account disable；创建新账号用 contact account create"},
+				Examples:     []string{"dws contact exclusive-account enable --staff-id user001"},
+			},
+			Parameters: []contract.ParamDecl{
+				{Name: "staff-id", Property: "uesrId", Required: boolPtr(true), Description: "企业账号的员工 userid（映射到 MCP 工具入参 uesrId，平台侧历史字段名）"},
+			},
+		},
+	})
+	contactExclusiveAccountCmd.AddCommand(contactExclusiveAccountDisableCmd, contactExclusiveAccountEnableCmd)
 
 	relationCmd.AddCommand(contactRelationListMyFollowingsCmd)
 
@@ -2679,7 +3616,7 @@ contact user profile fields 获取可用字段列表。
 
 	contactExtFieldCmd.AddCommand(contactExtFieldListCmd, contactExtFieldCreateCmd, contactExtFieldUpdateCmd, contactExtFieldDeleteCmd)
 
-	root.AddCommand(userCmd, contactDeptCmd, contactLabelCmd, contactExtFieldCmd, relationCmd, contactOrgCmd, contactAccountCmd)
+	root.AddCommand(userCmd, contactDeptCmd, contactLabelCmd, contactExtFieldCmd, relationCmd, contactOrgCmd, contactAccountCmd, contactExclusiveAccountCmd)
 
 	addQueryFlags := func(cmd *cobra.Command) {
 		cmd.Flags().String("query", "", "搜索关键词 (必填)")

--- a/internal/helpers/contact.go
+++ b/internal/helpers/contact.go
@@ -1174,12 +1174,11 @@ func newContactDeptInviteAuditCommand() *cobra.Command {
 // 投影到统一 meta.pagination。源字段位于 body["result"] 下的 hasMore 与
 // nextCursor（数值类型）；空响应或没有分页字段时返回 nil。
 // hasMore=false 时 nextCursor 是终端游标，不暴露为 next_token。
-func contactOrgPaginationMeta(result any) (*output.Meta, error) {
-	m, ok := result.(map[string]any)
-	if !ok {
+func contactOrgPaginationMeta(result map[string]any) (*output.Meta, error) {
+	if result == nil {
 		return nil, nil
 	}
-	rawHasMore, hasFlag := m["hasMore"]
+	rawHasMore, hasFlag := result["hasMore"]
 	hasMore, hasMoreBool := rawHasMore.(bool)
 	if hasFlag && !hasMoreBool {
 		return nil, fmt.Errorf("pagination hasMore must be a JSON boolean")
@@ -1191,18 +1190,14 @@ func contactOrgPaginationMeta(result any) (*output.Meta, error) {
 		return &output.Meta{Pagination: pg}, nil
 	}
 
-	rawCursor, hasCursor := m["nextCursor"]
+	rawCursor, hasCursor := result["nextCursor"]
 	cursor := ""
 	if hasCursor {
 		switch v := rawCursor.(type) {
 		case string:
 			cursor = strings.TrimSpace(v)
-		case json.Number:
-			cursor = strings.TrimSpace(v.String())
 		case float64:
 			cursor = strconv.FormatInt(int64(v), 10)
-		case int64:
-			cursor = strconv.FormatInt(v, 10)
 		default:
 			return nil, fmt.Errorf("pagination nextCursor must be a JSON string or number, got %T", rawCursor)
 		}
@@ -1213,22 +1208,19 @@ func contactOrgPaginationMeta(result any) (*output.Meta, error) {
 	if hasMore && cursor == "" {
 		return nil, fmt.Errorf("pagination hasMore=true is missing nextCursor")
 	}
-	pg, err := output.NewPagination(false, cursor)
-	if err != nil {
-		return nil, err
-	}
+	// 此时 cursor 非空且 hasMore=true，NewPagination 不会失败。
+	pg, _ := output.NewPagination(false, cursor)
 	return &output.Meta{Pagination: pg}, nil
 }
 
 // contactOrgDataWithoutPagination 从 result 对象中剥离源分页控制字段，
 // 保证业务 data 不再泄漏 hasMore/nextCursor。
-func contactOrgDataWithoutPagination(result any) any {
-	m, ok := result.(map[string]any)
-	if !ok {
-		return result
+func contactOrgDataWithoutPagination(result map[string]any) map[string]any {
+	if result == nil {
+		return nil
 	}
-	data := make(map[string]any, len(m))
-	for key, value := range m {
+	data := make(map[string]any, len(result))
+	for key, value := range result {
 		if key == "hasMore" || key == "nextCursor" {
 			continue
 		}
@@ -1238,11 +1230,10 @@ func contactOrgDataWithoutPagination(result any) any {
 }
 
 // contactOrgListResult 调用 MCP 列表工具并投影分页元数据到统一输出。
-// 错误分类与 callMCPToolInternalOptsContext 保持一致。
+// 非 dry-run 路径复用 callMCPToolReturnTextOnServer 完成错误分类，再在此做
+// 统一分页投影；dry-run 路径仅预览真实工具名与参数，不实际调用 Server。
 func contactOrgListResult(toolName string, args map[string]any) (output.CommandResult, error) {
 	if deps.Caller.DryRun() {
-		// 复用现有 MCP dry-run 预览契约：展示真实工具名与待发送参数，
-		// 不实际调用 Server；正常响应路径统一处理分页投影。
 		return output.Success(map[string]any{
 			"dry_run":   true,
 			"executed":  false,
@@ -1252,59 +1243,30 @@ func contactOrgListResult(toolName string, args map[string]any) (output.CommandR
 	}
 
 	serverID := resolveProductID()
-	result, err := deps.Caller.CallTool(context.Background(), serverID, toolName, args)
+	text, err := callMCPToolReturnTextOnServer(context.Background(), serverID, toolName, args)
 	if err != nil {
-		if patErr := reclassifyPATFromError(err); patErr != nil {
-			return nil, patErr
-		}
-		return nil, WrapErrorWithOperation(err, serverID+"/"+toolName)
+		return nil, err
 	}
 
-	for _, c := range result.Content {
-		if c.Type != "text" {
-			continue
-		}
-		var body map[string]any
-		if err := json.Unmarshal([]byte(c.Text), &body); err != nil {
-			return nil, &CLIError{Code: CodeMCPToolError, Message: "服务端返回非 JSON 文本"}
-		}
-		if body == nil {
-			return nil, &CLIError{Code: CodeMCPToolError, Message: "服务端返回 null"}
-		}
-		// 网关层错误（如 token 过期）
-		if _, ok := getDWSGatewayErrorCode(body); ok {
-			return nil, &CLIError{Code: CodeAuthTokenExpired, Message: c.Text, Suggestion: authExpiredSuggestion()}
-		}
-		// 未登录错误
-		if isNotLoggedInError(body) {
-			return nil, &CLIError{Code: CodeAuthNotConfigured, Message: "当前未登录", Suggestion: notLoggedInSuggestion()}
-		}
-		// PAT（个人访问令牌）相关错误
-		if patErr := classifyPATError(body); patErr != nil {
-			return nil, patErr
-		}
-		// 业务逻辑错误
-		if isBusinessError(body) {
-			return nil, &CLIError{Code: CodeMCPToolError, Message: businessErrorDisplayMessage(body, c.Text), Suggestion: suggestForBusinessError(body)}
-		}
-
-		resultData, _ := body["result"].(map[string]any)
-		meta, err := contactOrgPaginationMeta(resultData)
-		if err != nil {
-			return output.Failure(&output.ErrorInfo{
-				Type: "api", Subtype: "pagination_inconsistent", Message: err.Error(),
-				Hint: "保留原始响应并停止翻页；不要把当前页当作完整结果。",
-			}), nil
-		}
-		body["result"] = contactOrgDataWithoutPagination(resultData)
-		opts := []output.ResultOption{}
-		if meta != nil {
-			opts = append(opts, output.WithMeta(meta))
-		}
-		return output.Success(body, opts...), nil
+	var body map[string]any
+	if err := json.Unmarshal([]byte(text), &body); err != nil || body == nil {
+		return nil, &CLIError{Code: CodeMCPToolError, Message: "服务端返回非 JSON 文本或 null"}
 	}
 
-	return output.Success(result), nil
+	resultData, _ := body["result"].(map[string]any)
+	meta, err := contactOrgPaginationMeta(resultData)
+	if err != nil {
+		return output.Failure(&output.ErrorInfo{
+			Type: "api", Subtype: "pagination_inconsistent", Message: err.Error(),
+			Hint: "保留原始响应并停止翻页；不要把当前页当作完整结果。",
+		}), nil
+	}
+	body["result"] = contactOrgDataWithoutPagination(resultData)
+	opts := []output.ResultOption{}
+	if meta != nil {
+		opts = append(opts, output.WithMeta(meta))
+	}
+	return output.Success(body, opts...), nil
 }
 
 // newContactOrgInviteListCommand 构造 contact org invite-list 命令。

--- a/internal/helpers/contact.go
+++ b/internal/helpers/contact.go
@@ -1241,9 +1241,13 @@ func contactOrgDataWithoutPagination(result any) any {
 // 错误分类与 callMCPToolInternalOptsContext 保持一致。
 func contactOrgListResult(toolName string, args map[string]any) (output.CommandResult, error) {
 	if deps.Caller.DryRun() {
+		// 复用现有 MCP dry-run 预览契约：展示真实工具名与待发送参数，
+		// 不实际调用 Server；正常响应路径统一处理分页投影。
 		return output.Success(map[string]any{
-			"result":  map[string]any{"values": []any{}},
-			"success": true,
+			"dry_run":   true,
+			"executed":  false,
+			"tool":      toolName,
+			"arguments": args,
 		}, output.WithDryRun()), nil
 	}
 

--- a/internal/helpers/contact.go
+++ b/internal/helpers/contact.go
@@ -1196,10 +1196,14 @@ func contactOrgPaginationMeta(result map[string]any) (*output.Meta, error) {
 		switch v := rawCursor.(type) {
 		case string:
 			cursor = strings.TrimSpace(v)
-		case float64:
-			cursor = strconv.FormatInt(int64(v), 10)
+		case json.Number:
+			n, err := strconv.ParseInt(v.String(), 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("pagination nextCursor must be an integer, got %q", v.String())
+			}
+			cursor = strconv.FormatInt(n, 10)
 		default:
-			return nil, fmt.Errorf("pagination nextCursor must be a JSON string or number, got %T", rawCursor)
+			return nil, fmt.Errorf("pagination nextCursor must be a JSON string or integer, got %T", rawCursor)
 		}
 	}
 	if !hasFlag && !hasCursor {
@@ -1249,11 +1253,24 @@ func contactOrgListResult(toolName string, args map[string]any) (output.CommandR
 	}
 
 	var body map[string]any
-	if err := json.Unmarshal([]byte(text), &body); err != nil || body == nil {
+	dec := json.NewDecoder(strings.NewReader(text))
+	dec.UseNumber()
+	if err := dec.Decode(&body); err != nil || body == nil {
 		return nil, &CLIError{Code: CodeMCPToolError, Message: "服务端返回非 JSON 文本或 null"}
 	}
 
-	resultData, _ := body["result"].(map[string]any)
+	var resultData map[string]any
+	if rawResult, hasResult := body["result"]; hasResult {
+		m, ok := rawResult.(map[string]any)
+		if !ok {
+			return nil, &CLIError{
+				Code:       CodeMCPToolError,
+				Message:    fmt.Sprintf("服务端返回的 result 必须是对象，实际为 %T", rawResult),
+				Suggestion: "请检查 MCP 工具出参配置或联系服务提供方修正响应结构。",
+			}
+		}
+		resultData = m
+	}
 	meta, err := contactOrgPaginationMeta(resultData)
 	if err != nil {
 		return output.Failure(&output.ErrorInfo{

--- a/internal/helpers/contact.go
+++ b/internal/helpers/contact.go
@@ -3184,8 +3184,11 @@ contact user profile fields 获取可用字段列表。
 		risk: "high", aliases: []string{"remove", "apply-delete"},
 	})
 	DeclareLeafMetadata(contactOrgApplyRemoveCmd, LeafSpec{
+		// Safety：apply-remove 删除的申请记录不可恢复，因此 Effect 必须声明为
+		// destructive，让依赖 Effect 做风险分级的 Agent/消费者正确识别其破坏
+		// 性；保留 user_required 确认门禁与 non_idempotent 幂等语义。
 		Safety: contract.SafetySpec{
-			Effect: "write", Risk: "high",
+			Effect: "destructive", Risk: "high",
 			Confirmation: "user_required", Idempotency: "non_idempotent",
 		},
 		Contract: LeafContract{
@@ -3207,7 +3210,7 @@ contact user profile fields 获取可用字段列表。
 				Ref:          &contract.InterfaceRefSpec{ProductID: "contact", RPCName: "remove_org_apply"},
 			},
 			Selection: contract.SelectionSpec{
-				AgentSummary: "删除指定的「申请加入企业」记录",
+				AgentSummary: "删除指定的「申请加入企业」记录（删除后不可恢复）",
 				UseWhen:      []string{"用户明确要求删除某条申请记录且已理解删除后不可恢复"},
 				AvoidWhen:    []string{"正常审批用 apply-approve / apply-reject；删除不可恢复，优先考虑拒绝或屏蔽"},
 				Examples:     []string{"dws contact org apply-remove --id 12345"},

--- a/internal/helpers/contact.go
+++ b/internal/helpers/contact.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/spf13/cobra"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
@@ -1168,6 +1170,139 @@ func newContactDeptInviteAuditCommand() *cobra.Command {
 	return cmd
 }
 
+// contactOrgPaginationMeta 把 contact 企业邀请/申请列表响应中的分页字段
+// 投影到统一 meta.pagination。源字段位于 body["result"] 下的 hasMore 与
+// nextCursor（数值类型）；空响应或没有分页字段时返回 nil。
+// hasMore=false 时 nextCursor 是终端游标，不暴露为 next_token。
+func contactOrgPaginationMeta(result any) (*output.Meta, error) {
+	m, ok := result.(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	rawHasMore, hasFlag := m["hasMore"]
+	hasMore, hasMoreBool := rawHasMore.(bool)
+	if hasFlag && !hasMoreBool {
+		return nil, fmt.Errorf("pagination hasMore must be a JSON boolean")
+	}
+	if hasFlag && !hasMore {
+		// 已耗尽：钉钉可能仍回显一个 terminal cursor，但布尔是权威信号，
+		// 不能把不可续页的游标暴露为 next_token。
+		pg, _ := output.NewPagination(true, "")
+		return &output.Meta{Pagination: pg}, nil
+	}
+
+	rawCursor, hasCursor := m["nextCursor"]
+	cursor := ""
+	if hasCursor {
+		switch v := rawCursor.(type) {
+		case string:
+			cursor = strings.TrimSpace(v)
+		case json.Number:
+			cursor = strings.TrimSpace(v.String())
+		case float64:
+			cursor = strconv.FormatInt(int64(v), 10)
+		case int64:
+			cursor = strconv.FormatInt(v, 10)
+		default:
+			return nil, fmt.Errorf("pagination nextCursor must be a JSON string or number, got %T", rawCursor)
+		}
+	}
+	if !hasFlag && !hasCursor {
+		return nil, nil
+	}
+	if hasMore && cursor == "" {
+		return nil, fmt.Errorf("pagination hasMore=true is missing nextCursor")
+	}
+	pg, err := output.NewPagination(false, cursor)
+	if err != nil {
+		return nil, err
+	}
+	return &output.Meta{Pagination: pg}, nil
+}
+
+// contactOrgDataWithoutPagination 从 result 对象中剥离源分页控制字段，
+// 保证业务 data 不再泄漏 hasMore/nextCursor。
+func contactOrgDataWithoutPagination(result any) any {
+	m, ok := result.(map[string]any)
+	if !ok {
+		return result
+	}
+	data := make(map[string]any, len(m))
+	for key, value := range m {
+		if key == "hasMore" || key == "nextCursor" {
+			continue
+		}
+		data[key] = value
+	}
+	return data
+}
+
+// contactOrgListResult 调用 MCP 列表工具并投影分页元数据到统一输出。
+// 错误分类与 callMCPToolInternalOptsContext 保持一致。
+func contactOrgListResult(toolName string, args map[string]any) (output.CommandResult, error) {
+	if deps.Caller.DryRun() {
+		return output.Success(map[string]any{
+			"result":  map[string]any{"values": []any{}},
+			"success": true,
+		}, output.WithDryRun()), nil
+	}
+
+	serverID := resolveProductID()
+	result, err := deps.Caller.CallTool(context.Background(), serverID, toolName, args)
+	if err != nil {
+		if patErr := reclassifyPATFromError(err); patErr != nil {
+			return nil, patErr
+		}
+		return nil, WrapErrorWithOperation(err, serverID+"/"+toolName)
+	}
+
+	for _, c := range result.Content {
+		if c.Type != "text" {
+			continue
+		}
+		var body map[string]any
+		if err := json.Unmarshal([]byte(c.Text), &body); err != nil {
+			return nil, &CLIError{Code: CodeMCPToolError, Message: "服务端返回非 JSON 文本"}
+		}
+		if body == nil {
+			return nil, &CLIError{Code: CodeMCPToolError, Message: "服务端返回 null"}
+		}
+		// 网关层错误（如 token 过期）
+		if _, ok := getDWSGatewayErrorCode(body); ok {
+			return nil, &CLIError{Code: CodeAuthTokenExpired, Message: c.Text, Suggestion: authExpiredSuggestion()}
+		}
+		// 未登录错误
+		if isNotLoggedInError(body) {
+			return nil, &CLIError{Code: CodeAuthNotConfigured, Message: "当前未登录", Suggestion: notLoggedInSuggestion()}
+		}
+		// PAT（个人访问令牌）相关错误
+		if patErr := classifyPATError(body); patErr != nil {
+			return nil, patErr
+		}
+		// 业务逻辑错误
+		if isBusinessError(body) {
+			return nil, &CLIError{Code: CodeMCPToolError, Message: businessErrorDisplayMessage(body, c.Text), Suggestion: suggestForBusinessError(body)}
+		}
+
+		resultData, _ := body["result"].(map[string]any)
+		meta, err := contactOrgPaginationMeta(resultData)
+		if err != nil {
+			return output.Failure(&output.ErrorInfo{
+				Type: "api", Subtype: "pagination_inconsistent", Message: err.Error(),
+				Hint: "保留原始响应并停止翻页；不要把当前页当作完整结果。",
+			}), nil
+		}
+		body["result"] = contactOrgDataWithoutPagination(resultData)
+		opts := []output.ResultOption{}
+		if meta != nil {
+			opts = append(opts, output.WithMeta(meta))
+		}
+		return output.Success(body, opts...), nil
+	}
+
+	return output.Success(result), nil
+}
+
 // newContactOrgInviteListCommand 构造 contact org invite-list 命令。
 func newContactOrgInviteListCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -1195,7 +1330,15 @@ func newContactOrgInviteListCommand() *cobra.Command {
 			} else if ok {
 				toolArgs["cursor"] = cursor
 			}
-			return callMCPTool("list_team_invite", toolArgs)
+			result, err := contactOrgListResult("list_team_invite", toolArgs)
+			if err != nil {
+				return err
+			}
+			if err := output.StoreResult(cmd.Context(), result); err != nil {
+				_, emitErr := output.EmitResult(cmd, result)
+				return emitErr
+			}
+			return nil
 		},
 	}
 	cmd.Flags().String("status", "1", "邀请状态：1=未处理，2=已同意，3=已忽略或失效（默认 1）")
@@ -1235,7 +1378,15 @@ hasMore=true 时用 nextCursor 翻页。
 			} else if ok {
 				toolArgs["cursor"] = cursor
 			}
-			return callMCPTool("query_org_apply_list", toolArgs)
+			result, err := contactOrgListResult("query_org_apply_list", toolArgs)
+			if err != nil {
+				return err
+			}
+			if err := output.StoreResult(cmd.Context(), result); err != nil {
+				_, emitErr := output.EmitResult(cmd, result)
+				return emitErr
+			}
+			return nil
 		},
 	}
 	cmd.Flags().String("status", "1", "申请状态：0=全部，1=未处理，2=已通过，3=已拒绝，4=已屏蔽（默认 1）")
@@ -2977,6 +3128,7 @@ contact user profile fields 获取可用字段列表。
 
 	contactOrgInviteListCmd := newContactOrgInviteListCommand()
 	DeclareLeafMetadata(contactOrgInviteListCmd, LeafSpec{
+		OutputRollout: output.RolloutUnifiedActive,
 		Safety: contract.SafetySpec{
 			Effect: "read", Risk: "low",
 			Confirmation: "not_required", Idempotency: "idempotent",
@@ -2989,11 +3141,12 @@ contact user profile fields 获取可用字段列表。
 				CLIPath:        "contact org invite-list",
 				PrimaryCLIPath: "contact org invite-list",
 			},
-			Description: "分页查询企业已发出的成员邀请记录（管理员邀请加入企业的记录），按创建时间倒序，可按状态筛选",
+			Description: "分页查询企业已发出的成员邀请记录（管理员邀请加入企业的记录），按创建时间倒序，可按状态筛选；分页信息读取 meta.pagination",
 			Result: &contract.ResultSpec{
 				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
-				DataSchema: json.RawMessage(`{"type":"object","description":"企业邀请记录列表","properties":{"result":{"type":"object","description":"邀请记录列表","properties":{"values":{"type":"array","description":"邀请记录","items":{"type":"object","properties":{"id":{"type":"number","description":"邀请记录ID"},"status":{"type":"number","description":"邀请状态：1=未处理，2=已同意，3=已忽略或失效"},"empName":{"type":"string","description":"被邀请人姓名"},"optUserProfileModel":{"type":"object","description":"邀请人信息","properties":{"nick":{"type":"string","description":"邀请人昵称"}}}}}},"hasMore":{"type":"boolean","description":"是否还有更多数据"},"nextCursor":{"type":"number","description":"下一页游标，hasMore=true 时传回继续翻页"}}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+				DataSchema: json.RawMessage(`{"type":"object","description":"企业邀请记录列表","properties":{"result":{"type":"object","description":"邀请记录列表","properties":{"values":{"type":"array","description":"邀请记录","items":{"type":"object","properties":{"id":{"type":"number","description":"邀请记录ID"},"status":{"type":"number","description":"邀请状态：1=未处理，2=已同意，3=已忽略或失效"},"empName":{"type":"string","description":"被邀请人姓名"},"optUserProfileModel":{"type":"object","description":"邀请人信息","properties":{"nick":{"type":"string","description":"邀请人昵称"}}}}}}}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
 			},
+			Pagination: &contract.PaginationSpec{Kind: contract.PaginationKindCursor, CursorParameter: "cursor"},
 			Interface: &contract.InterfaceSpec{
 				Mode:         "mcp",
 				Availability: "available",
@@ -3021,6 +3174,7 @@ contact user profile fields 获取可用字段列表。
 	// 如实声明为 write（对齐 chat mark-read 先例）；副作用仅清除未读标记，
 	// Risk 仍为 low 且无需用户确认，重复查询幂等。
 	DeclareLeafMetadata(contactOrgApplyListCmd, LeafSpec{
+		OutputRollout: output.RolloutUnifiedActive,
 		Safety: contract.SafetySpec{
 			Effect: "write", Risk: "low",
 			Confirmation: "not_required", Idempotency: "idempotent",
@@ -3033,11 +3187,12 @@ contact user profile fields 获取可用字段列表。
 				CLIPath:        "contact org apply-list",
 				PrimaryCLIPath: "contact org apply-list",
 			},
-			Description: "分页查询用户主动申请加入企业的记录（可按状态筛选），返回申请 ID 供后续审批命令使用；查询后服务端会把未读申请标记为已读",
+			Description: "分页查询用户主动申请加入企业的记录（可按状态筛选），返回申请 ID 供后续审批命令使用；查询后服务端会把未读申请标记为已读；分页信息读取 meta.pagination",
 			Result: &contract.ResultSpec{
 				Outcomes:   []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
-				DataSchema: json.RawMessage(`{"type":"object","description":"加入企业申请列表","properties":{"result":{"type":"object","description":"申请记录列表","properties":{"values":{"type":"array","description":"申请记录","items":{"type":"object","properties":{"id":{"type":"number","description":"申请记录ID，供 apply-approve/reject/block/remove 使用"},"status":{"type":"number","description":"申请状态：1=未处理，2=已通过，3=已拒绝，4=已屏蔽"},"content":{"type":"string","description":"申请人姓名"},"gmtCreate":{"type":"number","description":"申请时间（毫秒时间戳）"},"dept":{"type":"object","description":"申请加入的部门","properties":{"deptId":{"type":"number","description":"部门ID"},"deptName":{"type":"string","description":"部门名称"},"deptPathName":{"type":"string","description":"部门名称全路径"}}},"inviterEmployeeModel":{"type":"object","description":"邀请人信息","properties":{"nick":{"type":"string","description":"邀请人昵称"},"name":{"type":"string","description":"邀请人姓名"}}},"optEmployeeModel":{"type":"object","description":"操作人信息","properties":{"nick":{"type":"string","description":"操作人昵称"},"name":{"type":"string","description":"操作人姓名"}}}}}},"hasMore":{"type":"boolean","description":"是否还有更多数据"},"nextCursor":{"type":"number","description":"下一页游标，hasMore=true 时传回继续翻页"}}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
+				DataSchema: json.RawMessage(`{"type":"object","description":"加入企业申请列表","properties":{"result":{"type":"object","description":"申请记录列表","properties":{"values":{"type":"array","description":"申请记录","items":{"type":"object","properties":{"id":{"type":"number","description":"申请记录ID，供 apply-approve/reject/block/remove 使用"},"status":{"type":"number","description":"申请状态：1=未处理，2=已通过，3=已拒绝，4=已屏蔽"},"content":{"type":"string","description":"申请人姓名"},"gmtCreate":{"type":"number","description":"申请时间（毫秒时间戳）"},"dept":{"type":"object","description":"申请加入的部门","properties":{"deptId":{"type":"number","description":"部门ID"},"deptName":{"type":"string","description":"部门名称"},"deptPathName":{"type":"string","description":"部门名称全路径"}}},"inviterEmployeeModel":{"type":"object","description":"邀请人信息","properties":{"nick":{"type":"string","description":"邀请人昵称"},"name":{"type":"string","description":"邀请人姓名"}}},"optEmployeeModel":{"type":"object","description":"操作人信息","properties":{"nick":{"type":"string","description":"操作人昵称"},"name":{"type":"string","description":"操作人姓名"}}}}}}}},"success":{"type":"boolean","description":"是否成功"},"errorCode":{"type":"string","description":"错误码"},"errorMsg":{"type":"string","description":"错误信息"}},"required":["success"],"additionalProperties":true}`),
 			},
+			Pagination: &contract.PaginationSpec{Kind: contract.PaginationKindCursor, CursorParameter: "cursor"},
 			Interface: &contract.InterfaceSpec{
 				Mode:         "mcp",
 				Availability: "available",

--- a/internal/helpers/contact_enterprise_test.go
+++ b/internal/helpers/contact_enterprise_test.go
@@ -56,6 +56,9 @@ func runContactEnterpriseCommand(t *testing.T, args ...string) (*contactEnterpri
 	cmd := newContactCommand()
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
+	// --yes 是 root 的 persistent flag，在 helpers 包内脱离完整 root 单测时
+	// 补注册以等价用户显式确认，使 user_required 命令的确认路径可被覆盖。
+	cmd.PersistentFlags().Bool("yes", false, "")
 	cmd.SetArgs(args)
 	return caller, cmd.Execute()
 }

--- a/internal/helpers/contact_enterprise_test.go
+++ b/internal/helpers/contact_enterprise_test.go
@@ -22,7 +22,8 @@ type contactEnterpriseCall struct {
 }
 
 type contactEnterpriseCaller struct {
-	calls []contactEnterpriseCall
+	calls        []contactEnterpriseCall
+	responseText string
 }
 
 func (c *contactEnterpriseCaller) CallTool(_ context.Context, productID, toolName string, args map[string]any) (*edition.ToolResult, error) {
@@ -31,7 +32,11 @@ func (c *contactEnterpriseCaller) CallTool(_ context.Context, productID, toolNam
 		toolName:  toolName,
 		args:      args,
 	})
-	return &edition.ToolResult{Content: []edition.ContentBlock{{Type: "text", Text: `{}`}}}, nil
+	text := c.responseText
+	if text == "" {
+		text = `{}`
+	}
+	return &edition.ToolResult{Content: []edition.ContentBlock{{Type: "text", Text: text}}}, nil
 }
 
 func (*contactEnterpriseCaller) Format() string { return "json" }

--- a/internal/helpers/contact_invite_admin_test.go
+++ b/internal/helpers/contact_invite_admin_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// runContactInviteAdminCommand 在 helpers 包内直接执行 contact 子树并捕获
+// MCP 调用。CI coverage gate 只统计 helpers 包内测试对 helpers 代码的覆盖
+// （app 包测试的跨包覆盖不进入 profile），invite/apply/exclusive-account
+// 新命令的分支因此需要包内用例兜底。--yes 是 root 的 persistent flag，
+// 脱离完整 root 单测时补注册以等价用户显式确认。
+func runContactInviteAdminCommand(t *testing.T, args ...string) (*contactEnterpriseCaller, error) {
+	t.Helper()
+	previousDeps := deps
+	previousArgs := os.Args
+	t.Cleanup(func() {
+		deps = previousDeps
+		os.Args = previousArgs
+	})
+
+	caller := &contactEnterpriseCaller{}
+	InitDeps(caller)
+	deps.Out.w = io.Discard
+	os.Args = append([]string{"dws", "contact"}, args...)
+
+	cmd := newContactCommand()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.PersistentFlags().Bool("yes", false, "")
+	cmd.SetArgs(append([]string{"--yes"}, args...))
+	return caller, cmd.Execute()
+}
+
+// TestContactInviteAdminFlagEdges 覆盖新增 invite/apply/exclusive-account 命令
+// 的 flag 边缘分支：可选布尔开关的空白值/非法值/合法值、布尔 flag 位置参数
+// 归并、必填项传空白值、以及 no-audit 缺失与类型错误。
+func TestContactInviteAdminFlagEdges(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		toolName string
+		wantArgs map[string]any
+	}{
+		{
+			name:     "invite switch blank optional bool is ignored",
+			args:     []string{"org", "invite-switch", "--open", "true", "--search-invite", " "},
+			toolName: "set_org_invite_switch",
+			wantArgs: map[string]any{"open": true},
+		},
+		{
+			name:     "invite switch apply code invite true",
+			args:     []string{"org", "invite-switch", "--open", "true", "--apply-code-invite", "true"},
+			toolName: "set_org_invite_switch",
+			wantArgs: map[string]any{"open": true, "orgApplyCodeInviteSwitch": true},
+		},
+		{
+			name:     "org invite audit positional false merges into flag",
+			args:     []string{"org", "invite-audit", "--no-audit", "false"},
+			toolName: "set_org_apply_audit",
+			wantArgs: map[string]any{"auditType": int64(1)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caller, err := runContactInviteAdminCommand(t, tc.args...)
+			if err != nil {
+				t.Fatalf("%s execute: %v", tc.name, err)
+			}
+			if len(caller.calls) != 1 {
+				t.Fatalf("%s want exactly 1 MCP call, got %d: %+v", tc.name, len(caller.calls), caller.calls)
+			}
+			call := caller.calls[0]
+			if call.productID != "contact" || call.toolName != tc.toolName {
+				t.Fatalf("%s call = %s/%s, want contact/%s", tc.name, call.productID, call.toolName, tc.toolName)
+			}
+			if !reflect.DeepEqual(call.args, tc.wantArgs) {
+				t.Fatalf("%s args = %#v, want %#v", tc.name, call.args, tc.wantArgs)
+			}
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "invite switch apply code invite rejects non boolean",
+			args: []string{"org", "invite-switch", "--open", "true", "--apply-code-invite", "yes"},
+			want: "--apply-code-invite 必须是 boolean",
+		},
+		{
+			name: "exclusive account disable rejects blank staff id",
+			args: []string{"exclusive-account", "disable", "--staff-id", " "},
+			want: "--staff-id 不能为空",
+		},
+		{
+			name: "org apply block rejects blank reason",
+			args: []string{"org", "apply-block", "--id", "123", "--reason", " "},
+			want: "--reason 不能为空",
+		},
+		{
+			name: "dept invite audit requires explicit no audit",
+			args: []string{"dept", "invite-audit", "--dept", "12345"},
+			want: "必须显式传 --no-audit",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caller, err := runContactInviteAdminCommand(t, tc.args...)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("%s err = %v, want contains %q", tc.name, err, tc.want)
+			}
+			if len(caller.calls) != 0 {
+				t.Fatalf("%s must not reach MCP, got calls: %+v", tc.name, caller.calls)
+			}
+		})
+	}
+
+	t.Run("no audit get bool type error", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "flags"}
+		cmd.Flags().String("no-audit", "", "")
+		_ = cmd.Flags().Set("no-audit", "unexpected")
+		if _, err := contactRequireNoAuditFlag(cmd); err == nil || !strings.Contains(err.Error(), "--no-audit 解析失败") {
+			t.Fatalf("contactRequireNoAuditFlag err = %v, want --no-audit 解析失败", err)
+		}
+	})
+}

--- a/internal/helpers/contact_invite_admin_test.go
+++ b/internal/helpers/contact_invite_admin_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contractfinal"
 	"github.com/spf13/cobra"
 )
 
@@ -142,4 +143,47 @@ func TestContactInviteAdminFlagEdges(t *testing.T) {
 			t.Fatalf("contactRequireNoAuditFlag err = %v, want --no-audit 解析失败", err)
 		}
 	})
+}
+
+// TestContactApplyListSafetyProjectionMatchesBehavior 是 apply-list 安全语义
+// 的包内回归（CI coverage gate 只统计包内覆盖）：查询会把服务端未读申请
+// 标记为已读，最终投影必须声明 Effect=write 而非把有副作用的查询伪装成
+// 纯读取；副作用仅清除未读标记，Confirmation 保持 not_required，运行侧
+// 不带 --yes 也直接调用 query_org_apply_list、不出现确认 gate。
+func TestContactApplyListSafetyProjectionMatchesBehavior(t *testing.T) {
+	root := newContactCommand()
+	applyList := requireWukongSyncCommand(t, root, "org", "apply-list")
+	payload, ok := contractfinal.RuntimeContractFinal(applyList)
+	if !ok {
+		t.Fatal("apply-list has no runtime contract final payload")
+	}
+	if payload.Safety == nil {
+		t.Fatal("apply-list payload has no safety declaration")
+	}
+	if got := payload.Safety; got.Effect != "write" || got.Risk != "low" ||
+		got.Confirmation != "not_required" || got.Idempotency != "idempotent" {
+		t.Fatalf("apply-list safety = %+v, want write/low/not_required/idempotent", got)
+	}
+	if !strings.Contains(payload.Description, "标记为已读") {
+		t.Fatalf("apply-list description %q must disclose the read-marking side effect", payload.Description)
+	}
+	if payload.Selection == nil || !strings.Contains(payload.Selection.AgentSummary, "标记为已读") {
+		t.Fatalf("apply-list selection must disclose the read-marking side effect: %+v", payload.Selection)
+	}
+
+	// 运行行为与声明一致：not_required 不设确认 gate，不带 --yes 直接执行。
+	caller, err := runContactEnterpriseCommand(t, "org", "apply-list")
+	if err != nil {
+		t.Fatalf("apply-list without --yes must not hit the confirmation gate: %v", err)
+	}
+	if len(caller.calls) != 1 {
+		t.Fatalf("apply-list want exactly 1 MCP call, got %d: %+v", len(caller.calls), caller.calls)
+	}
+	call := caller.calls[0]
+	if call.productID != "contact" || call.toolName != "query_org_apply_list" {
+		t.Fatalf("apply-list call = %s/%s, want contact/query_org_apply_list", call.productID, call.toolName)
+	}
+	if want := map[string]any{"status": int64(1), "size": int64(20)}; !reflect.DeepEqual(call.args, want) {
+		t.Fatalf("apply-list args = %#v, want %#v", call.args, want)
+	}
 }

--- a/internal/helpers/contact_invite_admin_test.go
+++ b/internal/helpers/contact_invite_admin_test.go
@@ -294,6 +294,14 @@ func TestContactOrgListPaginationProjection(t *testing.T) {
 			wantExhausted: true,
 			wantToken:     "",
 		},
+		{
+			name:          "large integer nextCursor preserves precision beyond float53",
+			path:          []string{"org", "invite-list"},
+			toolName:      "list_team_invite",
+			response:      `{"result":{"values":[{"id":3,"status":1,"empName":"王五"}],"hasMore":true,"nextCursor":9007199254740993},"success":true}`,
+			wantExhausted: false,
+			wantToken:     "9007199254740993",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			root := newContactCommand()
@@ -379,9 +387,11 @@ func TestContactOrgListResultEdgeCases(t *testing.T) {
 		wantCalls  int
 	}{
 		{
-			name:      "result is non-object falls back to no pagination",
-			response:  `{"result":"unexpected","success":true}`,
-			wantCalls: 1,
+			name:       "non-object result is rejected",
+			response:   `{"result":"unexpected","success":true}`,
+			wantErr:    true,
+			wantErrMsg: "服务端返回的 result 必须是对象",
+			wantCalls:  1,
 		},
 		{
 			name:       "non-boolean hasMore is rejected",
@@ -396,10 +406,29 @@ func TestContactOrgListResultEdgeCases(t *testing.T) {
 			wantCalls: 1,
 		},
 		{
+			name:      "large integer nextCursor preserves precision",
+			response:  `{"result":{"values":[],"hasMore":true,"nextCursor":9007199254740993},"success":true}`,
+			wantCalls: 1,
+		},
+		{
+			name:       "decimal nextCursor is rejected",
+			response:   `{"result":{"values":[],"hasMore":true,"nextCursor":42.5},"success":true}`,
+			wantErr:    true,
+			wantErrMsg: "nextCursor must be an integer",
+			wantCalls:  1,
+		},
+		{
+			name:       "out-of-range nextCursor is rejected",
+			response:   `{"result":{"values":[],"hasMore":true,"nextCursor":9223372036854775808},"success":true}`,
+			wantErr:    true,
+			wantErrMsg: "nextCursor must be an integer",
+			wantCalls:  1,
+		},
+		{
 			name:       "invalid nextCursor type is rejected",
 			response:   `{"result":{"values":[],"hasMore":true,"nextCursor":true},"success":true}`,
 			wantErr:    true,
-			wantErrMsg: "nextCursor must be a JSON string or number",
+			wantErrMsg: "nextCursor must be a JSON string or integer",
 			wantCalls:  1,
 		},
 		{

--- a/internal/helpers/contact_invite_admin_test.go
+++ b/internal/helpers/contact_invite_admin_test.go
@@ -14,12 +14,15 @@
 package helpers
 
 import (
+	"bytes"
+	"encoding/json"
 	"io"
 	"os"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contractfinal"
 	"github.com/spf13/cobra"
 )
@@ -231,5 +234,132 @@ func TestContactApplyRemoveSafetyProjectionMatchesBehavior(t *testing.T) {
 	}
 	if want := map[string]any{"id": int64(123)}; !reflect.DeepEqual(call.args, want) {
 		t.Fatalf("apply-remove args = %#v, want %#v", call.args, want)
+	}
+}
+
+// runContactOrgListCommandCapture 执行 invite-list / apply-list 并捕获 stdout，
+// 同时注入自定义 MCP 文本响应。用于验证统一分页映射与 DataSchema 剥离。
+func runContactOrgListCommandCapture(t *testing.T, responseText string, args ...string) (*contactEnterpriseCaller, string, error) {
+	t.Helper()
+	previousDeps := deps
+	previousArgs := os.Args
+	t.Cleanup(func() {
+		deps = previousDeps
+		os.Args = previousArgs
+	})
+
+	caller := &contactEnterpriseCaller{responseText: responseText}
+	InitDeps(caller)
+	os.Args = append([]string{"dws", "contact"}, args...)
+
+	var out bytes.Buffer
+	cmd := newContactCommand()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.PersistentFlags().Bool("yes", false, "")
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return caller, out.String(), err
+}
+
+// TestContactOrgListPaginationProjection 验证 invite-list / apply-list 的最终
+// Schema 声明了统一 Pagination 契约、DataSchema 不再包含分页字段，且运行侧
+// 把服务端返回的 hasMore/nextCursor 正确投影到 meta.pagination。
+func TestContactOrgListPaginationProjection(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		path          []string
+		toolName      string
+		response      string
+		wantExhausted bool
+		wantToken     string
+	}{
+		{
+			name:          "invite-list declares cursor pagination and maps hasMore/nextCursor",
+			path:          []string{"org", "invite-list"},
+			toolName:      "list_team_invite",
+			response:      `{"result":{"values":[{"id":1,"status":1,"empName":"张三"}],"hasMore":true,"nextCursor":42},"success":true}`,
+			wantExhausted: false,
+			wantToken:     "42",
+		},
+		{
+			name:          "apply-list declares cursor pagination and strips terminal cursor",
+			path:          []string{"org", "apply-list"},
+			toolName:      "query_org_apply_list",
+			response:      `{"result":{"values":[{"id":2,"status":1,"content":"李四"}],"hasMore":false,"nextCursor":99},"success":true}`,
+			wantExhausted: true,
+			wantToken:     "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := newContactCommand()
+			cmd := requireWukongSyncCommand(t, root, tc.path...)
+			payload, ok := contractfinal.RuntimeContractFinal(cmd)
+			if !ok {
+				t.Fatalf("%s has no runtime contract final payload", strings.Join(tc.path, " "))
+			}
+			if payload.Pagination == nil {
+				t.Fatalf("%s must declare pagination", strings.Join(tc.path, " "))
+			}
+			if payload.Pagination.Kind != contract.PaginationKindCursor || payload.Pagination.CursorParameter != "cursor" {
+				t.Fatalf("%s pagination = %+v, want cursor/cursor", strings.Join(tc.path, " "), payload.Pagination)
+			}
+			schema := string(payload.Result.DataSchema)
+			if strings.Contains(schema, "hasMore") || strings.Contains(schema, "nextCursor") {
+				t.Fatalf("%s data_schema must not contain pagination fields: %s", strings.Join(tc.path, " "), schema)
+			}
+
+			caller, out, err := runContactOrgListCommandCapture(t, tc.response, tc.path...)
+			if err != nil {
+				t.Fatalf("%s execute: %v\n%s", strings.Join(tc.path, " "), err, out)
+			}
+			if len(caller.calls) != 1 {
+				t.Fatalf("%s want 1 MCP call, got %d: %+v", strings.Join(tc.path, " "), len(caller.calls), caller.calls)
+			}
+			call := caller.calls[0]
+			if call.productID != "contact" || call.toolName != tc.toolName {
+				t.Fatalf("%s call = %s/%s, want contact/%s", strings.Join(tc.path, " "), call.productID, call.toolName, tc.toolName)
+			}
+
+			var envelope map[string]any
+			if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+				t.Fatalf("%s output is not valid JSON: %v\n%s", strings.Join(tc.path, " "), err, out)
+			}
+			meta, ok := envelope["meta"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s output missing meta: %s", strings.Join(tc.path, " "), out)
+			}
+			pg, ok := meta["pagination"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s output missing meta.pagination: %s", strings.Join(tc.path, " "), out)
+			}
+			if pg["endpoint_exhausted"] != tc.wantExhausted {
+				t.Fatalf("%s endpoint_exhausted = %v, want %v", strings.Join(tc.path, " "), pg["endpoint_exhausted"], tc.wantExhausted)
+			}
+			gotToken, hasToken := pg["next_token"]
+			if tc.wantExhausted {
+				if hasToken && gotToken != "" {
+					t.Fatalf("%s exhausted pagination must not carry next_token, got %v", strings.Join(tc.path, " "), gotToken)
+				}
+			} else if gotToken != tc.wantToken {
+				t.Fatalf("%s next_token = %v, want %q", strings.Join(tc.path, " "), gotToken, tc.wantToken)
+			}
+			data, ok := envelope["data"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s output missing data: %s", strings.Join(tc.path, " "), out)
+			}
+			result, ok := data["result"].(map[string]any)
+			if !ok {
+				t.Fatalf("%s output data.result missing or not object: %s", strings.Join(tc.path, " "), out)
+			}
+			if _, exists := result["hasMore"]; exists {
+				t.Fatalf("%s data.result must not leak hasMore", strings.Join(tc.path, " "))
+			}
+			if _, exists := result["nextCursor"]; exists {
+				t.Fatalf("%s data.result must not leak nextCursor", strings.Join(tc.path, " "))
+			}
+		})
 	}
 }

--- a/internal/helpers/contact_invite_admin_test.go
+++ b/internal/helpers/contact_invite_admin_test.go
@@ -15,6 +15,7 @@ package helpers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contractfinal"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -359,6 +361,137 @@ func TestContactOrgListPaginationProjection(t *testing.T) {
 			}
 			if _, exists := result["nextCursor"]; exists {
 				t.Fatalf("%s data.result must not leak nextCursor", strings.Join(tc.path, " "))
+			}
+		})
+	}
+}
+
+// TestContactOrgListResultEdgeCases 覆盖 contactOrgListResult 与分页映射的
+// 异常分支：非对象 result、非布尔 hasMore、字符串/非法类型 nextCursor、
+// hasMore=true 缺少 nextCursor、服务端返回非 JSON/分页不一致、以及结果
+// 成功写入 result store 的分支。
+func TestContactOrgListResultEdgeCases(t *testing.T) {
+	cases := []struct {
+		name       string
+		response   string
+		wantErr    bool
+		wantErrMsg string
+		wantCalls  int
+	}{
+		{
+			name:      "result is non-object falls back to no pagination",
+			response:  `{"result":"unexpected","success":true}`,
+			wantCalls: 1,
+		},
+		{
+			name:       "non-boolean hasMore is rejected",
+			response:   `{"result":{"hasMore":"yes"},"success":true}`,
+			wantErr:    true,
+			wantErrMsg: "hasMore must be a JSON boolean",
+			wantCalls:  1,
+		},
+		{
+			name:      "string nextCursor is accepted",
+			response:  `{"result":{"values":[],"hasMore":true,"nextCursor":"42"},"success":true}`,
+			wantCalls: 1,
+		},
+		{
+			name:       "invalid nextCursor type is rejected",
+			response:   `{"result":{"values":[],"hasMore":true,"nextCursor":true},"success":true}`,
+			wantErr:    true,
+			wantErrMsg: "nextCursor must be a JSON string or number",
+			wantCalls:  1,
+		},
+		{
+			name:       "hasMore=true without nextCursor is rejected",
+			response:   `{"result":{"values":[],"hasMore":true},"success":true}`,
+			wantErr:    true,
+			wantErrMsg: "hasMore=true is missing nextCursor",
+			wantCalls:  1,
+		},
+		{
+			name:       "non-JSON response is rejected",
+			response:   `not json`,
+			wantErr:    true,
+			wantErrMsg: "非 JSON 文本或 null",
+			wantCalls:  1,
+		},
+		{
+			name:       "null response is rejected",
+			response:   `null`,
+			wantErr:    true,
+			wantErrMsg: "非 JSON 文本或 null",
+			wantCalls:  1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, out, err := runContactOrgListCommandCapture(t, tc.response, "org", "invite-list")
+			if tc.wantErr {
+				// 分页不一致通过 output.Failure 返回，因此 err 可能为 nil 但输出含错误信息；
+				// 真正的调用/解析错误才会在 err 中返回。
+				if err != nil {
+					if !strings.Contains(err.Error(), tc.wantErrMsg) {
+						t.Fatalf("error does not contain %q: err=%v", tc.wantErrMsg, err)
+					}
+					return
+				}
+				if !strings.Contains(out, tc.wantErrMsg) {
+					t.Fatalf("output does not contain %q: out=%s", tc.wantErrMsg, out)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v\n%s", err, out)
+			}
+		})
+	}
+}
+
+// TestContactOrgListStoreEmission 验证命令在带有 result store 的上下文里
+// 成功通过 StoreResult 返回，覆盖 invite-list / apply-list RunE 中 StoreResult
+// 成功后的 return nil 分支。
+func TestContactOrgListStoreEmission(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		toolName string
+	}{
+		{name: "invite-list", args: []string{"org", "invite-list"}, toolName: "list_team_invite"},
+		{name: "apply-list", args: []string{"org", "apply-list"}, toolName: "query_org_apply_list"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			previousDeps := deps
+			previousArgs := os.Args
+			t.Cleanup(func() {
+				deps = previousDeps
+				os.Args = previousArgs
+			})
+
+			caller := &contactEnterpriseCaller{responseText: `{"result":{"values":[]},"success":true}`}
+			InitDeps(caller)
+			os.Args = append([]string{"dws", "contact"}, tc.args...)
+
+			ctx, _ := output.WithResultStore(context.Background())
+			cmd := newContactCommand()
+			output.SetCommandRollout(cmd, output.RolloutUnifiedActive)
+			cmd.SilenceErrors = true
+			cmd.SilenceUsage = true
+			cmd.PersistentFlags().Bool("yes", false, "")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tc.args)
+			cmd.SetContext(ctx)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("execute with store: %v", err)
+			}
+			if len(caller.calls) != 1 || caller.calls[0].toolName != tc.toolName {
+				t.Fatalf("want 1 %s call, got %+v", tc.toolName, caller.calls)
+			}
+			_, emitted, err := output.EmitStoredResult(cmd)
+			if err != nil || !emitted {
+				t.Fatalf("EmitStoredResult emitted=%t err=%v out=%s", emitted, err, out.String())
 			}
 		})
 	}

--- a/internal/helpers/contact_invite_admin_test.go
+++ b/internal/helpers/contact_invite_admin_test.go
@@ -187,3 +187,49 @@ func TestContactApplyListSafetyProjectionMatchesBehavior(t *testing.T) {
 		t.Fatalf("apply-list args = %#v, want %#v", call.args, want)
 	}
 }
+
+// TestContactApplyRemoveSafetyProjectionMatchesBehavior 是 apply-remove 安全语义的
+// 包内回归（CI coverage gate 只统计包内覆盖）：删除申请记录不可恢复，最终
+// 投影必须声明 Effect=destructive、Confirmation=user_required；运行侧未确认
+// 必须被门禁拦截，确认后精确调用 remove_org_apply。
+func TestContactApplyRemoveSafetyProjectionMatchesBehavior(t *testing.T) {
+	root := newContactCommand()
+	applyRemove := requireWukongSyncCommand(t, root, "org", "apply-remove")
+	payload, ok := contractfinal.RuntimeContractFinal(applyRemove)
+	if !ok {
+		t.Fatal("apply-remove has no runtime contract final payload")
+	}
+	if payload.Safety == nil {
+		t.Fatal("apply-remove payload has no safety declaration")
+	}
+	if got := payload.Safety; got.Effect != "destructive" || got.Risk != "high" ||
+		got.Confirmation != "user_required" || got.Idempotency != "non_idempotent" {
+		t.Fatalf("apply-remove safety = %+v, want destructive/high/user_required/non_idempotent", got)
+	}
+	if !strings.Contains(payload.Description, "不可恢复") {
+		t.Fatalf("apply-remove description %q must disclose non-recoverable deletion", payload.Description)
+	}
+	if payload.Selection == nil || !strings.Contains(payload.Selection.AgentSummary, "不可恢复") {
+		t.Fatalf("apply-remove selection must disclose non-recoverable deletion: %+v", payload.Selection)
+	}
+
+	// 运行行为与声明一致：user_required 必须显式 --yes 才执行。
+	if _, err := runContactEnterpriseCommand(t, "org", "apply-remove", "--id", "123"); err == nil {
+		t.Fatal("apply-remove without --yes must be rejected by confirmation gate")
+	}
+
+	caller, err := runContactEnterpriseCommand(t, "org", "apply-remove", "--id", "123", "--yes")
+	if err != nil {
+		t.Fatalf("apply-remove with --yes failed: %v", err)
+	}
+	if len(caller.calls) != 1 {
+		t.Fatalf("apply-remove want exactly 1 MCP call, got %d: %+v", len(caller.calls), caller.calls)
+	}
+	call := caller.calls[0]
+	if call.productID != "contact" || call.toolName != "remove_org_apply" {
+		t.Fatalf("apply-remove call = %s/%s, want contact/remove_org_apply", call.productID, call.toolName)
+	}
+	if want := map[string]any{"id": int64(123)}; !reflect.DeepEqual(call.args, want) {
+		t.Fatalf("apply-remove args = %#v, want %#v", call.args, want)
+	}
+}


### PR DESCRIPTION
## Summary

Add CLI commands for the contact "enterprise account management + member invitation/apply" MCP tools that have already been published:

- `dws contact exclusive-account disable|enable --staff-id <id>`
- `dws contact org invite-switch`, `invite-audit`, `invite-info`, `invite-list`, `apply-list`, `apply-approve`, `apply-reject`, `apply-block`, `apply-remove`
- `dws contact dept invite-audit --dept <dept-id> --no-audit <bool>`

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow,
  packaging, or interface behavior changed
- [x] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk: workflow/policy, package graph, generated Schema/registry,
  platform, auth/keychain, installer, packaging, release, transport, recovery,
  or another fail-closed infrastructure change

## Verification

- [x] Release fragment added for a user-visible behavior/interface change:
  `.changes/contact-invite-apply-admin.md`
- [x] Targeted test/check commands and results:
  - `make build` ✅
  - `go test ./internal/app/... -run 'Contact|TestRootKeeps|TestRootHelp' -count=1 -v` ✅ (see screenshot below)
  - `go test ./internal/helpers/... ./internal/cli/... -count=1` ✅
- [x] Behavior evidence (CLI dry-run output shape): see Agent test screenshots below
- [x] Documentation links/content/rendering checked: `docs/command-index.md` updated

## Agent test screenshots (contact)

`dws contact org invite-info --dry-run`:
![](https://raw.githubusercontent.com/lifeihong/dingtalk-workspace-cli/pr-1279-evidence/.github/pr-evidence/agent_invite_info.png)

`dws contact org invite-list --status 1 --size 1 --dry-run`:
![](https://raw.githubusercontent.com/lifeihong/dingtalk-workspace-cli/pr-1279-evidence/.github/pr-evidence/agent_invite_list.png)

`dws contact org apply-list --status 0 --size 1 --dry-run`:
![](https://raw.githubusercontent.com/lifeihong/dingtalk-workspace-cli/pr-1279-evidence/.github/pr-evidence/agent_apply_list.png)

`dws contact org invite-switch --open true --dry-run`:
![](https://raw.githubusercontent.com/lifeihong/dingtalk-workspace-cli/pr-1279-evidence/.github/pr-evidence/agent_invite_switch.png)

`dws contact dept invite-audit --dept 1 --no-audit true --dry-run`:
![](https://raw.githubusercontent.com/lifeihong/dingtalk-workspace-cli/pr-1279-evidence/.github/pr-evidence/agent_dept_audit.png)

`dws contact exclusive-account enable --staff-id NON_EXISTENT_CLI_TEST --dry-run`:
![](https://raw.githubusercontent.com/lifeihong/dingtalk-workspace-cli/pr-1279-evidence/.github/pr-evidence/agent_exclusive_enable.png)

## 指令 CI 集成测试截图（contact）

`go test ./internal/app/... -run 'Contact|TestRootKeeps|TestRootHelp' -count=1 -v`:
![](https://raw.githubusercontent.com/lifeihong/dingtalk-workspace-cli/pr-1279-evidence/.github/pr-evidence/ci_integration_test.png)

## Notes

- The `exclusive_account_set_status` MCP tool currently maps `staffId` to the misspelled runtime input field `uesrId`. The CLI adapter intentionally passes `uesrId` to match the published tool behavior; this is called out in a code comment and should be fixed on the MCP platform side in a follow-up release.
- All write commands use `--yes` / `Confirmation: user_required` and were exercised only in `--dry-run` mode for evidence to avoid side effects.
