### PR TITLE
ci: reuse admitted PR evidence on main

### DIFF
--- a/.changes/1280-post-merge-admission-reuse.md
+++ b/.changes/1280-post-merge-admission-reuse.md
@@ -1,0 +1,8 @@
+---
+category: Fixed
+---
+
+- **Post-merge CI admission reuse** — reuses exact successful full-suite
+  PR evidence for tree-identical protected-main merges and promotes the
+  verified coverage artifact to the merge SHA cache, reducing duplicate runner
+  work without adding jobs or weakening required contexts.

--- a/.github/workflows/ai-behavior-check.yml
+++ b/.github/workflows/ai-behavior-check.yml
@@ -32,6 +32,9 @@ jobs:
           script: |
             const pullRequest = context.payload.pull_request;
             const sha = context.eventName === 'push' ? context.sha : pullRequest.head.sha;
+            const statusTargetUrl = context.eventName === 'push'
+              ? `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${sha}`
+              : `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}`;
             const setStatus = (state, description) =>
               github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
@@ -40,6 +43,7 @@ jobs:
                 state,
                 context: 'AI Behavior',
                 description,
+                target_url: statusTargetUrl,
               });
 
             await setStatus('pending', 'Evaluating AI-generated PR boundaries');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      actions: read
       checks: read
       contents: read
       pull-requests: read
+      statuses: read
     outputs:
       changelog_only: ${{ steps.classify.outputs.changelog_only }}
       release_seal_only: ${{ steps.classify.outputs.release_seal_only }}
@@ -45,6 +47,11 @@ jobs:
       mcp_sensitive: ${{ steps.classify.outputs.mcp_sensitive }}
       edition_sensitive: ${{ steps.classify.outputs.edition_sensitive }}
       platform_sensitive: ${{ steps.classify.outputs.platform_sensitive }}
+      admitted_merge: ${{ steps.classify.outputs.admitted_merge }}
+      admitted_merge_head_sha: ${{ steps.classify.outputs.admitted_merge_head_sha }}
+      admitted_merge_run_id: ${{ steps.classify.outputs.admitted_merge_run_id }}
+      admitted_merge_artifact_id: ${{ steps.classify.outputs.admitted_merge_artifact_id }}
+      admitted_merge_artifact_digest: ${{ steps.classify.outputs.admitted_merge_artifact_digest }}
     steps:
       - name: Classify revision scope
         id: classify
@@ -61,8 +68,24 @@ jobs:
             let mcpSensitive = context.eventName === 'push';
             let editionSensitive = context.eventName === 'push';
             let platformSensitive = context.eventName === 'push';
+            let admittedMerge = false;
+            let admittedMergeHeadSha = '';
+            let admittedMergeRunId = '';
+            let admittedMergeArtifactId = '';
+            let admittedMergeArtifactDigest = '';
             let files = [];
             let fastPathTrust = 'not evaluated';
+            const requiredContexts = [
+              'Lint',
+              'Test',
+              'Coverage',
+              'Policy',
+              'Edition',
+              'Interface Integrity',
+              'AI Behavior',
+              'CLI Smoke',
+              'Mock MCP',
+            ];
 
             const isDocsOnly = (filename) =>
               typeof filename === 'string' &&
@@ -342,6 +365,17 @@ jobs:
               const expectedAfter = context.payload.after;
               const fullCommit = /^[0-9a-f]{40}$/;
               const zeroCommit = '0'.repeat(40);
