### PR TITLE
feat(chat): expose A2UI card annotations

### DIFF
--- a/.changes/chat-a2ui-annotations.md
+++ b/.changes/chat-a2ui-annotations.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **A2UI card annotations** — adds optional `--a2ui-annotations` JSON object arrays to `chat message send-a2ui-card` and `chat message update-a2ui-card`, preserving nested values and existing behavior when omitted.

--- a/internal/app/chat_parity_alias_test.go
+++ b/internal/app/chat_parity_alias_test.go
@@ -108,3 +108,22 @@ func TestCrossPlatformCoverageThreadTimeKeepsHistoricalFormat(t *testing.T) {
 		t.Fatalf("millisecond cursor must not inherit date-time format: %q", got)
 	}
 }
+
+func TestCrossPlatformCoverageA2UIAnnotationsSchema(t *testing.T) {
+	for _, path := range []string{"chat message send-a2ui-card", "chat message update-a2ui-card"} {
+		for _, compact := range []bool{false, true} {
+			args := []string{"--cli-path", path}
+			if compact {
+				args = append(args, "--compact")
+			}
+			payload := executeShortcutSchemaQuery(t, args...)
+			param := schemaContractMap(payload["parameters"])["a2ui-annotations"]
+			if param == nil || param["required"] == true || param["type"] != "string" || !strings.Contains(schemaContractString(param["description"]), "JSON 对象数组") {
+				t.Fatalf("%s compact=%v parameter=%#v", path, compact, param)
+			}
+			if !compact && (param["property"] != "a2uiAnnotations" || param["interface_type"] != "array") {
+				t.Fatalf("%s mapping=%#v", path, param)
+			}
+		}
+	}
+}

--- a/internal/helpers/chat.go
+++ b/internal/helpers/chat.go
@@ -71,6 +71,19 @@ func parseA2UIMessages(raw string) ([]string, error) {
 	return messages, nil
 }
 
+func parseA2UIAnnotations(raw string) ([]map[string]json.RawMessage, error) {
+	var annotations []map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &annotations); err != nil || annotations == nil {
+		return nil, fmt.Errorf("--a2ui-annotations must be a JSON object array")
+	}
+	for _, annotation := range annotations {
+		if annotation == nil {
+			return nil, fmt.Errorf("--a2ui-annotations must contain only JSON objects")
+		}
+	}
+	return annotations, nil
+}
+
 func normalizeChatGroupCreateResponse(resp map[string]any) {
 	result, ok := resp["result"].(map[string]any)
 	if !ok {
@@ -7332,6 +7345,14 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 			if groupID != "" && receiver != "" {
 				return fmt.Errorf("--conversation-id and --open-dingtalk-id are mutually exclusive")
 			}
+			var annotations []map[string]json.RawMessage
+			if cmd.Flags().Changed("a2ui-annotations") {
+				var err error
+				annotations, err = parseA2UIAnnotations(mustGetFlag(cmd, "a2ui-annotations"))
+				if err != nil {
+					return err
+				}
+			}
 			messages, err := parseA2UIMessages(mustGetFlag(cmd, "content"))
 			if err != nil {
 				return err
@@ -7343,6 +7364,9 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 				"flowStatus":      defaultA2UIFlowStatus,
 				"a2uiMessages":    messages,
 				"summary":         strings.Join(messages, "\n"),
+			}
+			if cmd.Flags().Changed("a2ui-annotations") {
+				toolArgs["a2uiAnnotations"] = annotations
 			}
 			if groupID != "" {
 				toolArgs["openConversationId"] = groupID
@@ -7383,6 +7407,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 			},
 			Parameters: []contract.ParamDecl{
 				{Name: "content", Property: "a2uiMessages", Required: boolPtr(true), InterfaceType: "array"},
+				{Name: "a2ui-annotations", Property: "a2uiAnnotations", Required: boolPtr(false), InterfaceType: "array"},
 				{Name: "conversation-id", Property: "openConversationId", Required: boolPtr(false)},
 				{Name: "open-dingtalk-id", Property: "receiverOpenDingTalkId", Required: boolPtr(false)},
 			},
@@ -7390,6 +7415,7 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 	})
 	chatMessageSendA2UICardCmd.Flags().String("conversation-id", "", "群聊 openConversationId（群聊时必填，与 --open-dingtalk-id 互斥）")
 	chatMessageSendA2UICardCmd.Flags().String("open-dingtalk-id", "", "单聊接收者 openDingTalkId（单聊时必填，与 --conversation-id 互斥）")
