### PR TITLE
chore(policy): plan recent conversations command migration

### DIFF
--- a/scripts/policy/interface-migrations/approved-command-migrations-v1.json
+++ b/scripts/policy/interface-migrations/approved-command-migrations-v1.json
@@ -2,6 +2,27 @@
   "version": 1,
   "migrations": [
     {
+      "kind": "command_move",
+      "legacy": {
+        "command": "dws chat +active-conversations",
+        "before": {"present": true, "runnable": true},
+        "after": {"present": true, "runnable": true, "hidden": true}
+      },
+      "replacement": {
+        "command": "dws chat +recent-conversations",
+        "before": {"present": false},
+        "after": {"present": true, "runnable": true}
+      },
+      "schema": {
+        "product_id": "chat",
+        "source_tool_id": "chat.shortcut_active_conversations",
+        "replacement_tool_id": "chat.shortcut_active_conversations",
+        "parameters": []
+      },
+      "state": "pending",
+      "reason": "Make recent-conversations the public time-window query entry while retaining active-conversations as a hidden executable compatibility command without deprecation warnings; preserve the stable Schema tool identity and do not rename parameters."
+    },
+    {
       "kind": "flag_extraction",
       "legacy": {
         "command": "dws chat group create",


### PR DESCRIPTION
## Summary

- 为后续产品 PR #1335 登记 `dws chat +active-conversations` → `dws chat +recent-conversations` 的精确 `command_move` 计划，状态仅为 `pending`。
- 本 PR 只有 `scripts/policy/interface-migrations/approved-command-migrations-v1.json` 新增的一条记录（21 行）。不改命令实现、参数、Help、Schema 声明、Skill、生成目录、比较器或 workflow。
- 从 main `55a3bd3f` 建分支。需先评审并合入本 PR，后续产品 PR 才能取得 base-owned 授权；本 PR 不自行消费该记录。

## Planned migration (not implemented in this PR)

| Surface | Before | After |
|---|---|---|
| `dws chat +active-conversations` | visible, runnable | hidden, runnable；保留旧 argv 执行，不输出弃用提示 |
| `dws chat +recent-conversations` | absent | visible, runnable，作为正式入口 |
| Schema tool identity | `chat.shortcut_active_conversations` | 保持不变，仅迁移主 CLI 路径 |
| Parameter rename mapping | 无 | 无；本记录不批准参数改名或其他不兼容变化 |

后续 #1335 需要把普通 Cobra alias 实现调整为门禁认可的隐藏兼容命令结构，保持查询执行等价，并补充隐藏旧入口、新旧命令调用及无弃用提示的验证。当前 #1335 的别名实现尚不满足这一 after 状态，本审批不是对该实现的通过声明。默认时间窗口、总超时等独立变化仍受普通兼容规则约束。

## Risk tier

- [x] High-risk：修改受评审迁移清单，需维护者审核。未修改任何保护规则或比较器。

## Verification

- [x] `git diff --check`
- [x] `DWS_PACKAGE_VERSION=0.0.0-test GOCACHE=/tmp/dws-synced-main-gate-cache go test ./internal/interfacesnapshot ./scripts/policy/schema-compat -count=1`：两个包的完整领域测试通过。
- [x] 使用 `cmd/interface-snapshot generate` 实测 before：旧命令 `hidden=false, runnable=true, aliases=[]`；新命令不存在。
- [x] `make interface-integrity BASE_REF=55a3bd3f CANDIDATE_REF=db2634cf`：通过；main / stable 均 compatible，main 无 blocking、无 additions。
- [x] `make schema-compatibility BASE_REF=55a3bd3f CANDIDATE_REF=db2634cf`：通过；PR merge-base（31 个历史产品）与 stable `v1.0.61`（29 个历史产品）均通过。上述命令均使用 `DWS_PACKAGE_VERSION=0.0.0-test GOCACHE=/tmp/dws-synced-main-gate-cache`，未覆盖 STABLE_REF，由仓库脚本按规则选择。
- 现有领域测试覆盖严格清单解析、pending/consumed 生命周期、拒绝自授权、仅允许精确 Schema 投影及无关变更继续阻塞；未新增生产实现，因此未新增覆盖率承载代码。
- 全仓库测试未在本地重复运行；本地执行完整迁移领域测试与权威跨版本门禁，完整高风险检查由 CI 执行。
- Release fragment / release-seal：N/A，本阶段没有用户可见行为或接口变化，不修改 CHANGELOG。
- Generated drift / strict command surface / packaging：N/A，没有生成输入、产品命令表面或打包变更。

## Follow-up

1. 本审批经评审合入 main。
2. #1335 合入新 main，按此计划实现精确 after，并仅将本条记录的 `pending` 改为 `consumed`。
3. 对 main merge-base 和最新可达稳定 GA 分别运行 CLI / Schema 兼容门禁；保留 consumed 回执直到历史参考追平。

依据：[CLI Help / Schema 兼容迁移治理](docs/cli-interface-flag-migrations.md)。
