### PR TITLE
ci: fail-fast PR cancellation and admitted-merge discovery retry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,16 +528,7 @@ jobs:
                       throw new Error('target is not an exact two-parent merge from push before');
                     }
                     const admittedHeadSha = targetCommit.parents[1].sha;
-                    const associatedPulls = await github.paginate(
-                      github.rest.pulls.listPullRequestsAssociatedWithCommit,
-                      {
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        commit_sha: expectedAfter,
-                        per_page: 100,
-                      },
-                    );
-                    const admittedPulls = associatedPulls.filter((pull) =>
+                    const matchesAdmittedMerge = (pull) =>
                       pull.state === 'closed' &&
                       typeof pull.merged_at === 'string' &&
                       pull.merged_at.length > 0 &&
@@ -550,11 +541,80 @@ jobs:
                       typeof pull.head?.ref === 'string' &&
                       pull.head.ref.length > 0 &&
                       typeof pull.head?.repo?.full_name === 'string' &&
-                      pull.head.repo.full_name.length > 0,
+                      pull.head.repo.full_name.length > 0;
+                    const findAdmittedPulls = async () => {
+                      const associatedPulls = await github.paginate(
+                        github.rest.pulls.listPullRequestsAssociatedWithCommit,
+                        {
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          commit_sha: expectedAfter,
+                          per_page: 100,
+                        },
+                      );
+                      const matched = associatedPulls.filter(matchesAdmittedMerge);
+                      if (matched.length > 0) {
+                        return matched;
+                      }
+                      // A protected-main push fires within seconds of the
+                      // merge, before the commit-to-PR association index
+                      // necessarily lists the fresh merge commit. The merge
+                      // transaction has already recorded merge_commit_sha on
+                      // the PR itself, so the most recently updated closed
+                      // PRs are a second discovery source under the identical
+                      // exact filter. One page only: the just-merged PR is
+                      // always among the latest updated closed main PRs.
+                      try {
+                        const {data: recentlyClosedPulls} =
+                          await github.rest.pulls.list({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            state: 'closed',
+                            base: 'main',
+                            sort: 'updated',
+                            direction: 'desc',
+                            per_page: 100,
+                          });
+                        return (recentlyClosedPulls || []).filter(matchesAdmittedMerge);
+                      } catch (error) {
+                        core.warning(
+                          `closed-PR fallback discovery failed: ${error.message}`,
+                        );
+                        return [];
+                      }
+                    };
+                    // Bounded retry so discovery can wait out association-index
+                    // lag instead of failing closed on the first snapshot.
+                    // Only zero matches retry; ambiguity throws immediately.
+                    const retryIntervalMs = Math.max(
+                      0,
+                      Number.parseInt(
+                        process.env.DWS_ADMITTED_MERGE_RETRY_INTERVAL_MS || '5000',
+                        10,
+                      ) || 0,
                     );
+                    const retryAttempts = Math.max(
+                      1,
+                      Number.parseInt(
+                        process.env.DWS_ADMITTED_MERGE_RETRY_ATTEMPTS || '12',
+                        10,
+                      ) || 1,
+                    );
+                    let admittedPulls = await findAdmittedPulls();
+                    let discoveryAttempts = 1;
+                    while (admittedPulls.length === 0 && discoveryAttempts < retryAttempts) {
+                      discoveryAttempts += 1;
+                      if (retryIntervalMs > 0) {
+                        await new Promise((resolve) => {
+                          setTimeout(resolve, retryIntervalMs);
+                        });
+                      }
+                      admittedPulls = await findAdmittedPulls();
+                    }
                     if (admittedPulls.length !== 1) {
                       throw new Error(
-                        `expected one associated merged PR, found ${admittedPulls.length}`,
+                        `expected one associated merged PR, found ${admittedPulls.length} ` +
+                          `after ${discoveryAttempts} discovery attempt(s)`,
                       );
                     }
                     const admittedPull = admittedPulls[0];

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3046,7 +3046,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3067,7 +3069,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3088,7 +3092,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3109,7 +3115,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3130,7 +3138,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3151,7 +3161,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3172,7 +3184,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3193,7 +3207,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3214,7 +3230,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3235,7 +3253,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3256,7 +3276,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3277,7 +3299,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3298,7 +3322,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3319,7 +3345,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3340,7 +3368,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3361,7 +3391,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3382,7 +3414,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3403,7 +3437,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3424,7 +3460,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi
@@ -3445,7 +3483,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+          # This job deliberately skips checkout, so gh has no git working
+          # directory to infer the repository from; bind it explicitly.
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" 2>&1)"; then
             printf '%s\n' "$cancel_output"
             echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3009,3 +3009,443 @@ jobs:
       - name: Record scoped fast path
         if: ${{ needs.lint.outputs.admitted_merge != 'true' && (needs.lint.outputs.changelog_only == 'true' || needs.lint.outputs.docs_only == 'true' || (needs.lint.outputs.full_suite != 'true' && needs.lint.outputs.edition_sensitive != 'true')) }}
         run: echo "Edition is unaffected by this classified revision." >> "$GITHUB_STEP_SUMMARY"
+
+  # Fail-fast tripwires: the first substantive failure in a pull-request
+  # admission run cancels the whole run so already-doomed siblings stop
+  # consuming hosted runners and concurrency slots while the author iterates.
+  # One tripwire per watched job is required because a job-level `needs`
+  # evaluates only after every watched job completes; a dedicated tripwire
+  # reacts to its own job's failure the moment it happens. Matrix jobs react
+  # after their last leg completes; the matrix `fail-fast: false` contract is
+  # deliberately preserved so every broken shard still reports in one run.
+  #
+  # Each tripwire also depends on lint directly, keeping the Draft-gated lint
+  # job the single admission entry point, and fires only after a successful
+  # lint classification: a failed lint already skips every dependent job, and
+  # Draft revisions never reach these tripwires. Protected-main pushes
+  # deliberately run to completion: they are the coverage-cache producer and
+  # need the full failure picture for post-merge triage, so every tripwire is
+  # scoped to pull-request events. A cancelled admission run still fails the
+  # nine required ruleset contexts (cancelled is not success), so this
+  # mechanism can never authorize a merge; it only reclaims wasted work.
+  # Tripwires are helper jobs, not ruleset contexts.
+
+  fail-fast-runtime-payload:
+    name: Fail fast (Runtime Payload)
+    needs:
+      - lint
+      - runtime-payload
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after Runtime Payload failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-test-focused:
+    name: Fail fast (focused tests)
+    needs:
+      - lint
+      - test-focused
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after focused tests failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-test-race:
+    name: Fail fast (race shards)
+    needs:
+      - lint
+      - test-race
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after race shards failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-test-release-scripts:
+    name: Fail fast (release contracts)
+    needs:
+      - lint
+      - test-release-scripts
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after release contracts failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-test-cross-platform:
+    name: Fail fast (cross-platform compile)
+    needs:
+      - lint
+      - test-cross-platform
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after cross-platform compile failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-test:
+    name: Fail fast (Test aggregate)
+    needs:
+      - lint
+      - test
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after Test aggregate failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-test-darwin:
+    name: Fail fast (macOS tests)
+    needs:
+      - lint
+      - test-darwin
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after macOS tests failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-test-windows:
+    name: Fail fast (Windows tests)
+    needs:
+      - lint
+      - test-windows
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after Windows tests failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-coverage-current:
+    name: Fail fast (scoped coverage)
+    needs:
+      - lint
+      - coverage-current
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after scoped coverage failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-coverage-current-full:
+    name: Fail fast (coverage shards)
+    needs:
+      - lint
+      - coverage-current-full
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after coverage shards failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-coverage-supporting:
+    name: Fail fast (supporting coverage)
+    needs:
+      - lint
+      - coverage-supporting
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after supporting coverage failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-coverage-baseline:
+    name: Fail fast (baseline coverage)
+    needs:
+      - lint
+      - coverage-baseline
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after baseline coverage failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-coverage-darwin:
+    name: Fail fast (macOS coverage)
+    needs:
+      - lint
+      - coverage-darwin
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after macOS coverage failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-coverage-windows:
+    name: Fail fast (Windows coverage)
+    needs:
+      - lint
+      - coverage-windows
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after Windows coverage failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-coverage:
+    name: Fail fast (Coverage gate)
+    needs:
+      - lint
+      - coverage
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after Coverage gate failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-policy:
+    name: Fail fast (Policy)
+    needs:
+      - lint
+      - policy
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after Policy failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-interface-integrity:
+    name: Fail fast (Interface Integrity)
+    needs:
+      - lint
+      - interface-integrity
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after Interface Integrity failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-cli-smoke:
+    name: Fail fast (CLI Smoke)
+    needs:
+      - lint
+      - cli-smoke
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after CLI Smoke failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-mock-mcp-smoke:
+    name: Fail fast (Mock MCP)
+    needs:
+      - lint
+      - mock-mcp-smoke
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after Mock MCP failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi
+
+  fail-fast-edition-tests:
+    name: Fail fast (Edition)
+    needs:
+      - lint
+      - edition-tests
+    if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    steps:
+      - name: Cancel run after Edition failed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! cancel_output="$(gh run cancel "$GITHUB_RUN_ID" 2>&1)"; then
+            printf '%s\n' "$cancel_output"
+            echo "::warning::fail-fast cancel request did not complete: ${cancel_output}"
+          fi

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -192,6 +192,38 @@ In particular, the governance PR that introduces or changes this mechanism
 must itself run the complete post-merge suite; only later eligible source
 merges can use the optimization.
 
+## Fail-fast cancellation on pull-request runs
+
+The first substantive job failure in a pull-request admission run cancels the
+whole run, so already-doomed siblings stop consuming hosted runners and
+concurrency slots while the author iterates. Cancellation is implemented by
+one `fail-fast-*` tripwire helper job per watched job: a job-level `needs`
+evaluates only after every watched job completes, so a shared watcher could
+not react to the first failure, while a dedicated tripwire fires the moment
+its own job fails. Matrix jobs react after their last leg completes; the
+matrix `fail-fast: false` contract is deliberately preserved so every broken
+shard still reports in one run before the tripwire cancels the remainder.
+
+Each tripwire also depends on `lint` directly and fires only after a
+successful lint classification, so the Draft-gated lint job remains the
+single admission entry point: a failed lint already skips every dependent
+job, and Draft revisions never reach a tripwire.
+
+Tripwires are scoped to `pull_request` events. Protected-main pushes run to
+completion: they are the coverage-cache producer and need the full failure
+picture for post-merge triage. `lint` is exempt because its failure skips
+every dependent job anyway; `coverage-main-metadata` is exempt because it is
+push-only.
+
+A cancelled admission run still fails the nine required contexts — a
+cancelled or skipped check is not a success — so fail-fast can never authorize
+a merge; it only reclaims wasted work. Tripwire check runs are helper
+contexts outside the ruleset.
+`TestCIFailFastTripwiresWatchEverySubstantiveJob` derives the watched set
+from the live job graph, so a new substantive job without a tripwire, or a
+tripwire orphaned by a removed or exempted job, fails the workflow contract
+tests.
+
 ## Risk tiers and downstream boundaries
 
 `Lint` resolves the complete base/head diff before any helper is skipped.

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -155,6 +155,18 @@ The classifier fails closed unless it can prove every one of these facts:
   published SHA-256 digest and the same head SHA; the archive's admission
   manifest independently binds the run ID, head SHA, and `full` profile kind.
 
+Merged-PR discovery tolerates GitHub's commit-to-PR association index lag. A
+protected-main push fires within seconds of the merge, and a single-shot
+association lookup was observed returning zero matches for eligible merges in
+production, silently forcing the complete suite. The classifier therefore
+re-polls discovery on a bounded budget (`DWS_ADMITTED_MERGE_RETRY_ATTEMPTS`
+attempts, `DWS_ADMITTED_MERGE_RETRY_INTERVAL_MS` apart; twelve attempts at
+five seconds by default) and additionally consults the most recently updated
+closed `main` PRs under the identical exact filter, because the merge
+transaction records `merge_commit_sha` on the PR before the push event fires.
+Only zero-match discovery retries; an ambiguous or mismatched result throws
+immediately, and an exhausted budget keeps the complete protected-main suite.
+
 When those facts hold, `Lint` publishes the bound PR head, run, artifact, and
 digest. The existing `coverage-main-metadata` job downloads the artifact by
 numeric ID, revalidates its API identity, verifies the downloaded archive's

--- a/scripts/release/pack-npm-package.sh
+++ b/scripts/release/pack-npm-package.sh
@@ -21,6 +21,11 @@ output_name="$(basename -- "$OUTPUT")"
 rm -f "$output_dir/$output_name"
 
 pack_json="$(
+  # The legacy npm audit endpoint is being retired by the registry; its
+  # deprecation notices (and the call latency behind them) are diagnostic
+  # noise for a deterministic, pinned-npm pack. Disable audit/fund banners
+  # so neither can reach this pipeline.
+  NPM_CONFIG_AUDIT=false NPM_CONFIG_FUND=false \
   npx --yes --package "npm@$NPM_PACK_VERSION" -- \
     npm pack "$PACKAGE_DIR" --pack-destination "$output_dir" --json --ignore-scripts
 )"

