### PR TITLE
fix(chat): preserve direct message integrity metadata

### DIFF
--- a/.changes/1297-1298-direct-message-integrity.md
+++ b/.changes/1297-1298-direct-message-integrity.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Direct message completeness** (#1297, #1298) — `chat +messages-list-direct --page-all` preserves `partial=true` after message decryption failures and reports `paginationKnown=false` when a fetched page lacks usable `hasMore` evidence. Existing pagination errors, retained messages, and decryption failure details remain available.

--- a/internal/shortcut/chat/chat_message.go
+++ b/internal/shortcut/chat/chat_message.go
@@ -816,6 +816,7 @@ func readAllDirectMessages(rt *shortcut.RuntimeContext, params map[string]any) (
 	pagesFetched := 0
 	complete := false
 	hasMore := false
+	paginationKnown := true
 	stopReason := "source_complete"
 	truncatedByPageLimit := false
 	var nextPage map[string]any
@@ -848,6 +849,7 @@ func readAllDirectMessages(rt *shortcut.RuntimeContext, params map[string]any) (
 		page := chatmsg.Pagination(data)
 		pageHasMore, known := page["hasMore"].(bool)
 		if !known {
+			paginationKnown = false
 			failures = append(failures, map[string]any{
 				"page": pagesFetched, "stage": "pagination",
 				"error": "单聊消息下层未返回可靠的 hasMore，无法证明结果完整",
@@ -901,9 +903,8 @@ func readAllDirectMessages(rt *shortcut.RuntimeContext, params map[string]any) (
 	decryptLedger := decryptMessageItemsIfRequested(rt, allItems)
 	messages := projectMessageMapsWithReactions(allItems, !rt.Bool("no-reactions"))
 	payload := chatmsg.NewMessageListPayload(messages)
-	applyMessageDecryptLedger(payload, decryptLedger)
 	payload["pagesFetched"] = pagesFetched
-	payload["paginationKnown"] = true
+	payload["paginationKnown"] = paginationKnown
 	payload["complete"] = complete && len(failures) == 0
 	payload["hasMore"] = hasMore
 	payload["stopReason"] = stopReason
@@ -912,6 +913,7 @@ func readAllDirectMessages(rt *shortcut.RuntimeContext, params map[string]any) (
 	payload["failedCount"] = len(failures)
 	payload["failures"] = failures
 	payload["partial"] = len(failures) > 0 && len(messages) > 0
+	applyMessageDecryptLedger(payload, decryptLedger)
 	if hasMore && nextPage != nil {
 		payload["nextPage"] = nextPage
 	}

--- a/internal/shortcut/chat/direct_message_integrity_regression_test.go
+++ b/internal/shortcut/chat/direct_message_integrity_regression_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package chat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
+	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
+)
+
+// These tests exercise the real Cobra leaf with injected MCP responses. They
+// perform no live requests and do not require credentials or a DingTalk account.
+func runDirectMessageIntegrityRegression(t *testing.T, caller *larkAlignmentCaller, args ...string) (map[string]any, error) {
+	t.Helper()
+	helpers.InitDepsForTest(t, caller)
+	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs(append([]string{
+		"chat", "+messages-list-direct", "--user", "fixture-user", "--time", "2026-09-01 00:00:00",
+	}, args...))
+	err := root.Execute()
+	var payload map[string]any
+	if decodeErr := json.Unmarshal(output.Bytes(), &payload); decodeErr != nil {
+		t.Fatalf("decode output: %v; command error: %v; output: %s", decodeErr, err, output.String())
+	}
+	return payload, err
+}
+
+func TestCrossPlatformCoverageDirectMessageIntegrityDecryptFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		allPages          bool
+		unknownPagination bool
+	}{
+		{name: "single_page_control"},
+		{name: "all_pages_regression", allPages: true},
+		{name: "decrypt_and_pagination_failure", allPages: true, unknownPagination: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var args []string
+			if tc.allPages {
+				args = []string{"--page-all"}
+			}
+			testseam.Swap(t, &messageReadCryptoClient, &messagecrypto.Client{
+				Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+					return messagecrypto.Identity{CorpID: "fixture-corp", StaffID: "fixture-user"}, nil
+				},
+				OpenSession: func(context.Context, messagecrypto.SessionOptions) (*messagecrypto.Session, error) {
+					return &messagecrypto.Session{Cipher: messageReadFakeCipher{}, CorpID: "fixture-corp", StaffID: "fixture-user"}, nil
+				},
+				BackendReady: func() bool { return true },
+				PolicyCache:  messagecrypto.NewPolicyCache(nil),
+			})
+			caller := &larkAlignmentCaller{
+				responses: map[string]string{
+					"chat/list_individual_chat_message": `{"result":{"messages":[{"openMessageId":"fixture-message","openConversationId":"fixture-conversation","content":"` + testCipher + `"}],"hasMore":false}}`,
+				},
+				failProductTool: "im/get_message_crypto_policy",
+			}
+			if tc.unknownPagination {
+				caller.responses["chat/list_individual_chat_message"] = `{"result":{"messages":[{"openMessageId":"fixture-message","openConversationId":"fixture-conversation","content":"` + testCipher + `"}]}}`
+			}
+			payload, err := runDirectMessageIntegrityRegression(t, caller, args...)
+			if tc.unknownPagination {
+				if err == nil || payload["complete"] != false || payload["paginationKnown"] != false || payload["failedCount"] != float64(1) || payload["stopReason"] != "pagination_error" {
+					t.Fatalf("combined failure must retain pagination evidence: payload=%#v error=%v", payload, err)
+				}
+			} else if err != nil {
+				t.Fatalf("existing decrypt fallback should return its ledger: %v", err)
+			}
+			if caller.callCounts["chat/list_individual_chat_message"] != 1 || caller.callCounts["im/get_message_crypto_policy"] != 1 {
+				t.Fatalf("fault injection did not reach read and policy paths: %#v", caller.calls)
+			}
+			if payload["decryptFailedCount"] != float64(1) || payload["decryptedCount"] != float64(0) {
+				t.Fatalf("expected one actual decrypt failure in ledger: %#v", payload)
+			}
+			messages := payload["messages"].([]any)
+			if len(messages) != 1 || messages[0].(map[string]any)["text"] != testCipher {
+				t.Fatalf("fallback must preserve original ciphertext: %#v", messages)
+			}
+			failures := payload["decryptFailures"].([]any)
+			if len(failures) != 1 || failures[0].(map[string]any)["stage"] != "message-decrypt" {
+				t.Fatalf("decryption failure details must be retained: %#v", failures)
+			}
+			if tc.allPages && !tc.unknownPagination && (payload["complete"] != true || payload["paginationKnown"] != true || payload["failedCount"] != float64(0)) {
+				t.Fatalf("decryption failure must not alter pagination completion: %#v", payload)
+			}
+			if payload["partial"] != true {
+				t.Fatalf("decryptFailedCount=1 requires partial=true; got partial=%v complete=%v stopReason=%v", payload["partial"], payload["complete"], payload["stopReason"])
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageDirectMessageIntegrityUnknownPagination(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		responses []string
+	}{
+		{"first_page_missing_hasMore", []string{`{"result":{"messages":[{"openMessageId":"fixture-1","content":"plain"}]}}`}},
+		{"later_page_missing_hasMore", []string{
+			`{"result":{"messages":[{"openMessageId":"fixture-1","content":"plain"}],"hasMore":true,"nextCursor":1785919699136}}`,
+			`{"result":{"messages":[{"openMessageId":"fixture-2","content":"plain"}]}}`,
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &larkAlignmentCaller{sequenceResponses: map[string][]string{"chat/list_individual_chat_message": tc.responses}}
+			payload, err := runDirectMessageIntegrityRegression(t, caller, "--page-all")
+			if err == nil || payload["stopReason"] != "pagination_error" || payload["complete"] != false || payload["failedCount"] != float64(1) {
+				t.Fatalf("unknown pagination must retain failure evidence: payload=%#v error=%v", payload, err)
+			}
+			if payload["count"] != float64(len(tc.responses)) || payload["partial"] != true {
+				t.Fatalf("already read messages must be retained: %#v", payload)
+			}
+			if caller.callCounts["chat/list_individual_chat_message"] != len(tc.responses) {
+				t.Fatalf("must stop at unknown pagination: %#v", caller.calls)
+			}
+			if payload["paginationKnown"] != false {
+				t.Fatalf("missing hasMore requires paginationKnown=false; got paginationKnown=%v stopReason=%v pagesFetched=%v", payload["paginationKnown"], payload["stopReason"], payload["pagesFetched"])
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageDirectMessageIntegrityCompleteControl(t *testing.T) {
+	caller := &larkAlignmentCaller{sequenceResponses: map[string][]string{"chat/list_individual_chat_message": {
+		`{"result":{"messages":[{"openMessageId":"fixture-1","content":"plain"}],"hasMore":true,"nextCursor":1785919699136}}`,
+		`{"result":{"messages":[{"openMessageId":"fixture-2","content":"plain"}],"hasMore":false}}`,
+	}}}
+	payload, err := runDirectMessageIntegrityRegression(t, caller, "--page-all")
+	if err != nil || payload["count"] != float64(2) || payload["complete"] != true || payload["paginationKnown"] != true || payload["partial"] != false {
+		t.Fatalf("normal completed pagination changed: payload=%#v error=%v", payload, err)
+	}
+}
+
+func TestCrossPlatformCoverageDirectMessageIntegrityKnownPagination(t *testing.T) {
+	const morePage = `{"result":{"messages":[{"openMessageId":"fixture-1","content":"plain"}],"hasMore":true,"nextCursor":1785919699136}}`
+	for _, tc := range []struct {
+		name       string
+		response   string
+		failAt     int
+		stopReason string
+		complete   bool
+		wantError  bool
+		calls      int
+	}{
+		{name: "explicit_complete", response: `{"result":{"messages":[{"openMessageId":"fixture-1","content":"plain"}],"hasMore":false}}`, stopReason: "source_complete", complete: true, calls: 1},
+		{name: "later_read_failure", response: morePage, failAt: 2, stopReason: "read_failure", wantError: true, calls: 2},
+		{name: "invalid_cursor", response: `{"result":{"messages":[{"openMessageId":"fixture-1","content":"plain"}],"hasMore":true}}`, stopReason: "pagination_error", wantError: true, calls: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := &larkAlignmentCaller{
+				responses:         map[string]string{"chat/list_individual_chat_message": tc.response},
+				failProductToolAt: map[string]int{"chat/list_individual_chat_message": tc.failAt},
+			}
+			payload, err := runDirectMessageIntegrityRegression(t, caller, "--page-all")
+			if (err != nil) != tc.wantError || payload["complete"] != tc.complete || payload["paginationKnown"] != true || payload["stopReason"] != tc.stopReason || payload["partial"] != tc.wantError {
+				t.Fatalf("known pagination evidence changed: payload=%#v error=%v", payload, err)
+			}
+			if payload["count"] != float64(1) || caller.callCounts["chat/list_individual_chat_message"] != tc.calls {
+				t.Fatalf("unexpected retained messages or requests: payload=%#v calls=%#v", payload, caller.calls)
+			}
+		})
+	}
+}

--- a/skills/multi/dingtalk-chat/references/chat/message-query.md
+++ b/skills/multi/dingtalk-chat/references/chat/message-query.md
@@ -88,6 +88,14 @@ dws chat +search-msg --sender-query "测试用户甲" --page-all --format json
 
 ## 其他查询
 
+### 单聊分页结果
+
+`+messages-list-direct --page-all` 的 `complete` 表示分页是否完成；即使分页完成，
+解密失败仍会返回 `partial=true`、原始密文和 `decryptFailures`。
+任一已读取页缺少可靠的 `hasMore` 时，命令停止并返回分页错误，
+`paginationKnown=false`，同时保留已读取的消息。请求失败或游标错误不会单独将
+已知的 `hasMore` 证据变为未知；仍需检查 `complete`、`stopReason` 和 `failures`。
+
 ### 已知消息、@我与话题回复
 
 - `+messages-mget --msg-ids <id...>`：最多 50 条；结果可直接用于回复、转发、撤回和资源下载。


### PR DESCRIPTION
## Summary

`chat +messages-list-direct --page-all` could report `partial=false` after recording a decryption failure, and `paginationKnown=true` after stopping on a page without usable `hasMore`. Preserve the decryption ledger's partial flag and track missing pagination evidence independently of read/cursor errors.

Retained messages, ciphertext, failure details, and pagination completion semantics remain unchanged. Add real Cobra regression coverage, a short result-semantics reference, and a release fragment.

Fixes #1297
Fixes #1298

## Risk tier

- [ ] Documentation-only
- [x] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk

## Verification

- [x] Release fragment: `.changes/1297-1298-direct-message-integrity.md`
- [x] `./scripts/policy/check-release-fragments.sh origin/main HEAD`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/shortcut/chat -run '^TestCrossPlatformCoverageDirectMessageIntegrity' -count=1 -v`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test -race ./internal/shortcut/chat ./internal/shortcut/chatmsg`
- [x] `make build`
- [x] `./scripts/policy/check-open-source-assets.sh`
- [x] `git diff --check`

Before the fix, the issue-provided fixture failed for decryption-only all-page reads and missing `hasMore` on the first/later page; single-page decryption and successful two-page controls passed. After the fix, all nine scenarios pass, including combined decryption/pagination failure, explicit completion, later request failure, and invalid cursor with known `hasMore`.

Live validation used one authorized account with persisted authentication: sent one user-approved text message, confirmed `sendStatus=SUCCESS`, and read that exact message back using the rebuilt CLI with `--limit 1 --page-all --page-limit 10`. The read returned `count=1`, `pagesFetched=1`, `complete=true`, `paginationKnown=true`, `partial=false`, `failedCount=0`, and `stopReason=source_complete`. Tenant/user/message identifiers are intentionally omitted.

## Notes

The two exceptional states are proven by deterministic MCP/crypto injection through the real Cobra command, not claimed as live-tenant failures. The live check proves ordinary send/read behavior only; successful multi-page traversal is covered locally.

No flags, command paths, generated inputs, packaging, or Schema declarations changed, so generated-drift, command-surface, and package-manager checks are N/A. Full-repository testing is left to CI for this standard change. The release-seal `check-changelog-pr.sh --content-only` check is N/A: it rejects fragment-only changes because it requires a CHANGELOG modification; the ordinary-PR release-fragment gate above passes. Local build/policy commands used system `awk` first in PATH because the installed Homebrew `gawk` has a missing readline dependency.
