### PR TITLE
fix(event): reject comma-separated group subscription targets

### DIFF
--- a/.changes/890-event-single-group-validation.md
+++ b/.changes/890-event-single-group-validation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Event group subscription validation** (#890) — reject comma-separated `--group` values before creating a subscription, including dry-run and multi-event commands, instead of accepting multiple groups and silently missing messages. Help now directs callers to start a separate consumer for each group.

--- a/internal/app/event_command.go
+++ b/internal/app/event_command.go
@@ -368,7 +368,7 @@ SIGTERM、关 stdin，或先用 dws event stop <subscribe_id> --dry-run 预览�
 	f.StringVar(&personalOpts.OpenDingTalkID, "open-dingtalk-id", "",
 		"单聊对端或指定发送人的 openDingtalkId（与 --user 二选一）")
 	f.StringVar(&personalOpts.GroupID, "group", "",
-		"group 规则：openConversationId")
+		"group 规则：仅接受单个 openConversationId，不支持逗号分隔；多群请分别启动 consume")
 	f.StringSliceVar(&personalOpts.RoleTypes, "role-types", nil,
 		"待办事件角色范围：creator,executor,participant；省略时订阅全部三种角色")
 	f.StringVar(&personalOpts.ControlBaseURL, "personal-event-base-url", "",

--- a/internal/app/event_group_validation_test.go
+++ b/internal/app/event_group_validation_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/event/consume"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/event/personal"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
+)
+
+func TestCrossPlatformCoverageEventConsumeRejectsMultipleGroups(t *testing.T) {
+	for _, multiEvent := range []bool{false, true} {
+		for _, dryRun := range []bool{false, true} {
+			name := "single_event"
+			if multiEvent {
+				name = "multiple_events"
+			}
+			if dryRun {
+				name += "_dry_run"
+			}
+			t.Run(name, func(t *testing.T) {
+				t.Setenv("DWS_CONFIG_DIR", t.TempDir())
+				testseam.Swap(t, &personalResolveEventIdentity, func(context.Context, string, string) (personal.Identity, error) {
+					return personal.Identity{ClientID: "fixture-client", CorpID: "fixture-corp", UserID: "fixture-user", SourceID: "open"}, nil
+				})
+				createCalls, consumeCalls := 0, 0
+				testseam.Swap(t, &personalCreateSubscription, func(*personal.Client, context.Context, personal.CreateSubscriptionRequest) (*personal.Subscription, error) {
+					createCalls++
+					return nil, errors.New("unexpected subscription creation")
+				})
+				testseam.Swap(t, &personalConsumeRun, func(context.Context, consume.Config) error {
+					consumeCalls++
+					return nil
+				})
+				testseam.Swap(t, &personalConsumeRunMany, func(context.Context, consume.Config, []consume.ConsumerSpec) error {
+					consumeCalls++
+					return nil
+				})
+				cmd := newEventConsumeCommand()
+				cmd.SetOut(io.Discard)
+				cmd.SetErr(io.Discard)
+				args := []string{personal.EventInChat}
+				if multiEvent {
+					args = append(args, personal.EventReadGroup)
+				}
+				args = append(args, "--group", "cid-fixture-a,cid-fixture-b", "--duration", "1s")
+				if dryRun {
+					args = append(args, "--dry-run")
+				}
+				cmd.SetArgs(args)
+				err := cmd.Execute()
+				if err == nil || !strings.Contains(err.Error(), "--group accepts exactly one openConversationId") {
+					t.Errorf("Execute() error = %v, want single-group validation error", err)
+				}
+				if createCalls != 0 || consumeCalls != 0 {
+					t.Fatalf("invalid group reached subscription/consumer: create=%d consume=%d", createCalls, consumeCalls)
+				}
+			})
+		}
+	}
+}

--- a/internal/event/personal/group_validation_test.go
+++ b/internal/event/personal/group_validation_test.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package personal
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCrossPlatformCoverageGroupRuleRejectsMultipleGroups(t *testing.T) {
+	for _, def := range Catalog("", true, false) {
+		if def.RuleType != "group" {
+			continue
+		}
+		t.Run(def.EventKey, func(t *testing.T) {
+			for _, group := range []string{"cid-a,cid-b", "cid-a, cid-b", ",cid-a", "cid-a,", "cid-a,cid-a"} {
+				_, params, err := BuildRuleParam(def.EventKey, RuleOptions{GroupID: group})
+				if err == nil || !strings.Contains(err.Error(), "--group accepts exactly one openConversationId") || params != nil {
+					t.Errorf("group %q: params=%#v error=%v; want rejection", group, params, err)
+				}
+			}
+			rule, params, err := BuildRuleParam(def.EventKey, RuleOptions{GroupID: "  cid-single+/==  "})
+			if err != nil || rule != "group" || params["openConversationId"] != "cid-single+/==" {
+				t.Fatalf("single group changed: rule=%q params=%#v error=%v", rule, params, err)
+			}
+		})
+	}
+}

