### PR TITLE
docs(release): record checksum validation fix

### DIFF
--- a/.changes/1288-release-module-checksums.md
+++ b/.changes/1288-release-module-checksums.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Release dependency checksums** (#1288) — removes stale module checksum records so release validation remains reproducible after `go mod tidy`.


### PR DESCRIPTION
## Summary
- add the missing release fragment for the merged #1288 checksum cleanup
- allow the controlled beta.4 changelog generator to produce a non-empty release section

## Verification
- `git diff --check`
- `./scripts/policy/check-release-fragments.sh origin/main HEAD`
- `./scripts/policy/open-source-audit.sh`

## Risk and rollback
Documentation-only release metadata. Revert this PR before the beta.4 seal if the release note should not be included.