--- a/test/scripts/admitted_merge_classifier_test.go
+++ b/test/scripts/admitted_merge_classifier_test.go
@@ -34,6 +34,9 @@ func TestAdmittedMergeClassifierFailsClosed(t *testing.T) {
 		admitted string
 	}{
 		{name: "exact evidence is reused", scenario: "success", admitted: "true"},
+		{name: "association index lag recovers on retry", scenario: "association-index-lag", admitted: "true"},
+		{name: "cold association index recovers via closed-PR discovery", scenario: "association-index-cold", admitted: "true"},
+		{name: "unresolvable merged PR recomputes full suite", scenario: "merged-pr-unresolvable", admitted: "false"},
 		{name: "comparison API failure recomputes full suite", scenario: "compare-error", admitted: "false"},
 		{name: "predecessor checks API failure recomputes full suite", scenario: "predecessor-check-error", admitted: "false"},
 		{name: "failed predecessor admission recomputes full suite", scenario: "predecessor-check-failure", admitted: "false"},
@@ -150,6 +153,11 @@ func runAdmittedMergeClassifier(t *testing.T, node, classifier, scenario string)
 	t.Helper()
 	const harnessPrefix = `
 const scenario = process.argv[2];
+// Keep the production discovery retry loop fast inside the harness; the
+// production defaults stay in the classifier script itself.
+process.env.DWS_ADMITTED_MERGE_RETRY_INTERVAL_MS = '1';
+process.env.DWS_ADMITTED_MERGE_RETRY_ATTEMPTS = '5';
+let associationCalls = 0;
 const before = 'b'.repeat(40);
 const after = 'a'.repeat(40);
 const head = 'c'.repeat(40);
@@ -257,7 +265,17 @@ const endpoints = {
     }]}),
   },
   pulls: {
-    listPullRequestsAssociatedWithCommit: async () => ({data: [pull]}),
+    listPullRequestsAssociatedWithCommit: async () => {
+      if (scenario === 'association-index-lag') {
+        associationCalls += 1;
+        return {data: associationCalls > 2 ? [pull] : []};
+      }
+      if (scenario === 'association-index-cold' || scenario === 'merged-pr-unresolvable') {
+        return {data: []};
+      }
+      return {data: [pull]};
+    },
+    list: async () => ({data: scenario === 'association-index-cold' ? [pull] : []}),
   },
   checks: {
     listForRef: async ({ref}) => {

--- a/test/scripts/ci_fail_fast_contract_test.go
+++ b/test/scripts/ci_fail_fast_contract_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package scripts_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type failFastWorkflowJob struct {
+	Name        string `yaml:"name"`
+	Needs       any    `yaml:"needs"`
+	If          string `yaml:"if"`
+	RunsOn      string `yaml:"runs-on"`
+	Timeout     int    `yaml:"timeout-minutes"`
+	Permissions map[string]string
+	Steps       []struct {
+		Name string `yaml:"name"`
+		Env  map[string]string
+		Run  string `yaml:"run"`
+	} `yaml:"steps"`
+}
+
+func failFastNeeds(needs any) []string {
+	switch value := needs.(type) {
+	case string:
+		return []string{value}
+	case []any:
+		result := make([]string, 0, len(value))
+		for _, item := range value {
+			if text, ok := item.(string); ok {
+				result = append(result, text)
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+// TestCIFailFastTripwiresWatchEverySubstantiveJob pins the fail-fast
+// cancellation contract: every substantive pull-request admission job has one
+// dedicated tripwire that cancels the whole run the moment that job fails, so
+// already-doomed siblings stop consuming hosted runners and concurrency
+// slots. The watched set is derived from the live job graph, so adding a new
+// substantive job without a tripwire fails here, and a tripwire left behind
+// by a removed or exempted job fails as stale. Protected-main pushes keep the
+// complete failure picture and the coverage-cache producer, so tripwires are
+// scoped to pull-request events and the exempt set is reviewed explicitly.
+func TestCIFailFastTripwiresWatchEverySubstantiveJob(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read CI workflow: %v", err)
+	}
+	var workflow struct {
+		Jobs map[string]failFastWorkflowJob `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse CI workflow: %v", err)
+	}
+
+	// lint failure skips every downstream job through `needs`, and
+	// coverage-main-metadata only runs on protected-main pushes, which are
+	// deliberately exempt from fail-fast cancellation.
+	exempt := map[string]string{
+		"lint":                   "its failure skips every dependent job already",
+		"coverage-main-metadata": "push-only job; tripwires are pull-request scoped",
+	}
+	requiredContexts := map[string]bool{
+		"Lint": true, "Test": true, "Coverage": true, "Policy": true,
+		"Edition": true, "Interface Integrity": true, "AI Behavior": true,
+		"CLI Smoke": true, "Mock MCP": true,
+	}
+
+	substantive := make(map[string]bool)
+	tripwires := make(map[string]string)
+	for jobID := range workflow.Jobs {
+		if strings.HasPrefix(jobID, "fail-fast-") {
+			tripwires[jobID] = strings.TrimPrefix(jobID, "fail-fast-")
+			continue
+		}
+		if _, skipped := exempt[jobID]; skipped {
+			continue
+		}
+		substantive[jobID] = true
+	}
+
+	for jobID := range substantive {
+		tripwireID := "fail-fast-" + jobID
+		tripwire, ok := workflow.Jobs[tripwireID]
+		if !ok {
+			t.Errorf("substantive job %q has no %q tripwire; a first failure must cancel doomed siblings", jobID, tripwireID)
+			continue
+		}
+		needs := failFastNeeds(tripwire.Needs)
+		if len(needs) != 2 || needs[0] != "lint" || needs[1] != jobID {
+			t.Errorf("%s needs = %v, want exactly [lint %s] so the tripwire fires the moment that job fails while lint stays the Draft-gated entry point", tripwireID, needs, jobID)
+		}
+		if tripwire.If != "failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'" {
+			t.Errorf("%s if = %q, want pull-request-scoped failure trigger guarded by a successful lint classification so protected-main pushes run to completion", tripwireID, tripwire.If)
+		}
+		if tripwire.RunsOn != "ubuntu-latest" {
+			t.Errorf("%s runs-on = %q, want ubuntu-latest", tripwireID, tripwire.RunsOn)
+		}
+		if tripwire.Timeout != 5 {
+			t.Errorf("%s timeout-minutes = %d, want 5", tripwireID, tripwire.Timeout)
+		}
+		if tripwire.Permissions["actions"] != "write" {
+			t.Errorf("%s must grant actions: write to cancel the run", tripwireID)
+		}
+		if len(tripwire.Steps) != 1 {
+			t.Fatalf("%s steps = %d, want exactly one cancellation step", tripwireID, len(tripwire.Steps))
+		}
+		step := tripwire.Steps[0]
+		if !strings.Contains(step.Run, `gh run cancel "$GITHUB_RUN_ID"`) {
+			t.Errorf("%s step must cancel the current run through gh run cancel", tripwireID)
+		}
+		if step.Env["GH_TOKEN"] != "${{ github.token }}" {
+			t.Errorf("%s step must authenticate gh with the job GITHUB_TOKEN", tripwireID)
+		}
+		if requiredContexts[tripwire.Name] {
+			t.Errorf("%s name %q collides with a required ruleset context", tripwireID, tripwire.Name)
+		}
+		if !strings.HasPrefix(tripwire.Name, "Fail fast (") || !strings.HasSuffix(tripwire.Name, ")") {
+			t.Errorf("%s name = %q, want the reviewed \"Fail fast (<watched job>)\" shape", tripwireID, tripwire.Name)
+		}
+	}
+
+	for tripwireID, watched := range tripwires {
+		if _, ok := substantive[watched]; !ok {
+			if reason, isExempt := exempt[watched]; isExempt {
+				t.Errorf("stale tripwire %s watches exempt job %q: %s", tripwireID, watched, reason)
+				continue
+			}
+			t.Errorf("stale tripwire %s watches unknown job %q", tripwireID, watched)
+		}
+	}
+}

