### PR TITLE
fix(ci): 恢复 blocked PR 的 App 自动合并

### DIFF
--- a/.changes/reviewer-router-blocked-automerge.md
+++ b/.changes/reviewer-router-blocked-automerge.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **自动合并**：修复 Reviewer Router 将可合并但显示 `blocked` 的 PR 持续跳过的问题；恢复 App 的同步合并尝试，并继续由 GitHub 强制执行审批和必需 CI 检查。

--- a/.github/workflows/reviewer-router.yml
+++ b/.github/workflows/reviewer-router.yml
@@ -1316,6 +1316,8 @@ jobs:
               return mergeResult.sha;
             }
 
+            // blocked 可能来自主干写入限制；可合并的 PR 仍需由 App 调用同步接口，
+            // 让 GitHub 执行 App 无权绕过的审批和必需检查。
             function classifyMergePreflight(pullRequest) {
               if (
                 pullRequest.mergeable === true &&
@@ -1331,7 +1333,7 @@ jobs:
               }
               if (
                 pullRequest.mergeable !== true ||
-                ['blocked', 'dirty', 'draft'].includes(pullRequest.mergeable_state)
+                ['dirty', 'draft'].includes(pullRequest.mergeable_state)
               ) {
                 return 'not_ready';
               }
@@ -1388,6 +1390,8 @@ jobs:
                 latestPull.base?.ref === 'main' &&
                 baseRepository === expectedBaseRepository &&
                 (latestMergePreflight === 'behind' ||
+                  (latestPull.mergeable === true &&
+                    latestPull.mergeable_state === 'blocked') ||
                   (latestMergePreflight === 'not_ready' && hasExplicitNotReadyState))
               ) {
                 return {outcome: 'not_ready'};

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -167,24 +167,22 @@ ruleset with one latest-head approval and exactly one repository-owned
 `never` on both and on every other non-writer ruleset. Every required context
 must be bound to the GitHub Actions App (`integration_id=15368`); a missing,
 different, or duplicate context/source entry fails closed together with
-deletion or weakening of either gate. A final PR state that is explicitly
-`behind`, the exact transient pair `mergeable=null` and
-`mergeable_state=unknown`, any state GitHub reports as `blocked`, `dirty`, or
-`draft`, or any response that does not explicitly prove `mergeable=true`,
-remains open for the next event without calling the merge endpoint. Unknown or
-incomplete mergeability never grants merge eligibility; it only defers the
-attempt until GitHub finishes computing the state.
+deletion or weakening of either gate.
+
+最终状态为 `behind`、`dirty`、`draft`，或未明确返回 `mergeable=true` 时，
+协调流程保留 PR，等待下一次事件，不调用合并接口；`null + unknown` 同样延后。
+`mergeable=true + blocked` 则继续同步合并尝试：`blocked` 可能来自主干写入限制，
+不能据此认定审批或 CI 未通过。App 仍须通过权限边界、当前 head/base 和合并意图校验，
+GitHub 在同步接口中强制执行 App 无权绕过的审批与九项必需检查。
+
 HTTP 405 means the PR is not ready, while 409 means its revision changed; both
-remain retriable. GitHub can also return HTTP 403 with
-`Resource not accessible by integration` for this protected, behind-main merge
-denial. That response is retriable only when a same-token read proves the PR is
-still open at the exact expected head and repository-owned `main` base and the
-same preflight still classifies it as `behind`, or reports an explicit
-`mergeable=false`, `blocked`, `dirty`, or `draft` not-ready state. A missing or
-otherwise unproven mergeability field cannot hide an App authorization failure.
-This also closes the race where a PR becomes blocked or conflicting after the
-final read but before the merge call. Every other 403 and all other failures
-make reconciliation red. A concurrent native merge is accepted only after the
+remain retriable.
+对于精确的 HTTP 403 `Resource not accessible by integration`，仍须用同一 App
+读取并证明 PR 保持打开、head 未变且目标为本仓库的 `main`。只有明确的 `behind`、
+`mergeable=true + blocked`，或原有显式不可合并状态才计为可重试；其他 403、
+身份变化及未命中上述状态的响应仍使协调失败。这样，检查或审批尚未通过的 PR
+会在 GitHub 拒绝后等待下一次事件，而不会拖红整批，也不会被当作已合并。
+A concurrent native merge is accepted only after the
 final PR state proves the exact head, App identity, and non-empty merge SHA.
 A staggered twice-hourly schedule provides eventual recovery if a webhook or
 workflow completion is delayed, and `workflow_dispatch` remains the on-demand

--- a/docs/ci-pr-gates.md
+++ b/docs/ci-pr-gates.md
@@ -376,12 +376,14 @@ the current head SHA, and treats server-declared not-ready or
 concurrent-revision responses as retriable. An exact behind-main state is also
 retriable before the merge request. The exact transient pair
 `mergeable=null` and `mergeable_state=unknown` is likewise deferred without a
-merge request; it is not treated as evidence that the PR is admissible. If
-GitHub instead reports a behind state as HTTP 403
-`Resource not accessible by integration`, reconciliation recovers
-only after a same-token read proves the unchanged open head, repository-owned
-`main` base, and exact behind mergeability; every other 403 remains a hard
-failure. The live preflight requires the
+merge request; it is not treated as evidence that the PR is admissible.
+`mergeable=false`、`dirty`、`draft` 及缺失的 `mergeable` 同样提前延后。
+`mergeable=true + blocked` 不会被一律跳过：主干写入限制可能使这个状态持续存在，
+因此仍由 App 尝试同步合并，让 GitHub 强制执行审批和必需检查。
+精确的 HTTP 403 `Resource not accessible by integration` 只有在同一 App
+重新读取并证明 PR 仍打开、head 未变、目标仍为本仓库 `main`，且状态为 `behind`、
+`true + blocked` 或原有显式不可合并状态时才可重试；其他 403 仍为失败。
+The live preflight requires the
 exact repository-owned approval ruleset and exact nine-check strict quality
 ruleset, with every context bound to the GitHub Actions App
 (`integration_id=15368`) and the Reviewer Router App unable to bypass either;

--- a/test/scripts/reviewer_router_merge_final_state_test.go
+++ b/test/scripts/reviewer_router_merge_final_state_test.go
@@ -80,7 +80,7 @@ const mergePreflightHelper = `function classifyMergePreflight(pullRequest) {
   }
   if (
     pullRequest.mergeable !== true ||
-    ['blocked', 'dirty', 'draft'].includes(pullRequest.mergeable_state)
+    ['dirty', 'draft'].includes(pullRequest.mergeable_state)
   ) {
     return 'not_ready';
   }
@@ -137,6 +137,8 @@ const mergeAttemptRecoveryHelper = `function classifyMergeAttemptRecovery(
     latestPull.base?.ref === 'main' &&
     baseRepository === expectedBaseRepository &&
     (latestMergePreflight === 'behind' ||
+      (latestPull.mergeable === true &&
+        latestPull.mergeable_state === 'blocked') ||
       (latestMergePreflight === 'not_ready' && hasExplicitNotReadyState))
   ) {
     return {outcome: 'not_ready'};
@@ -276,7 +278,8 @@ for (const [name, pull, expected] of [
   ['unknown', {mergeable: null, mergeable_state: 'unknown'}, 'unknown'],
   ['clean', {mergeable: true, mergeable_state: 'clean'}, 'attempt'],
   ['dirty', {mergeable: false, mergeable_state: 'dirty'}, 'not_ready'],
-  ['blocked', {mergeable: true, mergeable_state: 'blocked'}, 'not_ready'],
+  ['blocked', {mergeable: true, mergeable_state: 'blocked'}, 'attempt'],
+  ['false blocked', {mergeable: false, mergeable_state: 'blocked'}, 'not_ready'],
   ['draft', {mergeable: true, mergeable_state: 'draft'}, 'not_ready'],
   ['null blocked', {mergeable: null, mergeable_state: 'blocked'}, 'not_ready'],
   ['missing mergeable', {mergeable_state: 'unknown'}, 'not_ready'],

--- a/test/scripts/reviewer_router_reconcile_execution_test.go
+++ b/test/scripts/reviewer_router_reconcile_execution_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package scripts_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestReviewerRouterReconcilesBlockedCandidates(t *testing.T) {
+	t.Parallel()
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is required to execute Reviewer Router reconciliation")
+	}
+	path := filepath.Join("..", "..", ".github", "workflows", "reviewer-router.yml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow reviewerRouterWorkflow
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	var body string
+	for _, step := range workflow.Jobs["reconcile"].Steps {
+		script := step.With["script"]
+		if !strings.Contains(script, "const mergePulls =") {
+			continue
+		}
+		start := strings.Index(script, "const skipWorkflowPattern =")
+		if start < 0 || body != "" {
+			t.Fatal("expected one reconciliation body after the initial ruleset check")
+		}
+		body = script[start:]
+	}
+	if body == "" {
+		t.Fatal("reconciliation body not found")
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 直接执行 YAML 中的协调循环；规则内容由 required-rulesets 测试验证，
+	// 此处替换外部 API 和规则校验，检查调用顺序及最终合并结果。
+	const verification = `
+const assert = require('node:assert/strict');
+const body = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
+const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
+const run = new AsyncFunction('github', 'core', 'owner', 'repo',
+  'expectedAppOwner', 'repositorySource', 'assertReviewerRouterRulesetBoundary', body);
+const owner = 'DingTalk-Real-AI';
+const repo = 'dingtalk-workspace-cli';
+const app = 'dingtalk-dws-reviewer-router[bot]';
+const repository = (owner + '/' + repo).toLowerCase();
+const pull = {
+  number: 1284, node_id: 'pr-node', title: 'fix: ordinary command',
+  state: 'open', draft: false, merged_at: null,
+  head: {sha: 'reviewed-head'},
+  base: {sha: 'reviewed-base', ref: 'main', repo: {full_name: owner + '/' + repo}},
+  mergeable: true, mergeable_state: 'blocked',
+  auto_merge: {
+    enabled_by: {login: app},
+    commit_title: 'Merge pull request #1284',
+    commit_message: 'Merged by the dedicated Reviewer Router GitHub App for PR #1284.',
+  },
+};
+const denied = {status: 403, message: 'Resource not accessible by integration'};
+const cases = [
+  {name: 'App writer restriction: approved and green', attempts: 1, merged: 1},
+  {name: 'required approval denied by GitHub', error: {status: 405, message: 'Review required'}, attempts: 1, notReady: 1},
+  {name: 'required checks denied by GitHub', error: denied, attempts: 1, notReady: 1},
+  {name: 'conflict', patch: {mergeable: false, mergeable_state: 'dirty'}, notReady: 1},
+  {name: 'blocked without mergeability', patch: {mergeable: null}, notReady: 1},
+  {name: 'unknown', patch: {mergeable: null, mergeable_state: 'unknown'}, notReady: 1},
+  {name: 'behind main', patch: {mergeable_state: 'behind'}, notReady: 1},
+  {name: 'ruleset boundary fails', boundaryError: true, failed: 1},
+  {name: 'final head changed', final: {head: {sha: 'new-head'}}, skipped: 1},
+  {name: 'final intent disabled', final: {auto_merge: null}, skipped: 1},
+  {name: 'final draft', final: {draft: true}, skipped: 1},
+  {name: 'unrelated permission failure', error: {...denied, message: 'Forbidden'}, attempts: 1, failed: 1},
+  {name: '403 head changed', error: denied, after: {head: {sha: 'new-head'}}, attempts: 1, failed: 1},
+  {name: '403 base repository changed', error: denied, after: {base: {...pull.base, repo: {full_name: 'other/repo'}}}, attempts: 1, failed: 1},
+  {name: '403 mergeability unavailable', error: denied, after: {mergeable: null, mergeable_state: 'unknown'}, attempts: 1, failed: 1},
+  {name: 'successful response with wrong merger', after: {merged_by: {login: 'other-bot'}}, attempts: 1, failed: 1},
+];
+(async () => {
+  for (const c of cases) {
+    const candidate = {...pull, ...c.patch};
+    const finalPull = {...candidate, ...c.final};
+    const calls = [];
+    const messages = [];
+    const errors = [];
+    const failures = [];
+    let lists = 0, reads = 0, attempts = 0;
+    const github = {rest: {pulls: {
+      list: Symbol('list'), listFiles: Symbol('files'),
+      get: async ({pull_number}) => {
+        assert.equal(pull_number, pull.number);
+        calls.push('get');
+        reads++;
+        if (reads === 1) return {data: candidate};
+        if (reads === 2) return {data: finalPull};
+        assert.equal(attempts, 1);
+        const after = c.error ? finalPull : {...finalPull,
+          state: 'closed', merged_at: '2026-09-04T00:00:00Z',
+          merged_by: {login: app}, merge_commit_sha: 'merge-sha'};
+        return {data: {...after, ...c.after}};
+      },
+      merge: async (request) => {
+        calls.push('merge');
+        attempts++;
+        assert.deepEqual(calls, ['get', 'files', 'boundary', 'get', 'merge']);
+        assert.deepEqual(request, {
+          owner, repo, pull_number: pull.number, sha: 'reviewed-head',
+          merge_method: 'merge', commit_title: pull.auto_merge.commit_title,
+          commit_message: pull.auto_merge.commit_message,
+        });
+        if (c.error) throw Object.assign(new Error(c.error.message), {status: c.error.status});
+        return {data: {merged: true, sha: 'merge-sha'}};
+      },
+    }}};
+    github.paginate = async (endpoint) => {
+      if (endpoint === github.rest.pulls.list) return ++lists === 1 ? [] : [candidate];
+      assert.equal(endpoint, github.rest.pulls.listFiles);
+      calls.push('files');
+      return [{filename: 'internal/helpers/aitable.go'}];
+    };
+    const core = {
+      info: message => messages.push(message), notice: message => messages.push(message),
+      error: message => errors.push(message), setFailed: message => failures.push(message),
+    };
+    await run(github, core, owner, repo, app, repository, async () => {
+      calls.push('boundary');
+      if (c.boundaryError) throw new Error('App can bypass required checks');
+    });
+    assert.equal(attempts, c.attempts || 0, c.name + ': merge endpoint calls');
+    assert.equal(errors.length, c.failed || 0, c.name + ': candidate failures');
+    assert.equal(failures.length, c.failed || 0, c.name + ': workflow failures');
+    assert.equal(messages.at(-1),
+      'Reconciliation summary: migrated=0, merged=' + (c.merged || 0) +
+      ', not_ready=' + (c.notReady || 0) + ', skipped=' + (c.skipped || 0) +
+      ', failed=' + (c.failed || 0) + '.', c.name);
+  }
+})().catch(error => { console.error(error); process.exitCode = 1; });
+`
+	command := exec.Command(node, "-e", verification)
+	command.Stdin = strings.NewReader(string(encoded))
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("reconciliation execution failed: %v\n%s", err, output)
+	}
+}

--- a/test/scripts/reviewer_router_workflow_test.go
+++ b/test/scripts/reviewer_router_workflow_test.go
@@ -626,7 +626,7 @@ func TestReviewerRouterWorkflowContract(t *testing.T) {
 		"pullRequest.mergeable === null",
 		"pullRequest.mergeable_state === 'unknown'",
 		"pullRequest.mergeable !== true",
-		"['blocked', 'dirty', 'draft'].includes(pullRequest.mergeable_state)",
+		"['dirty', 'draft'].includes(pullRequest.mergeable_state)",
 		"const mergePreflight = classifyMergePreflight(finalPull)",
 		"is behind main at final synchronous merge preflight",
 		"has unknown mergeability at final synchronous merge preflight",


### PR DESCRIPTION
## 问题与修复

修复 #1281 引入的自动合并回归，关联受影响的 #1284。

#1284 的当前 head 已获审批、九项必需检查通过且未落后于 main，但 GitHub 返回 `mergeable=true + mergeable_state=blocked`。Reviewer Router 将所有 `blocked` 状态提前归为 `not_ready`，因此未调用同步合并接口，协调工作流仍显示成功。

本次允许 `true + blocked` 继续进入 App 的同步合并尝试。App 的权限边界、当前 head/base、合并意图及最终合并归属校验全部保留，GitHub 继续强制执行 App 无权绕过的审批和必需检查。冲突、草稿、落后及未知或缺失的 `mergeable` 仍提前延后。

同步接口若返回精确的 403 `Resource not accessible by integration`，仅在同一 App 重新确认 PR 仍打开、head 未变、目标为本仓库 main 且仍为 `true + blocked` 等已审查状态时等待下次重试；无关权限错误和身份变化仍失败。

## 现场证据

- [#1284 成功的 CI](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/33856939246)，head 为 `16d12efb821f2833a957d9236795f3b4e8fe9de6`。
- [审批后的协调日志](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/33859050224/job/100979062220)：#1284 被 `blocked` 预检跳过。
- [后续协调日志](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli/actions/runs/33874645909/job/101028755197)：同一 PR 再次被跳过，`merged=0, not_ready=11, failed=0`。

## 风险等级

- [x] 高风险：修改工作流的合并判断和拒绝恢复逻辑。

## 验证

验证环境：macOS arm64、Go 1.26.5、Node.js 22.22.3。Go 临时产物位于独立 worktree 管理的目录；以下测试命令均设置 `TMPDIR`、`GOTMPDIR`、`DWS_POLICY_TMPDIR` 指向该目录。

| 检查 | 结果 |
|---|---|
| 修复前运行新增的 `TestReviewerRouterReconcilesBlockedCandidates` | 复现失败：预期合并接口调用 1 次，实际 0 次 |
| `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run '^(TestReviewerRouterReconcilesBlockedCandidates\|TestReviewerRouterValidatesAppMergeFinalState\|TestReviewerRouterWorkflowContract)$' -count=1 -timeout=3m` | 通过 |
| `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -count=1 -timeout=20m` | 通过（1082.303 秒） |
| `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12` | 通过 |
| `./scripts/policy/check-release-fragments.sh origin/main HEAD` | 通过 |
| `git diff --check origin/main...HEAD` | 通过 |

新增测试直接执行 YAML 中的实际协调循环，替换外部 API 和规则校验边界，共验证 16 个场景：App 合并成功、审批或检查被 GitHub 拒绝、冲突/未知/落后状态、规则校验失败、最终 head/意图/草稿变化、403 后身份变化、无关权限失败和最终合并归属错误。既有 ruleset 测试继续负责验证不可绕过的审批及检查规则内容。

- [x] 新增 release fragment：`.changes/reviewer-router-blocked-automerge.md`。
- [x] 更新 `docs/automation.md` 与 `docs/ci-pr-gates.md`，解释 `blocked` 与同步合并的关系。
- [x] 采用工作流及发布契约领域完整测试；未重复运行不受此修改影响的全部产品 Go 测试。
- [ ] Schema 生成、命令面及安装包校验：不适用，本次未修改相关内容。

## 局限与回滚

本地验证使用受控 API 替身，没有执行真实合并。实际解除 #1284 阻塞须待本 PR 合入 main 后，由可信 Router 再次执行并核验结果。若届时 #1284 因主干推进变为 `behind`，仍须先更新分支并通过现有严格检查。

本 PR 修改 `.github/workflows/**`，按现有规则保持人工合并，不扩大 App 权限。风险在于恢复了 `true + blocked` 的接口尝试；服务端拒绝仍保留 PR，不会视为合并成功。若出现回归，可通过新的 PR 回滚本次提交；回滚会恢复 `blocked` PR 持续等待的旧行为。
