### PR TITLE
fix: scope pre-commit checks to staged changes

### DIFF
--- a/.changes/fix-precommit-staged-scope.md
+++ b/.changes/fix-precommit-staged-scope.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Local commits** — the opt-in pre-commit hook now checks only staged whitespace and Go formatting, so unrelated repository-wide lint debt no longer blocks contributors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,11 @@ Select the PR risk tier before choosing checks:
 | Standard | Ordinary implementation work with a stable package graph | Focused unit/integration tests and observable behavior for the changed path | Race tests for changed packages and their reverse dependencies, scope-matched HEAD/base coverage, and representative Darwin/Windows compilation |
 | High-risk | Workflow/policy, package graph, generated Schema/registry, platform, auth/keychain, installer, packaging, release, transport, recovery, or an unprovable infrastructure change | Relevant full or domain suite plus focused behavior evidence | Complete race suite, native platform tests, and all affected domain gates; protected `main` uses this tier unless an exact two-parent merge can reuse a complete, base-owned PR admission |
 
+Repository Git hooks are opt-in through `make setup-hooks`. The pre-commit hook
+checks staged whitespace and staged Go formatting only. It reads the Git index,
+does not modify the working tree, and does not run repository-wide lint, build,
+or test commands. Run the change-specific checks above before opening a PR.
+
 Classification fails closed: an incomplete diff, package add/remove/rename, or
 uncertain dependency graph selects the high-risk suite. Native changed-code
 coverage is additionally selected for platform-sensitive code.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GO_SOURCE_LIST = git ls-files -z --cached --others --exclude-standard -- '*.go'
 
 .PHONY: all help build check-safechat test-safechat rebuild test test-plan test-auth-legacy-compat shortcut-public-e2e-proof lint format-check fmt policy edition-test interface-integrity authoritative-interface-integrity coverage-gate coverage-gate-platform update-interface-baseline reset-interface-baseline schema-compatibility skill-command-integrity skill-context-budget multi-im-skill-chain-integrity cli-smoke mock-mcp-smoke test-schema-agent-examples generate-schema fetch-mcp-metadata generate-schema-catalog package release release-pre release-stable changelog-pre changelog-stable publish-homebrew-formula setup-hooks
 
-all: setup-hooks fmt lint build test rebuild
+all: fmt lint build test rebuild
 
 help:
 	@printf "Available targets:\n"
@@ -26,6 +26,7 @@ help:
 	@printf "  make lint          - Run formatting checks, go vet, and staticcheck\n"
 	@printf "  make format-check  - Check all repository Go source files with gofmt\n"
 	@printf "  make fmt           - Format all repository Go source files\n"
+	@printf "  make setup-hooks   - Opt in to staged-only repository Git hooks\n"
 	@printf "  make policy        - Check the built dws plus open-source and Schema policies\n"
 	@printf "  make interface-integrity [BASE_REF=<ref>] [STABLE_REF=<tag>] [CANDIDATE_REF=<ref>] - Check authoritative CLI history\n"
 	@printf "  make authoritative-interface-integrity BASE_REF=<ref> [STABLE_REF=<tag>] [CANDIDATE_REF=<ref>] - Check Git-owned CLI history\n"
@@ -250,7 +251,8 @@ publish-homebrew-formula:
 	@./scripts/release/publish-homebrew-formula.sh
 
 setup-hooks:
-	@git config core.hooksPath scripts/hooks 2>/dev/null || true
+	@git config core.hooksPath scripts/hooks
+	@printf '%s\n' 'Enabled staged-only repository Git hooks.'
 
 changelog-pre:
 	@test -n "$(VERSION)" || (printf 'VERSION is required, e.g. v1.2.3-beta.1\n' >&2; exit 2)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,7 @@ These repo-local entrypoints are the supported shell entrypoints for building, t
 - `make lint`: run the repository-wide format check, `go vet`, and required `staticcheck`
 - `make format-check`: check every tracked or non-ignored untracked repository Go source file with `gofmt`
 - `make fmt`: format every tracked or non-ignored untracked repository Go source file
+- `make setup-hooks`: opt in to Git hooks that check staged whitespace and staged Go formatting without modifying the working tree
 - `make policy`: reuse the current `dws` binary and run the complete policy suite (`make build` first)
 - `make package`: build all release artifacts locally
 - `make release-pre VERSION=vX.Y.Z-beta.N`: validate a prerelease (`PUBLISH=1` pushes its tag)
@@ -20,7 +21,7 @@ Script groups:
 - CI package and coverage plan: `./scripts/ci/test-packages.sh`,
   `./scripts/ci/run-coverage-shard.sh`, `./scripts/ci/run-full-coverage.sh`,
   `./scripts/ci/merge-coverage-profiles.sh`