--- a/test/scripts/ci_fail_fast_contract_test.go
+++ b/test/scripts/ci_fail_fast_contract_test.go
@@ -122,8 +122,8 @@ func TestCIFailFastTripwiresWatchEverySubstantiveJob(t *testing.T) {
 			t.Fatalf("%s steps = %d, want exactly one cancellation step", tripwireID, len(tripwire.Steps))
 		}
 		step := tripwire.Steps[0]
-		if !strings.Contains(step.Run, `gh run cancel "$GITHUB_RUN_ID"`) {
-			t.Errorf("%s step must cancel the current run through gh run cancel", tripwireID)
+		if !strings.Contains(step.Run, `gh run cancel "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY"`) {
+			t.Errorf("%s step must cancel the current run through gh run cancel with an explicit -R repository binding; the job has no checkout, so gh cannot infer the base repo", tripwireID)
 		}
 		if step.Env["GH_TOKEN"] != "${{ github.token }}" {
 			t.Errorf("%s step must authenticate gh with the job GITHUB_TOKEN", tripwireID)

--- a/test/scripts/release_script_test.go
+++ b/test/scripts/release_script_test.go
@@ -603,12 +603,18 @@ func TestReleaseNpmPackingIgnoresLifecycleScripts(t *testing.T) {
 	mustWriteFile(t, filepath.Join(packageDir, "README.md"), []byte("test package\n"), 0o644)
 	outputTarball := filepath.Join(t.TempDir(), "package.tgz")
 	cmd := exec.Command("sh", filepath.Join(sourceRoot, "scripts", "release", "pack-npm-package.sh"), packageDir, outputTarball)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("pack-npm-package error = %v\noutput:\n%s", err, output)
+	// The script's contract — the one release.yml consumes through command
+	// substitution — is that stdout carries only the integrity value. npm/npx
+	// diagnostics (registry deprecation notices, fund/audit banners) belong to
+	// stderr and must not pollute the assertion.
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("pack-npm-package error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
 	}
-	if !strings.HasPrefix(strings.TrimSpace(string(output)), "sha512-") {
-		t.Fatalf("pack output is not an integrity value: %s", output)
+	if !strings.HasPrefix(strings.TrimSpace(stdout.String()), "sha512-") {
+		t.Fatalf("pack stdout is not an integrity value: %s\nstderr:\n%s", stdout.String(), stderr.String())
 	}
 	if _, err := os.Stat(outputTarball); err != nil {
 		t.Fatalf("packed tarball missing: %v", err)


### PR DESCRIPTION
## Summary

Two evidence-driven fixes for the two biggest sources of wasted runner time in Code Admission, both derived from production Actions data (21-run/3.5h job-level sample plus a 12h follow-up window):

### 1. Admitted-merge evidence reuse never fired (0/2) — fix the discovery race

Every eligible protected-main push since #1282 fell back to the complete suite with:

```
admitted-merge reuse unavailable; full main suite required:
expected one associated merged PR, found 0
```

(run 33780854456 for #1261, run 33813015116 for #1016). Root cause: the push event fires 2–3 seconds after the merge, before GitHub's commit→PR association index lists the fresh merge commit — while the PR records themselves already bind the exact merge identity (verified for both cases: `base.sha`/`head.sha`/`merge_commit_sha` all match and merge tree == head tree).

Fix: discovery re-polls on a bounded budget (12 attempts × 5s by default, tunable via `DWS_ADMITTED_MERGE_RETRY_ATTEMPTS` / `DWS_ADMITTED_MERGE_RETRY_INTERVAL_MS`) and additionally consults the most recently updated closed `main` PRs under the identical exact filter, because the merge transaction records `merge_commit_sha` on the PR before the push event fires. Only zero-match discovery retries; ambiguity throws immediately; an exhausted budget keeps the complete protected-main suite. Fail-closed semantics are unchanged.

Expected saving: ~20 min wall + ~30 jobs per eligible merge→main push (observed full-suite pushes: 20–21 min each). Note this PR is itself ineligible by design (it changes `ci.yml`, so its own post-merge push runs the complete suite per the documented governance rule).

### 2. Fail-fast cancellation for pull-request admission runs

Production data: 14% of job-minutes went to cancelled runs, and failed runs kept burning 100+ doomed job-minutes after the first red check (Policy alone failed 7/21 runs while siblings ran 10–15 more minutes). GitHub has no cross-job fail-fast, and matrices deliberately keep `fail-fast: false` (pinned by contract) so every broken shard reports.

Fix: each substantive job gets a dedicated `fail-fast-*` tripwire — `needs: [lint, <job>]`, `if: failure() && needs.lint.result == 'success' && github.event_name == 'pull_request'` — that cancels the whole run via `gh run cancel` the moment that job fails. One tripwire per job is required because a job-level `needs` evaluates only after every watched job completes.

Safety boundaries:
- Pull-request events only. Protected-main pushes run to completion: they are the coverage-cache producer and need the full failure picture for post-merge triage.
- A cancelled admission run still fails the nine required ruleset contexts (cancelled ≠ success), so fail-fast can never authorize a merge; admitted-merge reuse only accepts green runs.
- `lint` is exempt (its failure already skips every dependent job); `coverage-main-metadata` is exempt (push-only). Draft revisions never reach a tripwire (lint-gated).
- Matrix tripwires react after the last leg completes, preserving the pinned `fail-fast: false` all-failures-report contract.

Expected saving: failed/superseded PR runs reclaim the doomed sibling tail (~50–70% of today's wasted minutes), and ~30 concurrency slots release earlier per failing run, directly reducing the peak-time queueing (observed ubuntu p90 job wait: 21 min, max 48.6 min).

## Test plan

- [x] New node-harness classifier scenarios extracted from `ci.yml` reproduce the production race: `association-index-lag` (empty first two lookups → retry recovers → `admitted_merge=true`), `association-index-cold` (association index empty → closed-PR fallback recovers → `admitted_merge=true`), `merged-pr-unresolvable` (both sources empty → bounded exhaustion → full suite + warning). All pre-existing fail-closed scenarios unchanged and green.
- [x] New `TestCIFailFastTripwiresWatchEverySubstantiveJob` derives the watched set from the live job graph: a new substantive job without a tripwire, or a tripwire orphaned by a removed/exempted job, fails; every tripwire's needs/if/permissions/cancel command is pinned.
- [x] Full `go test ./test/scripts/...` green in a pristine worktree (320s); pinned actionlint v1.7.12 clean; `reviewer-routing`/`reviewer-merge-authority` node tests green; `gofmt` clean; open-source audit ok.
- [x] `TestDraftPRCIWorkflowContract` green: tripwires depend on the Draft-gated lint job directly.
- [ ] This PR's own CI run exercises the tripwires live (all skipped on a green run).
- [ ] First eligible source merge after this lands verifies admitted-merge reuse actually fires (`Admitted merge reuse: true` in the Lint summary).

Docs: `docs/ci-pr-gates.md` updated for both contracts (discovery retry paragraph + new "Fail-fast cancellation on pull-request runs" section). CI-only change with no user-facing behavior, so no release fragment per `.changes/README.md` (precedent: #1272).


---

**Merge readiness note (author edit to re-trigger router adoption):** approval (05:03:55Z) landed after the last `pull_request_target` synchronize (04:46Z), so `manage-auto-merge` never re-evaluated and the PR stayed green+approved but unowned (`reconcile` only merges App-owned PRs). This body edit fires a fresh `edited` event for router adoption. All nine required contexts are green on head `efb333078` (run 33838023773, 17m wall); the edit-triggered CI rerun is expected green and additionally serves as a third full validation of the tripwires (silent when green) and the admitted-merge retry changes.