+	chatMessageSendA2UICardCmd.Flags().String("a2ui-annotations", "", "A2UI 组件注解 JSON 对象数组（可选，支持空数组 []）")
 	chatMessageSendA2UICardCmd.Flags().String("content", "", "A2UI 卡片消息 JSON 字符串数组 (必填)")
 	_ = chatMessageSendA2UICardCmd.MarkFlagRequired("content")
 	cli.AnnotateRuntimeConstraints(chatMessageSendA2UICardCmd, cli.RuntimeSchemaConstraints{
@@ -7515,6 +7541,14 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 			if err != nil {
 				return err
 			}
+			var annotations []map[string]json.RawMessage
+			if cmd.Flags().Changed("a2ui-annotations") {
+				var err error
+				annotations, err = parseA2UIAnnotations(mustGetFlag(cmd, "a2ui-annotations"))
+				if err != nil {
+					return err
+				}
+			}
 			messages, err := parseA2UIMessages(mustGetFlag(cmd, "content"))
 			if err != nil {
 				return err
@@ -7525,6 +7559,9 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 				"flowStatus":      flowStatus,
 				"a2uiMessages":    messages,
 				"a2uiAnnotations": []any{},
+			}
+			if cmd.Flags().Changed("a2ui-annotations") {
+				params["a2uiAnnotations"] = annotations
 			}
 			return callMCPToolOnServer("im", "update_a2ui_card", params)
 		},
@@ -7557,12 +7594,14 @@ flow-status 取值：1=处理中(PROCESSING)，2=输入中(INPUTTING)，3=完成
 			Parameters: []contract.ParamDecl{
 				{Name: "biz-id", Property: "bizId", Required: boolPtr(true)},
 				{Name: "content", Property: "a2uiMessages", Required: boolPtr(true), InterfaceType: "array"},
+				{Name: "a2ui-annotations", Property: "a2uiAnnotations", Required: boolPtr(false), InterfaceType: "array"},
 				{Name: "flow-status", Property: "flowStatus", Required: boolPtr(true), InterfaceType: "string", Enum: []string{"PROCESSING", "INPUTTING", "FINISH", "EXECUTING", "ERROR", "ABORTED", "TIMEOUT", "CONFIRMING", "CONFIRMED", "1", "2", "3", "4", "5", "6", "7", "8", "9"}},
 			},
 		},
 	})
 	chatMessageUpdateA2UICardCmd.Flags().String("biz-id", "", "卡片业务 ID (必填)")
 	_ = chatMessageUpdateA2UICardCmd.MarkFlagRequired("biz-id")
+	chatMessageUpdateA2UICardCmd.Flags().String("a2ui-annotations", "", "A2UI 组件注解 JSON 对象数组（可选，支持空数组 []）")
 	chatMessageUpdateA2UICardCmd.Flags().String("content", "", "A2UI 卡片消息 JSON 字符串数组 (必填)")
 	_ = chatMessageUpdateA2UICardCmd.MarkFlagRequired("content")
 	chatMessageUpdateA2UICardCmd.Flags().String("flow-status", "", "A2UI 状态枚举或兼容数字 1-9 (必填)")

--- a/internal/helpers/chat_card_update_test.go
+++ b/internal/helpers/chat_card_update_test.go
@@ -14,6 +14,7 @@
 package helpers
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -287,4 +288,67 @@ func TestCrossPlatformCoverageNativeMessageUpdateCardA2UIEngine(t *testing.T) {
 			t.Fatalf("bad a2ui status error = %v, want enum list", err)
 		}
 	})
