### PR TITLE
fix(chat): honor live category single-response contract

### DIFF
--- a/.changes/chat-category-single-response.md
+++ b/.changes/chat-category-single-response.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Chat conversation categories** — treat `im/list_conversations_by_category` as the declared single-response interface when its explicit conversation array contains no pagination signal, while continuing to fail closed on partial or non-resumable pagination metadata. `+category-list-conversations` and `+feed-group-query-item` now publish the resolved pagination mode and source-exhaustion facts instead of rejecting every live response that omits `hasMore`.

--- a/internal/app/chat_shortcut_discovery_test.go
+++ b/internal/app/chat_shortcut_discovery_test.go
@@ -83,3 +83,24 @@ func TestCrossPlatformCoverageFilteredIMSearchUsesResourceAndAnswerShapeBoundary
 		t.Fatalf("chat +search-msg final selection does not encode the resource/answer/predicate decision: %#v", search.Selection)
 	}
 }
+
+func TestCrossPlatformCoverageCategorySingleResponseCapabilityContract(t *testing.T) {
+	root := NewRootCommand()
+	atomic, remaining, err := root.Find([]string{"chat", "category", "list-conversations"})
+	if err != nil || atomic == nil || len(remaining) != 0 || !atomic.Runnable() {
+		t.Fatalf("category atomic command is not runnable: command=%v remaining=%v err=%v", atomic, remaining, err)
+	}
+	for _, name := range []string{"limit", "page-size", "cursor", "page-token"} {
+		if flag := atomic.LocalNonPersistentFlags().Lookup(name); flag != nil {
+			t.Errorf("category atomic unexpectedly exposes continuation flag --%s", name)
+		}
+	}
+
+	meta, ok := cli.ResolveMeta("chat +category-list-conversations")
+	useWhen := strings.Join(meta.Selection.UseWhen, "\n")
+	if !ok ||
+		!strings.Contains(useWhen, "没有续页参数") ||
+		!strings.Contains(useWhen, "分页信号") {
+		t.Fatalf("category Shortcut selection does not publish the capability boundary: %#v", meta.Selection)
+	}
+}

--- a/internal/shortcut/chat/chat_conversation.go
+++ b/internal/shortcut/chat/chat_conversation.go
@@ -955,7 +955,7 @@ func categoryListFirst(m map[string]any, keys ...string) (any, bool) {
 	return nil, false
 }
 
