### PR TITLE
fix(release): align Linux ABI test payload version

### DIFF
--- a/scripts/build/linux-abi/main_test.go
+++ b/scripts/build/linux-abi/main_test.go
@@ -11,13 +11,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/runtimepayload"
 	"github.com/DingTalk-Real-AI/dingtalk-workspace-cli/internal/testseam"
 )
 
 func TestCrossPlatformCoverageLinuxABIReleaseLibraries(t *testing.T) {
 	for _, arch := range []string{"amd64", "arm64"} {
 		t.Run(arch, func(t *testing.T) {
-			path := filepath.Join("..", "..", "..", "third_party", "runtimepayload", "20260825", "linux", arch, "libx7k2m9p4q1w8.so")
+			path := filepath.Join("..", "..", "..", "third_party", "runtimepayload", runtimepayload.PayloadVersion, "linux", arch, "libx7k2m9p4q1w8.so")
 			var stderr bytes.Buffer
 			if code := run([]string{path}, &stderr); code != 0 {
 				t.Fatalf("bundled library rejected: %d, %s", code, &stderr)


### PR DESCRIPTION
## Summary
- derive the Linux ABI fixture payload directory from `runtimepayload.PayloadVersion`
- restore Linux ABI coverage after the runtime payload moved to `20260908`

## Verification
- `DWS_PACKAGE_VERSION=0.0.0-test go test ./scripts/build/linux-abi -count=1`
- `./scripts/policy/check-runtime-payload.sh`
- `DWS_PACKAGE_VERSION=0.0.0-test GOMAXPROCS=2 GOFLAGS=-p=2 go test ./...` (attempted; `internal/app` exceeded its 10-minute test timeout, so this is not claimed as a pass)

## Release impact
This is a test/CI correctness fix required to make the current `main` beta-admission Linux ABI job evaluate the payload that is actually bundled.