+}
+
+func TestCrossPlatformCoverageA2UIAnnotations(t *testing.T) {
+	for _, target := range []struct {
+		name string
+		args []string
+		tool string
+	}{
+		{"group", []string{"message", "send-a2ui-card", "--conversation-id", "group-1"}, "create_and_send_a2ui_card"},
+		{"direct", []string{"message", "send-a2ui-card", "--open-dingtalk-id", "DAAAAAAAAAAAiE"}, "create_and_send_a2ui_card"},
+		{"update", []string{"message", "update-a2ui-card", "--biz-id", "biz-1", "--flow-status", "INPUTTING"}, "update_a2ui_card"},
+	} {
+		for _, tc := range []struct {
+			name    string
+			raw     string
+			invalid bool
+		}{
+			{name: "omitted"},
+			{name: "empty array", raw: "[]"},
+			{name: "objects", raw: `[{"id":9007199254740993,"nested":{"values":[true,null,"中文"]}},{}]`},
+			{name: "blank", raw: " ", invalid: true},
+			{name: "null", raw: "null", invalid: true},
+			{name: "object", raw: "{}", invalid: true},
+			{name: "string element", raw: `["annotation"]`, invalid: true},
+			{name: "null element", raw: `[null]`, invalid: true},
+			{name: "number element", raw: `[1]`, invalid: true},
+			{name: "malformed", raw: `[`, invalid: true},
+			{name: "trailing value", raw: `[] {}`, invalid: true},
+		} {
+			t.Run(target.name+"/"+tc.name, func(t *testing.T) {
+				caller := &scriptedToolCaller{}
+				args := append(append([]string{}, target.args...), "--content", `["message"]`)
+				if tc.name != "omitted" {
+					args = append(args, "--a2ui-annotations", tc.raw)
+				}
+				err := runNativeCardUpdate(t, caller, args...)
+				if tc.invalid {
+					if err == nil || !strings.Contains(err.Error(), "--a2ui-annotations") || caller.calls != 0 {
+						t.Fatalf("err=%v calls=%d", err, caller.calls)
+					}
+					return
+				}
+				if err != nil || caller.calls != 1 || caller.server != "im" || caller.tool != target.tool {
+					t.Fatalf("err=%v caller=%#v", err, caller)
+				}
+				value, exists := caller.args["a2uiAnnotations"]
+				if tc.name == "omitted" && target.name != "update" {
+					if exists {
+						t.Fatal("creation must preserve omitted annotations")
+					}
+					return
+				}
+				want := tc.raw
+				if tc.name == "omitted" {
+					want = "[]"
+				}
+				got, err := json.Marshal(value)
+				if err != nil || string(got) != want {
+					t.Fatalf("annotations=%s want=%s err=%v", got, want, err)
+				}
+			})
+		}
+	}
 }

--- a/skills/mono/references/products/chat.md
+++ b/skills/mono/references/products/chat.md
@@ -2480,7 +2480,7 @@ dws chat message send --conversation-id <openConversationId> --msg-type image --
 
 **注意：send-card 必须和 update-card 搭配使用。** 创建卡片时无需传入内容，后续通过 update-card 更新内容，最后一次更新必须将 --flow-status 设为 3（finish），否则卡片会一直处于"生成中"的加载状态。
 