+              const requireFullMain = () => {
+                changelogOnly = false;
+                releaseSealOnly = false;
+                docsOnly = false;
+                fullSuite = true;
+                releaseSensitive = true;
+                interfaceSensitive = true;
+                mcpSensitive = true;
+                editionSensitive = true;
+                platformSensitive = true;
+              };
 
               if (
                 context.ref !== 'refs/heads/main' ||
@@ -358,16 +392,35 @@ jobs:
                 fastPathTrust =
                   'push identity is not a non-forced update of the existing main branch';
               } else {
-                const { data: comparison } =
-                  await github.rest.repos.compareCommitsWithBasehead({
+                let comparison = {
+                  status: 'unknown',
+                  merge_base_commit: null,
+                  behind_by: 1,
+                  ahead_by: 0,
+                  total_commits: 0,
+                  files: [],
+                };
+                let comparisonAvailable = false;
+                try {
+                  const response = await github.rest.repos.compareCommitsWithBasehead({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     basehead: `${expectedBefore}...${expectedAfter}`,
                     per_page: 100,
                   });
+                  comparison = response.data;
+                  comparisonAvailable = true;
+                } catch (error) {
+                  fastPathTrust =
+                    `push comparison unavailable; full main suite required: ${error.message}`;
+                  core.warning(fastPathTrust);
+                }
                 files = Array.isArray(comparison.files) ? comparison.files : [];
                 const pushFilesComplete = files.length < 300;
                 classifyFiles(pushFilesComplete);
+                if (!comparisonAvailable) {
+                  requireFullMain();
+                }
                 const linearFromValidatedTip =
                   comparison.status === 'ahead' &&
                   comparison.merge_base_commit?.sha === expectedBefore &&
@@ -383,74 +436,407 @@ jobs:
                   pushFilesComplete && isExactReleaseSeal(files);
 
                 if (linearFromValidatedTip && (exactChangelogDiff || exactReleaseSealDiff)) {
-                  const requiredContexts = [
-                    'Lint',
-                    'Test',
-                    'Coverage',
-                    'Policy',
-                    'Edition',
-                    'Interface Integrity',
-                    'AI Behavior',
-                    'CLI Smoke',
-                    'Mock MCP',
-                  ];
-                  const runs = await github.paginate(
-                    github.rest.checks.listForRef,
-                    {
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      ref: expectedBefore,
-                      filter: 'latest',
-                      per_page: 100,
+                  try {
+                    const runs = await github.paginate(
+                      github.rest.checks.listForRef,
+                      {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        ref: expectedBefore,
+                        filter: 'latest',
+                        per_page: 100,
+                      }
+                    );
+                    const latestByName = new Map();
+                    for (const run of runs) {
+                      if (
+                        run.head_sha !== expectedBefore ||
+                        run.app?.slug !== 'github-actions' ||
+                        !requiredContexts.includes(run.name)
+                      ) {
+                        continue;
+                      }
+                      const current = latestByName.get(run.name);
+                      if (!current || run.id > current.id) {
+                        latestByName.set(run.name, run);
+                      }
                     }
-                  );
-                  const latestByName = new Map();
-                  for (const run of runs) {
-                    if (
-                      run.head_sha !== expectedBefore ||
-                      run.app?.slug !== 'github-actions' ||
-                      !requiredContexts.includes(run.name)
-                    ) {
-                      continue;
-                    }
-                    const current = latestByName.get(run.name);
-                    if (!current || run.id > current.id) {
-                      latestByName.set(run.name, run);
-                    }
-                  }
-                  const missing = requiredContexts.filter(
-                    (name) => !latestByName.has(name)
-                  );
-                  const nonSuccess = requiredContexts.flatMap((name) => {
-                    const run = latestByName.get(name);
-                    if (!run || run.conclusion === 'success') {
-                      return [];
-                    }
-                    return [
-                      `${name}=${run.conclusion || run.status || 'unknown'}`,
-                    ];
-                  });
+                    const missing = requiredContexts.filter(
+                      (name) => !latestByName.has(name)
+                    );
+                    const nonSuccess = requiredContexts.flatMap((name) => {
+                      const run = latestByName.get(name);
+                      if (!run || run.conclusion === 'success') {
+                        return [];
+                      }
+                      return [
+                        `${name}=${run.conclusion || run.status || 'unknown'}`,
+                      ];
+                    });
 
-                  if (missing.length === 0 && nonSuccess.length === 0) {
-                    changelogOnly = true;
-                    releaseSealOnly = exactReleaseSealDiff;
-                    changelogChanged = true;
-                    if (releaseSealOnly) {
-                      fullSuite = false;
+                    if (missing.length === 0 && nonSuccess.length === 0) {
+                      changelogOnly = true;
+                      releaseSealOnly = exactReleaseSealDiff;
+                      changelogChanged = true;
+                      if (releaseSealOnly) {
+                        fullSuite = false;
+                      }
+                      fastPathTrust =
+                        releaseSealOnly
+                          ? `exact release-seal successor of validated ${expectedBefore}`
+                          : `exact CHANGELOG-only successor of validated ${expectedBefore}`;
+                    } else {
+                      requireFullMain();
+                      fastPathTrust =
+                        'predecessor Code Admission is not fully successful; ' +
+                        `missing=${missing.join(',') || 'none'}; ` +
+                        `non-success=${nonSuccess.join(',') || 'none'}`;
+                      core.warning(fastPathTrust);
                     }
+                  } catch (error) {
+                    requireFullMain();
                     fastPathTrust =
-                      releaseSealOnly
-                        ? `exact release-seal successor of validated ${expectedBefore}`
-                        : `exact CHANGELOG-only successor of validated ${expectedBefore}`;
-                  } else {
-                    fastPathTrust =
-                      'predecessor Code Admission is not fully successful; ' +
-                      `missing=${missing.join(',') || 'none'}; ` +
-                      `non-success=${nonSuccess.join(',') || 'none'}`;
+                      `predecessor admission unavailable; full main suite required: ` +
+                      `${error.message}`;
+                    core.warning(fastPathTrust);
                   }
-                } else {
+                } else if (comparisonAvailable) {
                   fastPathTrust =
                     'push is not an exact linear CHANGELOG-only successor';
+                }
+
+                // A normal protected merge may produce a new commit SHA whose
+                // tree is byte-for-byte the already admitted PR head. Reuse is
+                // allowed only after binding the two-parent merge identity,
+                // every required check, the exact run of the base-owned CI
+                // definition, and its immutable coverage artifact. Any
+                // uncertainty falls back to the complete protected-main suite.
+                if (!changelogOnly && linearFromValidatedTip) {
+                  try {
+                    const {data: targetCommit} = await github.rest.repos.getCommit({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      ref: expectedAfter,
+                      per_page: 100,
+                    });
+                    if (
+                      targetCommit.sha !== expectedAfter ||
+                      targetCommit.parents.length !== 2 ||
+                      targetCommit.parents[0]?.sha !== expectedBefore ||
+                      !fullCommit.test(targetCommit.parents[1]?.sha || '')
+                    ) {
+                      throw new Error('target is not an exact two-parent merge from push before');
+                    }
+                    const admittedHeadSha = targetCommit.parents[1].sha;
+                    const associatedPulls = await github.paginate(
+                      github.rest.pulls.listPullRequestsAssociatedWithCommit,
+                      {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        commit_sha: expectedAfter,
+                        per_page: 100,
+                      },
+                    );
+                    const admittedPulls = associatedPulls.filter((pull) =>
+                      pull.state === 'closed' &&
+                      typeof pull.merged_at === 'string' &&
+                      pull.merged_at.length > 0 &&
+                      pull.base?.ref === 'main' &&
+                      pull.base?.sha === expectedBefore &&
+                      pull.base?.repo?.full_name ===
+                        'DingTalk-Real-AI/dingtalk-workspace-cli' &&
+                      pull.merge_commit_sha === expectedAfter &&
+                      pull.head?.sha === admittedHeadSha &&
+                      typeof pull.head?.ref === 'string' &&
+                      pull.head.ref.length > 0 &&
+                      typeof pull.head?.repo?.full_name === 'string' &&
+                      pull.head.repo.full_name.length > 0,
+                    );
+                    if (admittedPulls.length !== 1) {
+                      throw new Error(
+                        `expected one associated merged PR, found ${admittedPulls.length}`,
+                      );
+                    }
+                    const admittedPull = admittedPulls[0];
+                    const admittedMergedAt = Date.parse(admittedPull.merged_at);
+                    if (!Number.isFinite(admittedMergedAt)) {
+                      throw new Error('merged PR has an invalid merged_at timestamp');
+                    }
+                    const completedByMerge = (value) => {
+                      const timestamp = Date.parse(value || '');
+                      return Number.isFinite(timestamp) && timestamp <= admittedMergedAt;
+                    };
+                    const {data: headCommit} = await github.rest.repos.getCommit({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      ref: admittedHeadSha,
+                      per_page: 1,
+                    });
+                    if (
+                      headCommit.sha !== admittedHeadSha ||
+                      !targetCommit.commit?.tree?.sha ||
+                      targetCommit.commit?.tree?.sha !== headCommit.commit?.tree?.sha
+                    ) {
+                      throw new Error('merge commit tree differs from the admitted PR head tree');
+                    }
+
+                    // The PR run must have used the CI definition already
+                    // trusted on main. A PR that changes this workflow must
+                    // receive a fresh post-merge execution before later
+                    // source-only merges may reuse its admission evidence.
+                    const readProtectedWorkflowBlob = async (path, ref) => {
+                      const {data: content} = await github.rest.repos.getContent({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        path,
+                        ref,
+                      });
+                      if (
+                        Array.isArray(content) ||
+                        content.type !== 'file' ||
+                        !/^[0-9a-f]{40}$/.test(content.sha || '')
+                      ) {
+                        throw new Error(`cannot bind ${path} at ${ref}`);
+                      }
+                      return content.sha;
+                    };
+                    for (const protectedWorkflow of [
+                      '.github/workflows/ci.yml',
+                      '.github/workflows/ai-behavior-check.yml',
+                    ]) {
+                      const baseWorkflowBlob =
+                        await readProtectedWorkflowBlob(protectedWorkflow, expectedBefore);
+                      const headWorkflowBlob =
+                        await readProtectedWorkflowBlob(protectedWorkflow, admittedHeadSha);
+                      if (baseWorkflowBlob !== headWorkflowBlob) {
+                        throw new Error(`PR changed protected workflow ${protectedWorkflow}`);
+                      }
+                    }
+
+                    const fullSuiteEvidenceContexts = [
+                      'Coverage (current: app)',
+                      'Coverage (current: cli)',
+                      'Coverage (current: generators)',
+                      'Coverage (current: helpers)',
+                      'Coverage (current: remaining)',
+                      'Coverage (supporting)',
+                    ];
+                    const admissionContextNames = [
+                      ...requiredContexts,
+                      ...fullSuiteEvidenceContexts,
+                    ];
+                    const checkRuns = await github.paginate(
+                      github.rest.checks.listForRef,
+                      {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        ref: admittedHeadSha,
+                        filter: 'latest',
+                        per_page: 100,
+                      },
+                    );
+                    const latestByName = new Map();
+                    for (const run of checkRuns) {
+                      if (
+                        run.head_sha !== admittedHeadSha ||
+                        run.app?.slug !== 'github-actions' ||
+                        !admissionContextNames.includes(run.name)
+                      ) {
+                        continue;
+                      }
+                      const current = latestByName.get(run.name);
+                      if (!current || run.id > current.id) {
+                        latestByName.set(run.name, run);
+                      }
+                    }
+                    const invalidContexts = requiredContexts.filter((name) => {
+                      const run = latestByName.get(name);
+                      return !run ||
+                        run.status !== 'completed' ||
+                        run.conclusion !== 'success' ||
+                        !completedByMerge(run.completed_at);
+                    });
+                    if (invalidContexts.length > 0) {
+                      throw new Error(
+                        `PR head lacks successful Code Admission: ${invalidContexts.join(', ')}`,
+                      );
+                    }
+                    const invalidFullSuiteEvidence = fullSuiteEvidenceContexts.filter(
+                      (name) => {
+                        const run = latestByName.get(name);
+                        return !run ||
+                          run.status !== 'completed' ||
+                          run.conclusion !== 'success' ||
+                          !completedByMerge(run.completed_at);
+                      },
+                    );
+                    if (invalidFullSuiteEvidence.length > 0) {
+                      throw new Error(
+                        `PR head did not execute the complete coverage suite: ` +
+                        `${invalidFullSuiteEvidence.join(', ')}`,
+                      );
+                    }
+
+                    // AI Behavior is emitted by a separate base-owned
+                    // pull_request_target workflow. Bind both its PR-targeted
+                    // commit status and the automatic Actions check run.
+                    const aiBehaviorCheck = latestByName.get('AI Behavior');
+                    const expectedAIStatusTarget =
+                      `https://github.com/DingTalk-Real-AI/` +
+                      `dingtalk-workspace-cli/pull/${admittedPull.number}`;
+                    const aiStatuses = await github.paginate(
+                      github.rest.repos.listCommitStatusesForRef,
+                      {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        ref: admittedHeadSha,
+                        per_page: 100,
+                      },
+                    );
+                    const boundAIStatuses = aiStatuses
+                      .filter((status) =>
+                        status.context === 'AI Behavior' &&
+                        status.target_url === expectedAIStatusTarget,
+                      )
+                      .sort((left, right) => right.id - left.id);
+                    const latestAIStatus = boundAIStatuses[0];
+                    if (
+                      !latestAIStatus ||
+                      latestAIStatus.state !== 'success' ||
+                      !completedByMerge(latestAIStatus.updated_at)
+                    ) {
+                      throw new Error('AI Behavior status is not bound to the admitted PR before merge');
+                    }
+                    const aiDetailsMatch =
+                      /^https:\/\/github\.com\/DingTalk-Real-AI\/dingtalk-workspace-cli\/actions\/runs\/([1-9][0-9]*)\/job\/[1-9][0-9]*$/
+                        .exec(aiBehaviorCheck.details_url || '');
+                    if (!aiDetailsMatch) {
+                      throw new Error('AI Behavior check has an untrusted Actions URL');
+                    }
+                    const aiRunID = Number(aiDetailsMatch[1]);
+                    const {data: aiWorkflowRun} = await github.rest.actions.getWorkflowRun({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      run_id: aiRunID,
+                    });
+                    if (
+                      aiWorkflowRun.id !== aiRunID ||
+                      aiWorkflowRun.name !== 'Code Admission — AI Behavior' ||
+                      aiWorkflowRun.path !== '.github/workflows/ai-behavior-check.yml' ||
+                      aiWorkflowRun.event !== 'pull_request_target' ||
+                      aiWorkflowRun.head_sha !== admittedHeadSha ||
+                      aiWorkflowRun.head_branch !== admittedPull.head.ref ||
+                      aiWorkflowRun.head_repository?.full_name !==
+                        admittedPull.head?.repo?.full_name ||
+                      aiWorkflowRun.repository?.full_name !==
+                        'DingTalk-Real-AI/dingtalk-workspace-cli' ||
+                      aiWorkflowRun.status !== 'completed' ||
+                      aiWorkflowRun.conclusion !== 'success' ||
+                      !completedByMerge(aiWorkflowRun.updated_at)
+                    ) {
+                      throw new Error('AI Behavior workflow run is not bound to the admitted PR head');
+                    }
+
+                    const {data: ciWorkflow} = await github.rest.actions.getWorkflow({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      workflow_id: '.github/workflows/ci.yml',
+                    });
+                    if (
+                      ciWorkflow.name !== 'CI' ||
+                      ciWorkflow.path !== '.github/workflows/ci.yml' ||
+                      ciWorkflow.state !== 'active'
+                    ) {
+                      throw new Error('protected CI workflow identity is not active or exact');
+                    }
+                    const workflowRuns = await github.paginate(
+                      github.rest.actions.listWorkflowRuns,
+                      {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        workflow_id: ciWorkflow.id,
+                        event: 'pull_request',
+                        status: 'success',
+                        head_sha: admittedHeadSha,
+                        per_page: 100,
+                      },
+                    );
+                    const ciContextNames = [
+                      ...requiredContexts.filter((name) => name !== 'AI Behavior'),
+                      ...fullSuiteEvidenceContexts,
+                    ];
+                    const admittedRuns = workflowRuns.filter((run) =>
+                      run.name === 'CI' &&
+                      run.workflow_id === ciWorkflow.id &&
+                      run.path === ciWorkflow.path &&
+                      run.event === 'pull_request' &&
+                      run.head_sha === admittedHeadSha &&
+                      run.head_branch === admittedPull.head.ref &&
+                      run.head_repository?.full_name === admittedPull.head?.repo?.full_name &&
+                      run.repository?.full_name ===
+                        'DingTalk-Real-AI/dingtalk-workspace-cli' &&
+                      run.status === 'completed' &&
+                      run.conclusion === 'success' &&
+                      completedByMerge(run.updated_at) &&
+                      ciContextNames.every((name) =>
+                        latestByName.get(name)?.details_url?.includes(
+                          `/actions/runs/${run.id}/job/`,
+                        ),
+                      ),
+                    );
+                    if (admittedRuns.length !== 1) {
+                      throw new Error(
+                        `expected one exact successful PR CI run, found ${admittedRuns.length}`,
+                      );
+                    }
+                    const admittedRun = admittedRuns[0];
+                    const artifacts = await github.paginate(
+                      github.rest.actions.listWorkflowRunArtifacts,
+                      {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        run_id: admittedRun.id,
+                        per_page: 100,
+                      },
+                    );
+                    const coverageArtifacts = artifacts.filter((artifact) =>
+                      artifact.name === 'coverage-report' &&
+                      artifact.expired === false &&
+                      artifact.size_in_bytes > 0 &&
+                      artifact.size_in_bytes <= 134217728 &&
+                      artifact.workflow_run?.id === admittedRun.id &&
+                      artifact.workflow_run?.head_sha === admittedHeadSha &&
+                      /^sha256:[0-9a-f]{64}$/.test(artifact.digest || '') &&
+                      completedByMerge(artifact.updated_at),
+                    );
+                    if (coverageArtifacts.length !== 1) {
+                      throw new Error(
+                        `expected one immutable coverage artifact, found ${coverageArtifacts.length}`,
+                      );
+                    }
+
+                    const coverageArtifact = coverageArtifacts[0];
+                    admittedMerge = true;
+                    admittedMergeHeadSha = admittedHeadSha;
+                    admittedMergeRunId = String(admittedRun.id);
+                    admittedMergeArtifactId = String(coverageArtifact.id);
+                    admittedMergeArtifactDigest = coverageArtifact.digest;
+                    fullSuite = false;
+                    releaseSensitive = false;
+                    interfaceSensitive = false;
+                    mcpSensitive = false;
+                    editionSensitive = false;
+                    platformSensitive = false;
+                    fastPathTrust =
+                      `merge tree reuses PR #${admittedPull.number} ` +
+                      `CI run ${admittedRun.id} artifact ${coverageArtifact.id}`;
+                  } catch (error) {
+                    requireFullMain();
+                    fastPathTrust =
+                      `admitted-merge reuse unavailable; full main suite required: ` +
+                      `${error.message}`;
+                    core.warning(fastPathTrust);
+                  }
                 }
               }
             }
@@ -465,6 +851,11 @@ jobs:
             core.setOutput('mcp_sensitive', String(mcpSensitive));
             core.setOutput('edition_sensitive', String(editionSensitive));
             core.setOutput('platform_sensitive', String(platformSensitive));
+            core.setOutput('admitted_merge', String(admittedMerge));
+            core.setOutput('admitted_merge_head_sha', admittedMergeHeadSha);
+            core.setOutput('admitted_merge_run_id', admittedMergeRunId);
+            core.setOutput('admitted_merge_artifact_id', admittedMergeArtifactId);
+            core.setOutput('admitted_merge_artifact_digest', admittedMergeArtifactDigest);
             await core.summary
               .addHeading('Code Admission scope')
               .addRaw(`- Event: \`${context.eventName}\`\n`)
@@ -478,6 +869,7 @@ jobs:
               .addRaw(`- MCP-sensitive: \`${mcpSensitive}\`\n`)
               .addRaw(`- Edition-sensitive: \`${editionSensitive}\`\n`)
               .addRaw(`- Native-platform risk paths touched: \`${platformSensitive}\`\n`)
+              .addRaw(`- Admitted merge reuse: \`${admittedMerge}\`\n`)
               .addRaw(`- Changed files: \`${files.length}\`\n`)
               .addRaw(`- Fast-path trust: ${fastPathTrust}\n`)
               .write();
@@ -494,43 +886,52 @@ jobs:
           fi
 
       - name: Record documentation-only fast path
-        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only == 'true'
+        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only == 'true' && steps.classify.outputs.admitted_merge != 'true'
         run: echo "Lint is satisfied by the non-executable documentation scope." >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Record admitted-merge reuse
+        if: steps.classify.outputs.admitted_merge == 'true'
+        env:
+          ADMITTED_HEAD_SHA: ${{ steps.classify.outputs.admitted_merge_head_sha }}
+          ADMITTED_RUN_ID: ${{ steps.classify.outputs.admitted_merge_run_id }}
+        run: |
+          echo "Lint reuses successful Code Admission from PR head $ADMITTED_HEAD_SHA (CI run $ADMITTED_RUN_ID)." \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check out repository
-        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
+        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true' && steps.classify.outputs.admitted_merge != 'true'
         uses: actions/checkout@v4
 
       - name: Set up Go
-        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
+        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true' && steps.classify.outputs.admitted_merge != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Verify Test Package Plan
-        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
+        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true' && steps.classify.outputs.admitted_merge != 'true'
         run: make test-plan
 
       - name: Format Check
-        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
+        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true' && steps.classify.outputs.admitted_merge != 'true'
         run: make format-check
 
       - name: Go Vet
-        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
+        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true' && steps.classify.outputs.admitted_merge != 'true'
         run: go vet ./...
 
       - name: Check GitHub Actions workflows
-        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
+        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true' && steps.classify.outputs.admitted_merge != 'true'
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
       - name: Test reviewer routing and merge authority policy
-        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
+        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true' && steps.classify.outputs.admitted_merge != 'true'
         run: |
           node .github/reviewer-routing.test.js
           node .github/reviewer-merge-authority.test.js
 
       - name: Test npm installer smoke (prune, backup, publish)
-        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true'
+        if: steps.classify.outputs.changelog_only != 'true' && steps.classify.outputs.docs_only != 'true' && steps.classify.outputs.admitted_merge != 'true'
         env:
           XDG_CONFIG_HOME: ""
         run: node test/scripts/install_js_smoke.mjs
@@ -538,7 +939,7 @@ jobs:
   runtime-payload:
     name: Validate Runtime Payload
     needs: lint
-    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && (needs.lint.outputs.release_sensitive == 'true' || needs.lint.outputs.platform_sensitive == 'true') }}
+    if: ${{ needs.lint.outputs.admitted_merge == 'true' || (needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && (needs.lint.outputs.release_sensitive == 'true' || needs.lint.outputs.platform_sensitive == 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -573,7 +974,7 @@ jobs:
   test-focused:
     name: "Test (focused: ${{ matrix.shard }})"
     needs: lint
-    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.full_suite != 'true' }}
+    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true' && needs.lint.outputs.full_suite != 'true' }}
     runs-on: ubuntu-latest
     # Each shard owns one bounded slice of the impacted set, so no single job
     # carries internal/app together with every reverse dependency. The shard
@@ -829,7 +1230,7 @@ jobs:
   test-cross-platform:
     name: Test (cross-platform compile)
     needs: lint
-    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' }}
+    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -878,6 +1279,7 @@ jobs:
         env:
           CHANGELOG_ONLY: ${{ needs.lint.outputs.changelog_only }}
           DOCS_ONLY: ${{ needs.lint.outputs.docs_only }}
+          ADMITTED_MERGE: ${{ needs.lint.outputs.admitted_merge }}
           FULL_SUITE: ${{ needs.lint.outputs.full_suite }}
           RELEASE_SENSITIVE: ${{ needs.lint.outputs.release_sensitive }}
           FOCUSED_RESULT: ${{ needs.test-focused.result }}
@@ -888,7 +1290,9 @@ jobs:
           WINDOWS_RESULT: ${{ needs.test-windows.result }}
         run: |
           failed=0
-          if [ "$CHANGELOG_ONLY" = true ] || [ "$DOCS_ONLY" = true ]; then
+          if [ "$CHANGELOG_ONLY" = true ] ||
+             [ "$DOCS_ONLY" = true ] ||
+             [ "$ADMITTED_MERGE" = true ]; then
             for shard in \
               "focused shards:$FOCUSED_RESULT" \
               "race shards:$RACE_RESULT" \
@@ -1382,7 +1786,7 @@ jobs:
   coverage-current:
     name: Coverage (current)
     needs: lint
-    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.full_suite != 'true' }}
+    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true' && needs.lint.outputs.full_suite != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -1568,7 +1972,7 @@ jobs:
   coverage-baseline:
     name: Coverage (baseline)
     needs: lint
-    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' }}
+    if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1706,18 +2110,21 @@ jobs:
           path: coverage-base.txt
           retention-days: 1
 
-  # Documentation and release-seal pushes do not change executable coverage,
-  # but their new main SHA is still a future PR merge base. Promote only an
-  # exact predecessor cache after independently proving the whole push changed
-  # metadata paths; fall back to a full authoritative profile on a cold chain.
+  # Metadata-only pushes promote an exact predecessor profile. A protected
+  # two-parent merge whose final tree exactly equals an already admitted PR
+  # head instead reuses that successful CI run's immutable coverage artifact.
+  # Both paths publish and verify the new main SHA's exact cache key.
   coverage-main-metadata:
     name: Coverage (main metadata cache)
     needs: lint
-    if: ${{ github.event_name == 'push' && (needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true') }}
+    if: ${{ github.event_name == 'push' && (needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || needs.lint.outputs.admitted_merge == 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
     steps:
-      - name: Check out exact metadata-only main revision
+      - name: Check out exact main revision
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -1730,6 +2137,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Verify metadata-only main successor
+        if: needs.lint.outputs.admitted_merge != 'true'
         shell: bash
         env:
           PUSH_BEFORE_SHA: ${{ github.event.before }}
@@ -1782,23 +2190,103 @@ jobs:
           test -s coverage-cache.txt
           test "$(head -n 1 coverage-cache.txt)" = "mode: atomic"
 
+      - name: Download admitted PR coverage profile
+        id: admitted-coverage
+        if: needs.lint.outputs.admitted_merge == 'true' && steps.metadata-current-cache.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ADMITTED_HEAD_SHA: ${{ needs.lint.outputs.admitted_merge_head_sha }}
+          ADMITTED_RUN_ID: ${{ needs.lint.outputs.admitted_merge_run_id }}
+          ADMITTED_ARTIFACT_ID: ${{ needs.lint.outputs.admitted_merge_artifact_id }}
+          ADMITTED_ARTIFACT_DIGEST: ${{ needs.lint.outputs.admitted_merge_artifact_digest }}
+        run: |
+          if bash -euo pipefail <<'VERIFY'
+          full_commit='^[0-9a-f]{40}$'
+          positive_integer='^[1-9][0-9]*$'
+          artifact_digest='^sha256:[0-9a-f]{64}$'
+          [[ "$ADMITTED_HEAD_SHA" =~ $full_commit ]]
+          [[ "$ADMITTED_RUN_ID" =~ $positive_integer ]]
+          [[ "$ADMITTED_ARTIFACT_ID" =~ $positive_integer ]]
+          [[ "$ADMITTED_ARTIFACT_DIGEST" =~ $artifact_digest ]]
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ADMITTED_ARTIFACT_ID" \
+            > admitted-artifact.json
+          jq -e \
+            --argjson id "$ADMITTED_ARTIFACT_ID" \
+            --argjson run "$ADMITTED_RUN_ID" \
+            --arg head "$ADMITTED_HEAD_SHA" \
+            --arg digest "$ADMITTED_ARTIFACT_DIGEST" \
+            '.id == $id and
+             .name == "coverage-report" and
+             .expired == false and
+             .size_in_bytes > 0 and
+             .size_in_bytes <= 134217728 and
+             .digest == $digest and
+             .workflow_run.id == $run and
+             .workflow_run.head_sha == $head' admitted-artifact.json >/dev/null
+
+          gh api "repos/$GITHUB_REPOSITORY/actions/artifacts/$ADMITTED_ARTIFACT_ID/zip" \
+            > admitted-coverage.zip
+          actual_digest="$(sha256sum admitted-coverage.zip | awk '{print $1}')"
+          test "sha256:$actual_digest" = "$ADMITTED_ARTIFACT_DIGEST"
+          mkdir admitted-coverage
+          unzip -q admitted-coverage.zip \
+            coverage.txt coverage-admission.json \
+            -d admitted-coverage
+          test -f admitted-coverage/coverage.txt
+          test ! -L admitted-coverage/coverage.txt
+          test -f admitted-coverage/coverage-admission.json
+          test ! -L admitted-coverage/coverage-admission.json
+          test "$(wc -c < admitted-coverage/coverage-admission.json)" -le 4096
+          test "$(wc -c < admitted-coverage/coverage.txt)" -le 67108864
+          jq -e \
+            --argjson run "$ADMITTED_RUN_ID" \
+            --arg head "$ADMITTED_HEAD_SHA" \
+            '.schema_version == 1 and
+             .workflow_run_id == $run and
+             .head_sha == $head and
+             .coverage_kind == "full"' \
+            admitted-coverage/coverage-admission.json >/dev/null
+          test "$(head -n 1 admitted-coverage/coverage.txt)" = "mode: atomic"
+          test "$(wc -l < admitted-coverage/coverage.txt)" -gt 1
+          cp admitted-coverage/coverage.txt coverage-cache.txt
+          VERIFY
+          then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            rm -f coverage-cache.txt
+            echo "::warning::Admitted coverage artifact verification failed; recomputing the complete profile."
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Recompute admitted merge coverage profile
+        if: needs.lint.outputs.admitted_merge == 'true' && steps.metadata-current-cache.outputs.cache-hit != 'true' && steps.admitted-coverage.outputs.valid != 'true'
+        env:
+          DWS_PACKAGE_VERSION: 0.0.0-test
+        run: |
+          set -euo pipefail
+          ./scripts/ci/run-full-coverage.sh coverage-cache.txt
+          test -s coverage-cache.txt
+          test "$(head -n 1 coverage-cache.txt)" = "mode: atomic"
+
       - name: Restore exact predecessor coverage profile
         id: metadata-source-cache
-        if: steps.metadata-current-cache.outputs.cache-hit != 'true'
+        if: needs.lint.outputs.admitted_merge != 'true' && steps.metadata-current-cache.outputs.cache-hit != 'true'
         uses: actions/cache/restore@v4
         with:
           path: coverage-cache.txt
           key: dws-coverage-full-v2-${{ env.COVERAGE_SOURCE_REF }}-go${{ steps.setup-go-metadata.outputs.go-version }}
 
       - name: Validate promoted predecessor coverage profile
-        if: steps.metadata-current-cache.outputs.cache-hit != 'true' && steps.metadata-source-cache.outputs.cache-hit == 'true'
+        if: needs.lint.outputs.admitted_merge != 'true' && steps.metadata-current-cache.outputs.cache-hit != 'true' && steps.metadata-source-cache.outputs.cache-hit == 'true'
         run: |
           set -eu
           test -s coverage-cache.txt
           test "$(head -n 1 coverage-cache.txt)" = "mode: atomic"
 
       - name: Install archive tooling for cold metadata baseline
-        if: steps.metadata-current-cache.outputs.cache-hit != 'true' && steps.metadata-source-cache.outputs.cache-hit != 'true'
+        if: needs.lint.outputs.admitted_merge != 'true' && steps.metadata-current-cache.outputs.cache-hit != 'true' && steps.metadata-source-cache.outputs.cache-hit != 'true'
         run: |
           if command -v zip >/dev/null && command -v unzip >/dev/null; then
             echo "zip and unzip are already available"
@@ -1808,7 +2296,7 @@ jobs:
           fi
 
       - name: Recompute cold metadata baseline
-        if: steps.metadata-current-cache.outputs.cache-hit != 'true' && steps.metadata-source-cache.outputs.cache-hit != 'true'
+        if: needs.lint.outputs.admitted_merge != 'true' && steps.metadata-current-cache.outputs.cache-hit != 'true' && steps.metadata-source-cache.outputs.cache-hit != 'true'
         env:
           DWS_PACKAGE_VERSION: 0.0.0-test
         run: |
@@ -1817,7 +2305,7 @@ jobs:
           test -s coverage-cache.txt
           test "$(head -n 1 coverage-cache.txt)" = "mode: atomic"
 
-      - name: Save metadata main SHA coverage profile
+      - name: Save exact main SHA coverage profile
         if: steps.metadata-current-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
@@ -1859,6 +2347,7 @@ jobs:
         env:
           CHANGELOG_ONLY: ${{ needs.lint.outputs.changelog_only }}
           DOCS_ONLY: ${{ needs.lint.outputs.docs_only }}
+          ADMITTED_MERGE: ${{ needs.lint.outputs.admitted_merge }}
           FULL_SUITE: ${{ needs.lint.outputs.full_suite }}
           PLATFORM_SENSITIVE: ${{ needs.lint.outputs.platform_sensitive }}
           CURRENT_RESULT: ${{ needs.coverage-current.result }}
@@ -1876,7 +2365,11 @@ jobs:
           baseline_expected=success
           main_metadata_expected=skipped
           native_expected=skipped
-          if [ "$CHANGELOG_ONLY" = true ] || [ "$DOCS_ONLY" = true ]; then
+          if [ "$ADMITTED_MERGE" = true ]; then
+            current_expected=skipped
+            baseline_expected=skipped
+            main_metadata_expected=success
+          elif [ "$CHANGELOG_ONLY" = true ] || [ "$DOCS_ONLY" = true ]; then
             current_expected=skipped
             baseline_expected=skipped
             if [ "$GITHUB_EVENT_NAME" = push ]; then
@@ -1925,7 +2418,7 @@ jobs:
           test "$failed" -eq 0
 
       - name: Check out repository
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -1933,13 +2426,13 @@ jobs:
 
       - name: Set up Go
         id: setup-go
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Resolve authoritative coverage base
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true'
         env:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -1957,7 +2450,7 @@ jobs:
           echo "COVERAGE_BASE_REF=$base_ref" >> "$GITHUB_ENV"
 
       - name: Download current coverage profiles
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true'
         uses: actions/download-artifact@v4
         with:
           pattern: coverage-current-*
@@ -1965,14 +2458,14 @@ jobs:
           path: .
 
       - name: Download supporting coverage profiles
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.full_suite == 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true' && needs.lint.outputs.full_suite == 'true'
         uses: actions/download-artifact@v4
         with:
           name: coverage-supporting-profiles
           path: .
 
       - name: Download baseline coverage profile
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true'
         uses: actions/download-artifact@v4
         with:
           name: coverage-baseline-profile
@@ -1983,7 +2476,7 @@ jobs:
       # blocks by their greatest atomic count. Every expected shard must be
       # present; a missing shard would silently shrink the comparison.
       - name: Assemble full-suite coverage profile
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.full_suite == 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true' && needs.lint.outputs.full_suite == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -1998,7 +2491,7 @@ jobs:
           ./scripts/ci/merge-coverage-profiles.sh coverage.txt "${profiles[@]}"
 
       - name: Enforce coverage gate
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true'
         env:
           FULL_SUITE: ${{ needs.lint.outputs.full_suite }}
           COVERAGE_TARGET: "100"
@@ -2054,7 +2547,7 @@ jobs:
         run: test "$EXACT_CACHE_HIT" = true
 
       - name: Generate coverage report
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true'
         run: |
           if [ "$(wc -l < coverage.txt)" -gt 1 ]; then
             go tool cover -html=coverage.txt -o coverage.html
@@ -2063,8 +2556,37 @@ jobs:
               >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Record coverage admission metadata
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true'
+        shell: bash
+        env:
+          COVERAGE_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          COVERAGE_RUN_ID: ${{ github.run_id }}
+          FULL_SUITE: ${{ needs.lint.outputs.full_suite }}
+        run: |
+          set -euo pipefail
+          full_commit='^[0-9a-f]{40}$'
+          positive_integer='^[1-9][0-9]*$'
+          [[ "$COVERAGE_HEAD_SHA" =~ $full_commit ]]
+          [[ "$COVERAGE_RUN_ID" =~ $positive_integer ]]
+          case "$FULL_SUITE" in
+            true) coverage_kind=full ;;
+            false) coverage_kind=scoped ;;
+            *) echo "Unknown coverage suite kind: $FULL_SUITE" >&2; exit 1 ;;
+          esac
+          jq -n \
+            --argjson run "$COVERAGE_RUN_ID" \
+            --arg head "$COVERAGE_HEAD_SHA" \
+            --arg kind "$coverage_kind" \
+            '{
+              schema_version: 1,
+              workflow_run_id: $run,
+              head_sha: $head,
+              coverage_kind: $kind
+            }' > coverage-admission.json
+
       - name: Upload coverage artifact
-        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true'
+        if: needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
@@ -2074,6 +2596,7 @@ jobs:
             coverage-policy.txt
             coverage-shortcut.txt
             coverage.html
+            coverage-admission.json
           if-no-files-found: error
 
   policy:
@@ -2086,6 +2609,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Check out repository
+        if: needs.lint.outputs.admitted_merge != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -2192,8 +2716,17 @@ jobs:
               >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Record admitted-merge reuse
+        if: needs.lint.outputs.admitted_merge == 'true'
+        env:
+          ADMITTED_HEAD_SHA: ${{ needs.lint.outputs.admitted_merge_head_sha }}
+          ADMITTED_RUN_ID: ${{ needs.lint.outputs.admitted_merge_run_id }}
+        run: |
+          echo "Policy reuses successful Code Admission from PR head $ADMITTED_HEAD_SHA (CI run $ADMITTED_RUN_ID)." \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Validate scoped policy
-        if: ${{ needs.lint.outputs.changelog_only != 'true' && (needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.interface_sensitive != 'true')) }}
+        if: ${{ needs.lint.outputs.admitted_merge != 'true' && needs.lint.outputs.changelog_only != 'true' && (needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.interface_sensitive != 'true')) }}
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
@@ -2301,8 +2834,17 @@ jobs:
         if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && (needs.lint.outputs.full_suite == 'true' || needs.lint.outputs.interface_sensitive == 'true') }}
         run: make skill-command-integrity
 