-- Dev helpers: `./scripts/dev/build.sh`, `./scripts/dev/lint.sh`, `./scripts/dev/ci-local.sh`, `./scripts/dev/run-mock-e2e.sh`, `./scripts/dev/coverage.sh`
+- Dev helpers: `./scripts/dev/build.sh`, `./scripts/dev/lint.sh`, `./scripts/dev/check-staged-commit.sh`, `./scripts/dev/ci-local.sh`, `./scripts/dev/run-mock-e2e.sh`, `./scripts/dev/coverage.sh`
 - Policy checks: `./scripts/policy/check-generated-drift.sh`, `./scripts/policy/check-command-surface.sh`, `./scripts/policy/check-command-compatibility.sh --base-ref <main-ref> --stable-ref <latest-GA-tag> --candidate-ref <candidate-sha>`, `./scripts/policy/check-schema-catalog.sh`, `./scripts/policy/check-schema-binary.sh`, `./scripts/policy/check-open-source-assets.sh`
 - Policy runtime files: set `DWS_POLICY_TMPDIR` to override the default `.worktrees/policy-tmp` workspace
 - Release entrypoint and contract: `./scripts/release/release.sh`, `./scripts/release/release-contract.sh`; operator guide: [`docs/releasing.md`](../docs/releasing.md)

--- a/scripts/dev/check-staged-commit.sh
+++ b/scripts/dev/check-staged-commit.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+printf '%s\n' 'Running staged pre-commit checks...'
+
+# This reads only the index and reports whitespace errors without changing files.
+git diff --cached --check
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/dws-pre-commit.XXXXXX")
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+staged_go_files="$work_dir/staged-go-files"
+git diff --cached --name-only --diff-filter=ACMR -z -- '*.go' >"$staged_go_files"
+
+if [ ! -s "$staged_go_files" ]; then
+	printf '%s\n' 'Staged pre-commit checks passed.'
+	exit 0
+fi
+
+if ! command -v gofmt >/dev/null 2>&1; then
+	printf '%s\n' 'gofmt is required to check staged Go files.' >&2
+	exit 1
+fi
+
+if ! xargs -0 sh -c '
+	work_dir=$1
+	shift
+	failed=0
+	for path do
+		original="$work_dir/original"
+		formatted="$work_dir/formatted"
+		if ! git show ":$path" >"$original"; then
+			printf "Unable to read staged Go file: %s\n" "$path" >&2
+			failed=1
+			continue
+		fi
+		if ! gofmt <"$original" >"$formatted"; then
+			printf "Unable to format staged Go file: %s\n" "$path" >&2
+			failed=1
+			continue
+		fi
+		if ! cmp -s "$original" "$formatted"; then
+			printf "%s\n" "$path" >&2
+			failed=1
+		fi
+	done
+	exit "$failed"
+' sh "$work_dir" <"$staged_go_files"; then
+	printf '%s\n' 'Staged Go files are not formatted. Run gofmt, then stage them again.' >&2
+	exit 1
+fi
+
+printf '%s\n' 'Staged pre-commit checks passed.'

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/sh
-# Pre-commit hook: run make to ensure lint + tests pass before committing.
+# Pre-commit hook: validate staged content without modifying the working tree.
 
-echo "Running pre-commit checks (make)..."
-make
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "$script_dir/../dev/check-staged-commit.sh"

