### PR TITLE
feat(chat): support third-party message decrypt for read shortcuts

### DIFF
--- a/.changes/1318-chat-shortcut-decrypt.md
+++ b/.changes/1318-chat-shortcut-decrypt.md
@@ -1,0 +1,26 @@
+---
+category: Changed
+---
+
+- **Chat read shortcuts decrypt third-party messages** (#1318) — the
+  policy-driven DingTalk + SafeChat message decryption previously limited to
+  the atomic read commands is now applied by the smart-layer read shortcuts
+  `chat +chat-messages`, `chat +at-me`, `chat +search-msg` and
+  `chat +thread-replies` as well. Decrypted rows return plaintext in `text`
+  and carry the per-row markers `contentDecrypted`, `cryptoLayer` and
+  `dingKeyVersion`, matching the atomic commands.
+- **Additive decrypt ledger** — these shortcuts now publish the same
+  top-level ledger as the atomic commands: the four counters
+  `decryptCandidateCount` (candidates before policy filtering),
+  `decryptAllowedCount`, `decryptedCount` and `decryptFailedCount`, plus the
+  per-message `decryptFailures[]` entries and `partial=true` when any failure
+  is recorded. The counters appear whenever the decrypt pipeline runs, even
+  as zeros when no candidate message exists.
+- **Forwarded nested messages are decrypted** — encrypted sub-messages nested
+  under `forwardMessages` are now decrypted too, with the plaintext written
+  back to the `content` key of regular messages and the `text` key of
+  forwarded children.
+- **Atomic decrypt failure records are itemized** — when a batch decrypt hits
+  a transport error on the atomic read commands, one failure entry with the
+  message's `messageId` and `conversationId` is recorded per message instead
+  of a single entry without IDs.

--- a/docs/shortcut-handoff.md
+++ b/docs/shortcut-handoff.md
@@ -221,3 +221,29 @@ DWS_USAGE_TRACKING=0 dws contact +search-user --query <名>   # 投影输出示�
 ## 9. 未提交提醒
 
 所有工作在 `feature/shortcut`，**未 commit**。建议尽快分语义化 commit 留存（框架 / 511封装 / smart层 / 保真度升级 / P2 / 文档）。
+
+---
+
+## 10. 三方密文消息解密（2026-09-07 T9 文档同步）
+
+> 分支 `feat/86480181-im-shortcut-msg-decrypt`。三方消息解密已与原子命令同层接线，本节是后续会话/维护者的速查入口。
+
+### 已接解密命令清单（3→7）
+
+| 层 | 命令 | 备注 |
+|---|---|---|
+| 已有（chat 包） | `dws chat +messages-list` / `+messages-list-direct` / `+messages-mget` | 早前批次已接；`+messages-list-direct` 的 `--page-all` 全量聚合后统一解密 |
+| 新增（smart 包） | `dws chat +chat-messages` / `+at-me` / `+search-msg` / `+thread-replies` | b404f111 接线；`+chat-messages` 的 `--page-all` 聚合后统一解密；`+at-me` / `+thread-replies` 单页与自动分页聚合两路径均已接线 |
+
+原子命令先行支持：`dws chat message list` / `list-all` / `search` 等 helpers 投影读命令。
+
+### 行为与契约
+
+- **策略驱动自动生效**：`-tags safechat` 构建且组织开启三方消息解密策略时自动解密，**不新增任何 flag**（命令面零变化）；策略判定按会话缓存（TTL），候选收集递归 `forwardMessages` 子消息。
+- **门控跳过**：非 safechat 构建、解密后端不可用、`--dry-run` 时整段跳过——零策略调用、零解密字段，输出与接线前一致。
+- **ledger 字段与原子命令对齐**（输出顶层）：`decryptCandidateCount` / `decryptAllowedCount` / `decryptedCount` / `decryptFailedCount` / `decryptFailures`（逐条含 `stage="message-decrypt"`、`messageId`、`conversationId`、`reason`），有失败时 `partial=true`。解密管线运行时四计数恒出现（无候选即全零）；门控跳过时不出现。`reason` 例：`policy_disabled`（组织策略未放行该会话）、`empty_plaintext`、策略/后端调用错误文本。
+- **失败行 text=原密文**：解密失败或策略禁用的消息行，投影 `text` 恢复为原密文（而非 marker），便于直接取 `text` 走排障入口；单条失败不影响其它消息与退出码。
+- **解密成功行**：`text`=明文，并带逐条标记 `contentDecrypted=true`、`cryptoLayer="ding+safechat"`、`dingKeyVersion`（仅 >0 时出现）。三标记是运行时 ledger/调试字段，**不纳入** `messageResultContractV1.MessageFields`（MINOR-2 显式处置：沿用 Schema 零变化裁决，仅文档表述，不进契约声明面）。
+- **两层投影残差声明**（架构报告 §3.3）：解密未发生时，原子行同时含 `content`（密文）与 `text`（marker「[加密消息，无法解码]」）；shortcut 投影行仅 `text`（失败时恢复为原密文）。两层投影形状本就不同，接受该残差，跨层比对以 ledger 为准。
+- **排障入口**：`dws chat crypto decrypt --text <ciphertext> --format json` 手工解密单条密文。
+- **构建前提**：`-tags safechat`；默认构建零解密行为。

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
-	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/output"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/chatmsg"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/targetresolver"
@@ -307,144 +306,11 @@ func projectChatMessagesPayloadWithLedger(data map[string]any, search bool, ledg
 }
 
 func decryptProjectedChatMessagesByPolicy(cmd *cobra.Command, items []map[string]any) map[string]any {
-	if cmd == nil || commandBoolFlag(cmd, "dry-run") ||
-		chatCryptoClient == nil || chatCryptoClient.BackendReady == nil || !chatCryptoClient.BackendReady() {
+	if cmd == nil || commandBoolFlag(cmd, "dry-run") {
 		return nil
 	}
-	batchItems := make([]messagecrypto.BatchDecryptItem, 0)
-	for _, item := range items {
-		messageID := strings.TrimSpace(fmt.Sprint(chatmsg.MessageID(item)))
-		if messageID == "" || messageID == "<nil>" {
-			continue
-		}
-		content := strings.TrimSpace(fmt.Sprint(firstChatMapValue(item, "content", "text")))
-		if chatmsg.IsEncrypted(content) {
-			conversationID := strings.TrimSpace(fmt.Sprint(chatmsg.ConversationID(item)))
-			if conversationID == "<nil>" {
-				conversationID = ""
-			}
-			batchItems = append(batchItems, messagecrypto.BatchDecryptItem{
-				MessageID:      messageID,
-				ConversationID: conversationID,
-				Ciphertext:     content,
-			})
-		}
-	}
-	decryptCandidateCount := len(batchItems)
-	batchItems, policyFailures := filterProjectedDecryptItemsByPolicy(cmd, batchItems)
-	ledger := map[string]any{
-		"decryptCandidateCount": decryptCandidateCount,
-		"decryptAllowedCount":   len(batchItems),
-		"decryptedCount":        0,
-		"decryptFailedCount":    len(policyFailures),
-	}
-	if len(policyFailures) > 0 {
-		ledger["decryptFailures"] = policyFailures
-		ledger["partial"] = true
-	}
-	if len(batchItems) == 0 {
-		return ledger
-	}
-	result, err := chatCryptoClient.BatchDecryptInbound(cmd.Context(), chatCryptoRuntime{cmd: cmd}, messagecrypto.Options{}, batchItems)
-	if err != nil {
-		failures := append([]map[string]any{}, policyFailures...)
-		failures = append(failures, map[string]any{"stage": "message-decrypt", "reason": err.Error()})
-		ledger["decryptFailedCount"] = len(failures)
-		ledger["decryptFailures"] = failures
-		ledger["partial"] = true
-		return ledger
-	}
-	byID := map[string][]map[string]any{}
-	for _, item := range items {
-		messageID := strings.TrimSpace(fmt.Sprint(chatmsg.MessageID(item)))
-		if messageID != "" && messageID != "<nil>" {
-			byID[messageID] = append(byID[messageID], item)
-		}
-	}
-	decryptedCount := 0
-	failures := make([]map[string]any, 0)
-	for _, item := range result.Items {
-		if item.Status != "" && item.Status != "success" {
-			failures = append(failures, chatDecryptFailure(item.MessageID, item.ConversationID, item.Reason))
-			continue
-		}
-		if strings.TrimSpace(item.PlaintextContent) == "" {
-			failures = append(failures, chatDecryptFailure(item.MessageID, item.ConversationID, "empty_plaintext"))
-			continue
-		}
-		for _, message := range byID[item.MessageID] {
-			message["content"] = item.PlaintextContent
-			message["contentDecrypted"] = true
-			message["cryptoLayer"] = "ding+safechat"
-			if item.KeyVersion > 0 {
-				message["dingKeyVersion"] = item.KeyVersion
-			}
-		}
-		decryptedCount++
-	}
-	for _, item := range result.Failures {
-		failures = append(failures, chatDecryptFailure(item.MessageID, item.ConversationID, item.Reason))
-	}
-	failures = append(policyFailures, failures...)
-	ledger["decryptedCount"] = decryptedCount
-	ledger["decryptFailedCount"] = len(failures)
-	if len(failures) > 0 {
-		ledger["decryptFailures"] = failures
-		ledger["partial"] = true
-	}
-	return ledger
-}
-
-func filterProjectedDecryptItemsByPolicy(cmd *cobra.Command, items []messagecrypto.BatchDecryptItem) ([]messagecrypto.BatchDecryptItem, []map[string]any) {
-	filtered := make([]messagecrypto.BatchDecryptItem, 0, len(items))
-	failures := make([]map[string]any, 0)
-	for _, item := range items {
-		decision, err := chatCryptoClient.PolicyDecision(cmd.Context(), chatCryptoRuntime{cmd: cmd}, messagecrypto.Options{
-			Identity:           "user",
-			MsgType:            "text",
-			OpenConversationID: item.ConversationID,
-		})
-		if err != nil {
-			failures = append(failures, chatDecryptFailure(item.MessageID, item.ConversationID, err.Error()))
-			continue
-		}
-		if !decision.Enabled {
-			failures = append(failures, chatDecryptFailure(item.MessageID, item.ConversationID, "policy_disabled"))
-			continue
-		}
-		filtered = append(filtered, item)
-	}
-	return filtered, failures
-}
-
-func chatDecryptFailure(messageID, conversationID, reason string) map[string]any {
-	failure := map[string]any{
-		"stage":     "message-decrypt",
-		"messageId": strings.TrimSpace(messageID),
-		"reason":    firstNonEmptyLiteral(reason, "decrypt_failed"),
-	}
-	if strings.TrimSpace(conversationID) != "" {
-		failure["conversationId"] = strings.TrimSpace(conversationID)
-	}
-	return failure
-}
-
-func firstChatMapValue(message map[string]any, keys ...string) any {
-	for _, key := range keys {
-		if value, ok := message[key]; ok {
-			return value
-		}
-	}
-	return nil
-}
-
-func firstNonEmptyLiteral(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
+	return chatmsg.DecryptMessagesByPolicy(cmd.Context(), chatCryptoRuntime{cmd: cmd},
+		chatmsg.MessageDecryptClient(), items, chatmsg.DecryptOptions{})
 }
 
 func projectExistingChatMessageCollections(data map[string]any) map[string]any {

--- a/internal/helpers/chat_crypto_command.go
+++ b/internal/helpers/chat_crypto_command.go
@@ -14,18 +14,15 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/chatmsg"
 	"github.com/spf13/cobra"
 )
 
-var chatCryptoClient = messagecrypto.DefaultClient()
-
-// SetChatCryptoClient injects the app-owned SafeChat/Ding crypto client.
+// SetChatCryptoClient injects the app-owned SafeChat/Ding crypto client into
+// the shared chatmsg store. Reading always goes through chatmsg so the atomic
+// commands and the shortcuts share one client and one policy cache.
 func SetChatCryptoClient(client *messagecrypto.Client) {
-	if client == nil {
-		chatCryptoClient = messagecrypto.DefaultClient()
-		return
-	}
-	chatCryptoClient = client
+	chatmsg.SetMessageDecryptClient(client)
 }
 
 type chatCryptoRuntime struct {
@@ -117,7 +114,7 @@ func runChatCryptoDecrypt(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	layer, _ := cmd.Flags().GetString("layer")
-	result, err := chatCryptoClient.DecryptInbound(cmd.Context(), chatCryptoRuntime{cmd: cmd}, messagecrypto.Options{
+	result, err := chatmsg.MessageDecryptClient().DecryptInbound(cmd.Context(), chatCryptoRuntime{cmd: cmd}, messagecrypto.Options{
 		Layer:      layer,
 		Ciphertext: string(ciphertext),
 	})

--- a/internal/helpers/chat_crypto_command_test.go
+++ b/internal/helpers/chat_crypto_command_test.go
@@ -14,17 +14,18 @@ import (
 	"testing"
 
 	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/chatmsg"
 	"github.com/spf13/cobra"
 )
 
 func TestCrossPlatformCoverageChatCryptoCommand(t *testing.T) {
-	old := chatCryptoClient
-	t.Cleanup(func() { chatCryptoClient = old })
+	old := chatmsg.MessageDecryptClient()
+	t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
 
 	t.Run("set_nil_client_restores_default", func(t *testing.T) {
 		SetChatCryptoClient(nil)
-		if chatCryptoClient == nil || chatCryptoClient.PolicyCache == nil {
-			t.Fatalf("chatCryptoClient = %#v", chatCryptoClient)
+		if chatmsg.MessageDecryptClient() == nil || chatmsg.MessageDecryptClient().PolicyCache == nil {
+			t.Fatalf("chatCryptoClient = %#v", chatmsg.MessageDecryptClient())
 		}
 	})
 	t.Run("encrypt_command_is_not_registered", func(t *testing.T) {

--- a/internal/helpers/chat_message_page_all_test.go
+++ b/internal/helpers/chat_message_page_all_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/chatmsg"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
 
@@ -291,7 +292,7 @@ func TestCrossPlatformCoverageChatMessageListPageAllAggregatesAndDedups(t *testi
 }
 
 func TestCrossPlatformCoverageChatMessageListPageAllDecryptsAfterAggregation(t *testing.T) {
-	old := chatCryptoClient
+	old := chatmsg.MessageDecryptClient()
 	SetChatCryptoClient(&messagecrypto.Client{
 		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
 			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
@@ -302,7 +303,7 @@ func TestCrossPlatformCoverageChatMessageListPageAllDecryptsAfterAggregation(t *
 		BackendReady: func() bool { return true },
 		PolicyCache:  messagecrypto.NewPolicyCache(nil),
 	})
-	t.Cleanup(func() { chatCryptoClient = old })
+	t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
 
 	const cipher1 = "SwzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"
 	const cipher2 = "TWzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"

--- a/internal/helpers/im_read_result_contract_test.go
+++ b/internal/helpers/im_read_result_contract_test.go
@@ -287,7 +287,7 @@ func TestCrossPlatformCoverageChatMessageListProjectsStableFieldsAcrossEnvelopes
 }
 
 func TestCrossPlatformCoverageChatMessageListDecryptsEncryptedMessagesInBatch(t *testing.T) {
-	old := chatCryptoClient
+	old := chatmsg.MessageDecryptClient()
 	SetChatCryptoClient(&messagecrypto.Client{
 		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
 			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
@@ -298,7 +298,7 @@ func TestCrossPlatformCoverageChatMessageListDecryptsEncryptedMessagesInBatch(t 
 		BackendReady: func() bool { return true },
 		PolicyCache:  messagecrypto.NewPolicyCache(nil),
 	})
-	t.Cleanup(func() { chatCryptoClient = old })
+	t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
 
 	const cipher = "SwzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"
 	payload := `{"result":{"messages":[{"openMessageId":"msg-1","openConversationId":"cid","content":"` + cipher + `"}]}}`
@@ -331,8 +331,65 @@ func TestCrossPlatformCoverageChatMessageListDecryptsEncryptedMessagesInBatch(t 
 	}
 }
 
+func TestCrossPlatformCoverageChatMessageListDecryptsForwardedChildren(t *testing.T) {
+	old := chatmsg.MessageDecryptClient()
+	SetChatCryptoClient(&messagecrypto.Client{
+		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
+		},
+		OpenSession: func(context.Context, messagecrypto.SessionOptions) (*messagecrypto.Session, error) {
+			return &messagecrypto.Session{Cipher: imReadFakeCipher{}, CorpID: "corp-1", StaffID: "staff-1"}, nil
+		},
+		BackendReady: func() bool { return true },
+		PolicyCache:  messagecrypto.NewPolicyCache(nil),
+	})
+	t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
+
+	const cipher = "SwzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"
+	caller := &imReadResultCaller{responses: map[string]string{
+		"list_conversation_message_v2": `{"result":{"messages":[{"openMessageId":"root","openConversationId":"cid","content":"转发记录","forwardMessages":[{"openMessageId":"child-1","openConversationId":"cid","text":"` + cipher + `"}]}]}}`,
+		"get_message_crypto_policy":    `{"result":{"mode":"required"}}`,
+		"batch_ding_decrypt_messages":  `{"result":{"items":[{"messageId":"child-1","status":"success","plaintextContent":"子消息明文","keyVersion":4}]}}`,
+	}}
+	got, err := executeIMReadCommand(t, caller, []string{"dws", "chat"}, newChatCommand,
+		"message", "list", "--group", "cid", "--time", "2026-07-14 00:00:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(caller.calls, []imReadResultCall{
+		{productID: "chat", toolName: "list_conversation_message_v2"},
+		{productID: "im", toolName: "get_message_crypto_policy"},
+		{productID: "im", toolName: "batch_ding_decrypt_messages"},
+	}) {
+		t.Fatalf("calls = %#v", caller.calls)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(got), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["decryptCandidateCount"] != float64(1) || payload["decryptAllowedCount"] != float64(1) ||
+		payload["decryptedCount"] != float64(1) {
+		t.Fatalf("forwarded ledger = %#v", payload)
+	}
+	body, _ := payload["result"].(map[string]any)
+	messages, _ := body["messages"].([]any)
+	parent, _ := messages[0].(map[string]any)
+	forwarded, _ := parent["forwardMessages"].([]any)
+	child, _ := forwarded[0].(map[string]any)
+	// dingKeyVersion is not asserted: the atomic MCP path parses numbers as
+	// json.Number, which msgcrypto's intField does not recognize, so
+	// keyVersion never reaches the atomic write-back (pre-existing baseline).
+	if child["text"] != "子消息明文" || child["contentDecrypted"] != true ||
+		child["cryptoLayer"] != "ding+safechat" {
+		t.Fatalf("forwarded child = %#v", child)
+	}
+	if parent["content"] != "转发记录" {
+		t.Fatalf("parent plaintext changed: %#v", parent["content"])
+	}
+}
+
 func TestCrossPlatformCoverageChatMessageListSkipsCryptoWhenBackendUnavailable(t *testing.T) {
-	old := chatCryptoClient
+	old := chatmsg.MessageDecryptClient()
 	SetChatCryptoClient(&messagecrypto.Client{
 		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
 			t.Fatal("identity lookup must not run without the SafeChat backend")
@@ -341,7 +398,7 @@ func TestCrossPlatformCoverageChatMessageListSkipsCryptoWhenBackendUnavailable(t
 		BackendReady: func() bool { return false },
 		PolicyCache:  messagecrypto.NewPolicyCache(nil),
 	})
-	t.Cleanup(func() { chatCryptoClient = old })
+	t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
 
 	const encrypted = "SwzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"
 	caller := &imReadResultCaller{responses: map[string]string{
@@ -373,8 +430,8 @@ func TestCrossPlatformCoverageChatMessageListSkipsCryptoWhenBackendUnavailable(t
 }
 
 func TestCrossPlatformCoverageChatMessageListDecryptFailureLedgerEdges(t *testing.T) {
-	old := chatCryptoClient
-	t.Cleanup(func() { chatCryptoClient = old })
+	old := chatmsg.MessageDecryptClient()
+	t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
 
 	const encrypted = "SwzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"
 	t.Run("batch call failure degrades to ledger", func(t *testing.T) {
@@ -482,16 +539,6 @@ func TestCrossPlatformCoverageChatMessageListDecryptFailureLedgerEdges(t *testin
 		if got := projectChatMessagesPayload(map[string]any{"result": map[string]any{"messages": []any{}}}, false); got["messages"] == nil {
 			t.Fatalf("projected payload = %#v", got)
 		}
-		failure := chatDecryptFailure(" msg ", " cid ", "")
-		if failure["messageId"] != "msg" || failure["conversationId"] != "cid" || failure["reason"] != "decrypt_failed" {
-			t.Fatalf("failure = %#v", failure)
-		}
-		if got := firstNonEmptyLiteral("", " value "); got != "value" {
-			t.Fatalf("firstNonEmptyLiteral = %q", got)
-		}
-		if got := firstNonEmptyLiteral("", " "); got != "" {
-			t.Fatalf("firstNonEmptyLiteral empty = %q", got)
-		}
 	})
 
 	t.Run("legacy flags and policy failure helpers", func(t *testing.T) {
@@ -556,8 +603,8 @@ func TestCrossPlatformCoverageChatMessageListDecryptFailureLedgerEdges(t *testin
 			t.Fatal("promoting non-string legacy flag should fail")
 		}
 
-		old := chatCryptoClient
-		t.Cleanup(func() { chatCryptoClient = old })
+		old := chatmsg.MessageDecryptClient()
+		t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
 		cmd = &cobra.Command{}
 		cmd.Flags().Bool("dry-run", false, "")
 		SetChatCryptoClient(&messagecrypto.Client{
@@ -585,8 +632,8 @@ func TestCrossPlatformCoverageChatMessageListDecryptFailureLedgerEdges(t *testin
 	})
 
 	t.Run("safechat failure and string key version branches", func(t *testing.T) {
-		old := chatCryptoClient
-		t.Cleanup(func() { chatCryptoClient = old })
+		old := chatmsg.MessageDecryptClient()
+		t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
 		cmd := &cobra.Command{}
 		cmd.Flags().Bool("dry-run", false, "")
 

--- a/internal/shortcut/chat/chat_message.go
+++ b/internal/shortcut/chat/chat_message.go
@@ -14,7 +14,6 @@
 package chat
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,15 +27,12 @@ import (
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/corecmd/contract"
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
-	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto"
-	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/chatmsg"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/targetresolver"
 )
 
 const directMessagesHardPageLimit = 500
-const messageDecryptFailedOriginalContentKey = "_contentDecryptFailedOriginal"
 
 // MessagesSend sends a text/markdown message as the current user
 // (send_personal_message, chat server). Media/file variants are not covered.
@@ -323,10 +319,11 @@ var MessagesList = shortcut.Shortcut{
 			return err
 		}
 		rawMessages := listMessagesResolveMaps(data)
-		decryptLedger := decryptMessageItemsIfRequested(rt, rawMessages)
+		decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+			chatmsg.MessageDecryptClient(), rawMessages, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 		messages := projectMessageMapsWithReactions(rawMessages, !rt.Bool("no-reactions"))
 		payload := map[string]any{"count": len(messages), "messages": messages}
-		applyMessageDecryptLedger(payload, decryptLedger)
+		chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 		direction := "older"
 		if rt.Bool("forward") {
 			direction = "newer"
@@ -384,9 +381,6 @@ func listMessageProjectOne(m map[string]any) map[string]any {
 
 func listMessageProjectOneWithReactions(m map[string]any, includeReactions bool) map[string]any {
 	row := chatmsg.ProjectMessageV1(m, includeReactions)
-	if original, ok := m[messageDecryptFailedOriginalContentKey].(string); ok && strings.TrimSpace(original) != "" {
-		row["text"] = original
-	}
 	// The established mget/list projection omits absent scalar fields; keep
 	// that wire behavior even though the shared chat/search view retains them.
 	for _, key := range []string{"sender", "text", "createTime"} {
@@ -438,248 +432,6 @@ func listMessagesResolveMaps(data map[string]any) []map[string]any {
 		}
 	}
 	return out
-}
-
-type messageDecryptLedger struct {
-	candidateCount int
-	decryptedCount int
-	failures       []map[string]any
-}
-
-var messageReadCryptoClient = newMessageReadCryptoClient()
-
-var (
-	messageReadCurrentIdentity = msgcrypto.CurrentIdentity
-	messageReadOpenSession     = msgcrypto.OpenSession
-	messageReadAvailable       = msgcrypto.Available
-)
-
-func newMessageReadCryptoClient() *messagecrypto.Client {
-	return &messagecrypto.Client{
-		Identity: func(ctx context.Context, configDir string) (messagecrypto.Identity, error) {
-			identity, err := messageReadCurrentIdentity(ctx, configDir)
-			return messagecrypto.Identity{CorpID: identity.CorpID, StaffID: identity.StaffID}, err
-		},
-		OpenSession: func(ctx context.Context, opts messagecrypto.SessionOptions) (*messagecrypto.Session, error) {
-			session, err := messageReadOpenSession(ctx, msgcrypto.SessionOptions{
-				ConfigDir:           opts.ConfigDir,
-				CLIVersion:          opts.CLIVersion,
-				KeyServer:           firstNonEmptyShortcutString(opts.KeyServer, msgcrypto.DefaultSafeChatKeyServer),
-				AllowedRedirectHost: firstNonEmptyShortcutString(opts.AllowedRedirectHost, msgcrypto.DefaultSafeChatRedirectHost),
-				KeystoreDir:         opts.KeystoreDir,
-			})
-			if err != nil {
-				return nil, err
-			}
-			return &messagecrypto.Session{
-				Cipher:  session.Cipher,
-				CorpID:  session.CorpID,
-				StaffID: session.StaffID,
-				Close:   session.Close,
-			}, nil
-		},
-		BackendReady: messageReadAvailable,
-		PolicyCache:  messagecrypto.NewPolicyCache(time.Now),
-	}
-}
-
-func decryptMessageItemsIfRequested(rt *shortcut.RuntimeContext, messages []map[string]any) messageDecryptLedger {
-	if rt.DryRun() || messageReadCryptoClient == nil || messageReadCryptoClient.BackendReady == nil ||
-		!messageReadCryptoClient.BackendReady() {
-		return messageDecryptLedger{}
-	}
-	items := collectEncryptedMessageItems(messages)
-	if len(items) == 0 {
-		return messageDecryptLedger{}
-	}
-	filtered, ledger := filterMessageDecryptItemsByPolicy(rt, items)
-	if len(filtered) == 0 {
-		markMessageDecryptFailures(messages, ledger.failures)
-		return ledger
-	}
-	result, err := messageReadCryptoClient.BatchDecryptInbound(rt.Command().Context(), rt, messagecrypto.Options{}, filtered)
-	if err != nil {
-		for _, item := range filtered {
-			ledger.failures = append(ledger.failures, messageDecryptFailure(item.MessageID, item.ConversationID, err.Error()))
-		}
-		markMessageDecryptFailures(messages, ledger.failures)
-		return ledger
-	}
-	index := indexMessageMapsByID(messages)
-	for _, item := range result.Items {
-		if item.Status != "" && item.Status != "success" {
-			ledger.failures = append(ledger.failures, messageDecryptFailure(item.MessageID, item.ConversationID, item.Reason))
-			continue
-		}
-		if strings.TrimSpace(item.PlaintextContent) == "" {
-			ledger.failures = append(ledger.failures, messageDecryptFailure(item.MessageID, item.ConversationID, "empty_plaintext"))
-			continue
-		}
-		for _, message := range index[item.MessageID] {
-			message["content"] = item.PlaintextContent
-			message["contentDecrypted"] = true
-			message["cryptoLayer"] = "ding+safechat"
-			if item.KeyVersion > 0 {
-				message["dingKeyVersion"] = item.KeyVersion
-			}
-		}
-		ledger.decryptedCount++
-	}
-	for _, item := range result.Failures {
-		ledger.failures = append(ledger.failures, messageDecryptFailure(item.MessageID, item.ConversationID, item.Reason))
-	}
-	markMessageDecryptFailures(messages, ledger.failures)
-	return ledger
-}
-
-func filterMessageDecryptItemsByPolicy(
-	rt *shortcut.RuntimeContext,
-	items []messagecrypto.BatchDecryptItem,
-) ([]messagecrypto.BatchDecryptItem, messageDecryptLedger) {
-	filtered := make([]messagecrypto.BatchDecryptItem, 0, len(items))
-	ledger := messageDecryptLedger{candidateCount: len(items)}
-	for _, item := range items {
-		decision, err := messageReadCryptoClient.PolicyDecision(rt.Command().Context(), rt, messagecrypto.Options{
-			Identity:           "user",
-			MsgType:            "text",
-			OpenConversationID: item.ConversationID,
-		})
-		if err != nil {
-			ledger.failures = append(ledger.failures, messageDecryptFailure(item.MessageID, item.ConversationID, err.Error()))
-			continue
-		}
-		if decision.Enabled {
-			filtered = append(filtered, item)
-		}
-	}
-	ledger.candidateCount = len(filtered)
-	return filtered, ledger
-}
-
-func collectEncryptedMessageItems(messages []map[string]any) []messagecrypto.BatchDecryptItem {
-	items := make([]messagecrypto.BatchDecryptItem, 0)
-	var walk func(map[string]any)
-	walk = func(message map[string]any) {
-		messageID := strings.TrimSpace(fmt.Sprint(chatmsg.MessageID(message)))
-		if messageID == "" || messageID == "<nil>" {
-			messageID = strings.TrimSpace(fmt.Sprint(firstMessageDecryptValue(message, "openMessageId", "messageId", "msgId")))
-		}
-		conversationID := strings.TrimSpace(fmt.Sprint(chatmsg.ConversationID(message)))
-		if conversationID == "<nil>" {
-			conversationID = ""
-		}
-		content := firstMessageDecryptString(message, "content", "text")
-		if messageID != "" && chatmsg.IsEncrypted(content) {
-			items = append(items, messagecrypto.BatchDecryptItem{
-				MessageID:      messageID,
-				ConversationID: conversationID,
-				Ciphertext:     content,
-			})
-		}
-		if forwarded, ok := message["forwardMessages"].([]any); ok {
-			for _, item := range forwarded {
-				if child, ok := item.(map[string]any); ok {
-					walk(child)
-				}
-			}
-		}
-	}
-	for _, message := range messages {
-		walk(message)
-	}
-	return items
-}
-
-func indexMessageMapsByID(messages []map[string]any) map[string][]map[string]any {
-	index := map[string][]map[string]any{}
-	var walk func(map[string]any)
-	walk = func(message map[string]any) {
-		messageID := strings.TrimSpace(fmt.Sprint(chatmsg.MessageID(message)))
-		if messageID != "" && messageID != "<nil>" {
-			index[messageID] = append(index[messageID], message)
-		}
-		if forwarded, ok := message["forwardMessages"].([]any); ok {
-			for _, item := range forwarded {
-				if child, ok := item.(map[string]any); ok {
-					walk(child)
-				}
-			}
-		}
-	}
-	for _, message := range messages {
-		walk(message)
-	}
-	return index
-}
-
-func markMessageDecryptFailures(messages []map[string]any, failures []map[string]any) {
-	if len(failures) == 0 {
-		return
-	}
-	index := indexMessageMapsByID(messages)
-	for _, failure := range failures {
-		messageID := strings.TrimSpace(fmt.Sprint(failure["messageId"]))
-		if messageID == "" {
-			continue
-		}
-		for _, message := range index[messageID] {
-			content := firstMessageDecryptString(message, "content", "text")
-			if chatmsg.IsEncrypted(content) {
-				message[messageDecryptFailedOriginalContentKey] = content
-			}
-		}
-	}
-}
-
-func applyMessageDecryptLedger(payload map[string]any, ledger messageDecryptLedger) {
-	if ledger.candidateCount == 0 && ledger.decryptedCount == 0 && len(ledger.failures) == 0 {
-		return
-	}
-	payload["decryptCandidateCount"] = ledger.candidateCount
-	payload["decryptedCount"] = ledger.decryptedCount
-	payload["decryptFailedCount"] = len(ledger.failures)
-	if len(ledger.failures) > 0 {
-		payload["decryptFailures"] = ledger.failures
-		payload["partial"] = true
-	}
-}
-
-func messageDecryptFailure(messageID, conversationID, reason string) map[string]any {
-	failure := map[string]any{
-		"stage":     "message-decrypt",
-		"messageId": messageID,
-		"reason":    firstNonEmptyShortcutString(reason, "decrypt_failed"),
-	}
-	if strings.TrimSpace(conversationID) != "" {
-		failure["conversationId"] = strings.TrimSpace(conversationID)
-	}
-	return failure
-}
-
-func firstNonEmptyShortcutString(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
-}
-
-func firstMessageDecryptString(message map[string]any, keys ...string) string {
-	value := firstMessageDecryptValue(message, keys...)
-	if value == nil {
-		return ""
-	}
-	return strings.TrimSpace(fmt.Sprint(value))
-}
-
-func firstMessageDecryptValue(message map[string]any, keys ...string) any {
-	for _, key := range keys {
-		if value, ok := message[key]; ok {
-			return value
-		}
-	}
-	return nil
 }
 
 // MessagesListDirect pulls messages of a single chat (list_individual_chat_message, chat server).
@@ -786,10 +538,11 @@ func executeMessagesListDirect(rt *shortcut.RuntimeContext) error {
 		return err
 	}
 	rawMessages := listMessagesResolveMaps(data)
-	decryptLedger := decryptMessageItemsIfRequested(rt, rawMessages)
+	decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+		chatmsg.MessageDecryptClient(), rawMessages, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 	messages := projectMessageMapsWithReactions(rawMessages, !rt.Bool("no-reactions"))
 	payload := map[string]any{"count": len(messages), "messages": messages}
-	applyMessageDecryptLedger(payload, decryptLedger)
+	chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 	direction := "older"
 	if rt.Bool("forward") {
 		direction = "newer"
@@ -898,10 +651,11 @@ func readAllDirectMessages(rt *shortcut.RuntimeContext, params map[string]any) (
 		stopReason = "page_limit"
 	}
 
-	decryptLedger := decryptMessageItemsIfRequested(rt, allItems)
+	decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+		chatmsg.MessageDecryptClient(), allItems, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 	messages := projectMessageMapsWithReactions(allItems, !rt.Bool("no-reactions"))
 	payload := chatmsg.NewMessageListPayload(messages)
-	applyMessageDecryptLedger(payload, decryptLedger)
+	chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 	payload["pagesFetched"] = pagesFetched
 	payload["paginationKnown"] = true
 	payload["complete"] = complete && len(failures) == 0
@@ -1149,7 +903,8 @@ var MessagesMget = shortcut.Shortcut{
 			return err
 		}
 		rawMessages := listMessagesResolveMaps(data)
-		decryptLedger := decryptMessageItemsIfRequested(rt, rawMessages)
+		decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+			chatmsg.MessageDecryptClient(), rawMessages, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 		messages := projectMessageMapsWithReactions(rawMessages, !rt.Bool("no-reactions"))
 		found := map[string]bool{}
 		for _, message := range rawMessages {
@@ -1185,7 +940,7 @@ var MessagesMget = shortcut.Shortcut{
 			"failedCount":        len(failures),
 			"failures":           failures,
 		}
-		applyMessageDecryptLedger(payload, decryptLedger)
+		chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 		if rt.Bool("download-resources") {
 			AttachMessageResourceDownloads(payload, DownloadMessageResources(rt, rawMessages, ""))
 		}

--- a/internal/shortcut/chat/chat_message_coverage_test.go
+++ b/internal/shortcut/chat/chat_message_coverage_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
-	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto"
 	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/chatmsg"
 )
 
 type messageReadFakeCipher struct{}
@@ -26,18 +26,6 @@ func (messageReadFakeCipher) DecryptMessage(_ context.Context, _, _ string, ciph
 	return []byte("ding:" + string(ciphertext)), nil
 }
 
-type messageReadSessionCipher struct{}
-
-func (messageReadSessionCipher) EncryptMessage(context.Context, string, string, []byte) ([]byte, error) {
-	return nil, errors.New("not used")
-}
-
-func (messageReadSessionCipher) DecryptMessage(context.Context, string, string, []byte) ([]byte, error) {
-	return nil, errors.New("not used")
-}
-
-func (messageReadSessionCipher) Close() error { return nil }
-
 type messageReadFailingCipher struct{}
 
 func (messageReadFailingCipher) EncryptMessage(context.Context, string, string, []byte) ([]byte, error) {
@@ -48,11 +36,11 @@ func (messageReadFailingCipher) DecryptMessage(context.Context, string, string, 
 	return nil, errors.New("safechat failed")
 }
 
-func swapMessageReadCryptoClient(t *testing.T, client *messagecrypto.Client) {
+func swapMessageDecryptClient(t *testing.T, client *messagecrypto.Client) {
 	t.Helper()
-	old := messageReadCryptoClient
-	messageReadCryptoClient = client
-	t.Cleanup(func() { messageReadCryptoClient = old })
+	old := chatmsg.MessageDecryptClient()
+	chatmsg.SetMessageDecryptClient(client)
+	t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
 }
 
 func TestCrossPlatformCoverageListMessageRichProjection(t *testing.T) {
@@ -92,7 +80,7 @@ func TestCrossPlatformCoverageListMessageRichProjection(t *testing.T) {
 }
 
 func TestCrossPlatformCoverageMessagesMgetDecryptsEncryptedMessagesInBatch(t *testing.T) {
-	swapMessageReadCryptoClient(t, &messagecrypto.Client{
+	swapMessageDecryptClient(t, &messagecrypto.Client{
 		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
 			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
 		},
@@ -133,6 +121,7 @@ func TestCrossPlatformCoverageMessagesMgetDecryptsEncryptedMessagesInBatch(t *te
 		t.Fatal(err)
 	}
 	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(1) ||
 		payload["decryptedCount"] != float64(1) ||
 		payload["decryptFailedCount"] != float64(0) {
 		t.Fatalf("decrypt ledger = %#v", payload)
@@ -145,7 +134,7 @@ func TestCrossPlatformCoverageMessagesMgetDecryptsEncryptedMessagesInBatch(t *te
 }
 
 func TestCrossPlatformCoverageMessagesMgetFallsBackToOriginalWhenPolicyFails(t *testing.T) {
-	swapMessageReadCryptoClient(t, &messagecrypto.Client{
+	swapMessageDecryptClient(t, &messagecrypto.Client{
 		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
 			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
 		},
@@ -173,7 +162,9 @@ func TestCrossPlatformCoverageMessagesMgetFallsBackToOriginalWhenPolicyFails(t *
 	if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
 		t.Fatal(err)
 	}
-	if payload["decryptFailedCount"] != float64(1) || payload["partial"] != true {
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(0) ||
+		payload["decryptFailedCount"] != float64(1) || payload["partial"] != true {
 		t.Fatalf("decrypt fallback ledger = %#v", payload)
 	}
 	messages, _ := payload["messages"].([]any)
@@ -184,7 +175,7 @@ func TestCrossPlatformCoverageMessagesMgetFallsBackToOriginalWhenPolicyFails(t *
 }
 
 func TestCrossPlatformCoverageMessagesMgetSkipsCryptoWhenBackendUnavailable(t *testing.T) {
-	swapMessageReadCryptoClient(t, &messagecrypto.Client{
+	swapMessageDecryptClient(t, &messagecrypto.Client{
 		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
 			t.Fatal("identity lookup must not run without the SafeChat backend")
 			return messagecrypto.Identity{}, nil
@@ -223,7 +214,7 @@ func TestCrossPlatformCoverageMessagesMgetSkipsCryptoWhenBackendUnavailable(t *t
 }
 
 func TestCrossPlatformCoverageMessagesMgetFallsBackToOriginalWhenBatchDecryptFails(t *testing.T) {
-	swapMessageReadCryptoClient(t, &messagecrypto.Client{
+	swapMessageDecryptClient(t, &messagecrypto.Client{
 		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
 			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
 		},
@@ -253,6 +244,7 @@ func TestCrossPlatformCoverageMessagesMgetFallsBackToOriginalWhenBatchDecryptFai
 		t.Fatal(err)
 	}
 	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(1) ||
 		payload["decryptedCount"] != float64(0) ||
 		payload["decryptFailedCount"] != float64(1) ||
 		payload["partial"] != true {
@@ -265,88 +257,89 @@ func TestCrossPlatformCoverageMessagesMgetFallsBackToOriginalWhenBatchDecryptFai
 	}
 }
 
-func TestCrossPlatformCoverageMessageDecryptHelperEdges(t *testing.T) {
-	t.Run("new read crypto client default paths", func(t *testing.T) {
-		oldIdentity := messageReadCurrentIdentity
-		oldOpen := messageReadOpenSession
-		oldAvailable := messageReadAvailable
-		t.Cleanup(func() {
-			messageReadCurrentIdentity = oldIdentity
-			messageReadOpenSession = oldOpen
-			messageReadAvailable = oldAvailable
-		})
-		messageReadCurrentIdentity = func(context.Context, string) (msgcrypto.Identity, error) {
-			return msgcrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
-		}
-		messageReadOpenSession = func(context.Context, msgcrypto.SessionOptions) (*msgcrypto.Session, error) {
-			return &msgcrypto.Session{Cipher: messageReadSessionCipher{}, CorpID: "corp-1", StaffID: "staff-1"}, nil
-		}
-		messageReadAvailable = func() bool { return true }
-		client := newMessageReadCryptoClient()
-		if client == nil || client.PolicyCache == nil {
-			t.Fatalf("client = %#v", client)
-		}
-		if !client.BackendReady() {
-			t.Fatal("BackendReady() = false")
-		}
-		identity, err := client.Identity(context.Background(), t.TempDir())
-		if err != nil || identity.CorpID != "corp-1" || identity.StaffID != "staff-1" {
-			t.Fatalf("identity = %#v, %v", identity, err)
-		}
-		session, err := client.OpenSession(context.Background(), messagecrypto.SessionOptions{
-			ConfigDir:           t.TempDir(),
-			KeyServer:           "https://key.example.test",
-			AllowedRedirectHost: "redirect.example.test",
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if session.CorpID != "corp-1" || session.StaffID != "staff-1" || session.Cipher == nil {
-			t.Fatalf("session = %#v", session)
-		}
-
-		messageReadOpenSession = func(context.Context, msgcrypto.SessionOptions) (*msgcrypto.Session, error) {
-			return nil, errors.New("open failed")
-		}
-		if _, err := client.OpenSession(context.Background(), messagecrypto.SessionOptions{}); err == nil || err.Error() != "open failed" {
-			t.Fatalf("OpenSession error = %v", err)
-		}
-	})
-
-	messages := []map[string]any{
-		{
-			"openMessageId":      "root",
-			"openConversationId": "cid-root",
-			"content":            testCipher,
-			"forwardMessages": []any{
-				map[string]any{"openMessageId": "child", "text": testCipher},
-				"ignored",
-				map[string]any{"openMessageId": "", "content": testCipher},
-			},
+func TestCrossPlatformCoverageMessagesMgetPolicyOffRestoresOriginalText(t *testing.T) {
+	swapMessageDecryptClient(t, &messagecrypto.Client{
+		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
 		},
-		{"messageId": "<nil>", "content": testCipher},
-		{"openMessageId": "plain", "content": "plain text"},
-	}
-	items := collectEncryptedMessageItems(messages)
-	if len(items) != 3 || items[0].MessageID != "root" || items[1].MessageID != "child" {
-		t.Fatalf("items = %#v", items)
-	}
-	index := indexMessageMapsByID(messages)
-	if len(index["root"]) != 1 || len(index["child"]) != 1 {
-		t.Fatalf("index = %#v", index)
-	}
-	markMessageDecryptFailures(messages, []map[string]any{
-		messageDecryptFailure("root", "cid-root", ""),
-		{"messageId": ""},
+		OpenSession: func(context.Context, messagecrypto.SessionOptions) (*messagecrypto.Session, error) {
+			return &messagecrypto.Session{Cipher: messageReadFakeCipher{}, CorpID: "corp-1", StaffID: "staff-1"}, nil
+		},
+		BackendReady: func() bool { return true },
+		PolicyCache:  messagecrypto.NewPolicyCache(nil),
 	})
-	if got := messages[0][messageDecryptFailedOriginalContentKey]; got != testCipher {
-		t.Fatalf("original encrypted content = %#v", got)
+	fake := &larkAlignmentCaller{
+		responses: map[string]string{
+			"im/list_messages_by_ids":      `{"result":[{"openMessageId":"m1","openConversationId":"cid","content":"` + testCipher + `"}]}`,
+			"im/get_message_crypto_policy": `{"result":{"mode":"off"}}`,
+		},
 	}
-	if got := firstNonEmptyShortcutString("", " fallback "); got != "fallback" {
-		t.Fatalf("firstNonEmptyShortcutString = %q", got)
+	helpers.InitDeps(fake)
+	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{"chat", "+messages-mget", "--msg-ids", "m1"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
 	}
-	if got := firstNonEmptyShortcutString("", " "); got != "" {
-		t.Fatalf("firstNonEmptyShortcutString empty = %q", got)
+	var payload map[string]any
+	if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(0) ||
+		payload["decryptFailedCount"] != float64(1) ||
+		payload["partial"] != true {
+		t.Fatalf("policy-off ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != testCipher || first["contentDecrypted"] == true {
+		t.Fatalf("policy-off message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageMessagesListZeroCandidatesPublishesZeroCounters(t *testing.T) {
+	swapMessageDecryptClient(t, &messagecrypto.Client{
+		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+			t.Fatal("zero candidates must not query identity")
+			return messagecrypto.Identity{}, nil
+		},
+		BackendReady: func() bool { return true },
+		PolicyCache:  messagecrypto.NewPolicyCache(nil),
+	})
+	fake := &larkAlignmentCaller{responses: map[string]string{
+		"chat/list_conversation_message_v2": `{"result":{"messages":[{"openMessageId":"m1","openConversationId":"cid","content":"plain text"}]}}`,
+	}}
+	helpers.InitDeps(fake)
+	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{
+		"chat", "+messages-list", "--group", "cid", "--time", "2026-07-14 00:00:00",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	for key, want := range map[string]float64{
+		"decryptCandidateCount": 0,
+		"decryptAllowedCount":   0,
+		"decryptedCount":        0,
+		"decryptFailedCount":    0,
+	} {
+		if payload[key] != want {
+			t.Fatalf("%s = %#v, want %v; payload = %#v", key, payload[key], want, payload)
+		}
+	}
+	if _, ok := payload["decryptFailures"]; ok {
+		t.Fatalf("zero-candidate payload must not carry failures: %#v", payload)
+	}
+	if _, ok := payload["partial"]; ok {
+		t.Fatalf("zero-candidate payload must not carry partial: %#v", payload)
 	}
 }
 
@@ -402,7 +395,7 @@ func TestCrossPlatformCoverageMessageProjectionHelperEdges(t *testing.T) {
 }
 
 func TestCrossPlatformCoverageMessagesMgetDecryptItemFailureEdges(t *testing.T) {
-	swapMessageReadCryptoClient(t, &messagecrypto.Client{
+	swapMessageDecryptClient(t, &messagecrypto.Client{
 		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
 			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
 		},
@@ -439,7 +432,7 @@ func TestCrossPlatformCoverageMessagesMgetDecryptItemFailureEdges(t *testing.T) 
 }
 
 func TestCrossPlatformCoverageMessagesMgetRecordsSafeChatFailures(t *testing.T) {
-	swapMessageReadCryptoClient(t, &messagecrypto.Client{
+	swapMessageDecryptClient(t, &messagecrypto.Client{
 		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
 			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
 		},

--- a/internal/shortcut/chatmsg/chatmsg.go
+++ b/internal/shortcut/chatmsg/chatmsg.go
@@ -351,6 +351,9 @@ func ProjectMessageV1(m map[string]any, includeReactions bool) map[string]any {
 		"text":       projectedResourceText(m, ownedResources),
 		"createTime": CreateTime(m),
 	}
+	if original, ok := m[messageDecryptFailedOriginalContentKey].(string); ok && strings.TrimSpace(original) != "" {
+		row["text"] = original
+	}
 	if value := MessageID(m); value != nil {
 		row["messageId"] = value
 	}
@@ -371,6 +374,15 @@ func ProjectMessageV1(m map[string]any, includeReactions bool) map[string]any {
 	}
 	if value := MessageAISendFlag(m); value != nil {
 		row["messageAiSendFlag"] = value
+	}
+	if value := firstMessageValue(m, "contentDecrypted"); value != nil {
+		row["contentDecrypted"] = value
+	}
+	if value := firstMessageValue(m, "cryptoLayer"); value != nil {
+		row["cryptoLayer"] = value
+	}
+	if value := firstMessageValue(m, "dingKeyVersion"); value != nil {
+		row["dingKeyVersion"] = value
 	}
 	if value := UpdateTime(m); value != nil {
 		row["updateTime"] = value

--- a/internal/shortcut/chatmsg/chatmsg_test.go
+++ b/internal/shortcut/chatmsg/chatmsg_test.go
@@ -81,6 +81,50 @@ func TestCrossPlatformCoverageProjectMessageV1PublishesSharedIdentityAndContext(
 	}
 }
 
+func TestCrossPlatformCoverageProjectMessageV1PassesDecryptMarkersAndRestoresOriginal(t *testing.T) {
+	const original = "SwzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"
+
+	marked := ProjectMessageV1(map[string]any{
+		"openMessageId":    "msg-1",
+		"content":          "明文",
+		"contentDecrypted": true,
+		"cryptoLayer":      "ding+safechat",
+		"dingKeyVersion":   8,
+	}, false)
+	if marked["contentDecrypted"] != true || marked["cryptoLayer"] != "ding+safechat" || marked["dingKeyVersion"] != 8 {
+		t.Fatalf("decrypt markers lost: %#v", marked)
+	}
+
+	fallback := ProjectMessageV1(map[string]any{
+		"openMessageId":                        "msg-2",
+		"content":                              original,
+		messageDecryptFailedOriginalContentKey: original,
+	}, false)
+	if fallback["text"] != original {
+		t.Fatalf("text fallback = %#v, want original ciphertext", fallback["text"])
+	}
+	if _, has := fallback["contentDecrypted"]; has {
+		t.Fatalf("fallback row must not carry decrypt markers: %#v", fallback)
+	}
+
+	plain := ProjectMessageV1(map[string]any{
+		"openMessageId": "msg-3",
+		"content":       "你好",
+	}, false)
+	if plain["text"] != "你好" {
+		t.Fatalf("plain row text = %#v, want 你好", plain["text"])
+	}
+	if _, has := plain["contentDecrypted"]; has {
+		t.Fatalf("plain row unexpectedly has contentDecrypted: %#v", plain)
+	}
+	if _, has := plain["cryptoLayer"]; has {
+		t.Fatalf("plain row unexpectedly has cryptoLayer: %#v", plain)
+	}
+	if _, has := plain["dingKeyVersion"]; has {
+		t.Fatalf("plain row unexpectedly has dingKeyVersion: %#v", plain)
+	}
+}
+
 func TestCrossPlatformCoverageCleanText(t *testing.T) {
 	// Out-of-office auto-reply: readable body lives in items[].data.text; the
 	// decorative preview/config JSON lines and "empty" placeholder are dropped.

--- a/internal/shortcut/chatmsg/chatmsg_test.go
+++ b/internal/shortcut/chatmsg/chatmsg_test.go
@@ -14,6 +14,7 @@
 package chatmsg
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -122,6 +123,40 @@ func TestCrossPlatformCoverageProjectMessageV1PassesDecryptMarkersAndRestoresOri
 	}
 	if _, has := plain["dingKeyVersion"]; has {
 		t.Fatalf("plain row unexpectedly has dingKeyVersion: %#v", plain)
+	}
+}
+
+func TestCrossPlatformCoverageForwardedChildDecryptFailureRestoresProjectedText(t *testing.T) {
+	rt := &decryptTestRuntime{
+		batchData: `{"result":{"items":[{"messageId":"child","status":"failed","reason":"bad_key"}]}}`,
+	}
+	parent := map[string]any{
+		"openMessageId":      "root",
+		"openConversationId": "cid",
+		"content":            "plain root",
+		"forwardMessages": []any{
+			map[string]any{"openMessageId": "child", "openConversationId": "cid", "text": decryptTestCipher},
+		},
+	}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true),
+		[]map[string]any{parent}, DecryptOptions{MarkFailedOriginal: true})
+	if ledger["decryptCandidateCount"] != 1 || ledger["decryptAllowedCount"] != 1 ||
+		ledger["decryptedCount"] != 0 || ledger["decryptFailedCount"] != 1 || ledger["partial"] != true {
+		t.Fatalf("forwarded failure ledger = %#v", ledger)
+	}
+	child, _ := parent["forwardMessages"].([]any)[0].(map[string]any)
+	if child["text"] != decryptTestCipher {
+		t.Fatalf("failed child must keep ciphertext: %#v", child)
+	}
+	if child[messageDecryptFailedOriginalContentKey] != decryptTestCipher {
+		t.Fatalf("failed child must be marked with the original ciphertext: %#v", child)
+	}
+	row := ProjectMessageV1(child, false)
+	if row["text"] != decryptTestCipher {
+		t.Fatalf("projected child text = %#v, want original ciphertext", row["text"])
+	}
+	if _, has := row["contentDecrypted"]; has {
+		t.Fatalf("failed child row must not carry decrypt markers: %#v", row)
 	}
 }
 

--- a/internal/shortcut/chatmsg/decrypt.go
+++ b/internal/shortcut/chatmsg/decrypt.go
@@ -1,0 +1,284 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Policy-driven decrypt orchestration shared by the atomic helpers read
+// commands and the read-message shortcuts. Keep this file stdlib-only plus
+// internal/msgcrypto/message: internal/msgcrypto (root) imports internal/auth,
+// which imports internal/helpers, which imports this package — importing the
+// root here would create an import cycle.
+package chatmsg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
+)
+
+// messageDecryptFailedOriginalContentKey marks a raw message whose decrypt
+// failed so shortcut projections can restore the original ciphertext into
+// text. Projections that copy raw maps verbatim (helpers projectChatMessageItem)
+// must never receive this key; DecryptOptions.MarkFailedOriginal gates it.
+const messageDecryptFailedOriginalContentKey = "_contentDecryptFailedOriginal"
+
+// messageDecryptClient is the process-wide crypto client store. It starts as
+// the inert DefaultClient (no SafeChat backend in default builds) and is wired
+// once by app via helpers.SetChatCryptoClient.
+var messageDecryptClient = messagecrypto.DefaultClient()
+
+// SetMessageDecryptClient injects the process-wide crypto client; nil resets
+// to the inert DefaultClient.
+func SetMessageDecryptClient(client *messagecrypto.Client) {
+	if client == nil {
+		messageDecryptClient = messagecrypto.DefaultClient()
+		return
+	}
+	messageDecryptClient = client
+}
+
+// MessageDecryptClient returns the process-wide crypto client.
+func MessageDecryptClient() *messagecrypto.Client {
+	return messageDecryptClient
+}
+
+// DecryptOptions tunes the shared decrypt pipeline per caller class.
+type DecryptOptions struct {
+	// MarkFailedOriginal writes messageDecryptFailedOriginalContentKey onto
+	// failed raw message maps so downstream shortcut projections can restore
+	// the original ciphertext into text. Shortcut callers pass true; the
+	// atomic helpers projection passes the zero value because it copies raw
+	// maps verbatim and must keep its ciphertext-content + marker-text shape.
+	MarkFailedOriginal bool
+}
+
+// DecryptMessagesByPolicy runs gate → collect → policy filter → batch decrypt
+// → write-back → canonical ledger over raw message maps. It returns nil iff
+// gated (dry-run or no ready backend): no policy query, no decrypt call, and
+// no decrypt field may be emitted. A non-nil return is the canonical ledger
+// shared with the atomic commands: decryptCandidateCount is the pre-filter
+// count, policy_disabled is recorded as a per-message failure, and zero
+// candidates still publish zero-value counters.
+func DecryptMessagesByPolicy(
+	ctx context.Context,
+	rt messagecrypto.Runtime,
+	client *messagecrypto.Client,
+	messages []map[string]any,
+	opts DecryptOptions,
+) map[string]any {
+	if rt == nil || rt.DryRun() || client == nil || client.BackendReady == nil || !client.BackendReady() {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	items := collectEncryptedMessageItems(messages)
+	ledger := map[string]any{
+		"decryptCandidateCount": len(items),
+		"decryptAllowedCount":   0,
+		"decryptedCount":        0,
+		"decryptFailedCount":    0,
+	}
+	failures := make([]map[string]any, 0)
+	filtered := make([]messagecrypto.BatchDecryptItem, 0, len(items))
+	for _, item := range items {
+		decision, err := client.PolicyDecision(ctx, rt, messagecrypto.Options{
+			Identity:           "user",
+			MsgType:            "text",
+			OpenConversationID: item.ConversationID,
+		})
+		if err != nil {
+			failures = append(failures, messageDecryptFailure(item.MessageID, item.ConversationID, err.Error()))
+			continue
+		}
+		if !decision.Enabled {
+			failures = append(failures, messageDecryptFailure(item.MessageID, item.ConversationID, "policy_disabled"))
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	ledger["decryptAllowedCount"] = len(filtered)
+	if len(filtered) > 0 {
+		result, err := client.BatchDecryptInbound(ctx, rt, messagecrypto.Options{}, filtered)
+		if err != nil {
+			for _, item := range filtered {
+				failures = append(failures, messageDecryptFailure(item.MessageID, item.ConversationID, err.Error()))
+			}
+		} else {
+			index := indexMessageMapsByID(messages)
+			decryptedCount := 0
+			for _, item := range result.Items {
+				if item.Status != "" && item.Status != "success" {
+					failures = append(failures, messageDecryptFailure(item.MessageID, item.ConversationID, item.Reason))
+					continue
+				}
+				if strings.TrimSpace(item.PlaintextContent) == "" {
+					failures = append(failures, messageDecryptFailure(item.MessageID, item.ConversationID, "empty_plaintext"))
+					continue
+				}
+				for _, message := range index[item.MessageID] {
+					// Restore into whichever key held the ciphertext: top-level
+					// messages use content, forwardMessages children use text.
+					target := "content"
+					for _, key := range []string{"content", "text"} {
+						if IsEncrypted(firstMessageDecryptString(message, key)) {
+							target = key
+							break
+						}
+					}
+					message[target] = item.PlaintextContent
+					message["contentDecrypted"] = true
+					message["cryptoLayer"] = "ding+safechat"
+					if item.KeyVersion > 0 {
+						message["dingKeyVersion"] = item.KeyVersion
+					}
+				}
+				decryptedCount++
+			}
+			for _, item := range result.Failures {
+				failures = append(failures, messageDecryptFailure(item.MessageID, item.ConversationID, item.Reason))
+			}
+			ledger["decryptedCount"] = decryptedCount
+		}
+	}
+	if opts.MarkFailedOriginal {
+		markMessageDecryptFailures(messages, failures)
+	}
+	if len(failures) > 0 {
+		ledger["decryptFailedCount"] = len(failures)
+		ledger["decryptFailures"] = failures
+		ledger["partial"] = true
+	}
+	return ledger
+}
+
+// ApplyDecryptLedger merges the canonical decrypt ledger into a projected
+// payload. A nil ledger (gate skipped) writes nothing; a non-nil ledger always
+// carries the four counters and, with failures, decryptFailures and partial.
+func ApplyDecryptLedger(payload map[string]any, ledger map[string]any) {
+	if payload == nil || ledger == nil {
+		return
+	}
+	for key, value := range ledger {
+		payload[key] = value
+	}
+}
+
+// collectEncryptedMessageItems walks messages (recursing into forwardMessages)
+// and returns decrypt candidates carrying a stable message ID and ciphertext.
+func collectEncryptedMessageItems(messages []map[string]any) []messagecrypto.BatchDecryptItem {
+	items := make([]messagecrypto.BatchDecryptItem, 0)
+	var walk func(map[string]any)
+	walk = func(message map[string]any) {
+		messageID := strings.TrimSpace(fmt.Sprint(MessageID(message)))
+		if messageID == "" || messageID == "<nil>" {
+			messageID = strings.TrimSpace(fmt.Sprint(firstMessageDecryptValue(message, "openMessageId", "messageId", "msgId")))
+		}
+		conversationID := strings.TrimSpace(fmt.Sprint(ConversationID(message)))
+		if conversationID == "<nil>" {
+			conversationID = ""
+		}
+		content := firstMessageDecryptString(message, "content", "text")
+		if messageID != "" && messageID != "<nil>" && IsEncrypted(content) {
+			items = append(items, messagecrypto.BatchDecryptItem{
+				MessageID:      messageID,
+				ConversationID: conversationID,
+				Ciphertext:     content,
+			})
+		}
+		if forwarded, ok := message["forwardMessages"].([]any); ok {
+			for _, item := range forwarded {
+				if child, ok := item.(map[string]any); ok {
+					walk(child)
+				}
+			}
+		}
+	}
+	for _, message := range messages {
+		walk(message)
+	}
+	return items
+}
+
+func indexMessageMapsByID(messages []map[string]any) map[string][]map[string]any {
+	index := map[string][]map[string]any{}
+	var walk func(map[string]any)
+	walk = func(message map[string]any) {
+		messageID := strings.TrimSpace(fmt.Sprint(MessageID(message)))
+		if messageID != "" && messageID != "<nil>" {
+			index[messageID] = append(index[messageID], message)
+		}
+		if forwarded, ok := message["forwardMessages"].([]any); ok {
+			for _, item := range forwarded {
+				if child, ok := item.(map[string]any); ok {
+					walk(child)
+				}
+			}
+		}
+	}
+	for _, message := range messages {
+		walk(message)
+	}
+	return index
+}
+
+func markMessageDecryptFailures(messages []map[string]any, failures []map[string]any) {
+	if len(failures) == 0 {
+		return
+	}
+	index := indexMessageMapsByID(messages)
+	for _, failure := range failures {
+		messageID := strings.TrimSpace(fmt.Sprint(failure["messageId"]))
+		if messageID == "" {
+			continue
+		}
+		for _, message := range index[messageID] {
+			content := firstMessageDecryptString(message, "content", "text")
+			if IsEncrypted(content) {
+				message[messageDecryptFailedOriginalContentKey] = content
+			}
+		}
+	}
+}
+
+func messageDecryptFailure(messageID, conversationID, reason string) map[string]any {
+	failure := map[string]any{
+		"stage":     "message-decrypt",
+		"messageId": strings.TrimSpace(messageID),
+		"reason":    strings.TrimSpace(reason),
+	}
+	if failure["reason"] == "" {
+		failure["reason"] = "decrypt_failed"
+	}
+	if trimmed := strings.TrimSpace(conversationID); trimmed != "" {
+		failure["conversationId"] = trimmed
+	}
+	return failure
+}
+
+func firstMessageDecryptString(message map[string]any, keys ...string) string {
+	value := firstMessageDecryptValue(message, keys...)
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func firstMessageDecryptValue(message map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := message[key]; ok {
+			return value
+		}
+	}
+	return nil
+}

--- a/internal/shortcut/chatmsg/decrypt.go
+++ b/internal/shortcut/chatmsg/decrypt.go
@@ -38,7 +38,9 @@ const messageDecryptFailedOriginalContentKey = "_contentDecryptFailedOriginal"
 var messageDecryptClient = messagecrypto.DefaultClient()
 
 // SetMessageDecryptClient injects the process-wide crypto client; nil resets
-// to the inert DefaultClient.
+// to the inert DefaultClient. It mutates package-global state: production
+// calls it once on the main goroutine during app startup, and tests must not
+// call it from t.Parallel tests.
 func SetMessageDecryptClient(client *messagecrypto.Client) {
 	if client == nil {
 		messageDecryptClient = messagecrypto.DefaultClient()
@@ -181,9 +183,6 @@ func collectEncryptedMessageItems(messages []map[string]any) []messagecrypto.Bat
 	var walk func(map[string]any)
 	walk = func(message map[string]any) {
 		messageID := strings.TrimSpace(fmt.Sprint(MessageID(message)))
-		if messageID == "" || messageID == "<nil>" {
-			messageID = strings.TrimSpace(fmt.Sprint(firstMessageDecryptValue(message, "openMessageId", "messageId", "msgId")))
-		}
 		conversationID := strings.TrimSpace(fmt.Sprint(ConversationID(message)))
 		if conversationID == "<nil>" {
 			conversationID = ""

--- a/internal/shortcut/chatmsg/decrypt_test.go
+++ b/internal/shortcut/chatmsg/decrypt_test.go
@@ -35,13 +35,14 @@ func (decryptTestCipherFake) DecryptMessage(_ context.Context, _, _ string, ciph
 }
 
 type decryptTestRuntime struct {
-	dryRun     bool
-	policyMode string
-	policyErr  error
-	batchData  string
-	batchErr   error
-	readCalls  int
-	writeCalls int
+	dryRun           bool
+	policyMode       string
+	policyTTLSeconds int
+	policyErr        error
+	batchData        string
+	batchErr         error
+	readCalls        int
+	writeCalls       int
 }
 
 func (r *decryptTestRuntime) CallMCPReadData(_ string, _ string, params map[string]any) (map[string]any, error) {
@@ -53,7 +54,11 @@ func (r *decryptTestRuntime) CallMCPReadData(_ string, _ string, params map[stri
 	if mode == "" {
 		mode = "required"
 	}
-	return map[string]any{"result": map[string]any{"mode": mode, "openConversationId": params["openConversationId"]}}, nil
+	result := map[string]any{"mode": mode, "openConversationId": params["openConversationId"]}
+	if r.policyTTLSeconds > 0 {
+		result["ttlSeconds"] = r.policyTTLSeconds
+	}
+	return map[string]any{"result": result}, nil
 }
 
 func (r *decryptTestRuntime) CallMCPWriteDataStrict(_ string, _ string, params map[string]any) (map[string]any, error) {
@@ -306,6 +311,25 @@ func TestDecryptMessagesByPolicyTransportErrorRecordsPerItemFailures(t *testing.
 	}
 	if !ids["m1"] || !ids["m2"] {
 		t.Fatalf("transport failures must carry message ids: %#v", ids)
+	}
+}
+
+func TestDecryptMessagesByPolicyPolicyCacheTTLReusesConversationDecisions(t *testing.T) {
+	rt := &decryptTestRuntime{policyTTLSeconds: 60}
+	messages := []map[string]any{
+		encryptedTestMessage("m1"),
+		{"openMessageId": "m2", "openConversationId": "cid", "content": decryptTestCipher},
+		{"openMessageId": "m3", "openConversationId": "cid-2", "content": decryptTestCipher},
+	}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), messages, DecryptOptions{})
+	if ledger["decryptAllowedCount"] != 3 || ledger["decryptedCount"] != 3 {
+		t.Fatalf("ttl ledger = %#v", ledger)
+	}
+	if rt.readCalls != 2 {
+		t.Fatalf("readCalls = %d, want one per conversation (2), not per message (3)", rt.readCalls)
+	}
+	if rt.writeCalls != 1 {
+		t.Fatalf("writeCalls = %d, want a single batch decrypt", rt.writeCalls)
 	}
 }
 

--- a/internal/shortcut/chatmsg/decrypt_test.go
+++ b/internal/shortcut/chatmsg/decrypt_test.go
@@ -1,0 +1,411 @@
+// Copyright 2026 Alibaba Group
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chatmsg
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
+)
+
+const decryptTestCipher = "SwzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"
+
+type decryptTestCipherFake struct{}
+
+func (decryptTestCipherFake) EncryptMessage(context.Context, string, string, []byte) ([]byte, error) {
+	return nil, errors.New("not used")
+}
+
+func (decryptTestCipherFake) DecryptMessage(_ context.Context, _, _ string, ciphertext []byte) ([]byte, error) {
+	return []byte("ding:" + string(ciphertext)), nil
+}
+
+type decryptTestRuntime struct {
+	dryRun     bool
+	policyMode string
+	policyErr  error
+	batchData  string
+	batchErr   error
+	readCalls  int
+	writeCalls int
+}
+
+func (r *decryptTestRuntime) CallMCPReadData(_ string, _ string, params map[string]any) (map[string]any, error) {
+	r.readCalls++
+	if r.policyErr != nil {
+		return nil, r.policyErr
+	}
+	mode := r.policyMode
+	if mode == "" {
+		mode = "required"
+	}
+	return map[string]any{"result": map[string]any{"mode": mode, "openConversationId": params["openConversationId"]}}, nil
+}
+
+func (r *decryptTestRuntime) CallMCPWriteDataStrict(_ string, _ string, params map[string]any) (map[string]any, error) {
+	r.writeCalls++
+	if r.batchErr != nil {
+		return nil, r.batchErr
+	}
+	if r.batchData != "" {
+		var data map[string]any
+		if err := json.Unmarshal([]byte(r.batchData), &data); err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+	dingItems, _ := params["items"].([]map[string]any)
+	echo := make([]any, 0, len(dingItems))
+	for _, item := range dingItems {
+		echo = append(echo, map[string]any{
+			"messageId":        item["messageId"],
+			"conversationId":   item["conversationId"],
+			"status":           "success",
+			"plaintextContent": item["dingCiphertext"],
+		})
+	}
+	return map[string]any{"result": map[string]any{"items": echo}}, nil
+}
+
+func (r *decryptTestRuntime) DryRun() bool { return r.dryRun }
+
+func decryptTestClient(backendReady bool) *messagecrypto.Client {
+	return &messagecrypto.Client{
+		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
+		},
+		OpenSession: func(context.Context, messagecrypto.SessionOptions) (*messagecrypto.Session, error) {
+			return &messagecrypto.Session{Cipher: decryptTestCipherFake{}, CorpID: "corp-1", StaffID: "staff-1"}, nil
+		},
+		BackendReady: func() bool { return backendReady },
+		PolicyCache:  messagecrypto.NewPolicyCache(nil),
+	}
+}
+
+func encryptedTestMessage(id string) map[string]any {
+	return map[string]any{
+		"openMessageId":      id,
+		"openConversationId": "cid",
+		"content":            decryptTestCipher,
+	}
+}
+
+func TestDecryptMessagesByPolicySkipsWhenDryRun(t *testing.T) {
+	rt := &decryptTestRuntime{dryRun: true}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true),
+		[]map[string]any{encryptedTestMessage("m1")}, DecryptOptions{MarkFailedOriginal: true})
+	if ledger != nil {
+		t.Fatalf("dry-run ledger = %#v, want nil", ledger)
+	}
+	if rt.readCalls != 0 || rt.writeCalls != 0 {
+		t.Fatalf("dry-run calls = %d/%d, want zero", rt.readCalls, rt.writeCalls)
+	}
+}
+
+func TestDecryptMessagesByPolicySkipsWhenBackendUnavailable(t *testing.T) {
+	rt := &decryptTestRuntime{}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(false),
+		[]map[string]any{encryptedTestMessage("m1")}, DecryptOptions{})
+	if ledger != nil {
+		t.Fatalf("unavailable backend ledger = %#v, want nil", ledger)
+	}
+	if rt.readCalls != 0 || rt.writeCalls != 0 {
+		t.Fatalf("unavailable backend calls = %d/%d, want zero", rt.readCalls, rt.writeCalls)
+	}
+}
+
+func TestDecryptMessagesByPolicyZeroCandidatesPublishesZeroCounters(t *testing.T) {
+	rt := &decryptTestRuntime{}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true),
+		[]map[string]any{{"openMessageId": "m1", "openConversationId": "cid", "content": "plain text"}}, DecryptOptions{})
+	if ledger == nil {
+		t.Fatal("zero candidates must still publish the canonical counters")
+	}
+	if ledger["decryptCandidateCount"] != 0 || ledger["decryptAllowedCount"] != 0 ||
+		ledger["decryptedCount"] != 0 || ledger["decryptFailedCount"] != 0 {
+		t.Fatalf("zero-candidate ledger = %#v", ledger)
+	}
+	if _, ok := ledger["decryptFailures"]; ok {
+		t.Fatalf("zero-candidate ledger must not carry failures: %#v", ledger)
+	}
+	if _, ok := ledger["partial"]; ok {
+		t.Fatalf("zero-candidate ledger must not carry partial: %#v", ledger)
+	}
+	if rt.readCalls != 0 {
+		t.Fatalf("zero candidates must not query policy, readCalls = %d", rt.readCalls)
+	}
+}
+
+func TestDecryptMessagesByPolicyDecryptsEncryptedBatch(t *testing.T) {
+	rt := &decryptTestRuntime{}
+	messages := []map[string]any{encryptedTestMessage("m1"), encryptedTestMessage("m2")}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), messages, DecryptOptions{})
+	if ledger["decryptCandidateCount"] != 2 || ledger["decryptAllowedCount"] != 2 ||
+		ledger["decryptedCount"] != 2 || ledger["decryptFailedCount"] != 0 {
+		t.Fatalf("decrypt ledger = %#v", ledger)
+	}
+	if _, ok := ledger["partial"]; ok {
+		t.Fatalf("success ledger must not carry partial: %#v", ledger)
+	}
+	if rt.writeCalls != 1 || rt.readCalls != 2 {
+		t.Fatalf("calls = %d reads / %d writes, want 2/1", rt.readCalls, rt.writeCalls)
+	}
+	for _, message := range messages {
+		if message["content"] != "ding:"+decryptTestCipher {
+			t.Fatalf("decrypted content = %#v", message["content"])
+		}
+		if message["contentDecrypted"] != true || message["cryptoLayer"] != "ding+safechat" {
+			t.Fatalf("decrypt markers = %#v", message)
+		}
+	}
+}
+
+func TestDecryptMessagesByPolicyWritesDingCiphertextAndKeyVersion(t *testing.T) {
+	rt := &decryptTestRuntime{
+		batchData: `{"result":{"items":[{"messageId":"m1","status":"success","plaintextContent":"hello","keyVersion":8}]}}`,
+	}
+	messages := []map[string]any{encryptedTestMessage("m1")}
+	var batchParams map[string]any
+	recording := &batchRecordingRuntime{decryptTestRuntime: rt, capture: &batchParams}
+	DecryptMessagesByPolicy(context.Background(), recording, decryptTestClient(true), messages, DecryptOptions{})
+	items, _ := batchParams["items"].([]map[string]any)
+	if len(items) != 1 || items[0]["messageId"] != "m1" || items[0]["dingCiphertext"] != "ding:"+decryptTestCipher {
+		t.Fatalf("batch args = %#v", batchParams)
+	}
+	if messages[0]["content"] != "hello" {
+		t.Fatalf("plaintext content = %#v", messages[0]["content"])
+	}
+	if got, ok := messages[0]["dingKeyVersion"].(int); !ok || got != 8 {
+		t.Fatalf("dingKeyVersion = %#v, want 8", messages[0]["dingKeyVersion"])
+	}
+}
+
+type batchRecordingRuntime struct {
+	*decryptTestRuntime
+	capture *map[string]any
+}
+
+func (r *batchRecordingRuntime) CallMCPWriteDataStrict(product, tool string, params map[string]any) (map[string]any, error) {
+	*r.capture = params
+	return r.decryptTestRuntime.CallMCPWriteDataStrict(product, tool, params)
+}
+
+func TestDecryptMessagesByPolicyRecordsPolicyDisabled(t *testing.T) {
+	rt := &decryptTestRuntime{policyMode: "off"}
+	messages := []map[string]any{encryptedTestMessage("m1"), encryptedTestMessage("m2")}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), messages, DecryptOptions{MarkFailedOriginal: true})
+	if ledger["decryptCandidateCount"] != 2 || ledger["decryptAllowedCount"] != 0 || ledger["decryptFailedCount"] != 2 {
+		t.Fatalf("policy-off ledger = %#v", ledger)
+	}
+	if ledger["partial"] != true {
+		t.Fatalf("policy-off ledger must be partial: %#v", ledger)
+	}
+	if rt.writeCalls != 0 {
+		t.Fatalf("policy-off must not decrypt, writeCalls = %d", rt.writeCalls)
+	}
+	failures, _ := ledger["decryptFailures"].([]map[string]any)
+	if len(failures) != 2 {
+		t.Fatalf("decryptFailures = %#v", ledger["decryptFailures"])
+	}
+	for _, failure := range failures {
+		if failure["stage"] != "message-decrypt" || failure["reason"] != "policy_disabled" {
+			t.Fatalf("failure = %#v", failure)
+		}
+		if failure["messageId"] == "" || failure["conversationId"] != "cid" {
+			t.Fatalf("failure identity = %#v", failure)
+		}
+	}
+	for _, message := range messages {
+		if message["content"] != decryptTestCipher {
+			t.Fatalf("policy-off message must keep ciphertext: %#v", message["content"])
+		}
+		if message[messageDecryptFailedOriginalContentKey] != decryptTestCipher {
+			t.Fatalf("policy-off failure must mark original: %#v", message)
+		}
+	}
+}
+
+func TestDecryptMessagesByPolicyRecordsPolicyQueryFailure(t *testing.T) {
+	rt := &decryptTestRuntime{policyErr: errors.New("policy unavailable")}
+	messages := []map[string]any{encryptedTestMessage("m1")}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), messages, DecryptOptions{MarkFailedOriginal: true})
+	if ledger["decryptAllowedCount"] != 0 || ledger["decryptFailedCount"] != 1 {
+		t.Fatalf("policy failure ledger = %#v", ledger)
+	}
+	failures, _ := ledger["decryptFailures"].([]map[string]any)
+	if len(failures) != 1 || failures[0]["reason"] != "policy unavailable" {
+		t.Fatalf("decryptFailures = %#v", ledger["decryptFailures"])
+	}
+	if rt.writeCalls != 0 {
+		t.Fatalf("policy failure must not decrypt, writeCalls = %d", rt.writeCalls)
+	}
+}
+
+func TestDecryptMessagesByPolicyRecordsPerItemBatchFailures(t *testing.T) {
+	rt := &decryptTestRuntime{
+		batchData: `{"result":{"items":[` +
+			`{"messageId":"ok","status":"success","plaintextContent":"ok text","keyVersion":3},` +
+			`{"messageId":"failed","status":"failed","reason":"bad_key"},` +
+			`{"messageId":"empty","status":"success","plaintextContent":"  "},` +
+			`{"messageId":"lost","status":"failed","reason":"gone"}` +
+			`]}}`,
+	}
+	messages := []map[string]any{encryptedTestMessage("ok"), encryptedTestMessage("failed"), encryptedTestMessage("empty")}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), messages, DecryptOptions{MarkFailedOriginal: true})
+	if ledger["decryptedCount"] != 1 || ledger["decryptFailedCount"] != 3 || ledger["partial"] != true {
+		t.Fatalf("item failure ledger = %#v", ledger)
+	}
+	reasons := map[string]bool{}
+	for _, failure := range ledger["decryptFailures"].([]map[string]any) {
+		reason, _ := failure["reason"].(string)
+		reasons[reason] = true
+	}
+	if !reasons["bad_key"] || !reasons["empty_plaintext"] || !reasons["gone"] {
+		t.Fatalf("failure reasons = %#v", reasons)
+	}
+	if messages[0]["content"] != "ok text" {
+		t.Fatalf("successful message not decrypted: %#v", messages[0]["content"])
+	}
+	if messages[1]["content"] != decryptTestCipher || messages[2]["content"] != decryptTestCipher {
+		t.Fatalf("failed messages must keep ciphertext: %#v / %#v", messages[1]["content"], messages[2]["content"])
+	}
+}
+
+func TestDecryptMessagesByPolicyTransportErrorRecordsPerItemFailures(t *testing.T) {
+	rt := &decryptTestRuntime{batchErr: errors.New("ding batch failed")}
+	messages := []map[string]any{encryptedTestMessage("m1"), encryptedTestMessage("m2")}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), messages, DecryptOptions{MarkFailedOriginal: true})
+	if ledger["decryptFailedCount"] != 2 || ledger["partial"] != true {
+		t.Fatalf("transport error ledger = %#v", ledger)
+	}
+	failures, _ := ledger["decryptFailures"].([]map[string]any)
+	if len(failures) != 2 {
+		t.Fatalf("decryptFailures = %#v, want one per filtered item", ledger["decryptFailures"])
+	}
+	ids := map[string]bool{}
+	for _, failure := range failures {
+		id, _ := failure["messageId"].(string)
+		ids[id] = true
+		if failure["reason"] != "ding batch failed" {
+			t.Fatalf("failure = %#v", failure)
+		}
+	}
+	if !ids["m1"] || !ids["m2"] {
+		t.Fatalf("transport failures must carry message ids: %#v", ids)
+	}
+}
+
+func TestDecryptMessagesByPolicyCollectsForwardedChildren(t *testing.T) {
+	rt := &decryptTestRuntime{
+		batchData: `{"result":{"items":[{"messageId":"child","status":"success","plaintextContent":"child text","keyVersion":2}]}}`,
+	}
+	parent := map[string]any{
+		"openMessageId":      "root",
+		"openConversationId": "cid",
+		"content":            "plain root",
+		"forwardMessages": []any{
+			map[string]any{"openMessageId": "child", "openConversationId": "cid", "text": decryptTestCipher},
+			"ignored",
+		},
+	}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), []map[string]any{parent}, DecryptOptions{})
+	if ledger["decryptCandidateCount"] != 1 || ledger["decryptedCount"] != 1 {
+		t.Fatalf("forwarded ledger = %#v", ledger)
+	}
+	child, _ := parent["forwardMessages"].([]any)[0].(map[string]any)
+	if child["text"] != "child text" || child["contentDecrypted"] != true {
+		t.Fatalf("forwarded child = %#v", child)
+	}
+}
+
+func TestDecryptMessagesByPolicySkipsMessagesWithoutStableID(t *testing.T) {
+	rt := &decryptTestRuntime{}
+	messages := []map[string]any{
+		{"openConversationId": "cid", "content": decryptTestCipher},
+		{"messageId": "<nil>", "openConversationId": "cid", "content": decryptTestCipher},
+		{"openMessageId": "", "openConversationId": "cid", "content": decryptTestCipher},
+	}
+	ledger := DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), messages, DecryptOptions{})
+	if ledger["decryptCandidateCount"] != 0 {
+		t.Fatalf("unstable ids must not be collected: %#v", ledger)
+	}
+	if rt.readCalls != 0 || rt.writeCalls != 0 {
+		t.Fatalf("unstable ids must not trigger calls: %d/%d", rt.readCalls, rt.writeCalls)
+	}
+}
+
+func TestDecryptMessagesByPolicyMarkFailedOriginalGating(t *testing.T) {
+	rt := &decryptTestRuntime{policyMode: "off"}
+	messages := []map[string]any{encryptedTestMessage("m1"), {"openMessageId": "m2", "openConversationId": "cid", "content": "plain"}}
+	DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), messages, DecryptOptions{})
+	if _, ok := messages[0][messageDecryptFailedOriginalContentKey]; ok {
+		t.Fatalf("MarkFailedOriginal=false must not mark: %#v", messages[0])
+	}
+
+	rt = &decryptTestRuntime{policyMode: "off"}
+	messages = []map[string]any{encryptedTestMessage("m1"), {"openMessageId": "m2", "openConversationId": "cid", "content": "plain"}}
+	DecryptMessagesByPolicy(context.Background(), rt, decryptTestClient(true), messages, DecryptOptions{MarkFailedOriginal: true})
+	if messages[0][messageDecryptFailedOriginalContentKey] != decryptTestCipher {
+		t.Fatalf("MarkFailedOriginal=true must restore original: %#v", messages[0])
+	}
+	if _, ok := messages[1][messageDecryptFailedOriginalContentKey]; ok {
+		t.Fatalf("plaintext message must not be marked: %#v", messages[1])
+	}
+}
+
+func TestApplyDecryptLedger(t *testing.T) {
+	payload := map[string]any{"count": 1}
+	ApplyDecryptLedger(payload, nil)
+	if len(payload) != 1 {
+		t.Fatalf("nil ledger must not write: %#v", payload)
+	}
+	ledger := map[string]any{
+		"decryptCandidateCount": 2,
+		"decryptAllowedCount":   1,
+		"decryptedCount":        1,
+		"decryptFailedCount":    1,
+		"decryptFailures":       []map[string]any{{"stage": "message-decrypt"}},
+		"partial":               true,
+	}
+	ApplyDecryptLedger(payload, ledger)
+	if payload["decryptCandidateCount"] != 2 || payload["decryptAllowedCount"] != 1 ||
+		payload["decryptedCount"] != 1 || payload["decryptFailedCount"] != 1 ||
+		payload["partial"] != true {
+		t.Fatalf("merged payload = %#v", payload)
+	}
+	if _, ok := payload["decryptFailures"].([]map[string]any); !ok {
+		t.Fatalf("decryptFailures = %#v", payload["decryptFailures"])
+	}
+	ApplyDecryptLedger(nil, ledger)
+}
+
+func TestMessageDecryptClientStore(t *testing.T) {
+	t.Cleanup(func() { SetMessageDecryptClient(nil) })
+	defaultClient := MessageDecryptClient()
+	if defaultClient == nil || defaultClient.BackendReady == nil || defaultClient.BackendReady() {
+		t.Fatalf("default client = %#v, want inert DefaultClient", defaultClient)
+	}
+	custom := decryptTestClient(true)
+	SetMessageDecryptClient(custom)
+	if MessageDecryptClient() != custom {
+		t.Fatal("SetMessageDecryptClient must store the injected client")
+	}
+	SetMessageDecryptClient(nil)
+	if MessageDecryptClient() == nil || MessageDecryptClient().BackendReady() {
+		t.Fatal("nil reset must restore the inert DefaultClient")
+	}
+}

--- a/internal/shortcut/smart/at_me.go
+++ b/internal/shortcut/smart/at_me.go
@@ -154,6 +154,7 @@ func executeAtMe(rt *shortcut.RuntimeContext) error {
 	var items []map[string]any
 	var payload map[string]any
 	var readErr error
+	var decryptLedger map[string]any
 	if rt.Bool("page-all") {
 		payload, items, readErr = readAllAtMePages(rt, params)
 		if payload == nil {
@@ -165,6 +166,8 @@ func executeAtMe(rt *shortcut.RuntimeContext) error {
 			return err
 		}
 		items = atMeMessageItems(data)
+		decryptLedger = chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+			chatmsg.MessageDecryptClient(), items, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 		payload = atMePayload(items, !rt.Bool("no-reactions"))
 		chatmsg.ApplyPagination(payload, data)
 		payload["pagesFetched"] = 1
@@ -174,6 +177,7 @@ func executeAtMe(rt *shortcut.RuntimeContext) error {
 			payload["stopReason"] = "single_page"
 		}
 	}
+	chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 
 	results := make([]map[string]any, 0, len(items))
 	if projected, ok := payload["messages"].([]map[string]any); ok {
@@ -341,7 +345,10 @@ func readAllAtMePages(rt *shortcut.RuntimeContext, baseParams map[string]any) (m
 		stopReason = "page_limit"
 	}
 
+	decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+		chatmsg.MessageDecryptClient(), allItems, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 	payload := atMePayload(allItems, !rt.Bool("no-reactions"))
+	chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 	payload["pagesFetched"] = pagesFetched
 	payload["paginationKnown"] = true
 	payload["complete"] = complete && len(failures) == 0
@@ -497,6 +504,10 @@ func atMeToMaps(arr []any) []map[string]any {
 	return out
 }
 
+// messageDecryptFailedOriginalKeyForAtMe mirrors chatmsg's private decrypt
+// fallback key; the shared decrypt layer writes it onto failed raw messages.
+const messageDecryptFailedOriginalKeyForAtMe = "_contentDecryptFailedOriginal"
+
 // atMeProject reshapes one @me message into {sender, time, text, conversation},
 // running text through the shared chatmsg cleaning (card/auto-reply JSON →
 // readable, ciphertext → marker) and recursively expanding any forwarded chat
@@ -511,6 +522,14 @@ func atMeProjectWithReactions(m map[string]any, includeReactions bool) map[strin
 		"time":         atMeTime(m),
 		"text":         atMeCleanText(m),
 		"conversation": atMeConversation(m),
+	}
+	if original, ok := m[messageDecryptFailedOriginalKeyForAtMe].(string); ok && strings.TrimSpace(original) != "" {
+		row["text"] = original
+	}
+	for _, key := range []string{"contentDecrypted", "cryptoLayer", "dingKeyVersion"} {
+		if value, ok := m[key]; ok && value != nil {
+			row[key] = value
+		}
 	}
 	if messageID := chatmsg.MessageID(m); messageID != nil {
 		row["messageId"] = messageID

--- a/internal/shortcut/smart/at_me_search_msg_test.go
+++ b/internal/shortcut/smart/at_me_search_msg_test.go
@@ -14,8 +14,11 @@
 package smart
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
 )
 
 const testCipher = "SwzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"
@@ -164,6 +167,173 @@ func TestCrossPlatformCoverageSenderHelpers(t *testing.T) {
 		}
 		if got := c.fn(map[string]any{"senderName": "null"}); got != nil {
 			t.Errorf("%s \"null\" = %v, want nil", c.name, got)
+		}
+	}
+}
+
+func atMeDecryptResponse(content string) string {
+	return `{"result":{"hasMore":false,"conversationMessagesList":[{"openConversationId":"cid","title":"群A","messages":[{"openMessageId":"m1","openConversationId":"cid","sender":"张三","content":"` + content + `","createTime":"2026-01-02 00:00:00","msgType":"text"}]}]}}`
+}
+
+func TestCrossPlatformCoverageAtMeDecryptSinglePage(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/search_at_me_message":      atMeDecryptResponse(chatMessagesDecryptCipherText),
+		"im/get_message_crypto_policy":   `{"result":{"mode":"required"}}`,
+		"im/batch_ding_decrypt_messages": `{"result":{"items":[{"messageId":"m1","status":"success","plaintextContent":"hello decrypted","keyVersion":8}]}}`,
+	}}
+	payload := runChatMessagesDecrypt(t, caller, "chat", "+at-me")
+	if len(caller.calls) != 3 ||
+		caller.calls[0].tool != "search_at_me_message" ||
+		caller.calls[1].tool != "get_message_crypto_policy" ||
+		caller.calls[2].tool != "batch_ding_decrypt_messages" {
+		t.Fatalf("calls = %#v", caller.calls)
+	}
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(1) ||
+		payload["decryptedCount"] != float64(1) ||
+		payload["decryptFailedCount"] != float64(0) {
+		t.Fatalf("decrypt ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != "hello decrypted" || first["contentDecrypted"] != true ||
+		first["cryptoLayer"] != "ding+safechat" || first["dingKeyVersion"] != float64(8) {
+		t.Fatalf("decrypted message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageAtMeDecryptPolicyOffRestoresOriginalText(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/search_at_me_message":    atMeDecryptResponse(chatMessagesDecryptCipherText),
+		"im/get_message_crypto_policy": `{"result":{"mode":"off"}}`,
+	}}
+	payload := runChatMessagesDecrypt(t, caller, "chat", "+at-me")
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(0) ||
+		payload["decryptFailedCount"] != float64(1) ||
+		payload["partial"] != true {
+		t.Fatalf("policy-off ledger = %#v", payload)
+	}
+	failures, _ := payload["decryptFailures"].([]any)
+	failure, _ := failures[0].(map[string]any)
+	if failure["reason"] != "policy_disabled" || failure["stage"] != "message-decrypt" || failure["messageId"] != "m1" {
+		t.Fatalf("policy-off failure = %#v", failure)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != chatMessagesDecryptCipherText || first["contentDecrypted"] == true {
+		t.Fatalf("policy-off message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageAtMeDecryptBatchFailureFallsBackToOriginal(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{
+		responses: map[string]string{
+			"chat/search_at_me_message":    atMeDecryptResponse(chatMessagesDecryptCipherText),
+			"im/get_message_crypto_policy": `{"result":{"mode":"required"}}`,
+		},
+		failTool: "im/batch_ding_decrypt_messages",
+	}
+	payload := runChatMessagesDecrypt(t, caller, "chat", "+at-me")
+	if payload["decryptFailedCount"] != float64(1) || payload["partial"] != true {
+		t.Fatalf("batch-failure ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != chatMessagesDecryptCipherText || first["contentDecrypted"] == true {
+		t.Fatalf("batch-failure message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageAtMeDecryptSkipsWhenBackendUnavailable(t *testing.T) {
+	swapChatMessagesDecryptClient(t, &messagecrypto.Client{
+		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+			t.Fatal("identity lookup must not run without the SafeChat backend")
+			return messagecrypto.Identity{}, nil
+		},
+		BackendReady: func() bool { return false },
+		PolicyCache:  messagecrypto.NewPolicyCache(nil),
+	})
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/search_at_me_message": atMeDecryptResponse(chatMessagesDecryptCipherText),
+	}}
+	payload := runChatMessagesDecrypt(t, caller, "chat", "+at-me")
+	if len(caller.calls) != 1 {
+		t.Fatalf("calls = %#v, want search only", caller.calls)
+	}
+	for _, key := range []string{"decryptCandidateCount", "decryptAllowedCount", "decryptedCount", "decryptFailedCount", "decryptFailures"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("unavailable backend emitted %q: %#v", key, payload)
+		}
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if text, _ := first["text"].(string); !strings.Contains(text, "加密消息") {
+		t.Fatalf("message changed without backend: %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageAtMeDecryptPageAllSinglePolicyAndBatch(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{
+		pageTool: "chat/search_at_me_message",
+		listPages: []string{
+			`{"result":{"hasMore":true,"nextCursor":"cursor-2","conversationMessagesList":[{"openConversationId":"cid","title":"群A","messages":[{"openMessageId":"m1","openConversationId":"cid","content":"` + chatMessagesDecryptCipherText + `","createTime":"2026-01-02 00:00:00"}]}]}}`,
+			`{"result":{"hasMore":false,"conversationMessagesList":[{"openConversationId":"cid","title":"群A","messages":[{"openMessageId":"m2","openConversationId":"cid","content":"` + chatMessagesDecryptCipherText + `","createTime":"2026-01-01 00:00:00"}]}]}}`,
+		},
+		responses: map[string]string{
+			"im/get_message_crypto_policy":   `{"result":{"mode":"required","ttlSeconds":60}}`,
+			"im/batch_ding_decrypt_messages": `{"result":{"items":[{"messageId":"m1","status":"success","plaintextContent":"明文一"},{"messageId":"m2","status":"success","plaintextContent":"明文二"}]}}`,
+		},
+	}
+	payload := runChatMessagesDecrypt(t, caller, "chat", "+at-me", "--page-all", "--page-limit", "5")
+	listCalls, policyCalls, batchCalls := 0, 0, 0
+	for _, call := range caller.calls {
+		switch call.tool {
+		case "search_at_me_message":
+			listCalls++
+		case "get_message_crypto_policy":
+			policyCalls++
+		case "batch_ding_decrypt_messages":
+			batchCalls++
+		}
+	}
+	if listCalls != 2 || policyCalls != 1 || batchCalls != 1 {
+		t.Fatalf("calls = %d list / %d policy / %d batch, want 2/1/1", listCalls, policyCalls, batchCalls)
+	}
+	if payload["decryptCandidateCount"] != float64(2) ||
+		payload["decryptAllowedCount"] != float64(2) ||
+		payload["decryptedCount"] != float64(2) {
+		t.Fatalf("page-all decrypt ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	if len(messages) != 2 {
+		t.Fatalf("messages = %#v", messages)
+	}
+	first, _ := messages[0].(map[string]any)
+	second, _ := messages[1].(map[string]any)
+	if first["text"] != "明文一" || second["text"] != "明文二" {
+		t.Fatalf("page-all decrypted messages = %#v/%#v", first, second)
+	}
+}
+
+func TestCrossPlatformCoverageAtMeDecryptDryRunSkipsDecrypt(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/search_at_me_message": atMeDecryptResponse(chatMessagesDecryptCipherText),
+	}}
+	payload := runChatMessagesDecrypt(t, caller, "chat", "+at-me", "--dry-run")
+	for _, call := range caller.calls {
+		if call.tool == "get_message_crypto_policy" || call.tool == "batch_ding_decrypt_messages" {
+			t.Fatalf("dry-run must not call decrypt tools: %#v", caller.calls)
+		}
+	}
+	for _, key := range []string{"decryptCandidateCount", "decryptAllowedCount", "decryptedCount", "decryptFailedCount"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("dry-run emitted %q: %#v", key, payload)
 		}
 	}
 }

--- a/internal/shortcut/smart/chat_messages.go
+++ b/internal/shortcut/smart/chat_messages.go
@@ -655,9 +655,12 @@ func collectOneChatMessagesPage(rt *shortcut.RuntimeContext, request chatMessage
 	rawItems := chatMessageItems(data)
 	items, terminalReached, rangeFailures := request.timeRange.filter(rawItems)
 	sortMessagesByCreateTimeStable(items, request.timeRange.order)
+	decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+		chatmsg.MessageDecryptClient(), items, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 	results := projectChatMessages(items, !rt.Bool("no-reactions"))
 	payload := chatmsg.NewMessageListPayload(results)
 	chatmsg.ApplyMessagePagination(payload, data, rawItems, request.direction)
+	chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 	if metadata := request.timeRange.metadata(); metadata != nil {
 		payload["queryRange"] = metadata
 	}
@@ -864,8 +867,11 @@ func collectAllChatMessages(rt *shortcut.RuntimeContext, request chatMessagesReq
 	}
 
 	sortMessagesByCreateTimeStable(allItems, request.timeRange.order)
+	decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+		chatmsg.MessageDecryptClient(), allItems, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 	results := projectChatMessages(allItems, !rt.Bool("no-reactions"))
 	payload := chatmsg.NewMessageListPayload(results)
+	chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 	if metadata := request.timeRange.metadata(); metadata != nil {
 		payload["queryRange"] = metadata
 	}

--- a/internal/shortcut/smart/chat_messages_test.go
+++ b/internal/shortcut/smart/chat_messages_test.go
@@ -21,12 +21,15 @@ import (
 	"math"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
+	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut"
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/chatmsg"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/targetresolver"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
@@ -958,4 +961,276 @@ func TestCrossPlatformCoverageChatMessagesAdditionalCollectionEdges(t *testing.T
 			t.Fatalf("error=%v", err)
 		}
 	})
+}
+
+const chatMessagesDecryptCipherText = "SwzNkAraDE6lUHUNlVT3mjFdbxL6dWvmt77XtjACdpJx9VFibzTbW9KtDbkzGOYP||2||1||1"
+
+type chatMessagesDecryptCipher struct{}
+
+func (chatMessagesDecryptCipher) EncryptMessage(context.Context, string, string, []byte) ([]byte, error) {
+	return nil, stderrors.New("not used")
+}
+
+func (chatMessagesDecryptCipher) DecryptMessage(_ context.Context, _, _ string, ciphertext []byte) ([]byte, error) {
+	return []byte("ding:" + string(ciphertext)), nil
+}
+
+type chatMessagesDecryptCall struct {
+	product string
+	tool    string
+	args    map[string]any
+}
+
+type chatMessagesDecryptCaller struct {
+	calls     []chatMessagesDecryptCall
+	responses map[string]string
+	listPages []string
+	pageTool  string
+	failTool  string
+}
+
+func (c *chatMessagesDecryptCaller) CallTool(_ context.Context, product, tool string, args map[string]any) (*edition.ToolResult, error) {
+	c.calls = append(c.calls, chatMessagesDecryptCall{product: product, tool: tool, args: args})
+	key := product + "/" + tool
+	if c.failTool == key {
+		return nil, stderrors.New("fixture decrypt failure")
+	}
+	pagedKey := "chat/list_conversation_message_v2"
+	if c.pageTool != "" {
+		pagedKey = c.pageTool
+	}
+	if key == pagedKey && len(c.listPages) > 0 {
+		pagedTool := strings.TrimPrefix(pagedKey, "chat/")
+		index := 0
+		for _, call := range c.calls {
+			if call.product == "chat" && call.tool == pagedTool {
+				index++
+			}
+		}
+		if index > len(c.listPages) {
+			index = len(c.listPages)
+		}
+		return &edition.ToolResult{Content: []edition.ContentBlock{{
+			Type: "text",
+			Text: c.listPages[index-1],
+		}}}, nil
+	}
+	if text, ok := c.responses[key]; ok {
+		return &edition.ToolResult{Content: []edition.ContentBlock{{Type: "text", Text: text}}}, nil
+	}
+	return &edition.ToolResult{Content: []edition.ContentBlock{{Type: "text", Text: `{"success":true}`}}}, nil
+}
+
+func (c *chatMessagesDecryptCaller) CallReadTool(ctx context.Context, product, tool string, args map[string]any) (*edition.ToolResult, error) {
+	return c.CallTool(ctx, product, tool, args)
+}
+
+func (*chatMessagesDecryptCaller) Format() string { return "json" }
+func (*chatMessagesDecryptCaller) DryRun() bool   { return false }
+func (*chatMessagesDecryptCaller) Fields() string { return "" }
+func (*chatMessagesDecryptCaller) JQ() string     { return "" }
+
+func swapChatMessagesDecryptClient(t *testing.T, client *messagecrypto.Client) {
+	t.Helper()
+	old := chatmsg.MessageDecryptClient()
+	chatmsg.SetMessageDecryptClient(client)
+	t.Cleanup(func() { chatmsg.SetMessageDecryptClient(old) })
+}
+
+func chatMessagesDecryptReadyClient() *messagecrypto.Client {
+	return &messagecrypto.Client{
+		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+			return messagecrypto.Identity{CorpID: "corp-1", StaffID: "staff-1"}, nil
+		},
+		OpenSession: func(context.Context, messagecrypto.SessionOptions) (*messagecrypto.Session, error) {
+			return &messagecrypto.Session{Cipher: chatMessagesDecryptCipher{}, CorpID: "corp-1", StaffID: "staff-1"}, nil
+		},
+		BackendReady: func() bool { return true },
+		PolicyCache:  messagecrypto.NewPolicyCache(nil),
+	}
+}
+
+func runChatMessagesDecrypt(t *testing.T, caller *chatMessagesDecryptCaller, args ...string) map[string]any {
+	t.Helper()
+	helpers.InitDeps(caller)
+	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs(args)
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+func chatMessagesDecryptListResponse(content string) string {
+	return `{"result":{"hasMore":false,"messages":[{"openMessageId":"m1","openConversationId":"cid","sender":"张三","content":"` + content + `","createTime":"2026-01-02 00:00:00"}]}}`
+}
+
+func TestCrossPlatformCoverageChatMessagesDecryptSinglePage(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/list_conversation_message_v2": chatMessagesDecryptListResponse(chatMessagesDecryptCipherText),
+		"im/get_message_crypto_policy":      `{"result":{"mode":"required"}}`,
+		"im/batch_ding_decrypt_messages":    `{"result":{"items":[{"messageId":"m1","status":"success","plaintextContent":"hello decrypted","keyVersion":8}]}}`,
+	}}
+	payload := runChatMessagesDecrypt(t, caller,
+		"chat", "+chat-messages", "--conversation-id", "cid", "--time", "2026-01-03 00:00:00")
+	if len(caller.calls) != 3 ||
+		caller.calls[0].tool != "list_conversation_message_v2" ||
+		caller.calls[1].tool != "get_message_crypto_policy" ||
+		caller.calls[2].tool != "batch_ding_decrypt_messages" {
+		t.Fatalf("calls = %#v", caller.calls)
+	}
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(1) ||
+		payload["decryptedCount"] != float64(1) ||
+		payload["decryptFailedCount"] != float64(0) {
+		t.Fatalf("decrypt ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != "hello decrypted" || first["contentDecrypted"] != true ||
+		first["cryptoLayer"] != "ding+safechat" || first["dingKeyVersion"] != float64(8) {
+		t.Fatalf("decrypted message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageChatMessagesDecryptPolicyOff(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/list_conversation_message_v2": chatMessagesDecryptListResponse(chatMessagesDecryptCipherText),
+		"im/get_message_crypto_policy":      `{"result":{"mode":"off"}}`,
+	}}
+	payload := runChatMessagesDecrypt(t, caller,
+		"chat", "+chat-messages", "--conversation-id", "cid", "--time", "2026-01-03 00:00:00")
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(0) ||
+		payload["decryptFailedCount"] != float64(1) ||
+		payload["partial"] != true {
+		t.Fatalf("policy-off ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != chatMessagesDecryptCipherText || first["contentDecrypted"] == true {
+		t.Fatalf("policy-off message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageChatMessagesDecryptBatchFailureFallsBackToOriginal(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{
+		responses: map[string]string{
+			"chat/list_conversation_message_v2": chatMessagesDecryptListResponse(chatMessagesDecryptCipherText),
+			"im/get_message_crypto_policy":      `{"result":{"mode":"required"}}`,
+		},
+		failTool: "im/batch_ding_decrypt_messages",
+	}
+	payload := runChatMessagesDecrypt(t, caller,
+		"chat", "+chat-messages", "--conversation-id", "cid", "--time", "2026-01-03 00:00:00")
+	if payload["decryptFailedCount"] != float64(1) || payload["partial"] != true {
+		t.Fatalf("batch-failure ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != chatMessagesDecryptCipherText || first["contentDecrypted"] == true {
+		t.Fatalf("batch-failure message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageChatMessagesDecryptSkipsWhenBackendUnavailable(t *testing.T) {
+	swapChatMessagesDecryptClient(t, &messagecrypto.Client{
+		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+			t.Fatal("identity lookup must not run without the SafeChat backend")
+			return messagecrypto.Identity{}, nil
+		},
+		BackendReady: func() bool { return false },
+		PolicyCache:  messagecrypto.NewPolicyCache(nil),
+	})
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/list_conversation_message_v2": chatMessagesDecryptListResponse(chatMessagesDecryptCipherText),
+	}}
+	payload := runChatMessagesDecrypt(t, caller,
+		"chat", "+chat-messages", "--conversation-id", "cid", "--time", "2026-01-03 00:00:00")
+	if len(caller.calls) != 1 {
+		t.Fatalf("calls = %#v, want list only", caller.calls)
+	}
+	for _, key := range []string{"decryptCandidateCount", "decryptAllowedCount", "decryptedCount", "decryptFailedCount", "decryptFailures"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("unavailable backend emitted %q: %#v", key, payload)
+		}
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != "[加密消息，无法解码]" {
+		t.Fatalf("message changed without backend: %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageChatMessagesDecryptPageAllSinglePolicyAndBatch(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{
+		listPages: []string{
+			`{"result":{"hasMore":true,"nextCursor":1767225600123,"messages":[{"openMessageId":"m1","openConversationId":"cid","content":"` + chatMessagesDecryptCipherText + `","createTime":"2026-01-02 00:00:00"}]}}`,
+			`{"result":{"hasMore":false,"messages":[{"openMessageId":"m2","openConversationId":"cid","content":"` + chatMessagesDecryptCipherText + `","createTime":"2026-01-01 00:00:00"}]}}`,
+		},
+		responses: map[string]string{
+			"im/get_message_crypto_policy":   `{"result":{"mode":"required","ttlSeconds":60}}`,
+			"im/batch_ding_decrypt_messages": `{"result":{"items":[{"messageId":"m1","status":"success","plaintextContent":"明文一"},{"messageId":"m2","status":"success","plaintextContent":"明文二"}]}}`,
+		},
+	}
+	payload := runChatMessagesDecrypt(t, caller,
+		"chat", "+chat-messages", "--conversation-id", "cid", "--time", "2026-01-03 00:00:00",
+		"--page-all", "--page-limit", "5")
+	listCalls, policyCalls, batchCalls := 0, 0, 0
+	for _, call := range caller.calls {
+		switch call.tool {
+		case "list_conversation_message_v2":
+			listCalls++
+		case "get_message_crypto_policy":
+			policyCalls++
+		case "batch_ding_decrypt_messages":
+			batchCalls++
+		}
+	}
+	if listCalls != 2 || policyCalls != 1 || batchCalls != 1 {
+		t.Fatalf("calls = %d list / %d policy / %d batch, want 2/1/1", listCalls, policyCalls, batchCalls)
+	}
+	if payload["decryptCandidateCount"] != float64(2) ||
+		payload["decryptAllowedCount"] != float64(2) ||
+		payload["decryptedCount"] != float64(2) {
+		t.Fatalf("page-all decrypt ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	if len(messages) != 2 {
+		t.Fatalf("messages = %#v", messages)
+	}
+	first, _ := messages[0].(map[string]any)
+	second, _ := messages[1].(map[string]any)
+	if first["text"] != "明文一" || second["text"] != "明文二" {
+		t.Fatalf("page-all decrypted messages = %#v/%#v", first, second)
+	}
+}
+
+func TestCrossPlatformCoverageChatMessagesDecryptDryRunSkipsDecrypt(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/list_conversation_message_v2": chatMessagesDecryptListResponse(chatMessagesDecryptCipherText),
+	}}
+	payload := runChatMessagesDecrypt(t, caller,
+		"chat", "+chat-messages", "--conversation-id", "cid", "--time", "2026-01-03 00:00:00", "--dry-run")
+	for _, call := range caller.calls {
+		if call.tool == "get_message_crypto_policy" || call.tool == "batch_ding_decrypt_messages" {
+			t.Fatalf("dry-run must not call decrypt tools: %#v", caller.calls)
+		}
+	}
+	for _, key := range []string{"decryptCandidateCount", "decryptAllowedCount", "decryptedCount", "decryptFailedCount"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("dry-run emitted %q: %#v", key, payload)
+		}
+	}
 }

--- a/internal/shortcut/smart/search_msg.go
+++ b/internal/shortcut/smart/search_msg.go
@@ -293,6 +293,8 @@ var SearchMsg = shortcut.Shortcut{
 			order = "desc"
 		}
 		sortMessagesByCreateTimeStable(messages, order)
+		decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+			chatmsg.MessageDecryptClient(), messages, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 		results := make([]map[string]any, 0, len(messages))
 		for _, m := range messages {
 			results = append(results, searchMsgProjectWithReactions(m, !rt.Bool("no-reactions")))
@@ -313,6 +315,7 @@ var SearchMsg = shortcut.Shortcut{
 			"timeCoverage":    searchMessageTimeCoverage(rt),
 			"conclusionGuard": searchMessageConclusionGuard(rt, complete, len(results)),
 		}
+		chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 		if len(resolvedFilters.Chats) > 0 || len(resolvedFilters.Senders) > 0 {
 			payload["resolvedFilters"] = resolvedFilters
 		}

--- a/internal/shortcut/smart/search_msg_execution_test.go
+++ b/internal/shortcut/smart/search_msg_execution_test.go
@@ -10,11 +10,13 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
+	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/shortcut/targetresolver"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/pkg/edition"
 )
@@ -37,6 +39,8 @@ type searchMsgExecutionCaller struct {
 	groupResponse      string
 	failContactKeyword string
 	failGroupKeyword   string
+	policyResponse     string
+	batchResponse      string
 }
 
 const (
@@ -97,6 +101,16 @@ func (f *searchMsgExecutionCaller) CallTool(_ context.Context, product, tool str
 			return searchMsgToolResult(f.firstResponse), nil
 		}
 		return searchMsgToolResult(`{"result":{"messages":[{"openMessageId":"m1","openConversationId":"cid-1","senderOpenDingTalkId":"` + testCurrentDOpenID + `","content":"sparse-1"}],"hasMore":true,"nextCursor":"c2"}}`), nil
+	case "get_message_crypto_policy":
+		if f.policyResponse != "" {
+			return searchMsgToolResult(f.policyResponse), nil
+		}
+		return nil, errors.New("unexpected tool")
+	case "batch_ding_decrypt_messages":
+		if f.batchResponse != "" {
+			return searchMsgToolResult(f.batchResponse), nil
+		}
+		return nil, errors.New("unexpected tool")
 	case "list_messages_by_ids":
 		if f.failEnrichment {
 			return nil, errors.New("mget unavailable")
@@ -748,5 +762,166 @@ func TestCrossPlatformCoverageSearchMsgLarkTimeAliasesAndAscendingOrder(t *testi
 	rangeMeta := payload["queryRange"].(map[string]any)
 	if rangeMeta["order"] != "asc" || rangeMeta["semantics"] != "[start,end)" {
 		t.Fatalf("queryRange = %#v", rangeMeta)
+	}
+}
+
+func TestCrossPlatformCoverageSearchMsgDecryptEnrichedContentSinglePage(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &searchMsgExecutionCaller{
+		searchResponse: `{"result":{"messages":[{"openMessageId":"m1","openConversationId":"cid-1","content":"sparse-hit"}],"hasMore":false}}`,
+		mgetResponse:   `{"result":[{"openMessageId":"m1","openConversationId":"cid-1","content":"` + chatMessagesDecryptCipherText + `"}]}`,
+		policyResponse: `{"result":{"mode":"required"}}`,
+		batchResponse:  `{"result":{"items":[{"messageId":"m1","status":"success","plaintextContent":"hello decrypted","keyVersion":8}]}}`,
+	}
+	payload := executeSearchMsg(t, caller, "--query", "周报")
+	listCalls, enrichCalls, policyCalls, batchCalls := 0, 0, 0, 0
+	for _, call := range caller.calls {
+		switch call.tool {
+		case "search_messages":
+			listCalls++
+		case "list_messages_by_ids":
+			enrichCalls++
+		case "get_message_crypto_policy":
+			policyCalls++
+		case "batch_ding_decrypt_messages":
+			batchCalls++
+		}
+	}
+	if listCalls != 1 || enrichCalls != 1 || policyCalls != 1 || batchCalls != 1 {
+		t.Fatalf("calls = %d search / %d enrich / %d policy / %d batch, want 1/1/1/1", listCalls, enrichCalls, policyCalls, batchCalls)
+	}
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(1) ||
+		payload["decryptedCount"] != float64(1) ||
+		payload["decryptFailedCount"] != float64(0) {
+		t.Fatalf("decrypt ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != "hello decrypted" || first["contentDecrypted"] != true ||
+		first["cryptoLayer"] != "ding+safechat" || first["dingKeyVersion"] != float64(8) {
+		t.Fatalf("decrypted message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageSearchMsgDecryptPolicyOffRecordsFailure(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &searchMsgExecutionCaller{
+		searchResponse: `{"result":{"messages":[{"openMessageId":"m1","openConversationId":"cid-1","content":"` + chatMessagesDecryptCipherText + `"}],"hasMore":false}}`,
+		mgetResponse:   `{"result":[{"openMessageId":"m1","openConversationId":"cid-1","content":"` + chatMessagesDecryptCipherText + `"}]}`,
+		policyResponse: `{"result":{"mode":"off"}}`,
+	}
+	payload := executeSearchMsg(t, caller, "--query", "周报", "--no-enrich")
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(0) ||
+		payload["decryptFailedCount"] != float64(1) ||
+		payload["partial"] != true {
+		t.Fatalf("policy-off ledger = %#v", payload)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != chatMessagesDecryptCipherText || first["contentDecrypted"] == true {
+		t.Fatalf("policy-off message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageSearchMsgDecryptBatchFailureFallsBackToOriginal(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &searchMsgExecutionCaller{
+		searchResponse: `{"result":{"messages":[{"openMessageId":"m1","openConversationId":"cid-1","content":"` + chatMessagesDecryptCipherText + `"}],"hasMore":false}}`,
+		policyResponse: `{"result":{"mode":"required"}}`,
+		batchResponse:  `{"result":{"items":[{"messageId":"m1","status":"failed","reason":"key_unavailable"}]}}`,
+	}
+	payload := executeSearchMsg(t, caller, "--query", "周报", "--no-enrich")
+	if payload["decryptFailedCount"] != float64(1) || payload["partial"] != true {
+		t.Fatalf("batch-failure ledger = %#v", payload)
+	}
+	failures, _ := payload["decryptFailures"].([]any)
+	failure, _ := failures[0].(map[string]any)
+	if failure["reason"] != "key_unavailable" || failure["messageId"] != "m1" {
+		t.Fatalf("batch failure = %#v", failure)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != chatMessagesDecryptCipherText || first["contentDecrypted"] == true {
+		t.Fatalf("batch-failure message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageSearchMsgDecryptSkipsWhenBackendUnavailable(t *testing.T) {
+	swapChatMessagesDecryptClient(t, &messagecrypto.Client{
+		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+			t.Fatal("identity lookup must not run without the SafeChat backend")
+			return messagecrypto.Identity{}, nil
+		},
+		BackendReady: func() bool { return false },
+		PolicyCache:  messagecrypto.NewPolicyCache(nil),
+	})
+	caller := &searchMsgExecutionCaller{
+		searchResponse: `{"result":{"messages":[{"openMessageId":"m1","openConversationId":"cid-1","content":"` + chatMessagesDecryptCipherText + `"}],"hasMore":false}}`,
+	}
+	payload := executeSearchMsg(t, caller, "--query", "周报", "--no-enrich")
+	if len(caller.calls) != 1 {
+		t.Fatalf("calls = %#v, want search only", caller.calls)
+	}
+	for _, key := range []string{"decryptCandidateCount", "decryptAllowedCount", "decryptedCount", "decryptFailedCount", "decryptFailures"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("unavailable backend emitted %q: %#v", key, payload)
+		}
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if text, _ := first["text"].(string); !strings.Contains(text, "加密消息") {
+		t.Fatalf("message changed without backend: %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageSearchMsgDecryptNoEnrichCoexistsWithDecrypt(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &searchMsgExecutionCaller{
+		searchResponse: `{"result":{"messages":[{"openMessageId":"m1","openConversationId":"cid-1","content":"` + chatMessagesDecryptCipherText + `"}],"hasMore":false}}`,
+		policyResponse: `{"result":{"mode":"required"}}`,
+		batchResponse:  `{"result":{"items":[{"messageId":"m1","status":"success","plaintextContent":"no-enrich decrypted"}]}}`,
+	}
+	payload := executeSearchMsg(t, caller, "--query", "周报", "--no-enrich")
+	listCalls, enrichCalls, batchCalls := 0, 0, 0
+	for _, call := range caller.calls {
+		switch call.tool {
+		case "search_messages":
+			listCalls++
+		case "list_messages_by_ids":
+			enrichCalls++
+		case "batch_ding_decrypt_messages":
+			batchCalls++
+		}
+	}
+	if listCalls != 1 || enrichCalls != 0 || batchCalls != 1 {
+		t.Fatalf("calls = %d search / %d enrich / %d batch, want 1/0/1", listCalls, enrichCalls, batchCalls)
+	}
+	messages, _ := payload["messages"].([]any)
+	first, _ := messages[0].(map[string]any)
+	if first["text"] != "no-enrich decrypted" || first["contentDecrypted"] != true {
+		t.Fatalf("no-enrich decrypted message = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageSearchMsgDecryptDryRunSkipsDecrypt(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &searchMsgExecutionCaller{
+		searchResponse: `{"result":{"messages":[{"openMessageId":"m1","openConversationId":"cid-1","content":"` + chatMessagesDecryptCipherText + `"}],"hasMore":false}}`,
+	}
+	payload, err := executeSearchMsgResult(caller, "--query", "周报", "--no-enrich", "--dry-run")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range caller.calls {
+		if call.tool == "get_message_crypto_policy" || call.tool == "batch_ding_decrypt_messages" {
+			t.Fatalf("dry-run must not call decrypt tools: %#v", caller.calls)
+		}
+	}
+	for _, key := range []string{"decryptCandidateCount", "decryptAllowedCount", "decryptedCount", "decryptFailedCount"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("dry-run emitted %q: %#v", key, payload)
+		}
 	}
 }

--- a/internal/shortcut/smart/thread_replies.go
+++ b/internal/shortcut/smart/thread_replies.go
@@ -314,7 +314,10 @@ func collectOneThreadRepliesPage(rt *shortcut.RuntimeContext, params map[string]
 		return nil, nil, err
 	}
 	items := threadReplyItems(data)
+	decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+		chatmsg.MessageDecryptClient(), items, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 	payload := newThreadRepliesPayload(items, !rt.Bool("no-reactions"))
+	chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 	applyOneThreadRepliesPagination(payload, data)
 	if payload["complete"] == true {
 		payload["stopReason"] = "source_complete"
@@ -456,7 +459,10 @@ func collectAllThreadReplies(rt *shortcut.RuntimeContext, params map[string]any)
 		truncatedByPageLimit = true
 		stopReason = "page_limit"
 	}
+	decryptLedger := chatmsg.DecryptMessagesByPolicy(rt.Command().Context(), rt,
+		chatmsg.MessageDecryptClient(), allItems, chatmsg.DecryptOptions{MarkFailedOriginal: true})
 	payload := newThreadRepliesPayload(allItems, !rt.Bool("no-reactions"))
+	chatmsg.ApplyDecryptLedger(payload, decryptLedger)
 	payload["pagesFetched"] = pagesFetched
 	payload["paginationKnown"] = paginationKnown
 	payload["complete"] = complete && len(failures) == 0

--- a/internal/shortcut/smart/thread_replies_pagination_test.go
+++ b/internal/shortcut/smart/thread_replies_pagination_test.go
@@ -15,6 +15,7 @@ package smart
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	stderrors "errors"
 	"math"
@@ -23,6 +24,7 @@ import (
 
 	apperrors "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/errors"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/helpers"
+	messagecrypto "github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/msgcrypto/message"
 )
 
 func TestCrossPlatformCoverageThreadRepliesResolvesRootMessageIDBeforeReadingReplies(t *testing.T) {
@@ -489,4 +491,183 @@ func decodeThreadRepliesPayload(t *testing.T, raw []byte) map[string]any {
 		t.Fatalf("decode thread replies payload: %v\n%s", err, raw)
 	}
 	return payload
+}
+
+func threadRepliesDecryptResponse(content string, hasMore bool, extra string) string {
+	return `{"result":{"hasMore":` + boolToString(hasMore) + extra + `,"messages":[{"openMessageId":"m1","openConversationId":"cid","content":"` + content + `","createTime":"2026-08-05 19:46:00"}]}}`
+}
+
+func boolToString(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func TestCrossPlatformCoverageThreadRepliesDecryptSinglePage(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/list_topic_replies":        threadRepliesDecryptResponse(chatMessagesDecryptCipherText, false, ""),
+		"im/get_message_crypto_policy":   `{"result":{"mode":"required"}}`,
+		"im/batch_ding_decrypt_messages": `{"result":{"items":[{"messageId":"m1","status":"success","plaintextContent":"hello decrypted","keyVersion":8}]}}`,
+	}}
+	helpers.InitDeps(caller)
+	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{"chat", "+thread-replies", "--group", "cid", "--thread-id", "thread"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if len(caller.calls) != 3 ||
+		caller.calls[0].tool != "list_topic_replies" ||
+		caller.calls[1].tool != "get_message_crypto_policy" ||
+		caller.calls[2].tool != "batch_ding_decrypt_messages" {
+		t.Fatalf("calls = %#v", caller.calls)
+	}
+	payload := decodeThreadRepliesPayload(t, output.Bytes())
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(1) ||
+		payload["decryptedCount"] != float64(1) ||
+		payload["decryptFailedCount"] != float64(0) {
+		t.Fatalf("decrypt ledger = %#v", payload)
+	}
+	replies, _ := payload["replies"].([]any)
+	first, _ := replies[0].(map[string]any)
+	if first["text"] != "hello decrypted" || first["contentDecrypted"] != true ||
+		first["cryptoLayer"] != "ding+safechat" || first["dingKeyVersion"] != float64(8) {
+		t.Fatalf("decrypted reply = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageThreadRepliesDecryptPolicyOff(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/list_topic_replies":      threadRepliesDecryptResponse(chatMessagesDecryptCipherText, false, ""),
+		"im/get_message_crypto_policy": `{"result":{"mode":"off"}}`,
+	}}
+	helpers.InitDeps(caller)
+	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{"chat", "+thread-replies", "--group", "cid", "--thread-id", "thread"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeThreadRepliesPayload(t, output.Bytes())
+	if payload["decryptCandidateCount"] != float64(1) ||
+		payload["decryptAllowedCount"] != float64(0) ||
+		payload["decryptFailedCount"] != float64(1) ||
+		payload["partial"] != true {
+		t.Fatalf("policy-off ledger = %#v", payload)
+	}
+	replies, _ := payload["replies"].([]any)
+	first, _ := replies[0].(map[string]any)
+	if first["text"] != chatMessagesDecryptCipherText || first["contentDecrypted"] == true {
+		t.Fatalf("policy-off reply = %#v", first)
+	}
+}
+
+func TestCrossPlatformCoverageThreadRepliesDecryptSkipsWhenBackendUnavailable(t *testing.T) {
+	swapChatMessagesDecryptClient(t, &messagecrypto.Client{
+		Identity: func(context.Context, string) (messagecrypto.Identity, error) {
+			t.Fatal("identity lookup must not run without the SafeChat backend")
+			return messagecrypto.Identity{}, nil
+		},
+		BackendReady: func() bool { return false },
+		PolicyCache:  messagecrypto.NewPolicyCache(nil),
+	})
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/list_topic_replies": threadRepliesDecryptResponse(chatMessagesDecryptCipherText, false, ""),
+	}}
+	helpers.InitDeps(caller)
+	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{"chat", "+thread-replies", "--group", "cid", "--thread-id", "thread"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if len(caller.calls) != 1 {
+		t.Fatalf("calls = %#v, want replies read only", caller.calls)
+	}
+	payload := decodeThreadRepliesPayload(t, output.Bytes())
+	for _, key := range []string{"decryptCandidateCount", "decryptAllowedCount", "decryptedCount", "decryptFailedCount", "decryptFailures"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("unavailable backend emitted %q: %#v", key, payload)
+		}
+	}
+}
+
+func TestCrossPlatformCoverageThreadRepliesDecryptPageAllSinglePolicyAndBatch(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{
+		pageTool: "chat/list_topic_replies",
+		listPages: []string{
+			`{"result":{"hasMore":true,"nextCursor":1786022919361,"messages":[{"openMessageId":"m1","openConversationId":"cid","content":"` + chatMessagesDecryptCipherText + `","createTime":"2026-08-06 21:28:40"}]}}`,
+			`{"result":{"hasMore":false,"messages":[{"openMessageId":"m2","openConversationId":"cid","content":"` + chatMessagesDecryptCipherText + `","createTime":"2026-08-05 19:46:00"}]}}`,
+		},
+		responses: map[string]string{
+			"im/get_message_crypto_policy":   `{"result":{"mode":"required","ttlSeconds":60}}`,
+			"im/batch_ding_decrypt_messages": `{"result":{"items":[{"messageId":"m1","status":"success","plaintextContent":"明文一"},{"messageId":"m2","status":"success","plaintextContent":"明文二"}]}}`,
+		},
+	}
+	helpers.InitDeps(caller)
+	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{"chat", "+thread-replies", "--group", "cid", "--thread-id", "thread", "--page-all", "--page-limit", "5"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	listCalls, policyCalls, batchCalls := 0, 0, 0
+	for _, call := range caller.calls {
+		switch call.tool {
+		case "list_topic_replies":
+			listCalls++
+		case "get_message_crypto_policy":
+			policyCalls++
+		case "batch_ding_decrypt_messages":
+			batchCalls++
+		}
+	}
+	if listCalls != 2 || policyCalls != 1 || batchCalls != 1 {
+		t.Fatalf("calls = %d list / %d policy / %d batch, want 2/1/1", listCalls, policyCalls, batchCalls)
+	}
+	payload := decodeThreadRepliesPayload(t, output.Bytes())
+	if payload["decryptCandidateCount"] != float64(2) ||
+		payload["decryptAllowedCount"] != float64(2) ||
+		payload["decryptedCount"] != float64(2) {
+		t.Fatalf("page-all decrypt ledger = %#v", payload)
+	}
+	replies, _ := payload["replies"].([]any)
+	if len(replies) != 2 {
+		t.Fatalf("replies = %#v", replies)
+	}
+}
+
+func TestCrossPlatformCoverageThreadRepliesDecryptDryRunSkipsDecrypt(t *testing.T) {
+	swapChatMessagesDecryptClient(t, chatMessagesDecryptReadyClient())
+	caller := &chatMessagesDecryptCaller{responses: map[string]string{
+		"chat/list_topic_replies": threadRepliesDecryptResponse(chatMessagesDecryptCipherText, false, ""),
+	}}
+	helpers.InitDeps(caller)
+	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
+	root.SetArgs([]string{"chat", "+thread-replies", "--group", "cid", "--thread-id", "thread", "--dry-run"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range caller.calls {
+		if call.tool == "get_message_crypto_policy" || call.tool == "batch_ding_decrypt_messages" {
+			t.Fatalf("dry-run must not call decrypt tools: %#v", caller.calls)
+		}
+	}
+	payload := decodeThreadRepliesPayload(t, output.Bytes())
+	for _, key := range []string{"decryptCandidateCount", "decryptAllowedCount", "decryptedCount", "decryptFailedCount"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("dry-run emitted %q: %#v", key, payload)
+		}
+	}
 }

--- a/skills/multi/dingtalk-chat/references/chat.md
+++ b/skills/multi/dingtalk-chat/references/chat.md
@@ -62,6 +62,21 @@
 Favorite、消息 Pin、消息 Top 与会话 Top 是四种对象，不能互换。
 个人收藏表情与消息 reaction/文字回应不同；发送收藏表情使用 `chat emotion send`，给已有消息贴表情使用 `chat message add-emoji` 或 `chat message add-text-emotion`。
 
+## 解密
+
+`-tags safechat` 构建且组织开启三方消息解密策略时，以下读消息命令自动解密，无新增 flag：
+
+| 命令 | 覆盖 |
+|---|---|
+| `+chat-messages` / `+messages-list` / `+messages-list-direct` / `+messages-mget` | 会话消息读取；`--page-all`（`+chat-messages` / `+messages-list-direct`）聚合后统一解密 |
+| `+at-me` / `+search-msg` / `+thread-replies` | @我、条件搜索、话题回复；单页与自动分页聚合路径均已接线 |
+
+- 解密成功的行 `text` 为明文，并带运行时调试标记 `contentDecrypted=true`、`cryptoLayer="ding+safechat"`、`dingKeyVersion`（仅 >0 时出现）；三标记是运行时 ledger/调试字段，不在消息契约声明面内。
+- 解密 ledger 在输出顶层，与原子命令对齐：`decryptCandidateCount` / `decryptAllowedCount` / `decryptedCount` / `decryptFailedCount` / `decryptFailures`（逐条 `stage` / `messageId` / `conversationId` / `reason`），有失败时 `partial=true`。读法：先看 `decryptFailedCount` 是否非零，再到 `decryptFailures` 按 `messageId` 查原因；`policy_disabled` 表示组织策略未放行该会话。
+- 失败行的 `text` 恢复为原密文（不是 `[加密消息，无法解码]` marker），可复制到 `dws chat crypto decrypt --text <密文>` 手工解密排障；单条失败不影响其它消息。
+- 非 safechat 构建或解密后端不可用时整段跳过：零解密字段，输出与未接线前一致。
+- 原子命令（`chat message list` 等）的失败行形状不同：`content`=密文 + `text`=marker；两层投影残差属预期，跨层比对以 ledger 为准。
+
 ## 群与成员底层能力
 
 | 原子命令 | 用途 |


### PR DESCRIPTION
## Summary

- What: extend policy-driven third-party (Ding + SafeChat) message decryption to the smart-layer read shortcuts `chat +chat-messages`, `chat +at-me`, `chat +search-msg`, `chat +thread-replies`, and move the already-covered shortcuts (`chat +messages-list`, `chat +messages-list-direct`, `chat +messages-mget`) plus the atomic read path onto the same shared pipeline in `internal/shortcut/chatmsg` — 7 read shortcuts now decrypt third-party messages consistently.
- Why: the atomic IM read commands and `+messages-*` shortcuts already decrypt, but the sibling smart read shortcuts still emitted ciphertext projections; this closes the UX inconsistency for IM message reads.
- The decrypt ledger stays additive: payload-level `decryptCandidateCount` / `decryptAllowedCount` / `decryptedCount` / `decryptFailedCount` / `decryptFailures[]` and message-level `contentDecrypted` / `cryptoLayer` keep their existing shapes; policy-off output is unchanged (atomic path passes zero-value decrypt options and never marks failures).
- Commit stack (5 commits): `8f145d1d` shared policy-driven decrypt pipeline → `c21eed12` atomic chat decrypt delegates to the shared pipeline → `588e61c0` shortcuts adopt the shared pipeline → `b404f111` wire message decrypt into read shortcuts → `e049a728` document shortcut decrypt for read shortcuts (docs sync, 2 files).

## Risk tier

- [x] High-risk: touches chat message read behavior and user-visible projection (same tier as #1150).

## Verification

- [x] Release fragment added for a user-visible behavior/interface change: committed as `.changes/1318-chat-shortcut-decrypt.md` (category `Changed`) in follow-up commit `394b51ec6f47d1fd43f3387b1194cf6c6958fa4a`; `./scripts/policy/check-release-fragments.sh 36680f06 HEAD` green locally.
- [ ] Release-seal validation: N/A for this PR (the fragment lands via `394b51ec6f47d1fd43f3387b1194cf6c6958fa4a`; archival happens in the release-seal PR).
- [x] Targeted test/check commands and results (all at head `e049a728a0422f89890e79a75df993185738e5c5`):
  - 9/9 local gates green: build (default and `-tags safechat`), `./scripts/policy/check-command-surface.sh --strict` (ok; command surface unchanged), `make generate-schema` (ok, assembly determinism ok), `./scripts/policy/check-generated-drift.sh` (ok), 5 key message-decrypt tests across `internal/shortcut/chatmsg` + `internal/helpers` (all PASS), `go test ./internal/app/... -count=1` (ok, 544s), full `go test ./...` (failures confined to the declared baseline, below), baseline equivalence re-run at upstream baseline `36680f06` (per-item match), head-annotated screenshot evidence (see Screenshots).
  - Baseline equivalence: full-suite failures on this branch are exactly the declared pre-existing baseline — `internal/helpers/doc` (pre-existing build failure; zero diff in this range) and 3 JSONML tests in `internal/helpers` — and the independent `36680f06` re-run confirmed **0 out-of-scope failures for this change range**. The triage also corrected two packages missing from the previously documented baseline list: `internal/interfacesnapshot` (`TestCrossPlatformCoverageFlagMigrationStrictJSONSchemaErrors`) and `internal/jsonutil` (`TestCrossPlatformCoverageRejectDuplicateObjectKeysMalformed`).
- [x] Behavior evidence: fake-cipher unit/contract tests (forwarded-children decrypt, child decrypt failure restore, policy cache TTL reuse, no-stable-ID skip) plus a real-env read-only `chat +at-me` decrypt-ledger invocation (see Screenshots).
- [x] Documentation checked: `docs/shortcut-handoff.md` and `skills/multi/dingtalk-chat/references/chat.md` updated in `e049a728`.
- [x] Full local suite run because the change is high-risk: `go test ./...` — failures identical to the declared baseline (see above).
- [x] `./scripts/policy/check-generated-drift.sh`: ok.
- [x] `./scripts/policy/check-command-surface.sh --strict`: ok (no command surface change: no new flags, no Contract/Schema changes).
- [ ] `./scripts/release/verify-package-managers.sh`: N/A (no packaging changes).

## Notes

- **Known gap, tracked separately (not in this PR)**: the atomic MCP path's `internal/msgcrypto/message.intField` does not recognize `json.Number`, so `dingKeyVersion` is never populated on the atomic projection (the shortcut path is unaffected). The fix (add a `json.Number` branch and restore the atomic contract assertion) will be tracked in a separate follow-up issue; the link will be added here once filed.
- **Changelog fragment**: committed — `.changes/1318-chat-shortcut-decrypt.md` (category `Changed`) covers the additive decrypt ledger counts (D-1), forwarded nested-content decrypt with content/text write-back (D-2), and per-item decrypt-failure shape (D-γ); follow-up commit `394b51ec6f47d1fd43f3387b1194cf6c6958fa4a` on top of `e049a728`, with `./scripts/policy/check-release-fragments.sh` green locally.
- **Evidence degradation**: a screenshot of real ciphertext messages actually being decrypted in a real environment (non-zero decrypt ledger markers) could not be captured against the currently available org, so this PR stays **Draft** until that evidence is supplemented. The real-env read-only `+at-me` ledger invocation below is interim evidence.
- Upstream `main` advanced to `fb79103a` after the local verification baseline (`36680f06`); CI will run the full required suite on this PR.

## Screenshots / 验证截图

- Key message-decrypt tests at head `e049a728` (5 RUN/PASS pairs, both packages `ok`, EXIT=0):
  https://raw.githubusercontent.com/xlb1130/image-hosting/main/dws-pr-evidence/dingtalk-workspace-cli/feat/86480181-im-shortcut-msg-decrypt/e049a728-cli-tests-success.png
- Real-env read-only `chat +at-me` decrypt-ledger invocation at head `e049a728` (EXIT=0):
  https://raw.githubusercontent.com/xlb1130/image-hosting/main/dws-pr-evidence/dingtalk-workspace-cli/feat/86480181-im-shortcut-msg-decrypt/e049a728-at-me-decrypt-ledger.png