+      - name: Record admitted-merge reuse
+        if: needs.lint.outputs.admitted_merge == 'true'
+        env:
+          ADMITTED_HEAD_SHA: ${{ needs.lint.outputs.admitted_merge_head_sha }}
+          ADMITTED_RUN_ID: ${{ needs.lint.outputs.admitted_merge_run_id }}
+        run: |
+          echo "Interface Integrity reuses successful Code Admission from PR head $ADMITTED_HEAD_SHA (CI run $ADMITTED_RUN_ID)." \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Record scoped fast path
-        if: ${{ needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.interface_sensitive != 'true') }}
+        if: ${{ needs.lint.outputs.admitted_merge != 'true' && (needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.interface_sensitive != 'true')) }}
         run: echo "Interface Integrity is unaffected by this classified revision." >> "$GITHUB_STEP_SUMMARY"
 
   cli-smoke:
@@ -2329,8 +2871,17 @@ jobs:
         if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && (needs.lint.outputs.full_suite == 'true' || needs.lint.outputs.interface_sensitive == 'true') }}
         run: make cli-smoke
 
+      - name: Record admitted-merge reuse
+        if: needs.lint.outputs.admitted_merge == 'true'
+        env:
+          ADMITTED_HEAD_SHA: ${{ needs.lint.outputs.admitted_merge_head_sha }}
+          ADMITTED_RUN_ID: ${{ needs.lint.outputs.admitted_merge_run_id }}
+        run: |
+          echo "CLI Smoke reuses successful Code Admission from PR head $ADMITTED_HEAD_SHA (CI run $ADMITTED_RUN_ID)." \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Record scoped fast path
-        if: ${{ needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.interface_sensitive != 'true') }}
+        if: ${{ needs.lint.outputs.admitted_merge != 'true' && (needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.interface_sensitive != 'true')) }}
         run: echo "CLI Smoke is unaffected by this classified revision." >> "$GITHUB_STEP_SUMMARY"
 
   mock-mcp-smoke:
