### PR TITLE
feat(npm): honor DWS_NO_SKILLS=1 to skip skill installation

### DIFF
--- a/.changes/1320-npm-no-skills-env.md
+++ b/.changes/1320-npm-no-skills-env.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **npm 安装支持 `DWS_NO_SKILLS`** (#1320) — `npm install -g dingtalk-workspace-cli` 现在识别 `DWS_NO_SKILLS=1`，设置后只安装 CLI 本体并跳过 skill 安装，与 `scripts/install.sh`、`scripts/install.ps1` 已有语义对齐。适用于自行分发 skill、或需要规避 skill 写入失败（如 Windows 上 `renameSync` 抛 EPERM）导致整个 npm 安装失败的场景。

--- a/.changes/1320-npm-postinstall-skill-nonfatal.md
+++ b/.changes/1320-npm-postinstall-skill-nonfatal.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **npm postinstall skill 安装不再阻断 CLI 安装** (#1320) — skill 安装失败（如 Windows 上 `publishCacheAtomically` 的 `renameSync` 抛 EPERM）此前会让整个 `npm install` 以非零退出码失败，即使 CLI 二进制已解压可用；现在改为仅打印告警并提示运行 `dws skill setup` 补装。同时 npm 安装路径开始识别 `DWS_NO_SKILLS=1`，与 `scripts/install.sh`、`scripts/install.ps1` 已有语义对齐。

--- a/.changes/1320-npm-postinstall-skill-nonfatal.md
+++ b/.changes/1320-npm-postinstall-skill-nonfatal.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **npm postinstall skill 安装不再阻断 CLI 安装** (#1320) — skill 安装失败（如 Windows 上 `publishCacheAtomically` 的 `renameSync` 抛 EPERM）此前会让整个 `npm install` 以非零退出码失败，即使 CLI 二进制已解压可用；现在改为仅打印告警并提示运行 `dws skill setup` 补装。同时 npm 安装路径开始识别 `DWS_NO_SKILLS=1`，与 `scripts/install.sh`、`scripts/install.ps1` 已有语义对齐。

--- a/build/npm/install.js
+++ b/build/npm/install.js
@@ -1853,34 +1853,45 @@ function main() {
   }
 
   extractArchive(archivePath, vendorDir);
-  extractSkills(skillsPath, skillsStaging);
 
-  // For backward compatibility, the zip root carries a copy of mono content
-  // (SKILL.md + references/ + scripts/). Prefer the explicit mono/ subdir
-  // when present; fall back to the staging root otherwise.
-  const monoRoot = fs.existsSync(path.join(skillsStaging, "mono", "SKILL.md"))
-    ? path.join(skillsStaging, "mono")
-    : skillsStaging;
-  // A mono install requires an actual SKILL.md at the root of monoRoot. On a
-  // multi-only zip monoRoot would degrade to the staging root and copy the
-  // whole bundle (multi/ included) into a dws/ directory — skip instead.
-  const monoHasSkill = fs.existsSync(path.join(monoRoot, "SKILL.md"));
-  const multiRoot = path.join(skillsStaging, "multi");
-  const skillMode = resolveSkillMode();
-  if (skillMode === "multi" && multiTreeHasSkills(multiRoot)) {
-    console.log(`Skill mode: multi — installing per-product skills`);
-    installMultiSkillsToHomes(multiRoot);
-  } else {
-    if (skillMode === "multi") {
-      console.log("multi skill tree not found or empty in bundle; falling back to mono.");
-    }
-    if (monoHasSkill) {
-      installSkillsToHomes(monoRoot);
-    } else {
-      console.log("mono skill tree not found in bundle; skipping skill install.");
-    }
+  if ((process.env.DWS_NO_SKILLS || "").trim() === "1") {
+    console.log("[dws] DWS_NO_SKILLS=1; skipping skill installation.");
+    return;
   }
-  cacheUserSkills(skillsStaging);
+
+  try {
+    extractSkills(skillsPath, skillsStaging);
+
+    // For backward compatibility, the zip root carries a copy of mono content
+    // (SKILL.md + references/ + scripts/). Prefer the explicit mono/ subdir
+    // when present; fall back to the staging root otherwise.
+    const monoRoot = fs.existsSync(path.join(skillsStaging, "mono", "SKILL.md"))
+      ? path.join(skillsStaging, "mono")
+      : skillsStaging;
+    // A mono install requires an actual SKILL.md at the root of monoRoot. On a
+    // multi-only zip monoRoot would degrade to the staging root and copy the
+    // whole bundle (multi/ included) into a dws/ directory — skip instead.
+    const monoHasSkill = fs.existsSync(path.join(monoRoot, "SKILL.md"));
+    const multiRoot = path.join(skillsStaging, "multi");
+    const skillMode = resolveSkillMode();
+    if (skillMode === "multi" && multiTreeHasSkills(multiRoot)) {
+      console.log(`Skill mode: multi — installing per-product skills`);
+      installMultiSkillsToHomes(multiRoot);
+    } else {
+      if (skillMode === "multi") {
+        console.log("multi skill tree not found or empty in bundle; falling back to mono.");
+      }
+      if (monoHasSkill) {
+        installSkillsToHomes(monoRoot);
+      } else {
+        console.log("mono skill tree not found in bundle; skipping skill install.");
+      }
+    }
+    cacheUserSkills(skillsStaging);
+  } catch (err) {
+    console.warn(`[dws] skill installation failed (non-fatal): ${err.message}`);
+    console.warn("[dws] CLI is functional. Run 'dws skill setup' to retry skill installation.");
+  }
 }
 
 if (require.main === module) {

--- a/build/npm/install.js
+++ b/build/npm/install.js
@@ -1859,39 +1859,34 @@ function main() {
     return;
   }
 
-  try {
-    extractSkills(skillsPath, skillsStaging);
+  extractSkills(skillsPath, skillsStaging);
 
-    // For backward compatibility, the zip root carries a copy of mono content
-    // (SKILL.md + references/ + scripts/). Prefer the explicit mono/ subdir
-    // when present; fall back to the staging root otherwise.
-    const monoRoot = fs.existsSync(path.join(skillsStaging, "mono", "SKILL.md"))
-      ? path.join(skillsStaging, "mono")
-      : skillsStaging;
-    // A mono install requires an actual SKILL.md at the root of monoRoot. On a
-    // multi-only zip monoRoot would degrade to the staging root and copy the
-    // whole bundle (multi/ included) into a dws/ directory — skip instead.
-    const monoHasSkill = fs.existsSync(path.join(monoRoot, "SKILL.md"));
-    const multiRoot = path.join(skillsStaging, "multi");
-    const skillMode = resolveSkillMode();
-    if (skillMode === "multi" && multiTreeHasSkills(multiRoot)) {
-      console.log(`Skill mode: multi — installing per-product skills`);
-      installMultiSkillsToHomes(multiRoot);
-    } else {
-      if (skillMode === "multi") {
-        console.log("multi skill tree not found or empty in bundle; falling back to mono.");
-      }
-      if (monoHasSkill) {
-        installSkillsToHomes(monoRoot);
-      } else {
-        console.log("mono skill tree not found in bundle; skipping skill install.");
-      }
+  // For backward compatibility, the zip root carries a copy of mono content
+  // (SKILL.md + references/ + scripts/). Prefer the explicit mono/ subdir
+  // when present; fall back to the staging root otherwise.
+  const monoRoot = fs.existsSync(path.join(skillsStaging, "mono", "SKILL.md"))
+    ? path.join(skillsStaging, "mono")
+    : skillsStaging;
+  // A mono install requires an actual SKILL.md at the root of monoRoot. On a
+  // multi-only zip monoRoot would degrade to the staging root and copy the
+  // whole bundle (multi/ included) into a dws/ directory — skip instead.
+  const monoHasSkill = fs.existsSync(path.join(monoRoot, "SKILL.md"));
+  const multiRoot = path.join(skillsStaging, "multi");
+  const skillMode = resolveSkillMode();
+  if (skillMode === "multi" && multiTreeHasSkills(multiRoot)) {
+    console.log(`Skill mode: multi — installing per-product skills`);
+    installMultiSkillsToHomes(multiRoot);
+  } else {
+    if (skillMode === "multi") {
+      console.log("multi skill tree not found or empty in bundle; falling back to mono.");
     }
-    cacheUserSkills(skillsStaging);
-  } catch (err) {
-    console.warn(`[dws] skill installation failed (non-fatal): ${err.message}`);
-    console.warn("[dws] CLI is functional. Run 'dws skill setup' to retry skill installation.");
+    if (monoHasSkill) {
+      installSkillsToHomes(monoRoot);
+    } else {
+      console.log("mono skill tree not found in bundle; skipping skill install.");
+    }
   }
+  cacheUserSkills(skillsStaging);
 }
 
 if (require.main === module) {

--- a/test/scripts/install_js_smoke.mjs
+++ b/test/scripts/install_js_smoke.mjs
@@ -786,6 +786,25 @@ scenario("empty multi/ tree falls back to mono and keeps the old multi cache", (
   }
 });
 
+scenario("DWS_NO_SKILLS=1 installs the binary and skips skills entirely", () => {
+  const { tmp, pkg, home } = stagePkg({
+    "mono/SKILL.md": "# mono fixture\n",
+    "multi/dingtalk-test/SKILL.md": "# dingtalk-test\n",
+  });
+  try {
+    const res = runInstall(pkg, home, "multi", { DWS_NO_SKILLS: "1" });
+    assert.equal(res.status, 0, `exit=${res.status}\nstdout=${res.stdout}\nstderr=${res.stderr}`);
+    assert.match(res.stdout, /DWS_NO_SKILLS=1; skipping skill installation/);
+    // The CLI binary is still unpacked — that is the whole point of the flag.
+    assert.ok(fs.existsSync(path.join(pkg, "vendor")), "binary must still be extracted");
+    // No agent home was touched and no user-level cache was published.
+    assert.ok(!fs.existsSync(path.join(home, ".agents", "skills")), "no agent skills installed");
+    assert.ok(!fs.existsSync(path.join(home, ".dws", "skills")), "no user skill cache published");
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
 scenario("bogus DWS_SKILL_MODE fails fast with a clear error", () => {
   const { tmp, pkg, home } = stagePkg({
     "mono/SKILL.md": "# mono fixture\n",


### PR DESCRIPTION
## Summary

- `build/npm/install.js` now recognizes `DWS_NO_SKILLS=1`: when set, skill extraction and installation are skipped entirely after the CLI binary is extracted. The binary path is unaffected.
- This aligns npm postinstall with `scripts/install.sh` and `scripts/install.ps1`, which have supported `DWS_NO_SKILLS=1` for some time — only `build/npm/install.js` never implemented it.

Intended for downstream integrators that manage skill distribution separately and do not want postinstall touching agent home directories — e.g. to avoid EPERM failures on Windows during `publishCacheAtomically`'s `renameSync` (see #1320).

Fixes #1320

## Risk tier

- [x] High-risk: workflow/policy, package graph, generated Schema/registry, platform, auth/keychain, installer, packaging, release, transport, recovery, or another fail-closed infrastructure change

(This is an npm postinstall / installer change.)

## Verification

- [x] Release fragment added: `.changes/1320-npm-no-skills-env.md`
- [ ] Release-seal validation: N/A (no CHANGELOG.md modification)
- [x] Targeted test/check commands and results:
  - `node --check build/npm/install.js` — SYNTAX OK
  - `node test/scripts/install_js_smoke.mjs` — **27/27 scenarios passed** (includes new scenario: `DWS_NO_SKILLS=1 installs the binary and skips skills entirely`)
- [x] Behavior evidence: with `DWS_NO_SKILLS=1`, postinstall logs `DWS_NO_SKILLS=1; skipping skill installation.`, the binary vendor dir is still extracted, no agent home directories are touched, and no user skill cache is published. Without the variable, behavior is byte-for-byte unchanged.
- [ ] Documentation links/content/rendering checked: N/A
- [ ] Full local suite: N/A
- [ ] `check-generated-drift.sh`: N/A
- [ ] `check-command-surface.sh`: N/A (no command surface changed)
- [ ] `verify-package-managers.sh`: recommended after packaging — install.js ships in the npm package

## Notes

- **Scope intentionally cut:** #1320 also asked for skill install failures to become non-fatal. That was dropped: `test/scripts/install_js_smoke.mjs` asserts the opposite contract (`multi backup failure preserves mono and reports failure` requires a non-zero exit), so making skill failures non-fatal would mean rewriting an established behavior contract. Skill install failures still fail postinstall exactly as before.
- The underlying EPERM root cause is `publishCacheAtomically`'s bare `renameSync(tmp, dest)` not safely handling a non-empty destination. That fix is out of scope here and tracked in #1320.
- `DWS_NO_SKILLS=1` is the recommended injection for genie's `runInstall` as a workaround until that root cause is fixed.