### PR TITLE
feat(aitable): add bounded AI field execution shortcut

### DIFF
--- a/docs/shortcut-public-catalog.json
+++ b/docs/shortcut-public-catalog.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-27T10:19:25.811119",
-  "count": 439,
+  "generated_at": "2026-09-03T10:43:33.803569",
+  "count": 440,
   "results": [
     {
       "suite": "semantic",
@@ -80,6 +80,16 @@
       "status": "reviewed_available",
       "disposition": "schema_leaf",
       "semantic_delta": "开启 Base 高级权限总开关的一对一入口。",
+      "availability": "available"
+    },
+    {
+      "suite": "semantic",
+      "service": "aitable",
+      "command": "+ai-field-run",
+      "risk": "high-risk-write",
+      "status": "reviewed_available",
+      "disposition": "primary_smart",
+      "semantic_delta": "先精确验证一个 AI 字段与 1–100 条显式记录身份，再唯一调用 run_ai_field；只发布 submitted pending 回执，verified 固定 false。",
       "availability": "available"
     },
     {
@@ -879,7 +889,7 @@
       "risk": "read",
       "status": "reviewed_available",
       "disposition": "semantic_adapter",
-      "semantic_delta": "按名称关键词搜索 AI 表格模板并返回可用于创建的 templateId。",
+      "semantic_delta": "按非空名称关键词搜索 AI 表格模板，稳定投影 templateId，并将严格校验后的 nextCursor 发布到 meta.pagination；拒绝无关键词和不可续分页。",
       "availability": "available"
     },
     {
@@ -3779,7 +3789,7 @@
       "risk": "write",
       "status": "reviewed_available",
       "disposition": "primary_smart",
-      "semantic_delta": "Grants semantic view/download/edit permissions per stable member UID with stop/continue partial-write ledgers and explicit acknowledgements.",
+      "semantic_delta": "Grants semantic view/download/edit permissions per stable member UID or organization staffId with stop/continue partial-write ledgers and explicit acknowledgements.",
       "availability": "available"
     },
     {

--- a/internal/app/aitable_ai_field_schema_test.go
+++ b/internal/app/aitable_ai_field_schema_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/cli"
 )
 
 func TestCrossPlatformCoverageAIFieldRunFinalAndCompactSchema(t *testing.T) {
@@ -66,6 +68,33 @@ func TestCrossPlatformCoverageAIFieldRunFinalAndCompactSchema(t *testing.T) {
 	}
 	if !reflect.DeepEqual(compact["result"], result) {
 		t.Fatalf("compact/full Result differs\ncompact=%#v\nfull=%#v", compact["result"], result)
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunExampleDispositionIsExactAndReviewed(t *testing.T) {
+	plan := agentExampleExecutionPlan(t)
+	var matches []cli.AgentExampleExecution
+	for _, execution := range plan.Examples {
+		if execution.CanonicalPath == "aitable.shortcut_ai_field_run" {
+			matches = append(matches, execution)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("AI field example executions = %d, want exactly one: %#v", len(matches), matches)
+	}
+	execution := matches[0]
+	if execution.Index != 0 || execution.Mode != cli.AgentExampleModeContractOnly ||
+		execution.Source != cli.AgentExampleDispositionReviewed ||
+		execution.ReasonCode != cli.AgentExampleReasonStatefulPreflight || strings.TrimSpace(execution.Reason) == "" {
+		t.Fatalf("AI field example disposition = %#v", execution)
+	}
+	if execution.DryRun == nil || execution.DryRun.PreviewKind != "plan" || !execution.DryRun.RemoteReads {
+		t.Fatalf("AI field reviewed dry-run capability was changed: %#v", execution.DryRun)
+	}
+	if plan.Contract+plan.DryRun+plan.ContractOnly != plan.Total ||
+		plan.ReviewedContractOnly != plan.ContractOnly ||
+		plan.ContractOnlyByReason[cli.AgentExampleReasonStatefulPreflight] == 0 {
+		t.Fatalf("Agent example plan counts are inconsistent: %#v", plan)
 	}
 }
 

--- a/internal/app/aitable_ai_field_schema_test.go
+++ b/internal/app/aitable_ai_field_schema_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Alibaba Group
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCrossPlatformCoverageAIFieldRunFinalAndCompactSchema(t *testing.T) {
+	tool := fullSchemaSnapshotForTest(t).Tools["aitable.shortcut_ai_field_run"]
+	if tool == nil {
+		t.Fatal("final Schema missing aitable.shortcut_ai_field_run")
+	}
+	for key, want := range map[string]string{
+		"effect": "write", "risk": "high", "confirmation": "user_required", "idempotency": "non_idempotent",
+	} {
+		if got := schemaContractString(tool[key]); got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	parameters := schemaContractMap(tool["parameters"])
+	for _, name := range []string{"base-id", "table-id", "field-id", "record-ids"} {
+		if required, _ := parameters[name]["required"].(bool); !required {
+			t.Fatalf("--%s required = %#v", name, parameters[name]["required"])
+		}
+	}
+	result, ok := tool["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result = %#v", tool["result"])
+	}
+	outcomes, _ := result["outcomes"].([]any)
+	if !reflect.DeepEqual(outcomes, []any{"pending", "failure"}) {
+		t.Fatalf("outcomes = %#v", outcomes)
+	}
+	paths, _ := result["sensitive_paths"].([]any)
+	if !reflect.DeepEqual(paths, []any{"documentUrl"}) {
+		t.Fatalf("sensitive_paths = %#v", paths)
+	}
+	dryRun, _ := tool["dry_run"].(map[string]any)
+	if dryRun["preview_kind"] != "plan" || dryRun["remote_reads"] != true {
+		t.Fatalf("dry_run = %#v, want reviewed plan with remote reads", dryRun)
+	}
+	selectionText := strings.Join(append(schemaContractStrings(tool["use_when"]), schemaContractStrings(tool["avoid_when"])...), " ")
+	for _, want := range []string{"钉钉 AI 字段", "不要用于安装", "没有 AI 字段任务状态查询接口"} {
+		if !strings.Contains(selectionText, want) {
+			t.Fatalf("selection missing %q: %s", want, selectionText)
+		}
+	}
+
+	root := NewRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"schema", "--cli-path", "aitable +ai-field-run", "--compact", "--format", "json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("compact Schema: %v; %s", err, stderr.String())
+	}
+	var compact map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &compact); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(compact["result"], result) {
+		t.Fatalf("compact/full Result differs\ncompact=%#v\nfull=%#v", compact["result"], result)
+	}
+}
+
+func schemaContractStrings(value any) []string {
+	switch items := value.(type) {
+	case []string:
+		return append([]string(nil), items...)
+	case []any:
+		out := make([]string, 0, len(items))
+		for _, item := range items {
+			if text, ok := item.(string); ok {
+				out = append(out, text)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/internal/app/aitable_template_search_schema_test.go
+++ b/internal/app/aitable_template_search_schema_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestCrossPlatformCoverageAITableTemplateSearchFinalSchemaRequiresQuery(t *testing.T) {
+func TestCrossPlatformCoverageAITableTemplateSearchRuntimeRequiresQueryButSchemaStaysOptional(t *testing.T) {
 	snapshot := fullSchemaSnapshotForTest(t)
 	for _, test := range []struct {
 		canonical string
@@ -29,12 +29,12 @@ func TestCrossPlatformCoverageAITableTemplateSearchFinalSchemaRequiresQuery(t *t
 		if query == nil {
 			t.Fatalf("%s final Schema missing query parameter", canonical)
 		}
-		if required, _ := query["required"].(bool); !required {
-			t.Fatalf("%s query required=%#v", canonical, query["required"])
+		if required, _ := query["required"].(bool); required {
+			t.Fatalf("%s query required=%#v, want compatibility optional", canonical, query["required"])
 		}
 		if canonical == "aitable.template_search" {
-			if required, _ := query["cli_required"].(bool); !required {
-				t.Fatalf("%s query cli_required=%#v", canonical, query["cli_required"])
+			if required, _ := query["cli_required"].(bool); required {
+				t.Fatalf("%s query cli_required=%#v, want compatibility optional", canonical, query["cli_required"])
 			}
 		}
 		if canonical == "aitable.shortcut_template_search" {
@@ -81,8 +81,8 @@ func TestCrossPlatformCoverageAITableTemplateSearchFinalSchemaRequiresQuery(t *t
 			t.Fatalf("decode compact Schema %s: %v", test.cliPath, err)
 		}
 		compactQuery := schemaContractMap(compact["parameters"])["query"]
-		if required, _ := compactQuery["required"].(bool); !required {
-			t.Fatalf("compact %s query required=%#v", test.cliPath, compactQuery["required"])
+		if required, _ := compactQuery["required"].(bool); required {
+			t.Fatalf("compact %s query required=%#v, want compatibility optional", test.cliPath, compactQuery["required"])
 		}
 	}
 }

--- a/internal/app/aitable_template_search_schema_test.go
+++ b/internal/app/aitable_template_search_schema_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Alibaba Group
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCrossPlatformCoverageAITableTemplateSearchFinalSchemaRequiresQuery(t *testing.T) {
+	snapshot := fullSchemaSnapshotForTest(t)
+	for _, test := range []struct {
+		canonical string
+		cliPath   string
+	}{
+		{canonical: "aitable.shortcut_template_search", cliPath: "aitable +template-search"},
+		{canonical: "aitable.template_search", cliPath: "aitable template search"},
+	} {
+		canonical := test.canonical
+		tool := snapshot.Tools[canonical]
+		if tool == nil {
+			t.Fatalf("final Schema missing %s", canonical)
+		}
+		parameters := schemaContractMap(tool["parameters"])
+		query := parameters["query"]
+		if query == nil {
+			t.Fatalf("%s final Schema missing query parameter", canonical)
+		}
+		if required, _ := query["required"].(bool); !required {
+			t.Fatalf("%s query required=%#v", canonical, query["required"])
+		}
+		if canonical == "aitable.template_search" {
+			if required, _ := query["cli_required"].(bool); !required {
+				t.Fatalf("%s query cli_required=%#v", canonical, query["cli_required"])
+			}
+		}
+		if canonical == "aitable.shortcut_template_search" {
+			if tool["result"] == nil {
+				t.Fatal("shortcut template search final Schema missing Result")
+			}
+			result, _ := tool["result"].(map[string]any)
+			dataSchema, _ := result["data_schema"].(map[string]any)
+			properties, _ := dataSchema["properties"].(map[string]any)
+			templates, _ := properties["templates"].(map[string]any)
+			items, _ := templates["items"].(map[string]any)
+			itemProperties, _ := items["properties"].(map[string]any)
+			templateName, _ := itemProperties["templateName"].(map[string]any)
+			if schemaContractString(templateName["type"]) != "string" {
+				t.Fatalf("templateName type = %#v", templateName["type"])
+			}
+			pagination, _ := tool["pagination"].(map[string]any)
+			if schemaContractString(pagination["cursor_parameter"]) != "cursor" {
+				t.Fatalf("shortcut template search pagination = %#v", pagination)
+			}
+		}
+		texts := []string{schemaContractString(tool["description"])}
+		if useWhen, ok := tool["use_when"].([]any); ok {
+			for _, item := range useWhen {
+				texts = append(texts, schemaContractString(item))
+			}
+		}
+		for _, text := range texts {
+			if strings.Contains(text, "返回热门") || strings.Contains(text, "不传关键词") {
+				t.Fatalf("%s final Schema still claims unsupported fallback: %q", canonical, text)
+			}
+		}
+
+		root := NewRootCommand()
+		var stdout, stderr bytes.Buffer
+		root.SetOut(&stdout)
+		root.SetErr(&stderr)
+		root.SetArgs([]string{"schema", "--cli-path", test.cliPath, "--compact", "--format", "json"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("compact Schema %s: %v; %s", test.cliPath, err, stderr.String())
+		}
+		var compact map[string]any
+		if err := json.Unmarshal(stdout.Bytes(), &compact); err != nil {
+			t.Fatalf("decode compact Schema %s: %v", test.cliPath, err)
+		}
+		compactQuery := schemaContractMap(compact["parameters"])["query"]
+		if required, _ := compactQuery["required"].(bool); !required {
+			t.Fatalf("compact %s query required=%#v", test.cliPath, compactQuery["required"])
+		}
+	}
+}

--- a/internal/app/schema_shortcut_contract_test.go
+++ b/internal/app/schema_shortcut_contract_test.go
@@ -16,12 +16,12 @@ import (
 )
 
 const (
-	publicShortcutCount = 438
+	publicShortcutCount = 439
 	// schemaPublishedShortcutCount counts every delivered *.shortcut_* tool,
 	// including reviewed hidden compatibility and unavailable contracts.
-	schemaPublishedShortcutCount = 495
+	schemaPublishedShortcutCount = 496
 	// publiclyDeliveredShortcutCount is the public-catalog subset of that surface.
-	publiclyDeliveredShortcutCount = 438
+	publiclyDeliveredShortcutCount = 439
 )
 
 func TestDeliverySchemaCoversOrExactlyExcludesEveryPublicShortcutContract(t *testing.T) {

--- a/internal/app/server_failure_classifier.go
+++ b/internal/app/server_failure_classifier.go
@@ -14,6 +14,7 @@
 package app
 
 import (
+	"encoding/json"
 	"regexp"
 	"strings"
 
@@ -34,6 +35,7 @@ type serverFailureClass struct {
 	operation        string
 	retryable        *bool
 	executionStarted *bool
+	serverDiag       *apperrors.ServerDiagnostics
 }
 
 func classifyServerFailure(message, serverKey, tool string, diag apperrors.ServerDiagnostics) (serverFailureClass, bool) {
@@ -41,6 +43,33 @@ func classifyServerFailure(message, serverKey, tool string, diag apperrors.Serve
 	detail := strings.ToLower(strings.TrimSpace(diag.TechnicalDetail))
 	text := strings.ToLower(strings.TrimSpace(message))
 	combined := text + " " + detail
+
+	// The AITable get_base service returns this exact typed code after a Base
+	// has been deleted (or when the caller supplies an otherwise valid but
+	// nonexistent Base ID). Keep the match scoped to the owning read leaf: an
+	// English "does not exist" phrase, BASE_NOT_FOUND from another tool, or a
+	// different AITable input error is not enough to claim resource absence.
+	if envelopeDiag, ok := aitableGetBaseNotFoundEnvelope(message); ok &&
+		strings.EqualFold(strings.TrimSpace(serverKey), "aitable") &&
+		strings.EqualFold(strings.TrimSpace(tool), "get_base") {
+		mergedDiag := diag
+		mergedDiag.ServerErrorCode = envelopeDiag.ServerErrorCode
+		mergedDiag.ServerRetryable = envelopeDiag.ServerRetryable
+		if envelopeDiag.TraceID != "" {
+			mergedDiag.TraceID = envelopeDiag.TraceID
+		}
+		retryable := false
+		return serverFailureClass{
+			message:    "AI Table Base not found",
+			reason:     "not_found",
+			origin:     "aitable_service",
+			stage:      "resource_lookup",
+			operation:  "aitable/get_base",
+			retryable:  &retryable,
+			hint:       "Confirm the stable Base ID, or use aitable +base-search with the known Base name.",
+			serverDiag: &mergedDiag,
+		}, true
+	}
 
 	if strings.EqualFold(strings.TrimSpace(serverKey), "ding") &&
 		(strings.EqualFold(strings.TrimSpace(tool), "send_ding_message") ||
@@ -128,6 +157,33 @@ func classifyServerFailure(message, serverKey, tool string, diag apperrors.Serve
 	return serverFailureClass{}, false
 }
 
+func aitableGetBaseNotFoundEnvelope(message string) (apperrors.ServerDiagnostics, bool) {
+	var body map[string]any
+	if json.Unmarshal([]byte(message), &body) != nil {
+		return apperrors.ServerDiagnostics{}, false
+	}
+	status, statusOK := body["status"].(string)
+	success, successOK := body["success"].(bool)
+	errorBody, errorOK := body["error"].(map[string]any)
+	if !statusOK || !strings.EqualFold(strings.TrimSpace(status), "error") ||
+		!successOK || !success || !errorOK {
+		return apperrors.ServerDiagnostics{}, false
+	}
+	code, _ := errorBody["code"].(string)
+	errorType, _ := errorBody["type"].(string)
+	retryable, retryableOK := errorBody["retryable"].(bool)
+	if strings.TrimSpace(code) != "BASE_NOT_FOUND" ||
+		strings.TrimSpace(errorType) != "INPUT_ERROR" || !retryableOK || retryable {
+		return apperrors.ServerDiagnostics{}, false
+	}
+	notRetryable := false
+	diag := apperrors.ServerDiagnostics{ServerErrorCode: "BASE_NOT_FOUND", ServerRetryable: &notRetryable}
+	if traceID, ok := body["trace_id"].(string); ok {
+		diag.TraceID = strings.TrimSpace(traceID)
+	}
+	return diag, true
+}
+
 func newServerFailureAPIError(
 	message string,
 	fallbackReason string,
@@ -161,6 +217,9 @@ func newServerFailureAPIError(
 		}
 		if classified.executionStarted != nil {
 			opts = append(opts, apperrors.WithExecutionStarted(*classified.executionStarted))
+		}
+		if classified.serverDiag != nil {
+			opts = append(opts, apperrors.WithServerDiag(*classified.serverDiag))
 		}
 	}
 	return apperrors.NewAPI(message, opts...)

--- a/internal/app/server_failure_classifier_test.go
+++ b/internal/app/server_failure_classifier_test.go
@@ -101,7 +101,7 @@ func TestCrossPlatformCoverageServerFailureClassifierAITableBaseNotFound(t *test
 	}
 	diag := transport.ExtractServerDiagnosticsFromMap(content)
 	err := newServerFailureAPIError(
-		`{"data":{},"error":{"code":"BASE_NOT_FOUND","message":"Specified base does not exist, has been deleted, or is inaccessible","retryable":false,"type":"INPUT_ERROR"},"status":"error","success":true}`,
+		`{"data":{},"error":{"code":"BASE_NOT_FOUND","message":"Specified base does not exist, has been deleted, or is inaccessible","retryable":false,"type":"INPUT_ERROR"},"status":"error","success":true,"trace_id":"trace-redacted"}`,
 		"mcp_tool_error",
 		"check tool parameters",
 		"aitable",

--- a/internal/app/server_failure_classifier_test.go
+++ b/internal/app/server_failure_classifier_test.go
@@ -85,6 +85,109 @@ func TestCrossPlatformCoverageServerFailureClassifierRequiredConversationID(t *t
 	}
 }
 
+func TestCrossPlatformCoverageServerFailureClassifierAITableBaseNotFound(t *testing.T) {
+	content := map[string]any{
+		"data":     map[string]any{},
+		"status":   "error",
+		"success":  true,
+		"summary":  "Failed to get base because base does not exist or is inaccessible",
+		"trace_id": "trace-redacted",
+		"error": map[string]any{
+			"code":      "BASE_NOT_FOUND",
+			"message":   "Specified base does not exist, has been deleted, or is inaccessible",
+			"retryable": false,
+			"type":      "INPUT_ERROR",
+		},
+	}
+	diag := transport.ExtractServerDiagnosticsFromMap(content)
+	err := newServerFailureAPIError(
+		`{"data":{},"error":{"code":"BASE_NOT_FOUND","message":"Specified base does not exist, has been deleted, or is inaccessible","retryable":false,"type":"INPUT_ERROR"},"status":"error","success":true}`,
+		"mcp_tool_error",
+		"check tool parameters",
+		"aitable",
+		"get_base",
+		diag,
+	)
+
+	var typed *apperrors.Error
+	if !errors.As(err, &typed) {
+		t.Fatalf("error = %T, want *errors.Error", err)
+	}
+	if typed.Category != apperrors.CategoryAPI || typed.Reason != "not_found" || typed.ExitCode() != apperrors.ExitCodeAPI {
+		t.Fatalf("classification = category %q reason %q exit %d", typed.Category, typed.Reason, typed.ExitCode())
+	}
+	if typed.Operation != "aitable/get_base" || typed.Origin != "aitable_service" || typed.FailureStage != "resource_lookup" {
+		t.Fatalf("classification context = operation %q origin %q stage %q", typed.Operation, typed.Origin, typed.FailureStage)
+	}
+	if !typed.RetryableSet || typed.Retryable {
+		t.Fatalf("retryability = (%v, %v), want explicit false", typed.RetryableSet, typed.Retryable)
+	}
+	if typed.ServerDiag.ServerErrorCode != "BASE_NOT_FOUND" || typed.ServerDiag.TraceID != "trace-redacted" {
+		t.Fatalf("diagnostics = %#v", typed.ServerDiag)
+	}
+
+	info := errorInfoFromExecutionError(err)
+	if info.Type != "api" || info.Subtype != "not_found" || info.ExitCode != apperrors.ExitCodeAPI || info.UpstreamCode != "BASE_NOT_FOUND" {
+		t.Fatalf("outer error info = %#v", info)
+	}
+}
+
+func TestCrossPlatformCoverageServerFailureClassifierAITableBaseNotFoundBoundaries(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   string
+		serverKey string
+		tool      string
+		code      string
+	}{
+		{
+			name:      "adjacent invalid base id",
+			message:   `{"error":{"code":"INVALID_BASE_ID","message":"baseId format is invalid","retryable":false,"type":"INPUT_ERROR"},"status":"error","success":true}`,
+			serverKey: "aitable", tool: "get_base", code: "INVALID_BASE_ID",
+		},
+		{
+			name:      "same code different tool",
+			message:   `{"error":{"code":"BASE_NOT_FOUND","message":"base missing","retryable":false,"type":"INPUT_ERROR"},"status":"error","success":true}`,
+			serverKey: "aitable", tool: "delete_base", code: "BASE_NOT_FOUND",
+		},
+		{
+			name:      "phrase without structured code",
+			message:   "Specified base does not exist, has been deleted, or is inaccessible",
+			serverKey: "aitable", tool: "get_base", code: "",
+		},
+		{
+			name:      "same code different service",
+			message:   `{"error":{"code":"BASE_NOT_FOUND","message":"base missing"}}`,
+			serverKey: "other", tool: "get_base", code: "BASE_NOT_FOUND",
+		},
+		{
+			name:      "same code retryable envelope",
+			message:   `{"error":{"code":"BASE_NOT_FOUND","message":"base missing","retryable":true,"type":"INPUT_ERROR"},"status":"error","success":true}`,
+			serverKey: "aitable", tool: "get_base", code: "BASE_NOT_FOUND",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := newServerFailureAPIError(
+				test.message,
+				"mcp_tool_error",
+				"check tool parameters",
+				test.serverKey,
+				test.tool,
+				apperrors.ServerDiagnostics{ServerErrorCode: test.code},
+			)
+			var typed *apperrors.Error
+			if !errors.As(err, &typed) {
+				t.Fatalf("error = %T, want *errors.Error", err)
+			}
+			if typed.Reason != "mcp_tool_error" || typed.Origin != "" || typed.FailureStage != "" {
+				t.Fatalf("adjacent error was widened into not_found: %#v", typed)
+			}
+		})
+	}
+}
+
 func TestCrossPlatformCoverageServerFailureClassifierDingRobotNotInOrg(t *testing.T) {
 	for _, tool := range []string{"send_ding_message", "recall_ding_message"} {
 		t.Run(tool, func(t *testing.T) {

--- a/internal/helpers/aitable.go
+++ b/internal/helpers/aitable.go
@@ -3740,15 +3740,22 @@ fieldId 必须是 primaryDoc 类型的字段。`,
 		Long: `按名称关键词搜索 AI 表格模板，支持分页。
 返回每个模板的 templateId、name、description，以及分页信息 hasMore / nextCursor。
 返回的 templateId 可直接用于 base create。
-模板预览链接可通过 https://docs.dingtalk.com/table/template/{templateId} 拼接得到
-不传关键词时返回热门模板。`,
-		Example: `  dws aitable template search --query "项目管理"
-  dws aitable template search`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			toolArgs := map[string]any{}
-			if q := flagOrFallback(cmd, "query", "keyword"); q != "" {
-				toolArgs["query"] = q
+模板预览链接可通过 https://docs.dingtalk.com/table/template/{templateId} 拼接得到。
+--query 必填且去除首尾空白后不能为空；当前下层不支持省略关键词浏览热门模板。`,
+		Example: `  dws aitable template search --query "项目管理"`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			query := strings.TrimSpace(flagOrFallback(cmd, "query", "keyword"))
+			if query == "" {
+				return apperrors.NewValidation("--query 去除首尾空白后不能为空", apperrors.WithReason("missing_required_flags"))
 			}
+			if err := cmd.Flags().Set("query", query); err != nil {
+				return err
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			q := strings.TrimSpace(mustGetFlag(cmd, "query"))
+			toolArgs := map[string]any{"query": q}
 			if v, _ := cmd.Flags().GetInt("limit"); v > 0 {
 				toolArgs["limit"] = v
 			}
@@ -8230,6 +8237,7 @@ parentSectionId 为空串表示该节点在 Base 根目录下。
 	_ = templateSearchCmd.Flags().MarkHidden("keyword")
 	templateSearchCmd.Flags().Int("limit", 0, "每页返回数量。默认 10，最大 30")
 	templateSearchCmd.Flags().String("cursor", "", "分页游标。首次请求不传；后续请原样传入上次返回的 nextCursor")
+	_ = templateSearchCmd.MarkFlagRequired("query")
 	templateCmd.AddCommand(templateSearchCmd)
 
 	// attachment

--- a/internal/helpers/aitable.go
+++ b/internal/helpers/aitable.go
@@ -8232,12 +8232,11 @@ parentSectionId 为空串表示该节点在 Base 根目录下。
 	recordCmd.AddCommand(recordGetCmd)
 
 	// template
-	templateSearchCmd.Flags().String("query", "", "模板名称关键词 (必填)")
+	templateSearchCmd.Flags().String("query", "", "模板名称关键词（每次调用必须提供；兼容接口保持 optional）")
 	templateSearchCmd.Flags().String("keyword", "", "--query alias")
 	_ = templateSearchCmd.Flags().MarkHidden("keyword")
 	templateSearchCmd.Flags().Int("limit", 0, "每页返回数量。默认 10，最大 30")
 	templateSearchCmd.Flags().String("cursor", "", "分页游标。首次请求不传；后续请原样传入上次返回的 nextCursor")
-	_ = templateSearchCmd.MarkFlagRequired("query")
 	templateCmd.AddCommand(templateSearchCmd)
 
 	// attachment

--- a/internal/helpers/aitable_base_not_found_test.go
+++ b/internal/helpers/aitable_base_not_found_test.go
@@ -5,6 +5,7 @@ package helpers
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
@@ -47,6 +48,16 @@ func TestCrossPlatformCoverageAITableBaseNotFoundSurvivesHelperPipeline(t *testi
 	}
 }
 
+func TestCrossPlatformCoverageAITableBaseNotFoundSurvivesTerminalCallPipeline(t *testing.T) {
+	caller := &aitableTestCaller{responses: []string{`{"data":{},"error":{"code":"BASE_NOT_FOUND","message":"Specified base does not exist","retryable":false,"type":"INPUT_ERROR"},"status":"error","success":true}`}}
+	InitDepsForTest(t, caller)
+	err := callMCPToolInternalOpts("aitable", "get_base", map[string]any{"baseId": "base-redacted"}, false)
+	var typed *apperrors.Error
+	if !errors.As(err, &typed) || typed.Reason != "not_found" || typed.Operation != "aitable/get_base" || strings.TrimSpace(typed.Message) == "" {
+		t.Fatalf("terminal pipeline error = %#v", err)
+	}
+}
+
 func TestCrossPlatformCoverageAITableBaseNotFoundExactBoundaries(t *testing.T) {
 	tests := []struct {
 		name, serverID, toolName string
@@ -63,6 +74,9 @@ func TestCrossPlatformCoverageAITableBaseNotFoundExactBoundaries(t *testing.T) {
 		}},
 		{name: "wrong status", serverID: "aitable", toolName: "get_base", mutate: func(body map[string]any) {
 			body["status"] = "success"
+		}},
+		{name: "success false", serverID: "aitable", toolName: "get_base", mutate: func(body map[string]any) {
+			body["success"] = false
 		}},
 		{name: "retryable", serverID: "aitable", toolName: "get_base", mutate: func(body map[string]any) {
 			body["error"].(map[string]any)["retryable"] = true

--- a/internal/helpers/aitable_base_not_found_test.go
+++ b/internal/helpers/aitable_base_not_found_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Alibaba Group
+// SPDX-License-Identifier: Apache-2.0
+
+package helpers
+
+import (
+	"errors"
+	"testing"
+
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+)
+
+func aitableBaseNotFoundFixture() map[string]any {
+	return map[string]any{
+		"data":     map[string]any{},
+		"status":   "error",
+		"success":  true,
+		"summary":  "Failed to get base because base does not exist or is inaccessible",
+		"trace_id": "trace-redacted",
+		"error": map[string]any{
+			"code":      "BASE_NOT_FOUND",
+			"message":   "Specified base does not exist, has been deleted, or is inaccessible",
+			"retryable": false,
+			"type":      "INPUT_ERROR",
+		},
+	}
+}
+
+func TestCrossPlatformCoverageAITableBaseNotFoundSurvivesHelperPipeline(t *testing.T) {
+	text := `{"data":{},"error":{"code":"BASE_NOT_FOUND","message":"Specified base does not exist, has been deleted, or is inaccessible","retryable":false,"type":"INPUT_ERROR"},"meta":{},"status":"error","success":true,"summary":"Failed to get base because base does not exist or is inaccessible","trace_id":"trace-redacted"}`
+	gotText, err := parseMCPToolTextResult("aitable", "get_base", textToolResult(text), nil)
+	if gotText != "" {
+		t.Fatalf("text = %q, want empty on classified error", gotText)
+	}
+	var typed *apperrors.Error
+	if !errors.As(err, &typed) {
+		t.Fatalf("error = %T, want *errors.Error", err)
+	}
+	if typed.Category != apperrors.CategoryAPI || typed.Reason != "not_found" || typed.ExitCode() != apperrors.ExitCodeAPI {
+		t.Fatalf("classification = category %q reason %q exit %d", typed.Category, typed.Reason, typed.ExitCode())
+	}
+	if typed.Operation != "aitable/get_base" || typed.ServerDiag.ServerErrorCode != "BASE_NOT_FOUND" {
+		t.Fatalf("classification context = operation %q diagnostics %#v", typed.Operation, typed.ServerDiag)
+	}
+	if !typed.RetryableSet || typed.Retryable {
+		t.Fatalf("retryability = (%v, %v), want explicit false", typed.RetryableSet, typed.Retryable)
+	}
+}
+
+func TestCrossPlatformCoverageAITableBaseNotFoundExactBoundaries(t *testing.T) {
+	tests := []struct {
+		name, serverID, toolName string
+		mutate                   func(map[string]any)
+	}{
+		{name: "exact", serverID: "aitable", toolName: "get_base"},
+		{name: "different service", serverID: "other", toolName: "get_base"},
+		{name: "different tool", serverID: "aitable", toolName: "delete_base"},
+		{name: "adjacent invalid base id", serverID: "aitable", toolName: "get_base", mutate: func(body map[string]any) {
+			body["error"].(map[string]any)["code"] = "INVALID_BASE_ID"
+		}},
+		{name: "unstructured phrase", serverID: "aitable", toolName: "get_base", mutate: func(body map[string]any) {
+			body["error"] = "Specified base does not exist"
+		}},
+		{name: "wrong status", serverID: "aitable", toolName: "get_base", mutate: func(body map[string]any) {
+			body["status"] = "success"
+		}},
+		{name: "retryable", serverID: "aitable", toolName: "get_base", mutate: func(body map[string]any) {
+			body["error"].(map[string]any)["retryable"] = true
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := aitableBaseNotFoundFixture()
+			if test.mutate != nil {
+				test.mutate(body)
+			}
+			err := classifyServiceBusinessError(body, test.serverID, test.toolName)
+			if test.name == "exact" {
+				var typed *apperrors.Error
+				if !errors.As(err, &typed) || typed.Reason != "not_found" {
+					t.Fatalf("exact fixture = %#v, want typed not_found", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("adjacent response was widened into not_found: %#v", err)
+			}
+		})
+	}
+}

--- a/internal/helpers/aitable_template_search_test.go
+++ b/internal/helpers/aitable_template_search_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 Alibaba Group
+// SPDX-License-Identifier: Apache-2.0
+
+package helpers
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func runAITableTemplateSearch(t *testing.T, caller *aitableTestCaller, args ...string) error {
+	t.Helper()
+	InitDepsForTest(t, caller)
+	root := newAitableCommand()
+	installExampleGlobalFlags(root)
+	root.SilenceErrors = true
+	root.SilenceUsage = true
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	root.SetArgs(append([]string{"template", "search"}, args...))
+	return root.ExecuteContext(context.Background())
+}
+
+func TestCrossPlatformCoverageAITableTemplateSearchRequiresQueryBeforeMCP(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{name: "missing"},
+		{name: "blank", args: []string{"--query", "   "}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			caller := &aitableTestCaller{}
+			err := runAITableTemplateSearch(t, caller, test.args...)
+			if err == nil || !strings.Contains(err.Error(), "query") {
+				t.Fatalf("query validation error = %v", err)
+			}
+			if len(caller.calls) != 0 {
+				t.Fatalf("invalid query made %d MCP calls", len(caller.calls))
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageAITableTemplateSearchTrimsQueryAndPreservesKeywordAlias(t *testing.T) {
+	for _, args := range [][]string{
+		{"--query", "  项目  "},
+		{"--keyword", "  项目  "},
+	} {
+		caller := &aitableTestCaller{responses: []string{`{"success":true,"data":{"templates":[]}}`}}
+		if err := runAITableTemplateSearch(t, caller, args...); err != nil {
+			t.Fatalf("template search %v error = %v", args, err)
+		}
+		if len(caller.calls) != 1 || caller.calls[0].tool != "search_templates" || caller.calls[0].args["query"] != "项目" {
+			t.Fatalf("template search %v calls = %#v", args, caller.calls)
+		}
+	}
+}
+
+func TestCrossPlatformCoverageAITableTemplateSearchHelpMarksQueryRequired(t *testing.T) {
+	root := newAitableCommand()
+	command, _, err := root.Find([]string{"template", "search"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	flag := command.Flags().Lookup("query")
+	if flag == nil || flag.Annotations == nil || len(flag.Annotations[cobra.BashCompOneRequiredFlag]) == 0 || flag.Annotations[cobra.BashCompOneRequiredFlag][0] != "true" {
+		t.Fatalf("query required annotation = %#v", flag)
+	}
+	for _, text := range []string{command.Long, command.Example} {
+		if strings.Contains(text, "返回热门") || strings.Contains(text, "不传关键词") {
+			t.Fatalf("atomic help still claims unsupported fallback: %q", text)
+		}
+	}
+}

--- a/internal/helpers/aitable_template_search_test.go
+++ b/internal/helpers/aitable_template_search_test.go
@@ -69,20 +69,26 @@ func TestCrossPlatformCoverageAITableTemplateSearchTrimsQueryAndPreservesKeyword
 	}
 }
 
-func TestCrossPlatformCoverageAITableTemplateSearchHelpMarksQueryRequired(t *testing.T) {
+func TestCrossPlatformCoverageAITableTemplateSearchHelpRequiresValueWithoutBreakingRequiredMarker(t *testing.T) {
 	root := newAitableCommand()
 	command, _, err := root.Find([]string{"template", "search"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	flag := command.Flags().Lookup("query")
-	if flag == nil || flag.Annotations == nil || len(flag.Annotations[cobra.BashCompOneRequiredFlag]) == 0 || flag.Annotations[cobra.BashCompOneRequiredFlag][0] != "true" {
-		t.Fatalf("query required annotation = %#v", flag)
+	if flag == nil {
+		t.Fatal("query flag missing")
+	}
+	if flag.Annotations != nil && len(flag.Annotations[cobra.BashCompOneRequiredFlag]) > 0 {
+		t.Fatalf("query unexpectedly publishes breaking required annotation: %#v", flag.Annotations)
 	}
 	for _, text := range []string{command.Long, command.Example} {
 		if strings.Contains(text, "返回热门") || strings.Contains(text, "不传关键词") {
 			t.Fatalf("atomic help still claims unsupported fallback: %q", text)
 		}
+	}
+	if !strings.Contains(command.Long, "--query 必填") || !strings.Contains(command.Long, "不能为空") {
+		t.Fatalf("atomic help does not require a non-empty query at runtime: %q", command.Long)
 	}
 }
 

--- a/internal/helpers/aitable_template_search_test.go
+++ b/internal/helpers/aitable_template_search_test.go
@@ -5,12 +5,20 @@ package helpers
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+type rejectingTemplateQueryValue struct{ value string }
+
+func (v rejectingTemplateQueryValue) String() string { return v.value }
+func (v rejectingTemplateQueryValue) Type() string   { return "string" }
+func (v rejectingTemplateQueryValue) Get() any       { return v.value }
+func (rejectingTemplateQueryValue) Set(string) error { return errors.New("reject normalized query") }
 
 func runAITableTemplateSearch(t *testing.T, caller *aitableTestCaller, args ...string) error {
 	t.Helper()
@@ -75,5 +83,21 @@ func TestCrossPlatformCoverageAITableTemplateSearchHelpMarksQueryRequired(t *tes
 		if strings.Contains(text, "返回热门") || strings.Contains(text, "不传关键词") {
 			t.Fatalf("atomic help still claims unsupported fallback: %q", text)
 		}
+	}
+}
+
+func TestCrossPlatformCoverageAITableTemplateSearchPropagatesNormalizedFlagSetError(t *testing.T) {
+	root := newAitableCommand()
+	command, _, err := root.Find([]string{"template", "search"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := command.Flags().Lookup("query")
+	if query == nil {
+		t.Fatal("query flag missing")
+	}
+	query.Value = rejectingTemplateQueryValue{value: "项目"}
+	if err := command.PreRunE(command, nil); err == nil || !strings.Contains(err.Error(), "reject normalized query") {
+		t.Fatalf("PreRunE error = %v", err)
 	}
 }

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -309,6 +309,9 @@ func parseMCPToolTextResult(serverID, toolName string, result *edition.ToolResul
 				if patErr := classifyPATError(errBody); patErr != nil {
 					return "", patErr
 				}
+				if serviceErr := classifyServiceBusinessError(errBody, serverID, toolName); serviceErr != nil {
+					return "", serviceErr
+				}
 				if isBusinessError(errBody) {
 					return "", &CLIError{
 						Code: CodeMCPToolError,
@@ -539,6 +542,9 @@ func callMCPToolInternalOptsContext(ctx context.Context, explicitServerID, toolN
 				// PAT（个人访问令牌）相关错误
 				if patErr := classifyPATError(errBody); patErr != nil {
 					return patErr
+				}
+				if serviceErr := classifyServiceBusinessError(errBody, serverID, toolName); serviceErr != nil {
+					return serviceErr
 				}
 				// 业务逻辑错误
 				if isBusinessError(errBody) {
@@ -803,6 +809,49 @@ func isErrorCodeValue(v any) bool {
 	default:
 		return false
 	}
+}
+
+// classifyServiceBusinessError maps only reviewed, structured service errors
+// whose resource semantics are unambiguous. It deliberately takes the owning
+// server and tool so a generic English phrase or a same-named code from another
+// operation cannot become a false not-found result.
+func classifyServiceBusinessError(body map[string]any, serverID, toolName string) error {
+	if !strings.EqualFold(strings.TrimSpace(serverID), "aitable") ||
+		!strings.EqualFold(strings.TrimSpace(toolName), "get_base") {
+		return nil
+	}
+	if status, ok := body["status"].(string); !ok || !strings.EqualFold(strings.TrimSpace(status), "error") {
+		return nil
+	}
+	if success, ok := body["success"].(bool); !ok || !success {
+		return nil
+	}
+	errorBody, ok := body["error"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	code, _ := errorBody["code"].(string)
+	errorType, _ := errorBody["type"].(string)
+	retryable, retryableOK := errorBody["retryable"].(bool)
+	if strings.TrimSpace(code) != "BASE_NOT_FOUND" ||
+		strings.TrimSpace(errorType) != "INPUT_ERROR" ||
+		!retryableOK || retryable {
+		return nil
+	}
+	diag := apperrors.ServerDiagnostics{ServerErrorCode: "BASE_NOT_FOUND"}
+	if traceID, ok := body["trace_id"].(string); ok {
+		diag.TraceID = strings.TrimSpace(traceID)
+	}
+	return apperrors.NewAPI("AI Table Base not found",
+		apperrors.WithReason("not_found"),
+		apperrors.WithOperation("aitable/get_base"),
+		apperrors.WithServerKey("aitable"),
+		apperrors.WithOrigin("aitable_service"),
+		apperrors.WithFailureStage("resource_lookup"),
+		apperrors.WithRetryable(false),
+		apperrors.WithHint("Confirm the stable Base ID, or use aitable +base-search with the known Base name."),
+		apperrors.WithServerDiag(diag),
+	)
 }
 
 // isNotLoggedInError checks if the error body indicates missing authentication.

--- a/internal/shortcut/aitable/ai_field_run.go
+++ b/internal/shortcut/aitable/ai_field_run.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd"
@@ -55,13 +56,20 @@ var AIFieldRun = shortcut.Shortcut{
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "为明确选择的记录触发一个钉钉 AI 字段任务",
-			UseWhen:      []string{"已有一个配置完成的钉钉 AI 字段，需要为 1–100 条明确 recordId 触发一次计算任务时使用；结果只表示 submitted。"},
+			UseWhen:      []string{"当你已有一个配置完成的钉钉 AI 字段，并要为 1–100 条明确 recordId 触发计算时使用。命令只证明任务已受理，不等待或声明计算完成。"},
 			AvoidWhen: []string{
 				"不要用于安装、更新或清除 Lark field extension；这是钉钉原生 AI 字段执行入口。",
 				"不要用于整列或多字段执行；当前公开合同仅支持一个 fieldId 和显式 recordIds。",
 				"当前没有 AI 字段任务状态查询接口；pending 回执不代表计算完成。",
 			},
 			Examples: []string{"dws aitable +ai-field-run --base-id <BASE_ID> --table-id <TABLE_ID> --field-id <FIELD_ID> --record-ids <R1,R2>"},
+			ExampleDispositions: []contract.ExampleDisposition{{
+				Index:      aiFieldRunExampleIndex(),
+				Mode:       contract.ExampleDispositionModeContractOnly,
+				ReasonCode: contract.ExampleDispositionReasonStatefulPreflight,
+				Reason:     "dry-run must read the exact live AI field and selected records before producing a plan; the isolated Agent example runner has no remote AITable fixture",
+				Reviewed:   true,
+			}},
 		},
 		Parameters: []contract.ParamDecl{
 			{Name: "base-id", Property: "baseId"},
@@ -97,8 +105,8 @@ var AIFieldRun = shortcut.Shortcut{
 	Flags: []shortcut.Flag{
 		{Name: "base-id", Type: shortcut.FlagString, Desc: "目标 Base ID", Required: true},
 		{Name: "table-id", Type: shortcut.FlagString, Desc: "目标 Table ID", Required: true},
-		{Name: "field-id", Type: shortcut.FlagString, Desc: "一个已配置 AI 功能的字段 ID", Required: true},
-		{Name: "record-ids", Type: shortcut.FlagStringSlice, Desc: "明确选择的记录 ID，去重后 1–100 条", Required: true},
+		{Name: "field-id", Type: shortcut.FlagString, Desc: "一个已配置 AI 功能的字段 ID；仅支持一个非空 AI fieldId", Required: true},
+		{Name: "record-ids", Type: shortcut.FlagStringSlice, Desc: "明确选择的记录 ID；recordIds 去除空白并去重后必须为 1–100 条", Required: true},
 	},
 	Constraints: []shortcut.Constraint{
 		{Kind: shortcut.ConstraintCustom, Flags: []string{"field-id"}, Description: "仅支持一个非空 AI fieldId"},
@@ -110,6 +118,11 @@ var AIFieldRun = shortcut.Shortcut{
 		return err
 	},
 	Execute: executeAIFieldRun,
+}
+
+func aiFieldRunExampleIndex() *int {
+	index := 0
+	return &index
 }
 
 func aiFieldRunInputs(rt *shortcut.RuntimeContext) (string, []string, error) {
@@ -397,12 +410,22 @@ func projectAIFieldRunReceipt(receipt map[string]any, fieldID string, requestedC
 }
 
 func strictJSONInteger(value any) (int, bool) {
+	return strictJSONIntegerForBits(value, strconv.IntSize)
+}
+
+func strictJSONIntegerForBits(value any, intBits int) (int, bool) {
 	switch typed := value.(type) {
 	case int:
 		return typed, true
 	case int64:
-		if int64(int(typed)) != typed {
+		if intBits <= 0 || intBits > 64 {
 			return 0, false
+		}
+		if intBits < 64 {
+			limit := int64(1) << (intBits - 1)
+			if typed < -limit || typed >= limit {
+				return 0, false
+			}
 		}
 		return int(typed), true
 	case float64:

--- a/internal/shortcut/aitable/ai_field_run.go
+++ b/internal/shortcut/aitable/ai_field_run.go
@@ -1,0 +1,439 @@
+// Copyright 2026 Alibaba Group
+// SPDX-License-Identifier: Apache-2.0
+
+package aitable
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"strings"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
+)
+
+const aiFieldRunMaxRecords = 100
+
+var aiFieldRunOutputTypes = map[string]bool{
+	"text": true, "select": true, "multiSelect": true, "number": true,
+	"currency": true, "image": true, "video": true,
+}
+
+// AIFieldRun triggers one DingTalk-native AI field for an explicitly selected
+// record set. It is intentionally not an alias for Lark field extensions: DWS
+// neither installs nor configures extensions and exposes no task-status API.
+var AIFieldRun = shortcut.Shortcut{
+	OutputRollout: output.RolloutUnifiedActive,
+	Service:       "aitable",
+	Command:       "+ai-field-run",
+	Product:       serverMain,
+	Description:   "为明确选择的记录触发一个钉钉 AI 字段任务",
+	Intent:        "当你已有一个配置完成的钉钉 AI 字段，并要为 1–100 条明确 recordId 触发计算时使用。命令只证明任务已受理，不等待或声明计算完成。",
+	Risk:          shortcut.RiskHighWrite,
+	Safety: contract.SafetySpec{
+		Effect: "write", Risk: "high",
+		Confirmation: "user_required", Idempotency: "non_idempotent",
+	},
+	Contract: corecmd.ContractDecl{
+		Identity: contract.ToolIdentitySpec{
+			ProductID:      "aitable",
+			Name:           "shortcut_ai_field_run",
+			CanonicalPath:  "aitable.shortcut_ai_field_run",
+			CLIPath:        "aitable +ai-field-run",
+			PrimaryCLIPath: "aitable +ai-field-run",
+		},
+		Description: "为明确选择的记录触发一个钉钉 AI 字段任务",
+		Interface: &contract.InterfaceSpec{
+			Mode:         contract.InterfaceModeComposite,
+			Availability: contract.InterfaceAvailable,
+			Reason:       "DWS first verifies the exact AI field identity and complete selected-record set, then calls a single run_ai_field operation and strictly projects its submission receipt.",
+		},
+		Selection: contract.SelectionSpec{
+			AgentSummary: "为明确选择的记录触发一个钉钉 AI 字段任务",
+			UseWhen:      []string{"已有一个配置完成的钉钉 AI 字段，需要为 1–100 条明确 recordId 触发一次计算任务时使用；结果只表示 submitted。"},
+			AvoidWhen: []string{
+				"不要用于安装、更新或清除 Lark field extension；这是钉钉原生 AI 字段执行入口。",
+				"不要用于整列或多字段执行；当前公开合同仅支持一个 fieldId 和显式 recordIds。",
+				"当前没有 AI 字段任务状态查询接口；pending 回执不代表计算完成。",
+			},
+			Examples: []string{"dws aitable +ai-field-run --base-id <BASE_ID> --table-id <TABLE_ID> --field-id <FIELD_ID> --record-ids <R1,R2>"},
+		},
+		Parameters: []contract.ParamDecl{
+			{Name: "base-id", Property: "baseId"},
+			{Name: "table-id", Property: "tableId"},
+			{Name: "field-id", Property: "fieldIds"},
+			{Name: "record-ids", Property: "recordIds"},
+		},
+		DryRun: &contract.DryRunSpec{
+			PreviewKind: contract.DryRunPreviewPlan,
+			RemoteReads: true,
+		},
+		Result: &contract.ResultSpec{
+			Outcomes: []contract.ResultOutcome{contract.ResultOutcomePending, contract.ResultOutcomeFailure},
+			DataSchema: json.RawMessage(`{
+				"type":"object",
+				"description":"AI 字段任务的严格受理回执；不表示计算完成",
+				"properties":{
+					"scope":{"type":"string","description":"执行范围，固定为 selected_records","const":"selected_records"},
+					"fieldId":{"type":"string","description":"已受理任务绑定的稳定 AI 字段 ID"},
+					"taskId":{"type":"string","description":"下层返回的稳定任务 ID"},
+					"total":{"type":"integer","description":"下层确认接收的记录数量"},
+					"requestedRecordCount":{"type":"integer","description":"去重后请求的记录数量"},
+					"documentUrl":{"type":"string","description":"可选的 HTTPS 文档链接"},
+					"verified":{"type":"boolean","description":"固定 false；当前没有任务状态或结果读回接口","const":false},
+					"completionStatus":{"type":"string","description":"固定 unknown；任务最终状态不可观测","const":"unknown"}
+				},
+				"required":["scope","fieldId","taskId","total","requestedRecordCount","verified","completionStatus"],
+				"additionalProperties":false
+			}`),
+			SensitivePaths: []string{"documentUrl"},
+		},
+	},
+	Flags: []shortcut.Flag{
+		{Name: "base-id", Type: shortcut.FlagString, Desc: "目标 Base ID", Required: true},
+		{Name: "table-id", Type: shortcut.FlagString, Desc: "目标 Table ID", Required: true},
+		{Name: "field-id", Type: shortcut.FlagString, Desc: "一个已配置 AI 功能的字段 ID", Required: true},
+		{Name: "record-ids", Type: shortcut.FlagStringSlice, Desc: "明确选择的记录 ID，去重后 1–100 条", Required: true},
+	},
+	Constraints: []shortcut.Constraint{
+		{Kind: shortcut.ConstraintCustom, Flags: []string{"field-id"}, Description: "仅支持一个非空 AI fieldId"},
+		{Kind: shortcut.ConstraintCustom, Flags: []string{"record-ids"}, Description: "recordIds 去除空白并去重后必须为 1–100 条"},
+	},
+	Tips: []string{"dws aitable +ai-field-run --base-id BASE --table-id TABLE --field-id FIELD --record-ids R1,R2"},
+	Validate: func(rt *shortcut.RuntimeContext) error {
+		_, _, err := aiFieldRunInputs(rt)
+		return err
+	},
+	Execute: executeAIFieldRun,
+}
+
+func aiFieldRunInputs(rt *shortcut.RuntimeContext) (string, []string, error) {
+	if rt.Str("base-id") == "" {
+		return "", nil, apperrors.NewValidation("--base-id 去除首尾空白后不能为空")
+	}
+	if rt.Str("table-id") == "" {
+		return "", nil, apperrors.NewValidation("--table-id 去除首尾空白后不能为空")
+	}
+	fieldID := strings.TrimSpace(rt.Str("field-id"))
+	if fieldID == "" {
+		return "", nil, apperrors.NewValidation("--field-id 去除首尾空白后不能为空")
+	}
+	recordIDs, err := normalizeAIFieldRunRecordIDs(rt.StrSlice("record-ids"))
+	if err != nil {
+		return "", nil, err
+	}
+	return fieldID, recordIDs, nil
+}
+
+func normalizeAIFieldRunRecordIDs(values []string) ([]string, error) {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, apperrors.NewValidation("--record-ids 不能包含空记录 ID")
+		}
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	if len(out) == 0 || len(out) > aiFieldRunMaxRecords {
+		return nil, apperrors.NewValidation(fmt.Sprintf("--record-ids 去重后必须为 1–%d 条", aiFieldRunMaxRecords))
+	}
+	return out, nil
+}
+
+func executeAIFieldRun(rt *shortcut.RuntimeContext) error {
+	fieldID, recordIDs, err := aiFieldRunInputs(rt)
+	if err != nil {
+		return err
+	}
+	baseID, tableID := rt.Str("base-id"), rt.Str("table-id")
+	if err := preflightAIField(rt, baseID, tableID, fieldID); err != nil {
+		return err
+	}
+	if err := preflightAIFieldRecords(rt, baseID, tableID, fieldID, recordIDs); err != nil {
+		return err
+	}
+	params := map[string]any{
+		"baseId":    baseID,
+		"tableId":   tableID,
+		"fieldIds":  []string{fieldID},
+		"recordIds": recordIDs,
+	}
+	if rt.DryRun() {
+		return rt.Output(map[string]any{
+			"scope":                "selected_records",
+			"preview_kind":         contract.DryRunPreviewPlan,
+			"tool":                 "run_ai_field",
+			"arguments":            params,
+			"requestedRecordCount": len(recordIDs),
+			"preflight": map[string]any{
+				"fieldVerified":   true,
+				"recordsVerified": true,
+			},
+			"executed": false,
+			"verified": false,
+		})
+	}
+	receipt, err := rt.CallMCPWriteDataStrict(serverMain, "run_ai_field", params)
+	if err != nil {
+		return err
+	}
+	projected, err := projectAIFieldRunReceipt(receipt, fieldID, len(recordIDs))
+	if err != nil {
+		return err
+	}
+	nextCommand := aitableRecoveryCommand("dws", "aitable", "+record-query",
+		"--base-id", baseID, "--table-id", tableID,
+		"--record-ids", strings.Join(recordIDs, ","), "--field-ids", fieldID, "--format", "json")
+	return output.StoreResult(rt.Command().Context(), output.Pending(projected, &output.OperationInfo{
+		ID:          projected["taskId"].(string),
+		State:       "submitted",
+		NextCommand: nextCommand,
+	}))
+}
+
+func preflightAIField(rt *shortcut.RuntimeContext, baseID, tableID, fieldID string) error {
+	data, err := rt.CallMCPReadData(serverMain, "get_fields", map[string]any{
+		"baseId": baseID, "tableId": tableID, "fieldIds": []string{fieldID},
+	})
+	if err != nil {
+		return err
+	}
+	items, err := uniqueAIFieldPreflightList(data, "fields")
+	if err != nil || len(items) != 1 {
+		return aiFieldPreflightError("field_identity_mismatch", "get_fields 必须返回唯一目标字段", map[string]any{"fieldId": fieldID})
+	}
+	field, ok := items[0].(map[string]any)
+	if !ok {
+		return aiFieldPreflightError("malformed_field", "get_fields 字段条目必须是对象", nil)
+	}
+	returnedID, _ := field["fieldId"].(string)
+	if strings.TrimSpace(returnedID) != fieldID {
+		return aiFieldPreflightError("field_identity_mismatch", "get_fields 返回了不同的 fieldId", map[string]any{"fieldId": fieldID})
+	}
+	aiConfig, ok := field["aiConfig"].(map[string]any)
+	if !ok || validateAIFieldConfig(aiConfig) != nil {
+		return aiFieldPreflightError("field_not_ai", "目标字段没有可执行的 aiConfig", map[string]any{"fieldId": fieldID})
+	}
+	return nil
+}
+
+func preflightAIFieldRecords(rt *shortcut.RuntimeContext, baseID, tableID, fieldID string, recordIDs []string) error {
+	data, err := rt.CallMCPReadData(serverMain, "query_records", map[string]any{
+		"baseId": baseID, "tableId": tableID, "recordIds": recordIDs, "fieldIds": []string{fieldID},
+	})
+	if err != nil {
+		return err
+	}
+	items, err := uniqueAIFieldPreflightList(data, "records")
+	if err != nil {
+		return aiFieldPreflightError("malformed_records", err.Error(), nil)
+	}
+	wanted := make(map[string]bool, len(recordIDs))
+	for _, id := range recordIDs {
+		wanted[id] = true
+	}
+	seen := make(map[string]bool, len(items))
+	for index, item := range items {
+		record, ok := item.(map[string]any)
+		if !ok {
+			return aiFieldPreflightError("malformed_records", fmt.Sprintf("query_records records[%d] 必须是对象", index), nil)
+		}
+		id, ok := record["recordId"].(string)
+		id = strings.TrimSpace(id)
+		if !ok || id == "" || !wanted[id] || seen[id] {
+			return aiFieldPreflightError("record_identity_mismatch", "query_records 返回陌生、重复或畸形 recordId", map[string]any{"recordId": id})
+		}
+		seen[id] = true
+	}
+	if len(seen) != len(wanted) {
+		return aiFieldPreflightError("record_identity_mismatch", "query_records 未返回全部请求记录", map[string]any{"requested": len(wanted), "returned": len(seen)})
+	}
+	return nil
+}
+
+func uniqueAIFieldPreflightList(response map[string]any, key string) ([]any, error) {
+	if response == nil {
+		return nil, fmt.Errorf("response is nil")
+	}
+	type candidate struct {
+		name  string
+		items []any
+	}
+	candidates := make([]candidate, 0, 3)
+	if value, exists := response[key]; exists {
+		items, ok := value.([]any)
+		if !ok {
+			return nil, fmt.Errorf("top.%s must be an array", key)
+		}
+		candidates = append(candidates, candidate{name: "top", items: items})
+	}
+	for _, envelopeKey := range []string{"data", "result"} {
+		value, exists := response[envelopeKey]
+		if !exists {
+			continue
+		}
+		envelope, ok := value.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s envelope must be an object", envelopeKey)
+		}
+		value, exists = envelope[key]
+		if !exists {
+			continue
+		}
+		items, ok := value.([]any)
+		if !ok {
+			return nil, fmt.Errorf("%s.%s must be an array", envelopeKey, key)
+		}
+		candidates = append(candidates, candidate{name: envelopeKey, items: items})
+	}
+	if len(candidates) != 1 {
+		names := make([]string, 0, len(candidates))
+		for _, item := range candidates {
+			names = append(names, item.name)
+		}
+		return nil, fmt.Errorf("response must contain exactly one %s array; found %v", key, names)
+	}
+	return candidates[0].items, nil
+}
+
+func validateAIFieldConfig(config map[string]any) error {
+	outputType, ok := config["outputType"].(string)
+	outputType = strings.TrimSpace(outputType)
+	if !ok || !aiFieldRunOutputTypes[outputType] {
+		return fmt.Errorf("aiConfig.outputType is unsupported")
+	}
+	prompt, ok := config["prompt"].([]any)
+	if !ok || len(prompt) == 0 {
+		return fmt.Errorf("aiConfig.prompt must be a non-empty array")
+	}
+	hasFieldRef := false
+	for index, raw := range prompt {
+		item, ok := raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("aiConfig.prompt[%d] must be an object", index)
+		}
+		typeName, _ := item["type"].(string)
+		switch strings.TrimSpace(typeName) {
+		case "text":
+			value, ok := item["value"].(string)
+			if !ok || strings.TrimSpace(value) == "" {
+				return fmt.Errorf("aiConfig.prompt[%d].value must be non-empty", index)
+			}
+		case "fieldRef":
+			fieldID, ok := item["fieldId"].(string)
+			if !ok || strings.TrimSpace(fieldID) == "" {
+				return fmt.Errorf("aiConfig.prompt[%d].fieldId must be non-empty", index)
+			}
+			hasFieldRef = true
+		default:
+			return fmt.Errorf("aiConfig.prompt[%d].type is unsupported", index)
+		}
+	}
+	if !hasFieldRef {
+		return fmt.Errorf("aiConfig.prompt must contain at least one fieldRef")
+	}
+	return nil
+}
+
+func projectAIFieldRunReceipt(receipt map[string]any, fieldID string, requestedCount int) (map[string]any, error) {
+	data, ok := receipt["data"].(map[string]any)
+	if !ok {
+		return nil, aiFieldReceiptError("malformed_data", "run_ai_field receipt.data 必须是对象")
+	}
+	rawTasks, ok := data["tasks"].([]any)
+	if !ok || len(rawTasks) != 1 {
+		return nil, aiFieldReceiptError("malformed_tasks", "run_ai_field data.tasks 必须恰好包含一项")
+	}
+	task, ok := rawTasks[0].(map[string]any)
+	if !ok {
+		return nil, aiFieldReceiptError("malformed_tasks", "run_ai_field task 必须是对象")
+	}
+	returnedFieldID, _ := task["fieldId"].(string)
+	if strings.TrimSpace(returnedFieldID) != fieldID {
+		return nil, aiFieldReceiptError("field_identity_mismatch", "run_ai_field task.fieldId 与请求不一致")
+	}
+	status, _ := task["status"].(string)
+	if status != "submitted" {
+		return nil, aiFieldReceiptError("status_mismatch", "run_ai_field task.status 必须是 submitted")
+	}
+	taskID, _ := task["taskId"].(string)
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return nil, aiFieldReceiptError("missing_task_id", "run_ai_field task.taskId 不能为空")
+	}
+	total, ok := strictJSONInteger(task["total"])
+	if !ok || total != requestedCount {
+		return nil, aiFieldReceiptError("total_mismatch", "run_ai_field task.total 必须等于请求记录数")
+	}
+	out := map[string]any{
+		"scope":                "selected_records",
+		"fieldId":              fieldID,
+		"taskId":               taskID,
+		"total":                total,
+		"requestedRecordCount": requestedCount,
+		"verified":             false,
+		"completionStatus":     "unknown",
+	}
+	if rawURL, exists := data["documentUrl"]; exists {
+		documentURL, ok := rawURL.(string)
+		documentURL = strings.TrimSpace(documentURL)
+		parsed, parseErr := url.Parse(documentURL)
+		if !ok || parseErr != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil {
+			return nil, aiFieldReceiptError("invalid_document_url", "run_ai_field data.documentUrl 必须是无凭据 HTTPS URL")
+		}
+		out["documentUrl"] = documentURL
+	}
+	return out, nil
+}
+
+func strictJSONInteger(value any) (int, bool) {
+	switch typed := value.(type) {
+	case int:
+		return typed, true
+	case int64:
+		if int64(int(typed)) != typed {
+			return 0, false
+		}
+		return int(typed), true
+	case float64:
+		if math.IsNaN(typed) || math.IsInf(typed, 0) || math.Trunc(typed) != typed || typed < 0 || typed > float64(^uint(0)>>1) {
+			return 0, false
+		}
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}
+
+func aiFieldPreflightError(reason, message string, details map[string]any) error {
+	return apperrors.NewAPI(message,
+		apperrors.WithOperation("aitable/ai-field-run/preflight"),
+		apperrors.WithOrigin("mcp"),
+		apperrors.WithFailureStage("preflight"),
+		apperrors.WithExecutionStarted(false),
+		apperrors.WithRetryable(false),
+		apperrors.WithReason(reason),
+		apperrors.WithDetails(details),
+	)
+}
+
+func aiFieldReceiptError(reason, message string) error {
+	return apperrors.NewAPI(message,
+		apperrors.WithOperation("aitable/run_ai_field"),
+		apperrors.WithOrigin("mcp"),
+		apperrors.WithFailureStage("response_validation"),
+		apperrors.WithExecutionStarted(true),
+		apperrors.WithRetryable(false),
+		apperrors.WithReason(reason),
+	)
+}

--- a/internal/shortcut/aitable/ai_field_run_test.go
+++ b/internal/shortcut/aitable/ai_field_run_test.go
@@ -23,11 +23,11 @@ const (
 	aiRunFixture    = `{"data":{"tasks":[{"fieldId":"field-1","status":"submitted","taskId":"task-1","total":2}],"documentUrl":"https://alidocs.dingtalk.com/i/nodes/result"}}`
 )
 
-func runAIFieldFixture(t *testing.T, steps []upsertByKeyStep, args ...string) (string, error, *upsertByKeyCaller) {
+func runAIFieldFixture(t *testing.T, steps []upsertByKeyStep, args ...string) (string, *upsertByKeyCaller, error) {
 	t.Helper()
 	caller := &upsertByKeyCaller{steps: steps}
 	out, err := runAITableCompositeCLI(t, caller, "+ai-field-run", args...)
-	return out, err, caller
+	return out, caller, err
 }
 
 func aiFieldArgs(extra ...string) []string {
@@ -36,7 +36,7 @@ func aiFieldArgs(extra ...string) []string {
 }
 
 func TestCrossPlatformCoverageAIFieldRunRequiresConfirmationBeforeAnyMCP(t *testing.T) {
-	out, err, caller := runAIFieldFixture(t, nil, aiFieldArgs()...)
+	out, caller, err := runAIFieldFixture(t, nil, aiFieldArgs()...)
 	var typed *apperrors.Error
 	if err == nil || out != "" || !errors.As(err, &typed) || typed.Reason != "confirmation_required" {
 		t.Fatalf("confirmation = output:%q err:%#v", out, err)
@@ -48,7 +48,7 @@ func TestCrossPlatformCoverageAIFieldRunRequiresConfirmationBeforeAnyMCP(t *test
 
 func TestCrossPlatformCoverageAIFieldRunPayloadAndPendingReceipt(t *testing.T) {
 	args := []string{"--base-id", "base-1", "--table-id", "table-1", "--field-id", " field-1 ", "--record-ids", " record-1 , record-1 , record-2 ", "--yes"}
-	out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: aiRecordFixture}, {text: aiRunFixture}}, args...)
+	out, caller, err := runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: aiRecordFixture}, {text: aiRunFixture}}, args...)
 	if err != nil {
 		t.Fatalf("ai field run error = %v", err)
 	}
@@ -94,7 +94,7 @@ func TestCrossPlatformCoverageAIFieldRunRejectsInvalidLocalScopeBeforeMCP(t *tes
 		{name: "too many", args: []string{"--base-id", "base", "--table-id", "table", "--field-id", "field", "--record-ids", strings.Join(numberedIDs("record", 101), ","), "--yes"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			out, err, caller := runAIFieldFixture(t, nil, test.args...)
+			out, caller, err := runAIFieldFixture(t, nil, test.args...)
 			if err == nil || out != "" || len(caller.calls) != 0 {
 				t.Fatalf("local validation = output:%q err:%v calls:%#v", out, err, caller.calls)
 			}
@@ -136,7 +136,7 @@ func TestCrossPlatformCoverageAIFieldRunPropagatesMCPFailuresWithoutRetry(t *tes
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			out, err, caller := runAIFieldFixture(t, test.steps, aiFieldArgs("--yes")...)
+			out, caller, err := runAIFieldFixture(t, test.steps, aiFieldArgs("--yes")...)
 			if err == nil || out != "" || !strings.Contains(err.Error(), sentinel.Error()) || len(caller.calls) != len(test.steps) {
 				t.Fatalf("MCP failure propagation = output:%q err:%v calls:%#v", out, err, caller.calls)
 			}
@@ -156,7 +156,7 @@ func TestCrossPlatformCoverageAIFieldRunPreflightRejectsIdentityDriftBeforeRun(t
 	}
 	for index, response := range fieldCases {
 		t.Run("field-"+string(rune('a'+index)), func(t *testing.T) {
-			out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: response}}, aiFieldArgs("--yes")...)
+			out, caller, err := runAIFieldFixture(t, []upsertByKeyStep{{text: response}}, aiFieldArgs("--yes")...)
 			if err == nil || out != "" || len(caller.calls) != 1 || caller.calls[0].tool != "get_fields" {
 				t.Fatalf("field preflight = output:%q err:%v calls:%#v", out, err, caller.calls)
 			}
@@ -173,7 +173,7 @@ func TestCrossPlatformCoverageAIFieldRunPreflightRejectsIdentityDriftBeforeRun(t
 	}
 	for index, response := range recordCases {
 		t.Run("record-"+string(rune('a'+index)), func(t *testing.T) {
-			out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: response}}, aiFieldArgs("--yes")...)
+			out, caller, err := runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: response}}, aiFieldArgs("--yes")...)
 			if err == nil || out != "" || len(caller.calls) != 2 || caller.calls[1].tool != "query_records" {
 				t.Fatalf("record preflight = output:%q err:%v calls:%#v", out, err, caller.calls)
 			}
@@ -195,7 +195,7 @@ func TestCrossPlatformCoverageAIFieldRunRejectsMalformedNonEmptyAIConfig(t *test
 	for index, config := range configs {
 		t.Run(fmt.Sprintf("config-%d", index), func(t *testing.T) {
 			response := `{"data":{"fields":[{"fieldId":"field-1","aiConfig":` + config + `}]}}`
-			out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: response}}, aiFieldArgs("--yes")...)
+			out, caller, err := runAIFieldFixture(t, []upsertByKeyStep{{text: response}}, aiFieldArgs("--yes")...)
 			if err == nil || out != "" || len(caller.calls) != 1 || caller.calls[0].tool != "get_fields" {
 				t.Fatalf("malformed aiConfig = output:%q err:%v calls:%#v", out, err, caller.calls)
 			}
@@ -249,17 +249,17 @@ func TestCrossPlatformCoverageAIFieldRunStrictEnvelopeAndIntegerBoundaries(t *te
 
 func TestCrossPlatformCoverageAIFieldRunRejectsConflictingPreflightEnvelopes(t *testing.T) {
 	fieldConflict := `{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}],"data":{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}]}}`
-	out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: fieldConflict}}, aiFieldArgs("--yes")...)
+	out, caller, err := runAIFieldFixture(t, []upsertByKeyStep{{text: fieldConflict}}, aiFieldArgs("--yes")...)
 	if err == nil || out != "" || len(caller.calls) != 1 {
 		t.Fatalf("field envelope conflict = output:%q err:%v calls:%#v", out, err, caller.calls)
 	}
 	fieldConflict = `{"data":{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}]},"result":{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}]}}`
-	out, err, caller = runAIFieldFixture(t, []upsertByKeyStep{{text: fieldConflict}}, aiFieldArgs("--yes")...)
+	out, caller, err = runAIFieldFixture(t, []upsertByKeyStep{{text: fieldConflict}}, aiFieldArgs("--yes")...)
 	if err == nil || out != "" || len(caller.calls) != 1 {
 		t.Fatalf("field data/result conflict = output:%q err:%v calls:%#v", out, err, caller.calls)
 	}
 	recordConflict := `{"records":[{"recordId":"record-1"},{"recordId":"record-2"}],"data":{"records":[{"recordId":"record-1"},{"recordId":"record-2"}]}}`
-	out, err, caller = runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: recordConflict}}, aiFieldArgs("--yes")...)
+	out, caller, err = runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: recordConflict}}, aiFieldArgs("--yes")...)
 	if err == nil || out != "" || len(caller.calls) != 2 {
 		t.Fatalf("record envelope conflict = output:%q err:%v calls:%#v", out, err, caller.calls)
 	}
@@ -356,7 +356,7 @@ func TestCrossPlatformCoverageAIFieldRunRejectsMalformedRunReceipt(t *testing.T)
 	}
 	for index, response := range responses {
 		t.Run("receipt-"+string(rune('a'+index)), func(t *testing.T) {
-			out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: aiRecordFixture}, {text: response}}, aiFieldArgs("--yes")...)
+			out, caller, err := runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: aiRecordFixture}, {text: response}}, aiFieldArgs("--yes")...)
 			if err == nil || out != "" || len(caller.calls) != 3 || caller.calls[2].tool != "run_ai_field" {
 				t.Fatalf("receipt validation = output:%q err:%v calls:%#v", out, err, caller.calls)
 			}

--- a/internal/shortcut/aitable/ai_field_run_test.go
+++ b/internal/shortcut/aitable/ai_field_run_test.go
@@ -7,11 +7,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -99,6 +102,48 @@ func TestCrossPlatformCoverageAIFieldRunRejectsInvalidLocalScopeBeforeMCP(t *tes
 	}
 }
 
+func TestCrossPlatformCoverageAIFieldRunExecuteRevalidatesLocalScope(t *testing.T) {
+	for _, test := range []struct {
+		name, baseID, tableID, fieldID string
+	}{
+		{name: "blank base", tableID: "table", fieldID: "field"},
+		{name: "blank table", baseID: "base", fieldID: "field"},
+		{name: "blank field", baseID: "base", tableID: "table"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "ai-field-run"}
+			cmd.Flags().String("base-id", test.baseID, "")
+			cmd.Flags().String("table-id", test.tableID, "")
+			cmd.Flags().String("field-id", test.fieldID, "")
+			cmd.Flags().StringSlice("record-ids", []string{"record"}, "")
+			rt := shortcut.RuntimeContextForTest(cmd, AIFieldRun)
+			if err := executeAIFieldRun(rt); err == nil {
+				t.Fatal("executeAIFieldRun accepted invalid local scope")
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunPropagatesMCPFailuresWithoutRetry(t *testing.T) {
+	sentinel := errors.New("sentinel MCP failure")
+	tests := []struct {
+		name  string
+		steps []upsertByKeyStep
+	}{
+		{name: "field read", steps: []upsertByKeyStep{{err: sentinel}}},
+		{name: "record read", steps: []upsertByKeyStep{{text: aiFieldFixture}, {err: sentinel}}},
+		{name: "write", steps: []upsertByKeyStep{{text: aiFieldFixture}, {text: aiRecordFixture}, {err: sentinel}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out, err, caller := runAIFieldFixture(t, test.steps, aiFieldArgs("--yes")...)
+			if err == nil || out != "" || !strings.Contains(err.Error(), sentinel.Error()) || len(caller.calls) != len(test.steps) {
+				t.Fatalf("MCP failure propagation = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+		})
+	}
+}
+
 func TestCrossPlatformCoverageAIFieldRunPreflightRejectsIdentityDriftBeforeRun(t *testing.T) {
 	fieldCases := []string{
 		`{"data":{}}`,
@@ -144,6 +189,8 @@ func TestCrossPlatformCoverageAIFieldRunRejectsMalformedNonEmptyAIConfig(t *test
 		`{"outputType":"text","prompt":[{"type":"text","value":"only text"}]}`,
 		`{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":" "}]}`,
 		`{"outputType":"text","prompt":["bad"]}`,
+		`{"outputType":"text","prompt":[{"type":"text","value":" "},{"type":"fieldRef","fieldId":"source"}]}`,
+		`{"outputType":"text","prompt":[{"type":"unknown"},{"type":"fieldRef","fieldId":"source"}]}`,
 	}
 	for index, config := range configs {
 		t.Run(fmt.Sprintf("config-%d", index), func(t *testing.T) {
@@ -151,6 +198,50 @@ func TestCrossPlatformCoverageAIFieldRunRejectsMalformedNonEmptyAIConfig(t *test
 			out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: response}}, aiFieldArgs("--yes")...)
 			if err == nil || out != "" || len(caller.calls) != 1 || caller.calls[0].tool != "get_fields" {
 				t.Fatalf("malformed aiConfig = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunStrictEnvelopeAndIntegerBoundaries(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		response map[string]any
+		key      string
+	}{
+		{name: "nil", response: nil, key: "fields"},
+		{name: "top wrong type", response: map[string]any{"fields": "bad"}, key: "fields"},
+		{name: "data wrong type", response: map[string]any{"data": "bad"}, key: "fields"},
+		{name: "result list wrong type", response: map[string]any{"result": map[string]any{"fields": "bad"}}, key: "fields"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := uniqueAIFieldPreflightList(test.response, test.key); err == nil {
+				t.Fatalf("uniqueAIFieldPreflightList accepted %#v", test.response)
+			}
+		})
+	}
+
+	integerCases := []struct {
+		name   string
+		value  any
+		bits   int
+		want   int
+		wantOK bool
+	}{
+		{name: "int", value: 7, bits: 64, want: 7, wantOK: true},
+		{name: "int64", value: int64(8), bits: 64, want: 8, wantOK: true},
+		{name: "int64 32-bit overflow", value: int64(1) << 40, bits: 32},
+		{name: "zero width", value: int64(1), bits: 0},
+		{name: "invalid width", value: int64(1), bits: 65},
+		{name: "float integer", value: float64(9), bits: 64, want: 9, wantOK: true},
+		{name: "float nan", value: math.NaN(), bits: 64},
+		{name: "unsupported", value: "9", bits: 64},
+	}
+	for _, test := range integerCases {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := strictJSONIntegerForBits(test.value, test.bits)
+			if got != test.want || ok != test.wantOK {
+				t.Fatalf("strictJSONIntegerForBits(%#v, %d) = (%d, %v), want (%d, %v)", test.value, test.bits, got, ok, test.want, test.wantOK)
 			}
 		})
 	}
@@ -255,6 +346,7 @@ func TestCrossPlatformCoverageAIFieldRunRejectsMalformedRunReceipt(t *testing.T)
 		`{"tasks":[{"fieldId":"field-1","status":"submitted","taskId":"task","total":2}]}`,
 		`{"data":"bad","tasks":[{"fieldId":"field-1","status":"submitted","taskId":"task","total":2}]}`,
 		`{"data":{"tasks":[]}}`,
+		`{"data":{"tasks":["bad"]}}`,
 		`{"data":{"tasks":[{"fieldId":"other","status":"submitted","taskId":"task","total":2}]}}`,
 		`{"data":{"tasks":[{"fieldId":"field-1","status":"finished","taskId":"task","total":2}]}}`,
 		`{"data":{"tasks":[{"fieldId":"field-1","status":"submitted","taskId":"","total":2}]}}`,

--- a/internal/shortcut/aitable/ai_field_run_test.go
+++ b/internal/shortcut/aitable/ai_field_run_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Alibaba Group
+// SPDX-License-Identifier: Apache-2.0
+
+package aitable
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
+)
+
+const (
+	aiFieldFixture  = `{"data":{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"text","value":"summarize"},{"type":"fieldRef","fieldId":"source-field"}]}}]}}`
+	aiRecordFixture = `{"data":{"records":[{"recordId":"record-1"},{"recordId":"record-2"}]}}`
+	aiRunFixture    = `{"data":{"tasks":[{"fieldId":"field-1","status":"submitted","taskId":"task-1","total":2}],"documentUrl":"https://alidocs.dingtalk.com/i/nodes/result"}}`
+)
+
+func runAIFieldFixture(t *testing.T, steps []upsertByKeyStep, args ...string) (string, error, *upsertByKeyCaller) {
+	t.Helper()
+	caller := &upsertByKeyCaller{steps: steps}
+	out, err := runAITableCompositeCLI(t, caller, "+ai-field-run", args...)
+	return out, err, caller
+}
+
+func aiFieldArgs(extra ...string) []string {
+	args := []string{"--base-id", "base-1", "--table-id", "table-1", "--field-id", "field-1", "--record-ids", "record-1,record-2"}
+	return append(args, extra...)
+}
+
+func TestCrossPlatformCoverageAIFieldRunRequiresConfirmationBeforeAnyMCP(t *testing.T) {
+	out, err, caller := runAIFieldFixture(t, nil, aiFieldArgs()...)
+	var typed *apperrors.Error
+	if err == nil || out != "" || !errors.As(err, &typed) || typed.Reason != "confirmation_required" {
+		t.Fatalf("confirmation = output:%q err:%#v", out, err)
+	}
+	if len(caller.calls) != 0 {
+		t.Fatalf("unconfirmed run made %d MCP calls", len(caller.calls))
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunPayloadAndPendingReceipt(t *testing.T) {
+	args := []string{"--base-id", "base-1", "--table-id", "table-1", "--field-id", " field-1 ", "--record-ids", " record-1 , record-1 , record-2 ", "--yes"}
+	out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: aiRecordFixture}, {text: aiRunFixture}}, args...)
+	if err != nil {
+		t.Fatalf("ai field run error = %v", err)
+	}
+	if len(caller.calls) != 3 || caller.calls[0].tool != "get_fields" || caller.calls[1].tool != "query_records" || caller.calls[2].tool != "run_ai_field" {
+		t.Fatalf("ai field call sequence = %#v", caller.calls)
+	}
+	runArgs := caller.calls[2].args
+	fieldIDs, _ := runArgs["fieldIds"].([]string)
+	recordIDs, _ := runArgs["recordIds"].([]string)
+	if len(fieldIDs) != 1 || fieldIDs[0] != "field-1" || len(recordIDs) != 2 || recordIDs[0] != "record-1" || recordIDs[1] != "record-2" {
+		t.Fatalf("run_ai_field payload = %#v", runArgs)
+	}
+	for _, callIndex := range []int{0, 1} {
+		preflightFieldIDs, _ := caller.calls[callIndex].args["fieldIds"].([]string)
+		if len(preflightFieldIDs) != 1 || preflightFieldIDs[0] != "field-1" {
+			t.Fatalf("preflight %d fieldIds = %#v", callIndex, preflightFieldIDs)
+		}
+	}
+	queryRecordIDs, _ := caller.calls[1].args["recordIds"].([]string)
+	if len(queryRecordIDs) != 2 || queryRecordIDs[0] != "record-1" || queryRecordIDs[1] != "record-2" {
+		t.Fatalf("query_records recordIds = %#v", queryRecordIDs)
+	}
+	for _, want := range []string{`"outcome": "pending"`, `"scope": "selected_records"`, `"taskId": "task-1"`, `"documentUrl": "https://alidocs.dingtalk.com/i/nodes/result"`, `"verified": false`, `"completionStatus": "unknown"`, `"next_command": "dws aitable +record-query`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("pending output missing %s: %s", want, out)
+		}
+	}
+	if strings.Contains(out, `"verified": true`) || strings.Contains(out, `"completionStatus": "completed"`) {
+		t.Fatalf("pending output claimed completion: %s", out)
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunRejectsInvalidLocalScopeBeforeMCP(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{name: "blank field", args: []string{"--base-id", "base", "--table-id", "table", "--field-id", " ", "--record-ids", "record", "--yes"}},
+		{name: "blank base", args: []string{"--base-id", " ", "--table-id", "table", "--field-id", "field", "--record-ids", "record", "--yes"}},
+		{name: "blank table", args: []string{"--base-id", "base", "--table-id", " ", "--field-id", "field", "--record-ids", "record", "--yes"}},
+		{name: "blank records", args: []string{"--base-id", "base", "--table-id", "table", "--field-id", "field", "--record-ids", " ", "--yes"}},
+		{name: "empty record member", args: []string{"--base-id", "base", "--table-id", "table", "--field-id", "field", "--record-ids", "record, ", "--yes"}},
+		{name: "too many", args: []string{"--base-id", "base", "--table-id", "table", "--field-id", "field", "--record-ids", strings.Join(numberedIDs("record", 101), ","), "--yes"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			out, err, caller := runAIFieldFixture(t, nil, test.args...)
+			if err == nil || out != "" || len(caller.calls) != 0 {
+				t.Fatalf("local validation = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunPreflightRejectsIdentityDriftBeforeRun(t *testing.T) {
+	fieldCases := []string{
+		`{"data":{}}`,
+		`{"data":{"fields":{}}}`,
+		`{"data":{"fields":[]}}`,
+		`{"data":{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}},{"fieldId":"field-2","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}]}}`,
+		`{"data":{"fields":[{"fieldId":"other","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}]}}`,
+		`{"data":{"fields":[{"fieldId":"field-1"}]}}`,
+		`{"data":{"fields":["bad"]}}`,
+	}
+	for index, response := range fieldCases {
+		t.Run("field-"+string(rune('a'+index)), func(t *testing.T) {
+			out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: response}}, aiFieldArgs("--yes")...)
+			if err == nil || out != "" || len(caller.calls) != 1 || caller.calls[0].tool != "get_fields" {
+				t.Fatalf("field preflight = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+		})
+	}
+
+	recordCases := []string{
+		`{"data":{}}`,
+		`{"data":{"records":{}}}`,
+		`{"data":{"records":[{"recordId":"record-1"}]}}`,
+		`{"data":{"records":[{"recordId":"record-1"},{"recordId":"other"}]}}`,
+		`{"data":{"records":[{"recordId":"record-1"},{"recordId":"record-1"}]}}`,
+		`{"data":{"records":[{"recordId":"record-1"},"bad"]}}`,
+	}
+	for index, response := range recordCases {
+		t.Run("record-"+string(rune('a'+index)), func(t *testing.T) {
+			out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: response}}, aiFieldArgs("--yes")...)
+			if err == nil || out != "" || len(caller.calls) != 2 || caller.calls[1].tool != "query_records" {
+				t.Fatalf("record preflight = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunRejectsMalformedNonEmptyAIConfig(t *testing.T) {
+	configs := []string{
+		`{"outputType":"unsupported","prompt":[{"type":"fieldRef","fieldId":"source"}]}`,
+		`{"outputType":"text","prompt":"bad"}`,
+		`{"outputType":"text","prompt":[]}`,
+		`{"outputType":"text","prompt":[{"type":"text","value":"only text"}]}`,
+		`{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":" "}]}`,
+		`{"outputType":"text","prompt":["bad"]}`,
+	}
+	for index, config := range configs {
+		t.Run(fmt.Sprintf("config-%d", index), func(t *testing.T) {
+			response := `{"data":{"fields":[{"fieldId":"field-1","aiConfig":` + config + `}]}}`
+			out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: response}}, aiFieldArgs("--yes")...)
+			if err == nil || out != "" || len(caller.calls) != 1 || caller.calls[0].tool != "get_fields" {
+				t.Fatalf("malformed aiConfig = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunRejectsConflictingPreflightEnvelopes(t *testing.T) {
+	fieldConflict := `{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}],"data":{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}]}}`
+	out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: fieldConflict}}, aiFieldArgs("--yes")...)
+	if err == nil || out != "" || len(caller.calls) != 1 {
+		t.Fatalf("field envelope conflict = output:%q err:%v calls:%#v", out, err, caller.calls)
+	}
+	fieldConflict = `{"data":{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}]},"result":{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"fieldRef","fieldId":"source"}]}}]}}`
+	out, err, caller = runAIFieldFixture(t, []upsertByKeyStep{{text: fieldConflict}}, aiFieldArgs("--yes")...)
+	if err == nil || out != "" || len(caller.calls) != 1 {
+		t.Fatalf("field data/result conflict = output:%q err:%v calls:%#v", out, err, caller.calls)
+	}
+	recordConflict := `{"records":[{"recordId":"record-1"},{"recordId":"record-2"}],"data":{"records":[{"recordId":"record-1"},{"recordId":"record-2"}]}}`
+	out, err, caller = runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: recordConflict}}, aiFieldArgs("--yes")...)
+	if err == nil || out != "" || len(caller.calls) != 2 {
+		t.Fatalf("record envelope conflict = output:%q err:%v calls:%#v", out, err, caller.calls)
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunDryRunStopsBeforeWrite(t *testing.T) {
+	caller := &upsertByKeyCaller{dryRun: true, steps: []upsertByKeyStep{{text: aiFieldFixture}, {text: aiRecordFixture}}}
+	out, err := runAITableCompositeCLI(t, caller, "+ai-field-run", aiFieldArgs("--dry-run")...)
+	if err != nil {
+		t.Fatalf("dry-run = output:%q err:%v", out, err)
+	}
+	if len(caller.calls) != 2 || caller.calls[0].tool != "get_fields" || caller.calls[1].tool != "query_records" {
+		t.Fatalf("dry-run calls = %#v", caller.calls)
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("decode dry-run output %q: %v", out, err)
+	}
+	data, _ := envelope["data"].(map[string]any)
+	preflight, _ := data["preflight"].(map[string]any)
+	arguments, _ := data["arguments"].(map[string]any)
+	if envelope["ok"] != true || envelope["outcome"] != "success" || envelope["dry_run"] != true ||
+		data["scope"] != "selected_records" || data["preview_kind"] != "plan" || data["tool"] != "run_ai_field" ||
+		data["requestedRecordCount"] != float64(2) || data["executed"] != false || data["verified"] != false ||
+		preflight["fieldVerified"] != true || preflight["recordsVerified"] != true {
+		t.Fatalf("dry-run preview = %#v", envelope)
+	}
+	fieldIDs, _ := arguments["fieldIds"].([]any)
+	recordIDs, _ := arguments["recordIds"].([]any)
+	if arguments["baseId"] != "base-1" || arguments["tableId"] != "table-1" ||
+		!reflect.DeepEqual(fieldIDs, []any{"field-1"}) || !reflect.DeepEqual(recordIDs, []any{"record-1", "record-2"}) {
+		t.Fatalf("dry-run arguments = %#v", arguments)
+	}
+	if strings.Contains(out, `"pending"`) || strings.Contains(out, `"submitted"`) {
+		t.Fatalf("dry-run manufactured acceptance: %s", out)
+	}
+	for _, forbidden := range []string{"taskId", "completionStatus", "documentUrl"} {
+		if _, exists := data[forbidden]; exists {
+			t.Fatalf("dry-run preview manufactured %s: %#v", forbidden, data)
+		}
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunDryRunBadPreflightMakesZeroWrites(t *testing.T) {
+	tests := []struct {
+		name      string
+		steps     []upsertByKeyStep
+		wantCalls int
+	}{
+		{
+			name:      "non AI field",
+			steps:     []upsertByKeyStep{{text: `{"data":{"fields":[{"fieldId":"field-1"}]}}`}},
+			wantCalls: 1,
+		},
+		{
+			name:      "bad AI config",
+			steps:     []upsertByKeyStep{{text: `{"data":{"fields":[{"fieldId":"field-1","aiConfig":{"outputType":"text","prompt":[{"type":"text","value":"no field ref"}]}}]}}`}},
+			wantCalls: 1,
+		},
+		{
+			name:      "missing record",
+			steps:     []upsertByKeyStep{{text: aiFieldFixture}, {text: `{"data":{"records":[{"recordId":"record-1"}]}}`}},
+			wantCalls: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			caller := &upsertByKeyCaller{dryRun: true, steps: test.steps}
+			out, err := runAITableCompositeCLI(t, caller, "+ai-field-run", aiFieldArgs("--dry-run")...)
+			if err == nil || out != "" || len(caller.calls) != test.wantCalls {
+				t.Fatalf("bad preflight = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+			for _, call := range caller.calls {
+				if call.tool == "run_ai_field" {
+					t.Fatalf("bad preflight reached write tool: %#v", caller.calls)
+				}
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageAIFieldRunRejectsMalformedRunReceipt(t *testing.T) {
+	responses := []string{
+		`{"tasks":[{"fieldId":"field-1","status":"submitted","taskId":"task","total":2}]}`,
+		`{"data":"bad","tasks":[{"fieldId":"field-1","status":"submitted","taskId":"task","total":2}]}`,
+		`{"data":{"tasks":[]}}`,
+		`{"data":{"tasks":[{"fieldId":"other","status":"submitted","taskId":"task","total":2}]}}`,
+		`{"data":{"tasks":[{"fieldId":"field-1","status":"finished","taskId":"task","total":2}]}}`,
+		`{"data":{"tasks":[{"fieldId":"field-1","status":"submitted","taskId":"","total":2}]}}`,
+		`{"data":{"tasks":[{"fieldId":"field-1","status":"submitted","taskId":"task","total":1}]}}`,
+		`{"data":{"tasks":[{"fieldId":"field-1","status":"submitted","taskId":"task","total":2.5}]}}`,
+		`{"data":{"tasks":[{"fieldId":"field-1","status":"submitted","taskId":"task","total":2}],"documentUrl":"http://example.test/result"}}`,
+	}
+	for index, response := range responses {
+		t.Run("receipt-"+string(rune('a'+index)), func(t *testing.T) {
+			out, err, caller := runAIFieldFixture(t, []upsertByKeyStep{{text: aiFieldFixture}, {text: aiRecordFixture}, {text: response}}, aiFieldArgs("--yes")...)
+			if err == nil || out != "" || len(caller.calls) != 3 || caller.calls[2].tool != "run_ai_field" {
+				t.Fatalf("receipt validation = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+		})
+	}
+}
+
+func numberedIDs(prefix string, count int) []string {
+	out := make([]string, count)
+	for index := range out {
+		out[index] = prefix + fmt.Sprint(index)
+	}
+	return out
+}

--- a/internal/shortcut/aitable/aitable.go
+++ b/internal/shortcut/aitable/aitable.go
@@ -1086,7 +1086,7 @@ var TemplateSearch = shortcut.Shortcut{
 		},
 	},
 	Flags: []shortcut.Flag{
-		{Name: "query", Type: shortcut.FlagString, Desc: "非空模板名称关键词", Required: true},
+		{Name: "query", Type: shortcut.FlagString, Desc: "模板名称关键词，去除首尾空白后不能为空", Required: true},
 		{Name: "limit", Type: shortcut.FlagInt, Desc: "每页数量，默认 10，最大 30（可选）"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标（可选）"},
 	},

--- a/internal/shortcut/aitable/aitable.go
+++ b/internal/shortcut/aitable/aitable.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/aitabletarget"
@@ -1086,7 +1087,7 @@ var TemplateSearch = shortcut.Shortcut{
 		},
 	},
 	Flags: []shortcut.Flag{
-		{Name: "query", Type: shortcut.FlagString, Desc: "模板名称关键词，去除首尾空白后不能为空", Required: true},
+		{Name: "query", Type: shortcut.FlagString, Desc: "模板名称关键词；每次调用必须提供且去除首尾空白后不能为空（兼容接口保持 optional）"},
 		{Name: "limit", Type: shortcut.FlagInt, Desc: "每页数量，默认 10，最大 30（可选）"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标（可选）"},
 	},
@@ -1098,13 +1099,13 @@ var TemplateSearch = shortcut.Shortcut{
 	Tips: []string{`dws aitable +template-search --query "项目管理"`},
 	Validate: func(rt *shortcut.RuntimeContext) error {
 		if rt.Str("query") == "" {
-			return fmt.Errorf("--query 去除首尾空白后不能为空")
+			return apperrors.NewValidation("--query 去除首尾空白后不能为空")
 		}
 		if rt.Changed("cursor") && rt.Str("cursor") == "" {
-			return fmt.Errorf("--cursor 显式提供时去除首尾空白后不能为空")
+			return apperrors.NewValidation("--cursor 显式提供时去除首尾空白后不能为空")
 		}
 		if rt.Changed("limit") && (rt.Int("limit") < 1 || rt.Int("limit") > 30) {
-			return fmt.Errorf("--limit 必须在 1 到 30 之间")
+			return apperrors.NewValidation("--limit 必须在 1 到 30 之间")
 		}
 		return nil
 	},

--- a/internal/shortcut/aitable/aitable.go
+++ b/internal/shortcut/aitable/aitable.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/aitabletarget"
 )
@@ -1030,12 +1031,13 @@ var RecordPrimaryDocCreate = shortcut.Shortcut{
 
 // TemplateSearch 搜索模板（search_templates）。
 var TemplateSearch = shortcut.Shortcut{
-	Service:     "aitable",
-	Command:     "+template-search",
-	Product:     serverMain,
-	Description: "按名称关键词搜索 AI 表格模板",
-	Intent:      "当你要新建表格并想套用现成模板、需要先按关键词找模板（不传关键词则返回热门）时使用；返回模板列表及其模板 ID。",
-	Risk:        shortcut.RiskRead,
+	OutputRollout: output.RolloutUnifiedActive,
+	Service:       "aitable",
+	Command:       "+template-search",
+	Product:       serverMain,
+	Description:   "按名称关键词搜索 AI 表格模板",
+	Intent:        "当你要新建表格并想套用现成模板、需要先按非空关键词找模板时使用；返回当前页模板列表、稳定模板 ID 和可继续读取的游标。",
+	Risk:          shortcut.RiskRead,
 	Safety: contract.SafetySpec{
 		Effect: "read", Risk: "low",
 		Confirmation: "not_required", Idempotency: "idempotent",
@@ -1056,22 +1058,58 @@ var TemplateSearch = shortcut.Shortcut{
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "按名称关键词搜索 AI 表格模板",
-			UseWhen:      []string{"当你要新建表格并想套用现成模板、需要先按关键词找模板（不传关键词则返回热门）时使用；返回模板列表及其模板 ID。"},
+			UseWhen:      []string{"当你要新建表格并想套用现成模板、需要先按非空关键词找模板时使用；返回当前页模板列表、稳定模板 ID 和可继续读取的游标。"},
 			AvoidWhen:    []string{"需要该 Shortcut 未公开的底层参数、原始响应或不同执行语义时，改用对应原子命令"},
 			Examples:     []string{"dws aitable +template-search --query \"项目管理\""},
 		},
+		Parameters: []contract.ParamDecl{{Name: "query", Property: "query"}},
+		Result: &contract.ResultSpec{
+			Outcomes: []contract.ResultOutcome{contract.ResultOutcomeSuccess, contract.ResultOutcomeFailure},
+			DataSchema: json.RawMessage(`{
+				"type":"object",
+				"description":"按非空关键词搜索得到的当前页 AI 表格模板",
+				"properties":{
+					"count":{"type":"integer","description":"当前页模板数量"},
+					"templates":{"type":"array","description":"当前页模板列表","items":{"type":"object","description":"带稳定 templateId 的模板","properties":{"templateId":{"type":"string","description":"可用于创建 Base 的稳定模板 ID"},"templateName":{"type":"string","description":"模板名称"}},"required":["templateId"],"additionalProperties":false}}
+				},
+				"required":["count","templates"],
+				"additionalProperties":false
+			}`),
+			SensitivePaths: []string{"templates.templateName"},
+		},
+		Pagination: &contract.PaginationSpec{
+			Kind:                  contract.PaginationKindCursor,
+			CursorParameter:       "cursor",
+			MetaPath:              contract.PaginationMetaPath,
+			EndpointExhaustedPath: contract.PaginationExhaustedPath,
+			NextTokenPath:         contract.PaginationNextTokenPath,
+		},
 	},
 	Flags: []shortcut.Flag{
-		{Name: "query", Type: shortcut.FlagString, Desc: "模板名称关键词（可选，不传返回热门）"},
+		{Name: "query", Type: shortcut.FlagString, Desc: "非空模板名称关键词", Required: true},
 		{Name: "limit", Type: shortcut.FlagInt, Desc: "每页数量，默认 10，最大 30（可选）"},
 		{Name: "cursor", Type: shortcut.FlagString, Desc: "分页游标（可选）"},
 	},
+	Constraints: []shortcut.Constraint{{
+		Kind:        shortcut.ConstraintCustom,
+		Flags:       []string{"query"},
+		Description: "--query 去除首尾空白后不能为空",
+	}},
 	Tips: []string{`dws aitable +template-search --query "项目管理"`},
-	Execute: func(rt *shortcut.RuntimeContext) error {
-		params := map[string]any{}
-		if rt.Changed("query") {
-			params["query"] = rt.Str("query")
+	Validate: func(rt *shortcut.RuntimeContext) error {
+		if rt.Str("query") == "" {
+			return fmt.Errorf("--query 去除首尾空白后不能为空")
 		}
+		if rt.Changed("cursor") && rt.Str("cursor") == "" {
+			return fmt.Errorf("--cursor 显式提供时去除首尾空白后不能为空")
+		}
+		if rt.Changed("limit") && (rt.Int("limit") < 1 || rt.Int("limit") > 30) {
+			return fmt.Errorf("--limit 必须在 1 到 30 之间")
+		}
+		return nil
+	},
+	Execute: func(rt *shortcut.RuntimeContext) error {
+		params := map[string]any{"query": rt.Str("query")}
 		if rt.Changed("limit") {
 			params["limit"] = rt.Int("limit")
 		}
@@ -1082,12 +1120,127 @@ var TemplateSearch = shortcut.Shortcut{
 		if err != nil {
 			return err
 		}
-		templates, err := templateSearchProject(data)
+		page, err := templateSearchProjectPage(data, rt.Str("cursor"))
 		if err != nil {
 			return err
 		}
-		return rt.Output(map[string]any{"count": len(templates), "templates": templates})
+		return outputTemplateSearchPage(rt, page)
 	},
+}
+
+type templateSearchPage struct {
+	Templates  []map[string]any
+	HasMore    bool
+	NextCursor string
+}
+
+func templateSearchProjectPage(data map[string]any, requestCursor string) (templateSearchPage, error) {
+	envelope, err := templateSearchPageEnvelope(data)
+	if err != nil {
+		return templateSearchPage{}, err
+	}
+	rawTemplates, ok := envelope["templates"].([]any)
+	if !ok {
+		return templateSearchPage{}, fmt.Errorf("search_templates page envelope must contain a templates array")
+	}
+	for _, key := range []string{"list", "items", "result", "data"} {
+		if _, duplicate := envelope[key].([]any); duplicate {
+			return templateSearchPage{}, fmt.Errorf("search_templates page envelope contains multiple candidate lists")
+		}
+	}
+	templates, err := projectTemplateSearchItems(rawTemplates)
+	if err != nil {
+		return templateSearchPage{}, err
+	}
+	hasMore, known := envelope["hasMore"].(bool)
+	if !known {
+		return templateSearchPage{}, fmt.Errorf("search_templates response is missing hasMore pagination evidence")
+	}
+	nextCursor := ""
+	if value, exists := envelope["nextCursor"]; exists {
+		cursor, stringOK := value.(string)
+		if !stringOK {
+			return templateSearchPage{}, fmt.Errorf("search_templates nextCursor must be a string")
+		}
+		nextCursor = strings.TrimSpace(cursor)
+	}
+	if hasMore {
+		if nextCursor == "" {
+			return templateSearchPage{}, fmt.Errorf("search_templates response hasMore=true without nextCursor")
+		}
+		if requestCursor != "" && nextCursor == requestCursor {
+			return templateSearchPage{}, fmt.Errorf("search_templates response returned a non-advancing nextCursor")
+		}
+	} else {
+		nextCursor = ""
+	}
+	return templateSearchPage{Templates: templates, HasMore: hasMore, NextCursor: nextCursor}, nil
+}
+
+func templateSearchPageEnvelope(response map[string]any) (map[string]any, error) {
+	if response == nil {
+		return nil, fmt.Errorf("search_templates response is nil")
+	}
+	type candidate struct {
+		name  string
+		value map[string]any
+	}
+	candidates := make([]candidate, 0, 3)
+	if templateSearchHasPageFacts(response) {
+		candidates = append(candidates, candidate{name: "top", value: response})
+	}
+	for _, key := range []string{"data", "result"} {
+		value, exists := response[key]
+		if !exists {
+			continue
+		}
+		nested, ok := value.(map[string]any)
+		if !ok {
+			if key == "data" || templateSearchHasPageFacts(response) {
+				return nil, fmt.Errorf("search_templates %s envelope must be an object", key)
+			}
+			continue
+		}
+		if templateSearchHasPageFacts(nested) {
+			candidates = append(candidates, candidate{name: key, value: nested})
+		}
+	}
+	if len(candidates) != 1 {
+		names := make([]string, 0, len(candidates))
+		for _, item := range candidates {
+			names = append(names, item.name)
+		}
+		return nil, fmt.Errorf("search_templates response must contain exactly one page envelope; found %v", names)
+	}
+	return candidates[0].value, nil
+}
+
+func templateSearchHasPageFacts(value map[string]any) bool {
+	for _, key := range []string{"templates", "hasMore", "nextCursor", "cursor", "list", "items"} {
+		if _, exists := value[key]; exists {
+			return true
+		}
+	}
+	return false
+}
+
+func outputTemplateSearchPage(rt *shortcut.RuntimeContext, page templateSearchPage) error {
+	business := map[string]any{"count": len(page.Templates), "templates": page.Templates}
+	if !output.UsesUnifiedResult(rt.Command()) {
+		business["hasMore"] = page.HasMore
+		if page.NextCursor != "" {
+			business["nextCursor"] = page.NextCursor
+		}
+		return rt.Output(business)
+	}
+	pagination, err := output.NewPagination(!page.HasMore, page.NextCursor)
+	if err != nil {
+		return err
+	}
+	return output.StoreResult(rt.Command().Context(), output.Success(business, output.WithMeta(&output.Meta{
+		Count:      output.NewCount(len(page.Templates)),
+		Pagination: pagination,
+	})))
 }
 
 // templateSearchProject reshapes the raw search_templates response into a clean
@@ -1099,6 +1252,10 @@ func templateSearchProject(data map[string]any) ([]map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	return projectTemplateSearchItems(raw)
+}
+
+func projectTemplateSearchItems(raw []any) ([]map[string]any, error) {
 	out := make([]map[string]any, 0, len(raw))
 	for index, item := range raw {
 		m, ok := item.(map[string]any)
@@ -1106,11 +1263,20 @@ func templateSearchProject(data map[string]any) ([]map[string]any, error) {
 			return nil, fmt.Errorf("search_templates response item %d must be an object, got %T", index, item)
 		}
 		row := map[string]any{}
-		if v, ok := templateSearchFirst(m, "templateId", "template_id", "id"); ok {
-			row["templateId"] = v
+		if value, ok := templateSearchFirst(m, "templateId", "template_id", "id"); ok {
+			templateID, stringOK := value.(string)
+			templateID = strings.TrimSpace(templateID)
+			if !stringOK || templateID == "" {
+				return nil, fmt.Errorf("search_templates response item %d has invalid templateId", index)
+			}
+			row["templateId"] = templateID
 		}
-		if v, ok := templateSearchFirst(m, "templateName", "template_name", "name", "title"); ok {
-			row["templateName"] = v
+		if value, ok := templateSearchFirst(m, "templateName", "template_name", "name", "title"); ok {
+			templateName, stringOK := value.(string)
+			if !stringOK {
+				return nil, fmt.Errorf("search_templates response item %d has invalid templateName", index)
+			}
+			row["templateName"] = strings.TrimSpace(templateName)
 		}
 		if _, ok := row["templateId"]; !ok {
 			return nil, fmt.Errorf("search_templates response item %d is missing templateId", index)
@@ -3151,6 +3317,7 @@ func init() {
 		RecordPrimaryDocGet,
 		RecordPrimaryDocCreate,
 		TemplateSearch,
+		AIFieldRun,
 		AttachmentUpload,
 		AttachmentPut,
 		AttachmentRemove,

--- a/internal/shortcut/aitable/list_projection_e2e_test.go
+++ b/internal/shortcut/aitable/list_projection_e2e_test.go
@@ -17,7 +17,7 @@ func TestCrossPlatformCoverageAITableListProjectionExplicitEmptyIsSuccessE2E(t *
 	}{
 		{name: "base list", command: "+base-list", payload: `{"bases":[]}`},
 		{name: "base search", command: "+base-search", args: []string{"--query", "none"}, payload: `{"data":{"bases":[]}}`},
-		{name: "template search", command: "+template-search", payload: `{"data":{"templates":[]}}`},
+		{name: "template search", command: "+template-search", args: []string{"--query", "none"}, payload: `{"data":{"templates":[],"hasMore":false}}`},
 		{name: "view get", command: "+view-get", args: []string{"--base-id", "base", "--table-id", "table"}, payload: `{"views":[]}`},
 		{name: "form list", command: "+form-list", args: []string{"--base-id", "base", "--table-id", "table"}, payload: `{"data":{"formViews":[]}}`},
 		{name: "workflow list", command: "+workflow-list", args: []string{"--base-id", "base"}, payload: `{"data":{"list":[]}}`},
@@ -55,7 +55,7 @@ func TestCrossPlatformCoverageAITableListProjectionUnknownIsNotEmptySuccessE2E(t
 	}{
 		{name: "base list", command: "+base-list"},
 		{name: "base search", command: "+base-search", args: []string{"--query", "none"}},
-		{name: "template search", command: "+template-search"},
+		{name: "template search", command: "+template-search", args: []string{"--query", "none"}},
 		{name: "view get", command: "+view-get", args: []string{"--base-id", "base", "--table-id", "table"}},
 		{name: "form list", command: "+form-list", args: []string{"--base-id", "base", "--table-id", "table"}},
 		{name: "workflow list", command: "+workflow-list", args: []string{"--base-id", "base"}},
@@ -89,7 +89,7 @@ func TestCrossPlatformCoverageAITableListProjectionMalformedItemIsNotSilentlyDro
 		payload string
 	}{
 		{name: "base without id", command: "+base-list", payload: `{"bases":[{"baseName":"orphan"}]}`},
-		{name: "template scalar", command: "+template-search", payload: `{"templates":["bad"]}`},
+		{name: "template scalar", command: "+template-search", args: []string{"--query", "none"}, payload: `{"templates":["bad"],"hasMore":false}`},
 		{name: "view without id", command: "+view-get", args: []string{"--base-id", "base", "--table-id", "table"}, payload: `{"views":[{"viewName":"orphan"}]}`},
 		{name: "form without id", command: "+form-list", args: []string{"--base-id", "base", "--table-id", "table"}, payload: `{"forms":[{"viewName":"orphan"}]}`},
 		{name: "workflow without id", command: "+workflow-list", args: []string{"--base-id", "base"}, payload: `{"workflows":[{"name":"orphan"}]}`},

--- a/internal/shortcut/aitable/template_search_contract_test.go
+++ b/internal/shortcut/aitable/template_search_contract_test.go
@@ -5,10 +5,12 @@ package aitable
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
+	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
 	"github.com/spf13/cobra"
@@ -21,15 +23,22 @@ func TestCrossPlatformCoverageTemplateSearchRequiresNonEmptyQueryBeforeMCP(t *te
 	}{
 		{name: "missing"},
 		{name: "blank", args: []string{"--query", "   "}},
+		{name: "blank cursor", args: []string{"--query", "项目", "--cursor", "   "}},
+		{name: "limit below minimum", args: []string{"--query", "项目", "--limit", "0"}},
+		{name: "limit above maximum", args: []string{"--query", "项目", "--limit", "31"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			caller := &upsertByKeyCaller{}
 			out, err := runAITableCompositeCLI(t, caller, "+template-search", test.args...)
-			if err == nil || out != "" {
+			var typed *apperrors.Error
+			if err == nil || out != "" || !errors.As(err, &typed) {
 				t.Fatalf("query validation = output:%q err:%v", out, err)
 			}
+			if typed.Category != apperrors.CategoryValidation || typed.ExitCode() != apperrors.ExitCodeValidation {
+				t.Fatalf("validation contract = category:%q exit:%d error:%#v", typed.Category, typed.ExitCode(), typed)
+			}
 			if len(caller.calls) != 0 {
-				t.Fatalf("invalid query made %d MCP calls", len(caller.calls))
+				t.Fatalf("invalid template search made %d MCP calls", len(caller.calls))
 			}
 		})
 	}
@@ -95,8 +104,11 @@ func TestCrossPlatformCoverageTemplateSearchSelectionDoesNotClaimPopularFallback
 			t.Fatalf("template search still claims unsupported fallback: %q", text)
 		}
 	}
-	if len(TemplateSearch.Flags) == 0 || TemplateSearch.Flags[0].Name != "query" || !TemplateSearch.Flags[0].Required {
-		t.Fatalf("template search query flag is not required: %#v", TemplateSearch.Flags)
+	if len(TemplateSearch.Flags) == 0 || TemplateSearch.Flags[0].Name != "query" || TemplateSearch.Flags[0].Required {
+		t.Fatalf("template search query compatibility surface is not optional: %#v", TemplateSearch.Flags)
+	}
+	if !strings.Contains(TemplateSearch.Flags[0].Desc, "每次调用必须提供") || !strings.Contains(TemplateSearch.Flags[0].Desc, "不能为空") {
+		t.Fatalf("template search query runtime requirement is unclear: %#v", TemplateSearch.Flags[0])
 	}
 }
 

--- a/internal/shortcut/aitable/template_search_contract_test.go
+++ b/internal/shortcut/aitable/template_search_contract_test.go
@@ -1,0 +1,125 @@
+// Copyright 2026 Alibaba Group
+// SPDX-License-Identifier: Apache-2.0
+
+package aitable
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestCrossPlatformCoverageTemplateSearchRequiresNonEmptyQueryBeforeMCP(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{name: "missing"},
+		{name: "blank", args: []string{"--query", "   "}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			caller := &upsertByKeyCaller{}
+			out, err := runAITableCompositeCLI(t, caller, "+template-search", test.args...)
+			if err == nil || out != "" {
+				t.Fatalf("query validation = output:%q err:%v", out, err)
+			}
+			if len(caller.calls) != 0 {
+				t.Fatalf("invalid query made %d MCP calls", len(caller.calls))
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageTemplateSearchTrimsQueryPayload(t *testing.T) {
+	caller := &upsertByKeyCaller{steps: []upsertByKeyStep{{
+		text: `{"data":{"templates":[{"templateId":"template-1","name":"项目模板"}],"hasMore":false}}`,
+	}}}
+	out, err := runAITableCompositeCLI(t, caller, "+template-search", "--query", "  项目  ")
+	if err != nil {
+		t.Fatalf("template search error = %v", err)
+	}
+	if len(caller.calls) != 1 || caller.calls[0].tool != "search_templates" || caller.calls[0].args["query"] != "项目" {
+		t.Fatalf("template search calls = %#v", caller.calls)
+	}
+	if !strings.Contains(out, `"templateId": "template-1"`) {
+		t.Fatalf("template search output = %s", out)
+	}
+}
+
+func TestCrossPlatformCoverageTemplateSearchSelectionDoesNotClaimPopularFallback(t *testing.T) {
+	for _, text := range append([]string{TemplateSearch.Intent}, TemplateSearch.Contract.Selection.UseWhen...) {
+		if strings.Contains(text, "返回热门") || strings.Contains(text, "不传关键词") {
+			t.Fatalf("template search still claims unsupported fallback: %q", text)
+		}
+	}
+	if len(TemplateSearch.Flags) == 0 || TemplateSearch.Flags[0].Name != "query" || !TemplateSearch.Flags[0].Required {
+		t.Fatalf("template search query flag is not required: %#v", TemplateSearch.Flags)
+	}
+}
+
+func TestCrossPlatformCoverageTemplateSearchPublishesAdvancingPagination(t *testing.T) {
+	caller := &upsertByKeyCaller{steps: []upsertByKeyStep{{
+		text: `{"data":{"templates":[{"templateId":"template-1","name":"项目模板"}],"hasMore":true,"nextCursor":"cursor-2"}}`,
+	}}}
+	out, err := runAITableCompositeCLI(t, caller, "+template-search", "--query", "项目")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"endpoint_exhausted": false`, `"next_token": "cursor-2"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("template pagination missing %s: %s", want, out)
+		}
+	}
+}
+
+func TestCrossPlatformCoverageTemplateSearchRejectsInvalidPaginationEvidence(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		cursor   string
+		response string
+	}{
+		{name: "missing hasMore", response: `{"data":{"templates":[]}}`},
+		{name: "missing next cursor", response: `{"data":{"templates":[],"hasMore":true}}`},
+		{name: "non advancing cursor", cursor: "same", response: `{"data":{"templates":[],"hasMore":true,"nextCursor":"same"}}`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			caller := &upsertByKeyCaller{steps: []upsertByKeyStep{{text: test.response}}}
+			args := []string{"--query", "项目"}
+			if test.cursor != "" {
+				args = append(args, "--cursor", test.cursor)
+			}
+			out, err := runAITableCompositeCLI(t, caller, "+template-search", args...)
+			if err == nil || out != "" || len(caller.calls) != 1 {
+				t.Fatalf("pagination validation = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageTemplateSearchRejectsMalformedStableIdentity(t *testing.T) {
+	caller := &upsertByKeyCaller{steps: []upsertByKeyStep{{
+		text: `{"data":{"templates":[{"templateId":42,"name":"bad"}],"hasMore":false}}`,
+	}}}
+	out, err := runAITableCompositeCLI(t, caller, "+template-search", "--query", "项目")
+	if err == nil || out != "" || len(caller.calls) != 1 {
+		t.Fatalf("malformed identity = output:%q err:%v calls:%#v", out, err, caller.calls)
+	}
+}
+
+func TestCrossPlatformCoverageTemplateSearchRejectsConflictingPageEnvelopes(t *testing.T) {
+	responses := []string{
+		`{"hasMore":false,"data":{"templates":[],"hasMore":true,"nextCursor":"next"}}`,
+		`{"data":{"templates":[],"hasMore":true,"nextCursor":"next"},"result":{"hasMore":false}}`,
+		`{"data":{"templates":[],"list":[],"hasMore":false}}`,
+		`{"nextCursor":"outer","data":{"templates":[],"hasMore":true}}`,
+	}
+	for index, response := range responses {
+		t.Run(fmt.Sprintf("conflict-%d", index), func(t *testing.T) {
+			caller := &upsertByKeyCaller{steps: []upsertByKeyStep{{text: response}}}
+			out, err := runAITableCompositeCLI(t, caller, "+template-search", "--query", "项目")
+			if err == nil || out != "" || len(caller.calls) != 1 {
+				t.Fatalf("conflicting page envelope = output:%q err:%v calls:%#v", out, err, caller.calls)
+			}
+		})
+	}
+}

--- a/internal/shortcut/aitable/template_search_contract_test.go
+++ b/internal/shortcut/aitable/template_search_contract_test.go
@@ -4,9 +4,14 @@
 package aitable
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
+	"github.com/spf13/cobra"
 )
 
 func TestCrossPlatformCoverageTemplateSearchRequiresNonEmptyQueryBeforeMCP(t *testing.T) {
@@ -25,6 +30,44 @@ func TestCrossPlatformCoverageTemplateSearchRequiresNonEmptyQueryBeforeMCP(t *te
 			}
 			if len(caller.calls) != 0 {
 				t.Fatalf("invalid query made %d MCP calls", len(caller.calls))
+			}
+		})
+	}
+}
+
+func TestCrossPlatformCoverageTemplateSearchValidateExactFlagBoundaries(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		query  string
+		cursor *string
+		limit  *int
+	}{
+		{name: "blank query", query: " "},
+		{name: "explicit blank cursor", query: "项目", cursor: stringPointer(" ")},
+		{name: "limit below minimum", query: "项目", limit: intPointer(0)},
+		{name: "limit above maximum", query: "项目", limit: intPointer(31)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "template-search"}
+			cmd.Flags().String("query", "", "")
+			cmd.Flags().String("cursor", "", "")
+			cmd.Flags().Int("limit", 0, "")
+			if err := cmd.Flags().Set("query", test.query); err != nil {
+				t.Fatal(err)
+			}
+			if test.cursor != nil {
+				if err := cmd.Flags().Set("cursor", *test.cursor); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if test.limit != nil {
+				if err := cmd.Flags().Set("limit", fmt.Sprint(*test.limit)); err != nil {
+					t.Fatal(err)
+				}
+			}
+			rt := shortcut.RuntimeContextForTest(cmd, TemplateSearch)
+			if err := TemplateSearch.Validate(rt); err == nil {
+				t.Fatal("Validate accepted an invalid exact flag boundary")
 			}
 		})
 	}
@@ -97,12 +140,15 @@ func TestCrossPlatformCoverageTemplateSearchRejectsInvalidPaginationEvidence(t *
 }
 
 func TestCrossPlatformCoverageTemplateSearchRejectsMalformedStableIdentity(t *testing.T) {
-	caller := &upsertByKeyCaller{steps: []upsertByKeyStep{{
-		text: `{"data":{"templates":[{"templateId":42,"name":"bad"}],"hasMore":false}}`,
-	}}}
-	out, err := runAITableCompositeCLI(t, caller, "+template-search", "--query", "项目")
-	if err == nil || out != "" || len(caller.calls) != 1 {
-		t.Fatalf("malformed identity = output:%q err:%v calls:%#v", out, err, caller.calls)
+	for _, response := range []string{
+		`{"data":{"templates":[{"templateId":42,"name":"bad"}],"hasMore":false}}`,
+		`{"data":{"templates":[{"templateId":"template-1","name":42}],"hasMore":false}}`,
+	} {
+		caller := &upsertByKeyCaller{steps: []upsertByKeyStep{{text: response}}}
+		out, err := runAITableCompositeCLI(t, caller, "+template-search", "--query", "项目")
+		if err == nil || out != "" || len(caller.calls) != 1 {
+			t.Fatalf("malformed identity = output:%q err:%v calls:%#v", out, err, caller.calls)
+		}
 	}
 }
 
@@ -112,6 +158,9 @@ func TestCrossPlatformCoverageTemplateSearchRejectsConflictingPageEnvelopes(t *t
 		`{"data":{"templates":[],"hasMore":true,"nextCursor":"next"},"result":{"hasMore":false}}`,
 		`{"data":{"templates":[],"list":[],"hasMore":false}}`,
 		`{"nextCursor":"outer","data":{"templates":[],"hasMore":true}}`,
+		`{"result":"ignored"}`,
+		`{"data":"bad"}`,
+		`{"data":{"templates":[],"hasMore":true,"nextCursor":42}}`,
 	}
 	for index, response := range responses {
 		t.Run(fmt.Sprintf("conflict-%d", index), func(t *testing.T) {
@@ -123,3 +172,34 @@ func TestCrossPlatformCoverageTemplateSearchRejectsConflictingPageEnvelopes(t *t
 		})
 	}
 }
+
+func TestCrossPlatformCoverageTemplateSearchEnvelopeAndOutputModes(t *testing.T) {
+	if _, err := templateSearchPageEnvelope(nil); err == nil {
+		t.Fatal("nil response must fail")
+	}
+
+	legacy := &cobra.Command{Use: "template-search"}
+	var stdout bytes.Buffer
+	legacy.SetOut(&stdout)
+	legacyRT := shortcut.RuntimeContextForTest(legacy, TemplateSearch)
+	if err := outputTemplateSearchPage(legacyRT, templateSearchPage{
+		Templates: []map[string]any{{"templateId": "template-1"}}, HasMore: true, NextCursor: "next",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"hasMore": true`, `"nextCursor": "next"`, `"templateId": "template-1"`} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("legacy output missing %s: %s", want, stdout.String())
+		}
+	}
+
+	unified := &cobra.Command{Use: "template-search"}
+	output.SetCommandRollout(unified, output.RolloutUnifiedActive)
+	unifiedRT := shortcut.RuntimeContextForTest(unified, TemplateSearch)
+	if err := outputTemplateSearchPage(unifiedRT, templateSearchPage{HasMore: true}); err == nil {
+		t.Fatal("unified pagination accepted hasMore without next cursor")
+	}
+}
+
+func stringPointer(value string) *string { return &value }
+func intPointer(value int) *int          { return &value }

--- a/internal/shortcut/builtin/aitable_semantic_catalog_test.go
+++ b/internal/shortcut/builtin/aitable_semantic_catalog_test.go
@@ -36,8 +36,8 @@ func TestCrossPlatformCoverageAITableSemanticCatalogExactlyCoversRegisteredSurfa
 		}
 		registered[item.Command] = item
 	}
-	if len(registered) != 100 || len(source.Shortcuts) != 100 {
-		t.Fatalf("registered/catalog = %d/%d, want 100/100", len(registered), len(source.Shortcuts))
+	if len(registered) != 101 || len(source.Shortcuts) != 101 {
+		t.Fatalf("registered/catalog = %d/%d, want 101/101", len(registered), len(source.Shortcuts))
 	}
 
 	var missing, stale []string

--- a/internal/shortcut/public_catalog_generated.go
+++ b/internal/shortcut/public_catalog_generated.go
@@ -14,6 +14,7 @@ func generatedPublicShortcutCatalog() map[string]struct{} {
 		"aisearch\u0000+search-person":                  {},
 		"aitable\u0000+advperm-disable":                 {},
 		"aitable\u0000+advperm-enable":                  {},
+		"aitable\u0000+ai-field-run":                    {},
 		"aitable\u0000+attachment-put":                  {},
 		"aitable\u0000+attachment-remove":               {},
 		"aitable\u0000+attachment-upload":               {},

--- a/internal/shortcut/semantic_catalog_aitable.json
+++ b/internal/shortcut/semantic_catalog_aitable.json
@@ -36,7 +36,8 @@
     "+record-primary-doc-get": {"disposition":"schema_leaf","semantic_delta":"读取记录主键文档 nodeId 的一对一入口。","risk":"read","public":true,"reviewed":true},
     "+record-primary-doc-create": {"disposition":"semantic_adapter","semantic_delta":"以幂等意图为 primaryDoc 字段创建关联文档。","risk":"write","public":true,"reviewed":true},
 
-    "+template-search": {"disposition":"semantic_adapter","semantic_delta":"按名称关键词搜索 AI 表格模板并返回可用于创建的 templateId。","risk":"read","public":true,"reviewed":true},
+    "+template-search": {"disposition":"semantic_adapter","semantic_delta":"按非空名称关键词搜索 AI 表格模板，稳定投影 templateId，并将严格校验后的 nextCursor 发布到 meta.pagination；拒绝无关键词和不可续分页。","risk":"read","public":true,"reviewed":true},
+    "+ai-field-run": {"disposition":"primary_smart","semantic_delta":"先精确验证一个 AI 字段与 1–100 条显式记录身份，再唯一调用 run_ai_field；只发布 submitted pending 回执，verified 固定 false。","risk":"high-risk-write","public":true,"reviewed":true},
     "+attachment-upload": {"disposition":"schema_leaf","semantic_delta":"申请附件 OSS 直传地址和 fileToken；只负责上传准备，不伪造文件已上传。","risk":"write","public":true,"reviewed":true},
     "+attachment-put": {"disposition":"primary_smart","semantic_delta":"完整执行 prepare、HTTP PUT、attachment cell 覆盖和读回验证；空写回包只有最终附件可证明时成功。","risk":"write","public":true,"reviewed":true},
     "+attachment-remove": {"disposition":"primary_smart","semantic_delta":"清空或按文件名移除附件；若读回缺剩余 fileToken，会在写前明确停止而不破坏其他附件。","risk":"high-risk-write","public":true,"reviewed":true},

--- a/skills/mono/SKILL.md
+++ b/skills/mono/SKILL.md
@@ -45,7 +45,7 @@ cli_version: ">=1.0.61"
 |---|---:|---|
 | `agoal` | 5 | `—` |
 | `aisearch` | 1 | `—` |
-| `aitable` | 100 | `dingtalk-aitable` |
+| `aitable` | 101 | `dingtalk-aitable` |
 | `attendance` | 8 | `dingtalk-misc` |
 | `calendar` | 27 | `dingtalk-calendar` |
 | `chat` | 98 | `dingtalk-chat` |

--- a/skills/multi/dingtalk-aitable/SKILL.md
+++ b/skills/multi/dingtalk-aitable/SKILL.md
@@ -28,7 +28,7 @@ metadata:
 <!-- VISIBLE_SHORTCUTS_START -->
 ## Shortcut 发现（按需）
 
-`aitable` 当前有 100 条公开 shortcut，完整清单保留在 Runtime Catalog 与 Schema，不在高频产品根 Skill 中重复展开。已知 leaf 直接执行。只有参数不确定时，最多读取一次 `dws schema --cli-path "aitable <leaf>" --compact --format json`；仅当该 compact leaf Schema 与 Cobra 实际不一致时，才读取同一 leaf 的 `dws aitable <leaf> --help`。禁止用父级 Help、产品 Help 或完整 Catalog 探索命令；一个 Case 一旦读取 Reference，就不再读取 Help 或第二个 Reference。
+`aitable` 当前有 101 条公开 shortcut，完整清单保留在 Runtime Catalog 与 Schema，不在高频产品根 Skill 中重复展开。已知 leaf 直接执行。只有参数不确定时，最多读取一次 `dws schema --cli-path "aitable <leaf>" --compact --format json`；仅当该 compact leaf Schema 与 Cobra 实际不一致时，才读取同一 leaf 的 `dws aitable <leaf> --help`。禁止用父级 Help、产品 Help 或完整 Catalog 探索命令；一个 Case 一旦读取 Reference，就不再读取 Help 或第二个 Reference。
 
 仅当根路由、精确 task reference 和 `references/aitable.md` 的低频原子索引都无法定位能力时，才执行 `dws shortcut list --service aitable --format json` 做最终回退；不要为已知意图加载完整 Shortcut Catalog 或产品级 Schema。
 <!-- VISIBLE_SHORTCUTS_END -->


### PR DESCRIPTION
## 变更摘要

- 新增 `aitable +ai-field-run`：仅支持单个 AI 字段和显式 1–100 个 record ID。
- 提交前严格校验 AI field 配置及精确 record 集；非幂等写只调用一次。
- 返回诚实的 `pending` 合同：`verified=false`、`completionStatus=unknown`，不把 submitted 冒充计算完成。
- 支持两次只读预检后的 `--dry-run` plan preview，严格零写。
- 修复 AITable template search 的假热门模板声明、响应投影和 cursor 进度校验；保留 optional CLI/Schema 兼容面，但 omission/blank 在 MCP 前返回 typed validation。
- 将删除后精确 `BASE_NOT_FOUND` 窄映射为 `api/not_found`，不扩大到其他服务、工具或错误码。
- 机械更新公开 Shortcut Catalog 与生成 Skill 计数。

## 功能边界

该命令是 DingTalk-native AI 字段执行能力，只覆盖 Lark `field-extension-update-cells` 的受限子集；不提供 extension 安装/配置生命周期、多字段/整列范围或任务终态查询，因此不宣称 FULL parity。

## 验证

- Exact live E2E：9/9 confirmed。
  - template 两页 cursor 前进、stable ID 无重复及高熵零命中；
  - valid dry-run 与 non-AI negative 均零写；
  - 唯一一次 exact `+ai-field-run --yes` 返回严格 pending receipt；
  - continuation 可执行，stable-ID 读回观察到 AI 值非空且源字段不变；
  - 临时 Base 唯一删除，typed NotFound 与穷尽搜索共同确认零残留。
- 最新 `origin/main` rebase 无冲突；range-diff 显示功能补丁等价。
- `make policy` PASS（31 products / 1371 tools；1666 Agent examples）。
- `DWS_PACKAGE_VERSION=0.0.0-test go test ./... -count=1` PASS。
- Native changed-code coverage：380/380，100%。
- Interface Integrity、Schema Compatibility、生成漂移、runtime confirmation、Schema Catalog 均 PASS。
- staticcheck 与基线均为 81 条历史诊断，本变更新增 0。

## 交付说明

审计报告、原始 E2E 响应和业务缺口文档均保留在仓库外，未进入本 PR。