--- a/internal/event/personal/registry.go
+++ b/internal/event/personal/registry.go
@@ -581,6 +581,9 @@ func BuildRuleParam(eventKey string, opts RuleOptions) (ruleType string, rulePar
 		if groupID == "" {
 			return "", nil, fmt.Errorf("--group is required for %s", eventKey)
 		}
+		if strings.Contains(groupID, ",") {
+			return "", nil, fmt.Errorf("--group accepts exactly one openConversationId; start a separate event consume command for each group")
+		}
 		return def.RuleType, map[string]any{
 			"openConversationId": groupID,
 		}, nil

--- a/skills/multi/dingtalk-event/references/event-im-keys.md
+++ b/skills/multi/dingtalk-event/references/event-im-keys.md
@@ -25,7 +25,8 @@
 | `user_im_group_disbanded` | 群解散 | `--group` |
 
 `--user` 只接收 userId；明确 openDingTalkId 时用对应 flag。群目标必须是
-openConversationId。不要把两种身份混传或选择搜索第一项。
+单个 openConversationId，不接受逗号分隔的多个群 ID；多群请分别启动 consume。
+不要把两种身份混传或选择搜索第一项。
 
 ## 精确模板
 


### PR DESCRIPTION
## Summary

`event consume --group "<group-A>,<group-B>"` previously created a subscription and reported ready while silently missing group B's messages. Reject comma-separated group values in the shared group-rule builder before subscription creation, and explain in Help that callers must start a separate consumer per group.

The validation covers message, read, recall, reaction, and group lifecycle events, including multi-event commands and dry-run. Valid single-group inputs retain their existing behavior. Add regression tests, documentation, and a release fragment.

Fixes #890

## Risk tier

- [ ] Documentation-only
- [x] Standard: input validation and Help clarification; stable package graph
- [ ] High-risk

## Verification

- [x] Release fragment: `.changes/890-event-single-group-validation.md`
- [x] `./scripts/policy/check-release-fragments.sh origin/main HEAD`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/event/personal ./internal/app -run '^TestCrossPlatformCoverage(GroupRuleRejectsMultipleGroups|EventConsumeRejectsMultipleGroups)$' -count=1 -v`
- [x] Personal event package race tests passed.
- [ ] The combined `DWS_PACKAGE_VERSION=0.0.0-test go test -race ./internal/event/personal ./internal/app` run hit the default 10-minute total timeout in `internal/app`; this is not reported as a pass. At timeout, `TestCrossPlatformCoverageReviewedProductTemplatedParamAliasesCannotBypassConfirmation` had been running for 15 seconds. Targeted follow-up results are recorded below.
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test -race ./internal/app -run 'Test.*(Event|Personal)' -count=1 -timeout 10m` — passed (36.764s).
- [x] `DWS_PACKAGE_VERSION=0.0.0-test go test -race ./internal/app -run '^TestCrossPlatformCoverageReviewedProductTemplatedParamAliasesCannotBypassConfirmation$' -count=1 -timeout 5m` — passed in isolation (36.063s).
- [x] `make build`
- [x] `./scripts/policy/check-command-surface.sh --strict`
- [x] `./scripts/policy/check-open-source-assets.sh`
- [x] `git diff --check`

### Regression evidence

On unmodified main (`6f71222b`), the new Cobra tests reach the subscription-create seam with the invalid comma-separated group value; dry-run also incorrectly accepts it. After the fix, all four single/multi-event and live/dry-run cases reject it with no subscription creation or consumer execution. Rule-builder tests cover all eight group event types, five comma-containing input shapes, and a whitespace-trimmed single-ID control.

### Real service evidence (2026-09-06, Asia/Shanghai)

Tests used the same authenticated profile, two existing user-approved groups A/B, and an existing bot in B. Each send occurred after `[event] ready`, with distinct test markers. No synthetic IDs were sent to the service.

| Baseline subscription target | Bot message destination | Result |
| --- | --- | --- |
| A,B | B | Ready and no parameter error; 0 events in 45 seconds. A history read confirmed the message existed in B. |
| B | B | Received the matching bot event. |
| B,A | B | Received the matching bot event. |

After rebuilding with the fix, A,B returns exit 3, `category=validation`, `reason=personal_subscription_invalid`, and `retryable=false`. A single-B subscription still receives the bot test message and exits at its one-event bound. The final status check reports no test subscriptions or local consumers remaining. Public evidence omits tenant, group, bot, and message identifiers.

## Notes

This implements the issue's requested fail-closed single-group validation; it does not add multi-group fan-out. No command paths, flag names, generated inputs, transport, authentication, installer, or packaging behavior changed. Generated-drift and package-manager checks are N/A. The release-seal CHANGELOG check is N/A for this ordinary fragment-only PR; release-fragment validation is used instead. Full-repository testing remains with CI for this standard change.

Local build/policy commands used system `awk` first in PATH because the installed Homebrew `gawk` has a missing readline dependency.