@@ -2353,8 +2904,17 @@ jobs:
         if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && (needs.lint.outputs.full_suite == 'true' || needs.lint.outputs.mcp_sensitive == 'true') }}
         run: make mock-mcp-smoke
 
+      - name: Record admitted-merge reuse
+        if: needs.lint.outputs.admitted_merge == 'true'
+        env:
+          ADMITTED_HEAD_SHA: ${{ needs.lint.outputs.admitted_merge_head_sha }}
+          ADMITTED_RUN_ID: ${{ needs.lint.outputs.admitted_merge_run_id }}
+        run: |
+          echo "Mock MCP reuses successful Code Admission from PR head $ADMITTED_HEAD_SHA (CI run $ADMITTED_RUN_ID)." \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Record scoped fast path
-        if: ${{ needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.mcp_sensitive != 'true') }}
+        if: ${{ needs.lint.outputs.admitted_merge != 'true' && (needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.mcp_sensitive != 'true')) }}
         run: echo "Mock MCP is unaffected by this classified revision." >> "$GITHUB_STEP_SUMMARY"
 
   edition-tests:
@@ -2377,6 +2937,15 @@ jobs:
         if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && (needs.lint.outputs.full_suite == 'true' || needs.lint.outputs.edition_sensitive == 'true') }}
         run: go test -v -count=1 ./pkg/editiontest/...
 