-`send-a2ui-card` 调用 `im.create_and_send_a2ui_card`，必须传 `--content` JSON 字符串数组（元素为 A2UI 协议 JSON），例如 `'["{\"version\":\"v1.0\",\"updateDataModel\":{\"surfaceId\":\"surface\",\"path\":\"/status\",\"value\":\"starting\"}}"]'`。CLI 会解析为 `a2uiMessages`，并用换行拼接为 `summary`，单聊传 userId 时自动解析为 openDingTalkId。创建时默认 `flowStatus=PROCESSING`。
+`send-a2ui-card` 调用 `im.create_and_send_a2ui_card`，必须传 `--content` JSON 字符串数组（元素为 A2UI 协议 JSON），例如 `'["{\"version\":\"v1.0\",\"updateDataModel\":{\"surfaceId\":\"surface\",\"path\":\"/status\",\"value\":\"starting\"}}"]'`。CLI 会解析为 `a2uiMessages`，并用换行拼接为 `summary`，单聊传 userId 时自动解析为 openDingTalkId。创建时默认 `flowStatus=PROCESSING`。可选 `--a2ui-annotations` 接受 JSON 对象数组并透传为 `a2uiAnnotations`，支持 `[]`；省略时创建请求不携带该字段。
 ```
 Usage:
   dws chat message send-card [flags]
@@ -2502,7 +2502,7 @@ Flags:
 #### 更新卡片内容 — streaming 与 A2UI 独立命令
 
 `update-card` 通过 `im.update_streaming_card` 更新 streaming 卡片。`--flow-status` 的 CLI 类型为 string，仍只接受兼容数字 1-5，并向 RPC 发送 integer。
-`update-a2ui-card` 通过 `im.update_a2ui_card` 更新 A2UI 卡片，`--content` 必须是 JSON 字符串数组并发送为 `a2uiMessages`，固定附带 `a2uiAnnotations: []`。A2UI `--flow-status` 接受 PROCESSING、INPUTTING、FINISH、EXECUTING、ERROR、ABORTED、TIMEOUT、CONFIRMING、CONFIRMED，也兼容数字 1-9 并映射为对应枚举字符串。
+`update-a2ui-card` 通过 `im.update_a2ui_card` 更新 A2UI 卡片，`--content` 必须是 JSON 字符串数组并发送为 `a2uiMessages`，可通过 `--a2ui-annotations` 传入 JSON 对象数组，省略时发送 `a2uiAnnotations: []`。A2UI `--flow-status` 接受 PROCESSING、INPUTTING、FINISH、EXECUTING、ERROR、ABORTED、TIMEOUT、CONFIRMING、CONFIRMED，也兼容数字 1-9 并映射为对应枚举字符串。
 
 **最后一次更新必须将 --flow-status 设为 3（finish），否则卡片会一直处于"生成中"的加载状态。**
 更新结果不确定时不要再次执行更新；保留返回结果并告知用户。

--- a/skills/multi/dingtalk-chat/references/card/create.md
+++ b/skills/multi/dingtalk-chat/references/card/create.md
@@ -19,9 +19,20 @@ Runtime 会唯一解析为 openDingTalkId；已有 openDingTalkId 时传
 重试；明确未应用或 `bizId` 不一致时停止并保留真实错误。若结果中已经包含 `openTaskId`，
 可以按用户需要查询一次投递状态；该查询只确认消息投递，不代表卡片正文已经更新成功。
 
-当前内容仅为 streaming text，不接受 Lark Card JSON、组件树或按钮 callback。
+上述 `+messages-send-card` 的内容为 streaming text；A2UI 使用下方专用命令。
 
 ```bash
 dws chat +messages-send-card --group <openConversationId> --at-open-dingtalk-ids <mentionedOpenDingTalkId> --content "请确认"
 dws chat +messages-send-card --group <openConversationId> --at-all --content "请大家确认"
