### PR TITLE
fix(policy): accept required-parameter to one-of compatibility

### DIFF
--- a/.changes/schema-compat-required-one-of.md
+++ b/.changes/schema-compat-required-one-of.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Schema compatibility checks** — accept a new `require_one_of` group when a historical unconditional required parameter without a default already guarantees a supplied member. Other incompatible parameter changes remain rejected; CLI runtime behavior is unchanged.

--- a/scripts/policy/schema-compat/main.go
+++ b/scripts/policy/schema-compat/main.go
@@ -1230,7 +1230,8 @@ func compatibleInterfaceRefRedirect(toolPath string, oldTool, newTool toolSchema
 // historical public parameter: aliases and newly added parameters could not
 // have appeared together in an old invocation. A new require-together group is
 // safe only when it contains no historical public parameter. A new
-// require-one-of group always adds a requirement and is therefore incompatible.
+// require-one-of group is safe only if a historical unconditional required
+// parameter without a default already guarantees one of its members is supplied.
 func compatibleAdditiveConstraintEvolution(oldTool, newTool toolSchema) bool {
 	oldGroups, okOld := parseConstraintGroups(oldTool.Constraints)
 	newGroups, okNew := parseConstraintGroups(newTool.Constraints)
@@ -1278,9 +1279,14 @@ func compatibleAdditiveConstraintEvolution(oldTool, newTool toolSchema) bool {
 				continue
 			}
 			historicalMembers := 0
+			historicalRequired := false
 			for member := range stringSet(newGroup) {
-				if _, existed := oldTool.Parameters[member]; existed {
+				if parameter, existed := oldTool.Parameters[member]; existed {
 					historicalMembers++
+					// Conditional/defaulted inputs do not prove explicit presence.
+					if parameter.Required && parameter.RequiredWhen == "" && parameter.Default == "" {
+						historicalRequired = true
+					}
 				}
 			}
 			switch key {
@@ -1293,7 +1299,9 @@ func compatibleAdditiveConstraintEvolution(oldTool, newTool toolSchema) bool {
 					return false
 				}
 			default: // require_one_of
-				return false
+				if !historicalRequired {
+					return false
+				}
 			}
 		}
 	}

--- a/scripts/policy/schema-compat/required_one_of_test.go
+++ b/scripts/policy/schema-compat/required_one_of_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Alibaba Group
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "testing"
+
+func TestCrossPlatformCoverageRequiredParameterToOneOf(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		mutate     func(*toolSchema, *toolSchema)
+		compatible bool
+	}{
+		{name: "required becomes an alternative", compatible: true},
+		{name: "required remains required", compatible: true, mutate: func(_, next *toolSchema) {
+			p := next.Parameters["enabled"]
+			p.Required = true
+			next.Parameters["enabled"] = p
+		}},
+		{name: "historically optional", mutate: func(old, _ *toolSchema) {
+			p := old.Parameters["enabled"]
+			p.Required = false
+			old.Parameters["enabled"] = p
+		}},
+		{name: "conditional requirement", mutate: func(old, _ *toolSchema) {
+			p := old.Parameters["enabled"]
+			p.RequiredWhen = "mode=share"
+			old.Parameters["enabled"] = p
+		}},
+		{name: "default does not prove presence", mutate: func(old, next *toolSchema) {
+			for _, tool := range []*toolSchema{old, next} {
+				p := tool.Parameters["enabled"]
+				p.Default = `"false"`
+				tool.Parameters["enabled"] = p
+			}
+		}},
+		{name: "required member outside group", mutate: func(_, next *toolSchema) {
+			next.Constraints = `{"require_one_of":[["description"]]}`
+		}},
+		{name: "each new group must be implied", mutate: func(_, next *toolSchema) {
+			next.Constraints = `{"require_one_of":[["enabled","description"],["description"]]}`
+		}},
+		{name: "removed old parameter still fails", mutate: func(_, next *toolSchema) {
+			delete(next.Parameters, "enabled")
+		}},
+		{name: "parameter type drift still fails", mutate: func(_, next *toolSchema) {
+			p := next.Parameters["enabled"]
+			p.Type = `"boolean"`
+			next.Parameters["enabled"] = p
+		}},
+		{name: "interface type drift still fails", mutate: func(_, next *toolSchema) {
+			p := next.Parameters["enabled"]
+			p.InterfaceType = "boolean"
+			next.Parameters["enabled"] = p
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := toolSchema{Parameters: map[string]parameterSchema{
+				"enabled": {Type: `"string"`, Required: true},
+			}}
+			next := toolSchema{Parameters: map[string]parameterSchema{
+				"enabled":     {Type: `"string"`},
+				"description": {Type: `"string"`},
+			}, Constraints: `{"require_one_of":[["enabled","description"]]}`}
+			if tc.mutate != nil {
+				tc.mutate(&old, &next)
+			}
+			failures := checkToolCompatibility("example/example.partial_update", old, next)
+			if (len(failures) == 0) != tc.compatible {
+				t.Fatalf("compatible=%v failures=%v", tc.compatible, failures)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- 修复 Schema 比较器对兼容约束扩展的误报：新增 `require_one_of` 组时，只有组内存在历史上无条件必填、无默认值的参数，才认定旧有效调用已满足该组。
- 示例：历史要求 `enabled` 必填，新版本允许 `enabled` 或 `description` 至少传一项；原来合法的调用仍然合法。
- 不新增产品白名单，不修改迁移审批清单，不改变 CLI、Schema 产品声明或 MCP 运行时行为。
- 独立于 AI 表格业务 PR；本 PR 可先合入，后续业务分支同步主线后再使用基线拥有的比较器运行正式门禁。业务改动没有包含在本 PR 中。

## Risk tier

- [ ] Documentation-only
- [ ] Standard
- [x] High-risk: 修改通用兼容性 policy，影响所有产品的后续 Schema 检查，需要独立人工评审。

## Verification

- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test -race ./scripts/policy/schema-compat -count=1`：比较器整包测试通过。
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go vet ./scripts/policy/schema-compat`：通过。
- [x] `./scripts/policy/check-release-fragments.sh upstream/main HEAD`：通过。
- [x] `./scripts/policy/check-open-source-assets.sh`：通过。
- [x] `git diff --check upstream/main...HEAD`：通过。
- [x] Release fragment: `.changes/schema-compat-required-one-of.md`。
- [x] 新增 `TestCrossPlatformCoverageRequiredParameterToOneOf`，覆盖 10 个正反边界：旧必填转为可选项、保持必填、历史可选、条件必填、默认值、必填成员不在组内、多个独立组、删除旧参数、CLI 类型漂移和接口类型漂移。
- 全仓本地测试未运行；本地已运行受影响比较器的完整测试及 race 检查，完整高风险准入由 CI 验证。不将本地定向测试等同于正式 CI 通过。
- Generated drift / command surface / packaging checks: N/A，本 PR 不改对应输入或实现。
- Release-seal validation: N/A，未修改根 CHANGELOG 或执行版本封板。

## Notes

- 每个新增 `require_one_of` 组都必须独立满足上述历史必填证据；可选、条件必填或带默认值参数不提供放行依据。
- 参数删除、类型及其他契约漂移仍由既有检查拒绝。本 PR 不增加任何接口迁移授权。
- 当前治理 PR 的正式兼容性准入仍使用 merge-base 的原比较器；新规则正确性由新增反例测试和独立 review 证明，合入后才成为后续 PR 的基线规则。
- 变更范围仅比较器、对应测试及变更说明，共 3 个文件，单一提交。