+      - name: Record admitted-merge reuse
+        if: needs.lint.outputs.admitted_merge == 'true'
+        env:
+          ADMITTED_HEAD_SHA: ${{ needs.lint.outputs.admitted_merge_head_sha }}
+          ADMITTED_RUN_ID: ${{ needs.lint.outputs.admitted_merge_run_id }}
+        run: |
+          echo "Edition reuses successful Code Admission from PR head $ADMITTED_HEAD_SHA (CI run $ADMITTED_RUN_ID)." \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Record scoped fast path
-        if: ${{ needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.edition_sensitive != 'true') }}
+        if: ${{ needs.lint.outputs.admitted_merge != 'true' && (needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.edition_sensitive != 'true')) }}
         run: echo "Edition is unaffected by this classified revision." >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,11 +52,17 @@ Select the PR risk tier before choosing checks:
 |---|---|---|---|
 | Documentation-only | Prose and documentation assets with no executable, generated, workflow, packaging, or interface change | Links/content/rendering plus repository asset checks | Lightweight documentation validation; all nine named contexts still report |
 | Standard | Ordinary implementation work with a stable package graph | Focused unit/integration tests and observable behavior for the changed path | Race tests for changed packages and their reverse dependencies, scope-matched HEAD/base coverage, and representative Darwin/Windows compilation |
-| High-risk | Workflow/policy, package graph, generated Schema/registry, platform, auth/keychain, installer, packaging, release, transport, recovery, or an unprovable infrastructure change | Relevant full or domain suite plus focused behavior evidence | Complete race suite, native platform tests, and all affected domain gates; protected `main` uses this tier |
+| High-risk | Workflow/policy, package graph, generated Schema/registry, platform, auth/keychain, installer, packaging, release, transport, recovery, or an unprovable infrastructure change | Relevant full or domain suite plus focused behavior evidence | Complete race suite, native platform tests, and all affected domain gates; protected `main` uses this tier unless an exact two-parent merge can reuse a complete, base-owned PR admission |
 
 Classification fails closed: an incomplete diff, package add/remove/rename, or
 uncertain dependency graph selects the high-risk suite. Native changed-code
 coverage is additionally selected for platform-sensitive code.
+An eligible protected-main merge keeps all nine required contexts but records
+the already successful full-suite PR evidence instead of repeating it. The
+merge tree, PR identity, base-owned workflow blobs, check/status timestamps,
+workflow runs, and coverage artifact must all bind exactly; otherwise main runs
+the complete high-risk suite. Main-only Runtime Payload and integration checks
+still execute against the merge SHA.
 
 ## Pull Request Checklist
 

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -120,6 +120,66 @@ documentation changes are rejected. It still rejects invalid dates or
 versions, missing bullets, placeholder `TODO`/`TBD`, unmanaged-section
 changes, and unsafe tree modes.
 
+## Exact admitted-merge reuse on main
+
+Pull requests and protected `main` pushes remain separate GitHub trust events,
+so all nine required contexts are still published for both SHAs. For an
+ordinary merge whose final tree is identical to the already admitted PR head,
+the protected-main run may reuse that exact admission only when the PR already
+executed the complete coverage suite. It then avoids executing the same
+expensive suites again. This changes work performed inside the existing jobs;
+it does not add a new job or weaken the branch ruleset.
+
+The classifier fails closed unless it can prove every one of these facts:
+
+- the push is a non-forced update and the workflow SHA equals the event's exact
+  `after` SHA;
+- the new commit is a standard two-parent merge whose first parent is the event
+  `before` SHA and whose second parent is the admitted PR head;
+- exactly one closed PR binds that head, the `main` base, and the merge commit;
+- the merge commit tree and PR-head tree are byte-for-byte identical;
+- `.github/workflows/ci.yml` and
+  `.github/workflows/ai-behavior-check.yml` have the same Git blobs on the
+  previous main tip and the PR head, so a PR cannot redefine a check that
+  authorizes its own reuse;
+- the PR head has successful latest GitHub Actions checks for all nine required
+  Code Admission contexts, all completed before merge;
+- the base-owned `AI Behavior` status targets that exact PR URL, and its
+  `pull_request_target` workflow run binds the same head repository, branch,
+  SHA, and pre-merge completion time;
+- exactly one successful, completed `pull_request` run of the protected `CI`
+  workflow binds the eight CI-owned contexts to that PR head before it merged;
+- all five complete current-coverage shards plus supporting coverage completed
+  successfully in that same run, proving this was not a scoped profile;
+- that run owns exactly one non-expired `coverage-report` artifact with a
+  published SHA-256 digest and the same head SHA; the archive's admission
+  manifest independently binds the run ID, head SHA, and `full` profile kind.
+
+When those facts hold, `Lint` publishes the bound PR head, run, artifact, and
+digest. The existing `coverage-main-metadata` job downloads the artifact by
+numeric ID, revalidates its API identity, verifies the downloaded archive's
+digest before extraction, validates the manifest and `coverage.txt`, and saves
+the profile under the exact merge SHA cache key. A lookup-only restore must
+then observe that exact key. `Test`, `Coverage`, `Policy`, `Edition`,
+`Interface Integrity`, `CLI Smoke`, and `Mock MCP` still report their stable
+required names while explicitly recording or verifying the reused admission;
+base-owned `AI Behavior` remains independent.
+The non-ruleset `Validate Runtime Payload` helper still executes on the merge
+SHA because that protected-main validation is not guaranteed to have run on
+every full-suite PR.
+
+Any missing, duplicate, stale, or mismatched API evidence keeps the existing
+complete protected-main suite. If an already-bound artifact later cannot be
+downloaded or fails its digest, manifest, or profile validation, the existing
+main-cache helper recomputes the complete coverage profile authoritatively
+instead of promoting those bytes. Squash/rebase merges, stale branches whose
+merge tree differs, direct pushes, and PRs that modify the CI workflow are
+therefore ineligible. A standard PR that ran only scoped coverage is also
+ineligible because it cannot populate a complete future merge-base profile.
+In particular, the governance PR that introduces or changes this mechanism
+must itself run the complete post-merge suite; only later eligible source
+merges can use the optimization.
+
 ## Risk tiers and downstream boundaries
 
 `Lint` resolves the complete base/head diff before any helper is skipped.
@@ -129,7 +189,7 @@ Unknown or truncated input fails closed into the high-risk tier.
 |---|---|---|
 | Documentation-only | Only prose/documentation assets; no executable, generated, workflow, packaging, or interface surface | Documentation and repository-asset validation; expensive code helpers skip while every required context still succeeds |
 | Standard | Ordinary code change with a stable package graph | Race tests for changed Go packages and their reverse dependencies; candidate and merge-base coverage over the same impacted scope and `coverpkg`; representative Darwin/Windows compilation |
-| High-risk / protected `main` | Workflow/policy, package add/remove/rename, generated Schema/registry, platform, auth/keychain, installer, packaging, release, transport, recovery, or an unprovable infrastructure classification | Complete race suite and full native macOS/Windows tests, plus every affected domain gate |
+| High-risk / unproven protected `main` | Workflow/policy, package add/remove/rename, generated Schema/registry, platform, auth/keychain, installer, packaging, release, transport, recovery, or a protected-main revision without exact admitted-merge evidence | Complete race suite and full native macOS/Windows tests, plus every affected domain gate |
 
 Domain helpers (`Edition`, `Interface Integrity`, `CLI Smoke`, and `Mock MCP`,
 for example) execute their substantive suites when the diff can affect that