--- a/test/scripts/pre_commit_hook_test.go
+++ b/test/scripts/pre_commit_hook_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPreCommitChecksOnlyStagedContent(t *testing.T) {
+	repository := newPreCommitFixture(t)
+	script := preCommitScriptPath(t)
+
+	writePreCommitFixture(t, filepath.Join(repository, "legacy.go"), "package fixture\nfunc legacy( ){ }\n")
+	writePreCommitFixture(t, filepath.Join(repository, "README.md"), "staged documentation change\n")
+	runPreCommitGit(t, repository, "add", "README.md")
+
+	output, err := runPreCommitCheck(repository, script)
+	if err != nil {
+		t.Fatalf("staged-only check rejected an unrelated unstaged Go file: %v\n%s", err, output)
+	}
+}
+
+func TestPreCommitRejectsStagedUnformattedGoWithoutModifyingIt(t *testing.T) {
+	repository := newPreCommitFixture(t)
+	script := preCommitScriptPath(t)
+	path := filepath.Join(repository, "feature.go")
+	content := "package fixture\nfunc feature( ){ }\n"
+	writePreCommitFixture(t, path, content)
+	runPreCommitGit(t, repository, "add", "feature.go")
+
+	output, err := runPreCommitCheck(repository, script)
+	if err == nil {
+		t.Fatalf("staged-only check accepted unformatted Go source:\n%s", output)
+	}
+	if !strings.Contains(output, "feature.go") {
+		t.Fatalf("failure does not identify the staged file:\n%s", output)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read staged Go source: %v", readErr)
+	}
+	if string(got) != content {
+		t.Fatalf("pre-commit check modified the working tree:\nwant: %q\n got: %q", content, got)
+	}
+}
+
+func TestPreCommitUsesIndexForPartiallyStagedGoFile(t *testing.T) {
+	repository := newPreCommitFixture(t)
+	script := preCommitScriptPath(t)
+	path := filepath.Join(repository, "feature.go")
+	writePreCommitFixture(t, path, "package fixture\n\nfunc feature() {}\n")
+	runPreCommitGit(t, repository, "add", "feature.go")
+	writePreCommitFixture(t, path, "package fixture\nfunc feature( ){ }\n")
+
+	output, err := runPreCommitCheck(repository, script)
+	if err != nil {
+		t.Fatalf("check inspected unstaged content instead of the index: %v\n%s", err, output)
+	}
+}
+
+func TestPreCommitRejectsStagedWhitespaceErrors(t *testing.T) {
+	repository := newPreCommitFixture(t)
+	script := preCommitScriptPath(t)
+	writePreCommitFixture(t, filepath.Join(repository, "notes.txt"), "trailing whitespace   \n")
+	runPreCommitGit(t, repository, "add", "notes.txt")
+
+	output, err := runPreCommitCheck(repository, script)
+	if err == nil {
+		t.Fatalf("staged-only check accepted a whitespace error:\n%s", output)
+	}
+	if !strings.Contains(output, "trailing whitespace") {
+		t.Fatalf("failure does not explain the whitespace error:\n%s", output)
+	}
+}
+
+func TestPreCommitHookIsOptInAndDoesNotRunMake(t *testing.T) {
+	root := preCommitRepositoryRoot(t)
+	makefile, err := os.ReadFile(filepath.Join(root, "Makefile"))
+	if err != nil {
+		t.Fatalf("read Makefile: %v", err)
+	}
+	for _, line := range strings.Split(string(makefile), "\n") {
+		if strings.HasPrefix(line, "all:") && strings.Contains(line, "setup-hooks") {
+			t.Fatalf("default make target must not install repository hooks: %s", line)
+		}
+	}
+
+	hook, err := os.ReadFile(filepath.Join(root, "scripts", "hooks", "pre-commit"))
+	if err != nil {
+		t.Fatalf("read pre-commit hook: %v", err)
+	}
+	if strings.Contains(string(hook), "\nmake") {
+		t.Fatalf("pre-commit hook must not run the repository-wide make target:\n%s", hook)
+	}
+	if !strings.Contains(string(hook), "check-staged-commit.sh") {
+		t.Fatalf("pre-commit hook does not delegate to the staged-only check:\n%s", hook)
+	}
+}
+
+func newPreCommitFixture(t *testing.T) string {
+	t.Helper()
+	repository := t.TempDir()
+	runPreCommitGit(t, repository, "init", "--quiet")
+	runPreCommitGit(t, repository, "config", "user.name", "Pre-commit Test")
+	runPreCommitGit(t, repository, "config", "user.email", "pre-commit@example.com")
+	writePreCommitFixture(t, filepath.Join(repository, "legacy.go"), "package fixture\n\nfunc legacy() {}\n")
+	writePreCommitFixture(t, filepath.Join(repository, "README.md"), "initial\n")
+	runPreCommitGit(t, repository, "add", ".")
+	runPreCommitGit(t, repository, "commit", "--quiet", "-m", "initial")
+	return repository
+}
+
+func preCommitScriptPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(preCommitRepositoryRoot(t), "scripts", "dev", "check-staged-commit.sh")
+}
+
+func preCommitRepositoryRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+	return root
+}
+
+func writePreCommitFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func runPreCommitGit(t *testing.T, repository string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = repository
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}
+
+func runPreCommitCheck(repository, script string) (string, error) {
+	command := exec.Command("sh", script)
+	command.Dir = repository
+	output, err := command.CombinedOutput()
+	return string(output), err
+}


### PR DESCRIPTION
## 问题

仓库 pre-commit hook 当前直接运行默认 make 目标，因此一次本地提交会执行全仓格式化、lint、构建和测试。默认 make 还会静默配置 core.hooksPath，导致不同业务线的未触及存量代码和本机 staticcheck 版本差异阻塞提交，而 GitHub CI 当前并不执行 staticcheck。

## 修复

- pre-commit 只读取 Git 暂存区，检查 staged whitespace 和 staged Go formatting
- hook 不修改工作区，并正确处理同一文件的部分暂存场景
- 从默认 make 目标移除隐式 setup-hooks；make setup-hooks 继续作为显式 opt-in
- 保留显式 make lint 的全仓语义，不降低仓库质量门禁
- 补充贡献文档、脚本文档和 release fragment

## 验证

- go test ./test/scripts -run ^TestPreCommit -count=1
- go test ./test/scripts -count=1 -timeout=20m：通过，327.350s
- scripts/hooks/pre-commit：通过真实暂存区检查
- ./scripts/policy/check-release-fragments.sh origin/main HEAD
- git diff --check origin/main...HEAD

## 风险与回滚

风险等级：High-risk（Makefile 和开发脚本）。变更不涉及产品运行时代码、CLI 接口、构建产物或发布工作流。若需回滚，可整体 revert 本提交，恢复原 hook 行为。