+```
+
+## A2UI 卡片
+
+A2UI 使用 `dws chat message send-a2ui-card`。群聊传 `--conversation-id`，
+单聊传 `--open-dingtalk-id`，二者互斥；`--content` 必填，接受非空 JSON 字符串数组。
+可选 `--a2ui-annotations` 接受 JSON 对象数组并透传为 `a2uiAnnotations`，
+支持 `[]`；省略时创建请求不携带该字段。创建状态默认为 `PROCESSING`。
+
+```bash
+dws chat message send-a2ui-card --open-dingtalk-id <openDingTalkId> --content '<A2UI消息JSON字符串数组>' --a2ui-annotations '[]' -f json
 ```

--- a/skills/multi/dingtalk-chat/references/card/schema.md
+++ b/skills/multi/dingtalk-chat/references/card/schema.md
@@ -33,7 +33,8 @@ A2UI 原子命令规则：
   7 TIMEOUT、8 CONFIRMING、9 CONFIRMED，由 CLI 映射为枚举字符串发送。
 - A2UI `send-a2ui-card` 在 CLI 侧自动生成 `requestId`、`bizCardId`，并固定
   `protocolVersion="1.0"`；创建默认 `flowStatus=PROCESSING`。
-- A2UI `update-a2ui-card` 固定附带 `a2uiAnnotations: []`。
+- 两个 A2UI 命令均支持可选 `--a2ui-annotations`，接受 JSON 对象数组并透传为
+  `a2uiAnnotations`。省略时创建请求不携带该字段，更新请求保持发送 `[]`。
 - A2UI 命令不提供 `--at-open-dingtalk-ids` / `--at-all`；@ 仅 streaming
   `send-card` 群聊可用。
 

--- a/skills/multi/dingtalk-chat/references/card/update.md
+++ b/skills/multi/dingtalk-chat/references/card/update.md
@@ -11,3 +11,14 @@
 结果中 `verified=true` 表示已有明确更新证据；`accepted=true, verified=false` 仅表示服务端
 接受了请求但未提供独立生效证据，应如实说明且不得重复执行相同更新。只有错误明确标记
 `retryable=true` 时才重试；明确未应用或 `bizId` 不一致时停止。
+
+## A2UI 卡片
+
+A2UI 使用 `dws chat message update-a2ui-card`，必填 `--biz-id`、`--content` 和
+`--flow-status`。内容为非空 JSON 字符串数组，状态支持 `INPUTTING`、`FINISH` 等枚举。
+可选 `--a2ui-annotations` 接受 JSON 对象数组并透传为 `a2uiAnnotations`，
+支持 `[]`；省略时保持发送空注解数组的既有行为。数组中的对象字段按服务端契约填写。
+
+```bash
+dws chat message update-a2ui-card --biz-id <bizId> --content '<A2UI消息JSON字符串数组>' --flow-status FINISH --a2ui-annotations '[]' -f json
+```


### PR DESCRIPTION
## Summary

Both A2UI card commands now accept optional `--a2ui-annotations` and pass its JSON object array to the MCP `a2uiAnnotations` field. Previously creation omitted this field and updates always sent an empty array, so callers could not supply component annotations.

Validation rejects malformed JSON, non-array values and non-object elements before any MCP call. Nested values and large integers retain their JSON precision. Omitting the flag preserves existing behavior: creation omits the field and updates send `[]`. Leaf parameter declarations, mono/multi guidance and release notes are updated together.

## Risk tier

- [ ] Documentation-only: prose/assets only; no executable, generated, workflow, packaging, or interface behavior changed
- [x] Standard: ordinary implementation change with a stable package graph
- [ ] High-risk: workflow/policy, package graph, generated Schema/registry, platform, auth/keychain, installer, packaging, release, transport, recovery, or another fail-closed infrastructure change

## Verification

- [x] Release fragment: `.changes/chat-a2ui-annotations.md`; `check-release-fragments.sh upstream/main HEAD` passed.
- Release-seal validation: N/A (ordinary feature PR).
- [x] Targeted tests on `748a613032b5c5e49ad4730090ee664c5c8ccd1a`: `DWS_PACKAGE_VERSION=0.0.0-test go test ./internal/helpers ./internal/app -run 'TestCrossPlatformCoverage.*(A2UI|A2ui)|^TestRuntimeSchemaCompleteness' -count=1`.
- [x] Behavior evidence: `TestCrossPlatformCoverageA2UIAnnotations` checks group creation, direct creation and updates with omitted, empty, nested/large-integer and invalid annotations. `TestCrossPlatformCoverageA2UIAnnotationsSchema` checks full/compact discovery and the RPC property mapping.
- [x] `make build`, `make generate-schema`, `./scripts/policy/check-schema-catalog.sh`, and CLI Help/compact Schema inspection passed on the same implementation before final documentation synchronization.
- [x] Documentation reviewed and `git diff --check` passed.
- Full local suite: N/A; focused implementation and contract gates used.
- [x] `./scripts/policy/check-generated-drift.sh` passed; no generated diff.
- [x] `./scripts/policy/check-command-surface.sh --strict` passed.
- Package-manager verification: N/A.

## Notes

Published preproduction MCP definitions confirm an optional array of objects for both tools; inner object fields remain server-defined. Validation here covers CLI transport and schema delivery with mocked MCP calls; live card rendering has not been exercised. Kept as a draft for CI and review.