@@ -138,10 +198,11 @@ contexts still report a successful, explicit unaffected result. Release-script
 tests follow the same impact rule. This preserves the ruleset contract without
 charging every developer for unrelated work.
 
-Platform-sensitive changes additionally run native changed-code coverage.
-Protected `main` always runs native tests; generic portable changes are held to
-the Linux changed-code gate rather than being forced to manufacture
-platform-only coverage.
+Platform-sensitive changes additionally run native changed-code coverage. A
+protected-main revision without exact admitted-merge reuse always runs native
+tests; eligible merges retain the native evidence already recorded on the PR
+head. Generic portable changes are held to the Linux changed-code gate rather
+than being forced to manufacture platform-only coverage.
 
 Complete `Multi-profile E2E` is not a PR admission context. It belongs to the
 `Main Integration — 主干集成` workflow and runs only after a push to `main` (or
@@ -167,7 +228,10 @@ flowchart TB
   ADMISSION --> S["CLI Smoke"]
   ADMISSION --> M["Mock MCP"]
   ADMISSION --> MAIN["Protected main"]
-  MAIN --> NATIVE["Full native platform matrix"]
+  MAIN --> REUSE{"Exact full-suite PR evidence?"}
+  REUSE -->|yes| RECORDED["Reuse admission and exact coverage artifact"]
+  REUSE -->|no| NATIVE["Full native platform matrix"]
+  MAIN --> PAYLOAD["Validate Runtime Payload"]
   MAIN --> E2E["Multi-profile E2E"]
   MAIN --> RELEASE["Release delivery"]
 ```
@@ -372,8 +436,9 @@ base_ref=$(git merge-base HEAD origin/main)
 `make coverage-gate` is an enforcement step, not a profile generator. For a
 standard PR, CI derives changed packages and their reverse-dependency test
 closure, then generates candidate and merge-base profiles with the same test
-scope and `coverpkg`. High-risk and protected-main runs use the complete
-profiles. The complete candidate profile is produced by five fixed per-shard
+scope and `coverpkg`. High-risk and protected-main runs without exact
+admitted-merge reuse use the complete profiles. The complete candidate profile
+is produced by five fixed per-shard
 helper jobs (`scripts/ci/test-packages.sh list-coverage`; `verify`
 proves the shard union equals the full-suite scope exactly once). Packages
 remain serial within each runner except for the large `remaining` shard, which
@@ -410,8 +475,10 @@ verifies the live App/writer-ruleset identity contract. Reviewer Router
 additionally binds auto-merge to the exact head OID and writes a fixed safe
 merge headline/body. The sole break-glass publisher must retain a safe final
 message; the release-controlled Formula-only path
-is the sole supported use of `[skip ci]`. A full source push
-saves the assembled profile after the aggregate gate passes. A trusted
+is the sole supported use of `[skip ci]`. A source push that cannot prove exact
+admitted-merge reuse saves the newly assembled profile after the aggregate gate
+passes. An eligible tree-identical merge instead verifies and promotes the
+bound PR run's immutable coverage artifact to the exact merge-SHA key. A trusted
 documentation or release-seal push independently verifies that the complete
 `before...after` diff contains only the reviewed metadata allowlist, restores
 only the exact `before` cache, recomputes the full profile if the chain is

--- a/test/scripts/admitted_merge_classifier_test.go
+++ b/test/scripts/admitted_merge_classifier_test.go
@@ -1,0 +1,378 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package scripts_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type admittedMergeClassifierResult struct {
+	Outputs  map[string]string `json:"outputs"`
+	Warnings []string          `json:"warnings"`
+}
+
+func TestAdmittedMergeClassifierFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to execute the admitted-merge classifier")
+	}
+	classifier := readWorkflowGitHubScript(t, ".github/workflows/ci.yml", "lint", "Classify revision scope")
+
+	tests := []struct {
+		name     string
+		scenario string
+		admitted string
+	}{
+		{name: "exact evidence is reused", scenario: "success", admitted: "true"},
+		{name: "comparison API failure recomputes full suite", scenario: "compare-error", admitted: "false"},
+		{name: "predecessor checks API failure recomputes full suite", scenario: "predecessor-check-error", admitted: "false"},
+		{name: "failed predecessor admission recomputes full suite", scenario: "predecessor-check-failure", admitted: "false"},
+		{name: "AI status for another PR recomputes full suite", scenario: "ai-target-mismatch", admitted: "false"},
+		{name: "post-merge CI result recomputes full suite", scenario: "stale-ci", admitted: "false"},
+		{name: "duplicate artifact recomputes full suite", scenario: "duplicate-artifact", admitted: "false"},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := runAdmittedMergeClassifier(t, node, classifier, test.scenario)
+			if got := result.Outputs["admitted_merge"]; got != test.admitted {
+				t.Fatalf("admitted_merge = %q, want %q; warnings=%v", got, test.admitted, result.Warnings)
+			}
+			if test.admitted == "true" {
+				for key, want := range map[string]string{
+					"full_suite":                     "false",
+					"release_sensitive":              "false",
+					"interface_sensitive":            "false",
+					"mcp_sensitive":                  "false",
+					"edition_sensitive":              "false",
+					"platform_sensitive":             "false",
+					"admitted_merge_head_sha":        strings.Repeat("c", 40),
+					"admitted_merge_run_id":          "100",
+					"admitted_merge_artifact_id":     "300",
+					"admitted_merge_artifact_digest": "sha256:" + strings.Repeat("d", 64),
+				} {
+					if got := result.Outputs[key]; got != want {
+						t.Errorf("%s = %q, want %q", key, got, want)
+					}
+				}
+				return
+			}
+
+			for _, key := range []string{
+				"changelog_only",
+				"docs_only",
+			} {
+				if got := result.Outputs[key]; got != "false" {
+					t.Errorf("fail-closed %s = %q, want false", key, got)
+				}
+			}
+			for _, key := range []string{
+				"full_suite",
+				"release_sensitive",
+				"interface_sensitive",
+				"mcp_sensitive",
+				"edition_sensitive",
+				"platform_sensitive",
+			} {
+				if got := result.Outputs[key]; got != "true" {
+					t.Errorf("fail-closed %s = %q, want true", key, got)
+				}
+			}
+			for _, key := range []string{
+				"admitted_merge_head_sha",
+				"admitted_merge_run_id",
+				"admitted_merge_artifact_id",
+				"admitted_merge_artifact_digest",
+			} {
+				if got := result.Outputs[key]; got != "" {
+					t.Errorf("failed admission leaked %s = %q", key, got)
+				}
+			}
+			if len(result.Warnings) == 0 {
+				t.Error("fail-closed scenario must explain why reuse was rejected")
+			}
+		})
+	}
+}
+
+func readWorkflowGitHubScript(t *testing.T, relativePath, jobName, stepName string) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, relativePath))
+	if err != nil {
+		t.Fatalf("read %s: %v", relativePath, err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name string `yaml:"name"`
+				Uses string `yaml:"uses"`
+				With struct {
+					Script string `yaml:"script"`
+				} `yaml:"with"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse %s: %v", relativePath, err)
+	}
+	job, ok := workflow.Jobs[jobName]
+	if !ok {
+		t.Fatalf("workflow %s has no job %q", relativePath, jobName)
+	}
+	for _, step := range job.Steps {
+		if step.Name == stepName && strings.HasPrefix(step.Uses, "actions/github-script@") {
+			if step.With.Script == "" {
+				t.Fatalf("workflow step %q has no script", stepName)
+			}
+			return step.With.Script
+		}
+	}
+	t.Fatalf("workflow %s job %s has no github-script step %q", relativePath, jobName, stepName)
+	return ""
+}
+
+func runAdmittedMergeClassifier(t *testing.T, node, classifier, scenario string) admittedMergeClassifierResult {
+	t.Helper()
+	const harnessPrefix = `
+const scenario = process.argv[2];
+const before = 'b'.repeat(40);
+const after = 'a'.repeat(40);
+const head = 'c'.repeat(40);
+const mergedAt = '2026-09-03T12:00:00Z';
+const completedAt = '2026-09-03T11:59:00Z';
+const lateAt = '2026-09-03T12:01:00Z';
+const repository = 'DingTalk-Real-AI/dingtalk-workspace-cli';
+const headRepository = 'example/dingtalk-workspace-cli';
+const headBranch = 'feature/admitted-merge';
+const ciRunID = 100;
+const aiRunID = 200;
+const pullNumber = 1280;
+const requiredContexts = [
+  'Lint', 'Test', 'Coverage', 'Policy', 'Edition',
+  'Interface Integrity', 'AI Behavior', 'CLI Smoke', 'Mock MCP',
+];
+const fullCoverageContexts = [
+  'Coverage (current: app)', 'Coverage (current: cli)',
+  'Coverage (current: generators)', 'Coverage (current: helpers)',
+  'Coverage (current: remaining)', 'Coverage (supporting)',
+];
+const checks = [...requiredContexts, ...fullCoverageContexts].map((name, index) => ({
+  id: 1000 + index,
+  name,
+  head_sha: head,
+  app: {slug: 'github-actions'},
+  status: 'completed',
+  conclusion: 'success',
+  completed_at: completedAt,
+  details_url: name === 'AI Behavior'
+    ? 'https://github.com/' + repository + '/actions/runs/' + aiRunID + '/job/2001'
+    : 'https://github.com/' + repository + '/actions/runs/' + ciRunID + '/job/' + (1000 + index),
+}));
+const pull = {
+  number: pullNumber,
+  state: 'closed',
+  merged_at: mergedAt,
+  base: {ref: 'main', sha: before, repo: {full_name: repository}},
+  head: {ref: headBranch, sha: head, repo: {full_name: headRepository}},
+  merge_commit_sha: after,
+};
+const ciRun = {
+  id: ciRunID,
+  name: 'CI',
+  workflow_id: 10,
+  path: '.github/workflows/ci.yml',
+  event: 'pull_request',
+  head_sha: head,
+  head_branch: headBranch,
+  head_repository: {full_name: headRepository},
+  repository: {full_name: repository},
+  status: 'completed',
+  conclusion: 'success',
+  updated_at: scenario === 'stale-ci' ? lateAt : completedAt,
+};
+const aiRun = {
+  id: aiRunID,
+  name: 'Code Admission — AI Behavior',
+  path: '.github/workflows/ai-behavior-check.yml',
+  event: 'pull_request_target',
+  head_sha: head,
+  head_branch: headBranch,
+  head_repository: {full_name: headRepository},
+  repository: {full_name: repository},
+  status: 'completed',
+  conclusion: 'success',
+  updated_at: completedAt,
+};
+const artifact = {
+  id: 300,
+  name: 'coverage-report',
+  expired: false,
+  size_in_bytes: 4096,
+  digest: 'sha256:' + 'd'.repeat(64),
+  updated_at: completedAt,
+  workflow_run: {id: ciRunID, head_sha: head},
+};
+const endpoints = {
+  repos: {
+    compareCommitsWithBasehead: async () => {
+      if (scenario === 'compare-error') throw new Error('comparison unavailable');
+      return {data: {
+        status: 'ahead', merge_base_commit: {sha: before},
+        behind_by: 0, ahead_by: 1, total_commits: 1,
+        files: scenario.startsWith('predecessor-')
+          ? [{filename: 'CHANGELOG.md', status: 'modified'}]
+          : [{filename: 'internal/app/root.go', status: 'modified'}],
+      }};
+    },
+    getCommit: async ({ref}) => ({data: ref === after
+      ? {sha: after, parents: scenario.startsWith('predecessor-')
+          ? [{sha: before}]
+          : [{sha: before}, {sha: head}], commit: {tree: {sha: 'tree'}}}
+      : {sha: head, commit: {tree: {sha: 'tree'}}}
+    }),
+    getContent: async () => ({data: {type: 'file', sha: 'e'.repeat(40)}}),
+    listCommitStatusesForRef: async () => ({data: [{
+      id: 500,
+      context: 'AI Behavior',
+      state: 'success',
+      target_url: scenario === 'ai-target-mismatch'
+        ? 'https://github.com/' + repository + '/pull/1279'
+        : 'https://github.com/' + repository + '/pull/' + pullNumber,
+      updated_at: completedAt,
+    }]}),
+  },
+  pulls: {
+    listPullRequestsAssociatedWithCommit: async () => ({data: [pull]}),
+  },
+  checks: {
+    listForRef: async ({ref}) => {
+      if (ref === before && scenario === 'predecessor-check-error') {
+        throw new Error('checks unavailable');
+      }
+      if (ref === before) {
+        return {data: {check_runs: requiredContexts.map((name, index) => ({
+          id: 2000 + index,
+          name,
+          head_sha: before,
+          app: {slug: 'github-actions'},
+          status: 'completed',
+          conclusion: scenario === 'predecessor-check-failure' && name === 'Coverage'
+            ? 'failure'
+            : 'success',
+        }))}};
+      }
+      return {data: {check_runs: checks}};
+    },
+  },
+  actions: {
+    getWorkflow: async () => ({data: {id: 10, name: 'CI', path: '.github/workflows/ci.yml', state: 'active'}}),
+    getWorkflowRun: async () => ({data: aiRun}),
+    listWorkflowRuns: async () => ({data: {workflow_runs: [ciRun]}}),
+    listWorkflowRunArtifacts: async () => ({data: {artifacts:
+      scenario === 'duplicate-artifact' ? [artifact, {...artifact, id: 301}] : [artifact],
+    }}),
+  },
+};
+const unwrapPage = (response) => {
+  const data = response?.data;
+  if (Array.isArray(data)) return data;
+  for (const key of ['check_runs', 'workflow_runs', 'artifacts']) {
+    if (Array.isArray(data?.[key])) return data[key];
+  }
+  throw new Error('mock endpoint did not return a pageable collection');
+};
+const github = {
+  rest: endpoints,
+  paginate: async (endpoint, args) => unwrapPage(await endpoint(args)),
+};
+const outputs = {};
+const warnings = [];
+const summary = {
+  addHeading() { return this; },
+  addRaw() { return this; },
+  async write() { return this; },
+};
+const core = {
+  setOutput(name, value) { outputs[name] = String(value); },
+  warning(value) { warnings.push(String(value)); },
+  summary,
+};
+const context = {
+  eventName: 'push',
+  ref: 'refs/heads/main',
+  sha: after,
+  repo: {owner: 'DingTalk-Real-AI', repo: 'dingtalk-workspace-cli'},
+  payload: {
+    before,
+    after,
+    ref: 'refs/heads/main',
+    created: false,
+    deleted: false,
+    forced: false,
+  },
+};
+(async () => {
+`
+	const harnessSuffix = `
+  process.stdout.write(JSON.stringify({outputs, warnings}));
+})().catch((error) => {
+  process.stderr.write(error.stack || String(error));
+  process.exit(1);
+});
+`
+	source := harnessPrefix + classifier + harnessSuffix
+	scriptPath := filepath.Join(t.TempDir(), "admitted-merge-classifier.js")
+	if err := os.WriteFile(scriptPath, []byte(source), 0o600); err != nil {
+		t.Fatalf("write classifier harness: %v", err)
+	}
+	command := exec.Command(node, scriptPath, scenario)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute classifier scenario %q: %v\n%s", scenario, err, output)
+	}
+	var result admittedMergeClassifierResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("decode classifier scenario %q: %v\n%s", scenario, err, output)
+	}
+	if result.Outputs == nil {
+		t.Fatalf("classifier scenario %q produced no outputs", scenario)
+	}
+	return result
+}
+
+func TestAIBehaviorStatusBindsPullRequestURL(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ai-behavior-check.yml"))
+	if err != nil {
+		t.Fatalf("read AI Behavior workflow: %v", err)
+	}
+	workflow := string(data)
+	for _, want := range []string{
+		"const statusTargetUrl = context.eventName === 'push'",
+		"`https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${context.issue.number}`",
+		"target_url: statusTargetUrl",
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Errorf("AI Behavior status is missing PR binding %q", want)
+		}
+	}
+}

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -1336,8 +1336,8 @@ func TestChangelogPRFastPathWorkflowContract(t *testing.T) {
 		t.Fatal("Code Admission workflow missing focused test job boundaries")
 	}
 	focusedJob := admission[focusedStart:focusedEnd]