-const categoryListConversationsIntent = "当已有稳定 categoryId、需要列出该自定义会话分组中的会话时使用。若只有标题或用户明确授权任选一个分组，先用 chat +category-list 得到真实 categoryId，再调用本命令；本命令严格校验 conversations 数组、稳定会话身份和分页耗尽。"
+const categoryListConversationsIntent = "当已有稳定 categoryId、需要列出该自定义会话分组中的会话时使用。若只有标题或用户明确授权任选一个分组，先用 chat +category-list 得到真实 categoryId，再调用本命令；本命令严格校验 conversations 数组和稳定会话身份。下层接口没有续页参数且未返回分页信号时，明确数组按单响应集合处理；一旦出现分页信号，则严格验证 hasMore 和可继续性。"
 
 // CategoryListConversations lists conversations in a category (list_conversations_by_category, im).
 var CategoryListConversations = shortcut.Shortcut{
@@ -981,7 +981,7 @@ var CategoryListConversations = shortcut.Shortcut{
 		Interface: &contract.InterfaceSpec{
 			Mode:         "composite",
 			Availability: "available",
-			Reason:       "Reviewed category reader: it preserves the published stable-ID input while validating the collection shape, stable conversation identity, and source exhaustion.",
+			Reason:       "Reviewed category reader: it preserves the published stable-ID input while validating the collection shape and stable conversation identity. The bound lower interface has no continuation input, so an explicit collection without pagination signals is one complete response; any reported pagination signal is validated strictly.",
 		},
 		Selection: contract.SelectionSpec{
 			AgentSummary: "按稳定 categoryId 列出会话分组中的会话",
@@ -1018,7 +1018,7 @@ func executeCategoryListConversations(rt *shortcut.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	hasMore, err := requireCategoryConversationsPagination(data)
+	hasMore, paginationMode, err := resolveCategoryConversationsPagination(data)
 	if err != nil {
 		return err
 	}
@@ -1040,22 +1040,114 @@ func executeCategoryListConversations(rt *shortcut.RuntimeContext) error {
 		"count":           len(conversations),
 		"conversations":   conversations,
 		"complete":        true,
+		"hasMore":         false,
 		"paginationKnown": true,
+		"paginationMode":  paginationMode,
+		"sourceExhausted": true,
 	}
 	return rt.Output(payload)
 }
 
-func requireCategoryConversationsPagination(data map[string]any) (bool, error) {
-	page := chatmsg.Pagination(data)
-	hasMore, paginationKnown := page["hasMore"].(bool)
-	if !paginationKnown {
-		return false, invalidCategoryResponse(
+const (
+	categoryPaginationModeSingleResponse = "single_response"
+	categoryPaginationModeReported       = "reported"
+)
+
+// resolveCategoryConversationsPagination follows the capability contract of
+// im/list_conversations_by_category. The interface exposes categoryId and
+// excludeMuted only: it has no limit, cursor, or page-token input. Therefore
+// an explicit conversations array with no pagination signal is one complete
+// response, not an unknown page. If the lower layer does start reporting any
+// continuation signal, hasMore becomes authoritative and must be present.
+func resolveCategoryConversationsPagination(data map[string]any) (bool, string, error) {
+	type paginationScope struct {
+		name string
+		data map[string]any
+	}
+	scopes := []paginationScope{{name: "root", data: data}}
+	for _, key := range []string{"result", "data"} {
+		if inner, ok := data[key].(map[string]any); ok {
+			scopes = append(scopes, paginationScope{name: key, data: inner})
+		}
+	}
+
+	sawPaginationSignal := false
+	sawHasMore := false
+	hasMore := false
+	continuationPresent := false
+	for _, scope := range scopes {
+		for _, key := range []string{"hasMore", "has_more"} {
+			value, exists := scope.data[key]
+			if !exists {
+				continue
+			}
+			sawPaginationSignal = true
+			resolved, ok := value.(bool)
+			if !ok {
+				return false, "", invalidCategoryResponse(
+					"im/list_conversations_by_category",
+					"响应中的 hasMore 不是布尔值，无法判断分组会话是否完整",
+					map[string]any{"field": key, "scope": scope.name, "actualType": fmt.Sprintf("%T", value)},
+				)
+			}
+			if sawHasMore && resolved != hasMore {
+				return false, "", invalidCategoryResponse(
+					"im/list_conversations_by_category",
+					"响应中的 hasMore 分页信号相互冲突",
+					map[string]any{"field": key, "scope": scope.name},
+				)
+			}
+			sawHasMore = true
+			hasMore = resolved
+		}
+		for _, key := range []string{"nextCursor", "next_cursor", "nextToken", "next_token", "pageToken", "page_token"} {
+			if value, exists := scope.data[key]; exists {
+				sawPaginationSignal = true
+				continuationPresent = continuationPresent || categoryPaginationValuePresent(value)
+			}
+		}
+	}
+
+	if !sawPaginationSignal {
+		return false, categoryPaginationModeSingleResponse, nil
+	}
+	if !sawHasMore {
+		return false, "", invalidCategoryResponse(
 			"im/list_conversations_by_category",
-			"响应未返回 hasMore，无法证明分组会话结果完整",
+			"响应返回了 continuation 但缺少 hasMore，无法判断分组会话是否完整",
 			nil,
 		)
 	}
-	return hasMore, nil
+	if !hasMore && continuationPresent {
+		return false, "", invalidCategoryResponse(
+			"im/list_conversations_by_category",
+			"响应同时返回 hasMore=false 和非空 continuation，分页信号相互冲突",
+			nil,
+		)
+	}
+	return hasMore, categoryPaginationModeReported, nil
+}
+
+func categoryPaginationValuePresent(value any) bool {
+	switch typed := value.(type) {
+	case nil:
+		return false
+	case string:
+		text := strings.TrimSpace(typed)
+		return text != "" && text != "0"
+	case int:
+		return typed != 0
+	case int32:
+		return typed != 0
+	case int64:
+		return typed != 0
+	case float32:
+		return typed != 0
+	case float64:
+		return typed != 0
+	default:
+		return true
+	}
 }
 
 // categoryConversationsProject reshapes the raw list_conversations_by_category

--- a/internal/shortcut/chat/coverage_completion_test.go
+++ b/internal/shortcut/chat/coverage_completion_test.go
@@ -211,7 +211,7 @@ func TestCrossPlatformCoverageCategoryListConversationsRejectsUnknownEnvelope(t 
 	}
 }
 
-func TestCrossPlatformCoverageCategoryListConversationsRequiresExhaustion(t *testing.T) {
+func TestCrossPlatformCoverageCategoryListConversationsRespectsInterfacePagination(t *testing.T) {
 	t.Run("read failure", func(t *testing.T) {
 		fake := &larkAlignmentCaller{failProductTool: "im/list_conversations_by_category"}
 		helpers.InitDeps(fake)
@@ -222,15 +222,74 @@ func TestCrossPlatformCoverageCategoryListConversationsRequiresExhaustion(t *tes
 		}
 	})
 
-	t.Run("missing pagination", func(t *testing.T) {
+	t.Run("single response interface omits pagination", func(t *testing.T) {
 		fake := &larkAlignmentCaller{category: `{"result":{"list":[]}}`}
+		helpers.InitDeps(fake)
+		root := newPlatformCoverageRoot()
+		var output bytes.Buffer
+		root.SetOut(&output)
+		root.SetArgs([]string{"chat", "+category-list-conversations", "--category-id", "1"})
+		if err := root.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		var payload map[string]any
+		if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
+			t.Fatal(err)
+		}
+		if payload["complete"] != true ||
+			payload["hasMore"] != false ||
+			payload["paginationKnown"] != true ||
+			payload["paginationMode"] != categoryPaginationModeSingleResponse ||
+			payload["sourceExhausted"] != true {
+			t.Fatalf("single response payload = %#v", payload)
+		}
+	})
+
+	t.Run("continuation without has more", func(t *testing.T) {
+		fake := &larkAlignmentCaller{category: `{"result":{"list":[],"nextCursor":"cursor"}}`}
 		helpers.InitDeps(fake)
 		root := newPlatformCoverageRoot()
 		root.SetArgs([]string{"chat", "+category-list-conversations", "--category-id", "1"})
 		err := root.Execute()
 		var typed *apperrors.Error
 		if !errors.As(err, &typed) || typed.Reason != "chat_category_response_invalid" {
-			t.Fatalf("missing pagination error = %#v", err)
+			t.Fatalf("partial pagination error = %#v", err)
+		}
+	})
+
+	t.Run("non boolean has more", func(t *testing.T) {
+		fake := &larkAlignmentCaller{category: `{"result":{"list":[],"hasMore":"true"}}`}
+		helpers.InitDeps(fake)
+		root := newPlatformCoverageRoot()
+		root.SetArgs([]string{"chat", "+category-list-conversations", "--category-id", "1"})
+		err := root.Execute()
+		var typed *apperrors.Error
+		if !errors.As(err, &typed) || typed.Reason != "chat_category_response_invalid" {
+			t.Fatalf("non-boolean pagination error = %#v", err)
+		}
+	})
+
+	t.Run("conflicting terminal continuation", func(t *testing.T) {
+		fake := &larkAlignmentCaller{category: `{"result":{"list":[],"hasMore":false,"nextCursor":"cursor"}}`}
+		helpers.InitDeps(fake)
+		root := newPlatformCoverageRoot()
+		root.SetArgs([]string{"chat", "+category-list-conversations", "--category-id", "1"})
+		err := root.Execute()
+		var typed *apperrors.Error
+		if !errors.As(err, &typed) || typed.Reason != "chat_category_response_invalid" {
+			t.Fatalf("conflicting pagination error = %#v", err)
+		}
+	})
+
+	t.Run("conflicting envelope has more", func(t *testing.T) {
+		fake := &larkAlignmentCaller{category: `{"hasMore":false,"result":{"list":[],"hasMore":true}}`}
+		helpers.InitDeps(fake)
+		root := newPlatformCoverageRoot()
+		root.SetArgs([]string{"chat", "+category-list-conversations", "--category-id", "1"})
+		err := root.Execute()
+		var typed *apperrors.Error
+		if !errors.As(err, &typed) || typed.Reason != "chat_category_response_invalid" {
+			t.Fatalf("conflicting envelope pagination error = %#v", err)
 		}
 	})
 
@@ -252,7 +311,7 @@ func TestCrossPlatformCoverageCategoryListConversationsRequiresExhaustion(t *tes
 	})
 
 	t.Run("success output failure", func(t *testing.T) {
-		fake := &larkAlignmentCaller{category: `{"result":{"list":[{"openConversationId":"cid-a"}],"hasMore":false}}`}
+		fake := &larkAlignmentCaller{category: `{"result":{"list":[{"openConversationId":"cid-a"}]}}`}
 		helpers.InitDeps(fake)
 		root := newPlatformCoverageRoot()
 		root.SetOut(chatOutputErrorWriter{err: errors.New("category output failed")})
@@ -263,13 +322,44 @@ func TestCrossPlatformCoverageCategoryListConversationsRequiresExhaustion(t *tes
 	})
 }
 
+func TestCrossPlatformCoverageCategoryPaginationValuePresence(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value any
+		want  bool
+	}{
+		{name: "nil", value: nil, want: false},
+		{name: "empty string", value: "", want: false},
+		{name: "zero string", value: "0", want: false},
+		{name: "string", value: "cursor", want: true},
+		{name: "int zero", value: int(0), want: false},
+		{name: "int", value: int(1), want: true},
+		{name: "int32 zero", value: int32(0), want: false},
+		{name: "int32", value: int32(1), want: true},
+		{name: "int64 zero", value: int64(0), want: false},
+		{name: "int64", value: int64(1), want: true},
+		{name: "float32 zero", value: float32(0), want: false},
+		{name: "float32", value: float32(1), want: true},
+		{name: "float64 zero", value: float64(0), want: false},
+		{name: "float64", value: float64(1), want: true},
+		{name: "invalid object", value: map[string]any{}, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := categoryPaginationValuePresent(tc.value); got != tc.want {
+				t.Fatalf("categoryPaginationValuePresent(%#v) = %t, want %t", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCrossPlatformCoverageFeedGroupQueryRejectsUnknownConversationEnvelope(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		category string
 	}{
 		{name: "missing collection", category: `{"result":{"hasMore":false}}`},
-		{name: "missing pagination fact", category: `{"result":{"list":[{"openConversationId":"cid-a"}]}}`},
+		{name: "continuation without has more", category: `{"result":{"list":[{"openConversationId":"cid-a"}],"nextCursor":"cursor"}}`},
+		{name: "non boolean has more", category: `{"result":{"list":[{"openConversationId":"cid-a"}],"hasMore":"true"}}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			fake := &larkAlignmentCaller{category: tc.category}
@@ -578,9 +668,11 @@ func TestCrossPlatformCoverageRecallCardAndLedgerBoundaries(t *testing.T) {
 }
 
 func TestCrossPlatformCoverageFeedCompleteAndExcludeMuted(t *testing.T) {
-	fake := &larkAlignmentCaller{category: `{"result":{"hasMore":false,"list":[{"openConversationId":"cid"}]}}`}
+	fake := &larkAlignmentCaller{category: `{"result":{"list":[{"openConversationId":"cid"}]}}`}
 	helpers.InitDeps(fake)
 	root := newPlatformCoverageRoot()
+	var output bytes.Buffer
+	root.SetOut(&output)
 	root.SetArgs([]string{
 		"chat", "+feed-group-query-item",
 		"--category-id", "1",
@@ -592,6 +684,19 @@ func TestCrossPlatformCoverageFeedCompleteAndExcludeMuted(t *testing.T) {
 	}
 	if len(fake.calls) != 1 || fake.calls[0].args["excludeMuted"] != true {
 		t.Fatalf("feed calls = %#v", fake.calls)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["complete"] != true ||
+		payload["hasMore"] != false ||
+		payload["paginationKnown"] != true ||
+		payload["paginationMode"] != categoryPaginationModeSingleResponse ||
+		payload["sourceExhausted"] != true ||
+		payload["foundCount"] != float64(1) ||
+		payload["notFoundCount"] != float64(0) {
+		t.Fatalf("feed single response payload = %#v", payload)
 	}
 }
 

--- a/internal/shortcut/chat/lark_alignment.go
+++ b/internal/shortcut/chat/lark_alignment.go
@@ -848,7 +848,7 @@ var FeedGroupQueryItem = shortcut.Shortcut{
 	Command:     "+feed-group-query-item",
 	Product:     "im",
 	Description: "在会话分组结果中按会话 ID 精确查询多项",
-	Intent:      "当你已知一个钉钉会话分组 ID 和若干 openConversationId、想精确取回这些分组项时使用；先读取该分组，再按 ID 本地过滤并返回未找到清单。若下层表明结果仍有后续页但未提供可执行游标，本命令会把缺失项标为 unresolved 并返回失败 ledger，不会误报 notFound。它不提供 Lark deleted_items 或服务端多 ID 查询语义。",
+	Intent:      "当你已知一个钉钉会话分组 ID 和若干 openConversationId、想精确取回这些分组项时使用；先读取该分组，再按 ID 本地过滤并返回未找到清单。下层接口没有续页参数且未返回分页信号时，明确数组按单响应集合处理；若下层表明仍有后续页但未提供可执行游标，本命令会把缺失项标为 unresolved 并返回失败 ledger，不会误报 notFound。它不提供 Lark deleted_items 或服务端多 ID 查询语义。",
 	Risk:        shortcut.RiskRead,
 	Flags: []shortcut.Flag{
 		{Name: "category-id", Type: shortcut.FlagInt, Desc: "钉钉会话分组 ID", Required: true},
@@ -871,14 +871,17 @@ var FeedGroupQueryItem = shortcut.Shortcut{
 		}
 		payload := feedGroupQueryProject(conversations, rt.StrSlice("conversation-ids"))
 		chatmsg.ApplyPagination(payload, data)
-		hasMore, err := requireCategoryConversationsPagination(data)
+		hasMore, paginationMode, err := resolveCategoryConversationsPagination(data)
 		if err != nil {
 			return err
 		}
+		payload["paginationKnown"] = true
+		payload["paginationMode"] = paginationMode
 		if hasMore {
 			unresolved, _ := payload["notFoundConversationIds"].([]string)
 			payload["ok"] = false
 			payload["complete"] = false
+			payload["sourceExhausted"] = false
 			payload["notFoundCount"] = 0
 			payload["notFoundConversationIds"] = []string{}
 			payload["unresolvedCount"] = len(unresolved)
@@ -890,6 +893,8 @@ var FeedGroupQueryItem = shortcut.Shortcut{
 			}}
 		} else {
 			payload["complete"] = true
+			payload["hasMore"] = false
+			payload["sourceExhausted"] = true
 			payload["unresolvedCount"] = 0
 			payload["unresolvedConversationIds"] = []string{}
 		}


### PR DESCRIPTION
## Summary

- Fix the live regression introduced by #1271 where every real `chat +category-list-conversations` and `chat +feed-group-query-item` invocation failed because `im/list_conversations_by_category` does not return `hasMore`.
- Resolve completeness from the bound interface capability: the lower command exposes no limit, cursor, or page-token input, so an explicit conversations array without pagination signals is one complete response.
- Continue to fail closed when any continuation signal is present without `hasMore`, or when `hasMore=true` cannot be resumed.
- Publish `paginationMode`, `paginationKnown`, `hasMore`, and `sourceExhausted` so the model can distinguish a reviewed single-response contract from inferred exhaustion.
- Add a final assembled-Cobra guard that fails if the atomic interface later gains continuation flags without revisiting this mechanism.

## Live E2E evidence

Tested exact code commit: `671db3417bf86cb799294552cc98d5c7a9d0b466`.

All business responses and identifiers were retained only in a repository-external temporary directory. Reported facts below are sanitized counts and contract assertions.

| Exact public path | Fixture | Result |
|---|---|---|
| `chat +search-msg --group <stable-id> --has-reactions --page-all` | current real group | PASS: 8 messages, all stable message IDs, all with reaction evidence, 1 page, complete |
| same reaction path | guaranteed future time window | PASS: explicit empty array, complete/source exhausted |
| same reaction path with explicit `--cursor 0` | guaranteed future time window | PASS: original search cursor domain, complete |
| `chat +search-msg` sender + keyword + July window | two real users | PASS: one nonempty (2), one explicit empty; stable sender identity verified |
| `chat search-common --page-all --limit 1 --max-items 2` | two real users, OR | PASS: 2 pages, stable-ID dedupe, request satisfied, source exhausted |
| same common-group path | random impossible nickname | PASS: explicit empty, source exhausted |
| `chat +category-list` | current tenant real tenant | PASS: 6 categories; upper/lower counts agree |
| `chat +category-list-conversations` before fix | all 6 real category IDs | FAIL: all rejected because live response omits `hasMore` |
| lower atomic category reader | one real category | PASS: explicit conversations array, no pagination fields, no continuation parameters |
| `chat +category-list-conversations` after fix | real nonempty category | PASS: 1 stable conversation, `single_response`, complete/source exhausted |
| `chat +feed-group-query-item` after fix | existing stable conversation ID | PASS: found 1, no unresolved item |
| same feed query | random absent ID | PASS: notFound 1, no unresolved item |
| `aisearch enterprise` | real IM keyword/time fixture | PASS: 9 real results with stable resource identity |
| same enterprise path | impossible future query | PASS: explicit empty array |
| `aisearch behavior` | current-user send behavior fixture | PASS: 8 real results with stable resource identity |
| same behavior path | impossible future query | PASS: explicit empty array |

The repository PII-safe Chat live-read audit was run twice against the same real fixture. Before the fix, `+category-list-conversations` was `backend_error`; after the fix it is PASS with upper/lower count 1/1. The audit improved from 25 PASS to 26 PASS with no new regression. Existing unrelated audit findings remain separately classified.

A read-only Qoder route audit on the current command surface selected:

- structured IM reaction and sender/time queries → `chat +search-msg`
- cross-source topic discovery → `aisearch enterprise`
- current-user action history → `aisearch behavior`
- category title lookup → `chat +category-list` then `chat +category-list-conversations`

## Deterministic validation

- focused category and feed tests
- full `internal/shortcut/chat`, `internal/shortcut/smart`, and `internal/helpers` tests
- `make build`
- `make generate-schema`
- generated drift and Schema Catalog policy
- runtime confirmation truth
- changed-code coverage: 100.0000% (69 executable statements)
- 31 products / 1373 assembled tools

## Downstream review

No downstream change is required for this defect. The raw lower call succeeds and the bound interface intentionally has no continuation input; the regression was introduced entirely by the Shortcut applying a paginated-interface invariant to a non-paginated endpoint.