-	if !strings.Contains(focusedJob, `if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.full_suite != 'true' }}`) {
-		t.Error("focused test shards must run for every non-doc, non-full-suite revision")
+	if !strings.Contains(focusedJob, `if: ${{ needs.lint.outputs.changelog_only != 'true' && needs.lint.outputs.docs_only != 'true' && needs.lint.outputs.admitted_merge != 'true' && needs.lint.outputs.full_suite != 'true' }}`) {
+		t.Error("focused test shards must run for every non-doc, non-reused, non-full-suite revision")
 	}
 	if !strings.Contains(focusedJob, "timeout-minutes: 20") {
 		t.Error("focused test job must allow the scoped race suite up to 20 minutes")

--- a/test/scripts/coverage_workflow_contract_test.go
+++ b/test/scripts/coverage_workflow_contract_test.go
@@ -311,6 +311,217 @@ func TestCoverageWorkflowShardsAndBaselineCache(t *testing.T) {
 	}
 }
 
+func TestCoverageWorkflowReusesExactAdmittedMergeEvidence(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("Abs(repo root) error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("ReadFile(ci.yml) error = %v", err)
+	}
+	admission := string(data)
+
+	lintStart := strings.Index(admission, "\n  lint:\n")
+	runtimeStart := strings.Index(admission, "\n  runtime-payload:\n")
+	if lintStart < 0 || runtimeStart <= lintStart {
+		t.Fatal("CI workflow missing Lint job boundaries")
+	}
+	lintJob := admission[lintStart:runtimeStart]
+	for _, want := range []string{
+		"actions: read",
+		"statuses: read",
+		"admitted_merge: ${{ steps.classify.outputs.admitted_merge }}",
+		"admitted_merge_head_sha: ${{ steps.classify.outputs.admitted_merge_head_sha }}",
+		"admitted_merge_run_id: ${{ steps.classify.outputs.admitted_merge_run_id }}",
+		"admitted_merge_artifact_id: ${{ steps.classify.outputs.admitted_merge_artifact_id }}",
+		"admitted_merge_artifact_digest: ${{ steps.classify.outputs.admitted_merge_artifact_digest }}",
+		"let admittedMerge = false;",
+		"github.rest.repos.getCommit",
+		"targetCommit.parents.length !== 2",
+		"targetCommit.parents[0]?.sha !== expectedBefore",
+		"github.rest.pulls.listPullRequestsAssociatedWithCommit",
+		"pull.merge_commit_sha === expectedAfter",
+		"pull.base?.sha === expectedBefore",
+		"pull.base?.repo?.full_name ===",
+		"pull.head?.sha === admittedHeadSha",
+		"targetCommit.commit?.tree?.sha !== headCommit.commit?.tree?.sha",
+		"github.rest.repos.getContent",
+		"'.github/workflows/ci.yml'",
+		"'.github/workflows/ai-behavior-check.yml'",
+		"await readProtectedWorkflowBlob(protectedWorkflow, expectedBefore)",
+		"await readProtectedWorkflowBlob(protectedWorkflow, admittedHeadSha)",
+		"baseWorkflowBlob !== headWorkflowBlob",
+		"PR changed protected workflow",
+		"github.rest.checks.listForRef",
+		"const requiredContexts = [",
+		"const fullSuiteEvidenceContexts = [",
+		"'Coverage (current: app)'",
+		"'Coverage (current: remaining)'",
+		"'Coverage (supporting)'",
+		"PR head did not execute the complete coverage suite",
+		"github.rest.repos.listCommitStatusesForRef",
+		"status.target_url === expectedAIStatusTarget",
+		"github.rest.actions.getWorkflowRun",
+		"aiWorkflowRun.event !== 'pull_request_target'",
+		"aiWorkflowRun.head_sha !== admittedHeadSha",
+		"AI Behavior workflow run is not bound to the admitted PR head",
+		"github.rest.actions.getWorkflow",
+		"github.rest.actions.listWorkflowRuns",
+		"run.event === 'pull_request'",
+		"run.head_sha === admittedHeadSha",
+		"run.head_repository?.full_name === admittedPull.head?.repo?.full_name",
+		"run.status === 'completed'",
+		"run.conclusion === 'success'",
+		"completedByMerge(run.updated_at)",
+		"github.rest.actions.listWorkflowRunArtifacts",
+		"artifact.name === 'coverage-report'",
+		"artifact.size_in_bytes <= 134217728",
+		"artifact.workflow_run?.head_sha === admittedHeadSha",
+		"/^sha256:[0-9a-f]{64}$/.test(artifact.digest || '')",
+		"core.setOutput('admitted_merge', String(admittedMerge))",
+		"core.setOutput('admitted_merge_head_sha', admittedMergeHeadSha)",
+		"core.setOutput('admitted_merge_run_id', admittedMergeRunId)",
+		"core.setOutput('admitted_merge_artifact_id', admittedMergeArtifactId)",
+		"core.setOutput('admitted_merge_artifact_digest', admittedMergeArtifactDigest)",
+		"fullSuite = false;",
+		"releaseSensitive = false;",
+		"interfaceSensitive = false;",
+		"mcpSensitive = false;",
+		"editionSensitive = false;",
+		"platformSensitive = false;",
+		"name: Record admitted-merge reuse",
+	} {
+		if !strings.Contains(lintJob, want) {
+			t.Errorf("Lint admitted-merge classifier missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"restore-keys",
+		"targetCommit.parents.length === 1",
+		"comparison.files.every",
+	} {
+		if strings.Contains(lintJob, forbidden) {
+			t.Errorf("Lint admitted-merge classifier contains unsafe shortcut %q", forbidden)
+		}
+	}
+	for _, forbiddenJob := range []string{
+		"\n  admitted-merge:\n",
+		"\n  coverage-admitted-merge:\n",
+	} {
+		if strings.Contains(admission, forbiddenJob) {
+			t.Errorf("admitted-merge reuse must not add a new job %q", forbiddenJob)
+		}
+	}
+
+	focusedStart := strings.Index(admission, "\n  test-focused:\n")
+	if focusedStart <= runtimeStart {
+		t.Fatal("CI workflow missing Runtime Payload job boundaries")
+	}
+	runtimeJob := admission[runtimeStart:focusedStart]
+	if !strings.Contains(runtimeJob, "needs.lint.outputs.admitted_merge == 'true'") {
+		t.Error("main-only Runtime Payload validation must still run for admitted merges")
+	}
+
+	testStart := strings.Index(admission, "\n  test:\n")
+	coverageCurrentStart := strings.Index(admission, "\n  coverage-current:\n")
+	if testStart < 0 || coverageCurrentStart <= testStart {
+		t.Fatal("CI workflow missing Test and coverage job boundaries")
+	}
+	testJob := admission[testStart:coverageCurrentStart]
+	for _, want := range []string{
+		"ADMITTED_MERGE: ${{ needs.lint.outputs.admitted_merge }}",
+		`[ "$ADMITTED_MERGE" = true ]`,
+		"focused shards:$FOCUSED_RESULT",
+		"race shards:$RACE_RESULT",
+	} {
+		if !strings.Contains(testJob, want) {
+			t.Errorf("Test aggregate missing admitted-merge contract %q", want)
+		}
+	}
+
+	metadataStart := strings.Index(admission, "\n  coverage-main-metadata:\n")
+	coverageStart := strings.Index(admission, "\n  coverage:\n")
+	policyStart := strings.Index(admission, "\n  policy:\n")
+	if metadataStart < 0 || coverageStart <= metadataStart || policyStart <= coverageStart {
+		t.Fatal("CI workflow missing main-cache, Coverage, or Policy boundaries")
+	}
+	mainCacheJob := admission[metadataStart:coverageStart]
+	for _, want := range []string{
+		"needs.lint.outputs.admitted_merge == 'true'",
+		"actions: read",
+		"name: Download admitted PR coverage profile",
+		"id: admitted-coverage",
+		"ADMITTED_HEAD_SHA: ${{ needs.lint.outputs.admitted_merge_head_sha }}",
+		"ADMITTED_RUN_ID: ${{ needs.lint.outputs.admitted_merge_run_id }}",
+		"ADMITTED_ARTIFACT_ID: ${{ needs.lint.outputs.admitted_merge_artifact_id }}",
+		"ADMITTED_ARTIFACT_DIGEST: ${{ needs.lint.outputs.admitted_merge_artifact_digest }}",
+		"gh api \"repos/$GITHUB_REPOSITORY/actions/artifacts/$ADMITTED_ARTIFACT_ID\"",
+		".size_in_bytes <= 134217728",
+		".workflow_run.head_sha == $head",
+		"gh api \"repos/$GITHUB_REPOSITORY/actions/artifacts/$ADMITTED_ARTIFACT_ID/zip\"",
+		`test "sha256:$actual_digest" = "$ADMITTED_ARTIFACT_DIGEST"`,
+		"unzip -q admitted-coverage.zip",
+		"coverage-admission.json",
+		".schema_version == 1",
+		".workflow_run_id == $run",
+		".head_sha == $head",
+		`.coverage_kind == "full"`,
+		`test "$(wc -c < admitted-coverage/coverage-admission.json)" -le 4096`,
+		`test "$(wc -c < admitted-coverage/coverage.txt)" -le 67108864`,
+		`echo "valid=true" >> "$GITHUB_OUTPUT"`,
+		`echo "valid=false" >> "$GITHUB_OUTPUT"`,
+		"cp admitted-coverage/coverage.txt coverage-cache.txt",
+		"name: Recompute admitted merge coverage profile",
+		"steps.admitted-coverage.outputs.valid != 'true'",
+		"./scripts/ci/run-full-coverage.sh coverage-cache.txt",
+		"lookup-only: true",
+		"fail-on-cache-miss: true",
+	} {
+		if !strings.Contains(mainCacheJob, want) {
+			t.Errorf("main cache producer missing admitted-merge contract %q", want)
+		}
+	}
+	if strings.Contains(mainCacheJob, "restore-keys") {
+		t.Error("admitted-merge cache producer must retain exact keys")
+	}
+	if strings.Contains(mainCacheJob, "name: Install archive tooling for admitted merge") {
+		t.Error("archive tooling failure must be handled by artifact fallback, not block full recomputation")
+	}
+
+	coverageJob := admission[coverageStart:policyStart]
+	for _, want := range []string{
+		"ADMITTED_MERGE: ${{ needs.lint.outputs.admitted_merge }}",
+		`if [ "$ADMITTED_MERGE" = true ]; then`,
+		"main_metadata_expected=success",
+		"needs.lint.outputs.admitted_merge != 'true'",
+		"name: Record coverage admission metadata",
+		"COVERAGE_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}",
+		"COVERAGE_RUN_ID: ${{ github.run_id }}",
+		"coverage_kind",
+		"coverage-admission.json",
+	} {
+		if !strings.Contains(coverageJob, want) {
+			t.Errorf("Coverage aggregate missing admitted-merge contract %q", want)
+		}
+	}
+
+	policyJob := admission[policyStart:]
+	for _, want := range []string{
+		"name: Record admitted-merge reuse",
+		"needs.lint.outputs.admitted_merge == 'true'",
+		"Policy reuses successful Code Admission",
+		"Interface Integrity reuses successful Code Admission",
+		"CLI Smoke reuses successful Code Admission",
+		"Mock MCP reuses successful Code Admission",
+		"Edition reuses successful Code Admission",
+	} {
+		if !strings.Contains(policyJob, want) {
+			t.Errorf("Policy required context missing admitted-merge contract %q", want)
+		}
+	}
+}
+
 func TestFormulaCoverageBaselinePromotionContract(t *testing.T) {
 	root, err := filepath.Abs(filepath.Join("..", ".."))
 	if err != nil {


### PR DESCRIPTION
## 需求与目标

Fixes #1280

PR 与 main push 是两个独立的 GitHub 信任事件，但对于 tree 与已完成完整 Code Admission 的 PR head 完全相同的标准 merge，重复执行整套 race/coverage 矩阵会放大 Hosted Runner 排队和 shutdown 风险。本 PR 保留两个事件、九项 required contexts 与 main exact-SHA coverage producer，同时复用可严格证明的完整 PR 证据。

## 实现摘要

- 在现有 `Lint` 分类器中 fail-closed 绑定非 force 两父 merge、唯一 merged PR、base/head/merge SHA、相同 Git tree，以及合并前 main 与 PR head 相同的 `ci.yml` / `ai-behavior-check.yml` Git blob；compare API 异常只会回退完整套件，不会使 `Lint` 失败。
- 只接受九项 Code Admission 与五个完整 current coverage 分片、supporting coverage 全绿且绑定同一成功 PR CI run 的结果；标准 scoped PR 不复用。
- `AI Behavior` 同时校验绑定精确 PR URL 的 commit status，以及同一 head 仓库、分支、SHA 且在 merge 前完成的 base-owned `pull_request_target` workflow run，避免复用同名或过期绿灯。
- 为 `coverage-report` 增加 run ID、head SHA、`full|scoped` 类型 manifest；main 按 artifact ID 下载并复核 API 身份、大小上限、SHA-256、manifest 与 atomic profile。
- 复用成功后由原有 `coverage-main-metadata` Job 保存并 lookup-only 验证 merge SHA 的 exact cache；artifact 字节级验证失败时在同一 helper 中权威重算完整 profile。
- 九项 required context 保持原名并显式记录/验证复用；main 独有的 `Validate Runtime Payload` 仍在 merge SHA 上真实执行。
- Job 图保持 22 个，没有新增 Job；同步保留了 #1278 的三条 app race lane。

## 环境与风险等级

- 基线：`main` / `aac7703bee5095939711a8e44afbae5401230e20`
- 风险等级：High-risk（GitHub Actions workflow / CI governance）
- 本地环境：macOS，Go 1.26.5

## 验证

| 验证 | 结果 |
|---|---|
| `go test ./test/scripts -count=1 -timeout=20m` | 通过，715.137s |
| 行为级 classifier mock | 通过；覆盖成功、compare/前序 checks API 异常、前序检查失败、AI 状态串 PR、late CI、重复 artifact |
| 聚焦 workflow/coverage/changelog/JS syntax/三 lane 契约 | 通过 |
| `make test-plan` | 通过；134 个默认包、105 个完整 coverage 包各覆盖一次 |
| `make format-check` | 通过 |
| `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12` | 通过（全部 workflows） |
| `./scripts/policy/check-open-source-assets.sh` | 通过 |
| `git diff --check` | 通过 |
| base/current Job ID 对比 | `22 -> 22`，无新增 Job |
| 历史成功 PR run `33752417167` / artifact `9893858409` 实测 | API identity、18.5 MB 下载、archive SHA-256 与发布 digest 一致；完整 helper checks 同 run |

## 局限与 fail-closed 边界

- 只有标准两父 merge、tree 完全相同、两个 base-owned admission workflow 均未变且 PR 已跑完整套件时才复用；squash/rebase、直推、force push、scoped PR 或任何证据不确定均继续执行完整 main CI。
- 本 PR 自身修改 `ci.yml`，因此合入后的第一次 main CI 必然走完整套件；优化从后续符合条件的 merge 开始生效。
- 本 PR 修改 `.github/workflows/**`，按现有 Reviewer Router 边界只能由维护者手动合并，不会申请 App 自动合并。
- Artifact API 证据在分类阶段缺失会走完整 main CI；分类后下载或字节校验异常会在原 cache helper 中重算完整 coverage profile，不会提升不可信内容。

## 回滚

回滚本提交即可恢复原完整 main CI 行为；分类器默认值始终是完整套件，因此 API 变化和读取失败不会静默放宽门禁。
