### PR TITLE
ci: shard embedded skill changes through full suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,10 @@ jobs:
                 filename === '.github/actionlint.yaml' ||
                 filename.startsWith('scripts/') ||
                 filename.startsWith('verify/') ||
+                // Skills are embedded into the shipped binary. Their reverse
+                // dependencies must use the bounded full-suite shards rather
+                // than one focused coverage runner.
+                filename.startsWith('skills/') ||
                 filename.startsWith('internal/helpers/') ||
                 // Shortcut declarations feed the live command tree and Schema
                 // assembly. Their reverse dependencies include the expensive

--- a/test/scripts/changelog_pr_gate_test.go
+++ b/test/scripts/changelog_pr_gate_test.go
@@ -1132,6 +1132,12 @@ if (!isHighRisk("internal/helpers/minutes.go")) {
 if (isHighRisk("internal/helpersx/minutes.go")) {
   throw new Error("helper high-risk classification must respect the path boundary");
 }
+if (!isHighRisk("skills/multi/dingtalk-chat/SKILL.md")) {
+  throw new Error("embedded skill changes must use the sharded full suite");
+}
+if (isHighRisk("skillsx/multi/dingtalk-chat/SKILL.md")) {
+  throw new Error("skill high-risk classification must respect the path boundary");
+}
 if (!isHighRisk("internal/shortcut/wiki/wiki.go")) {
   throw new Error("shortcut changes must use the sharded full suite");
 }


### PR DESCRIPTION
## 背景

PR #1345 只修改了 `skills/**`，但现有 `isHighRisk` 没有把这类变更送入 full-suite 分片，导致单个 scoped coverage runner 承担 Skill embed 的反向依赖测试闭包，并多次以 runner shutdown / exit 143 结束。

Skill 会通过 `skills_embed.go` 进入发布二进制并影响 Agent 运行时行为，因此不能归为 docs-only。

## 修改

- 将 `skills/**` 纳入 `isHighRisk`，复用现有 full-suite race/coverage 分片。
- 保留 `skills/**` 现有 Interface Integrity 分类。
- 在 `TestHighRiskClassificationShardsFanoutChanges` 中增加正向路径 `skills/multi/dingtalk-chat/SKILL.md` 和边界反例 `skillsx/...`。

## 验证

- [x] `go test ./test/scripts -run "TestHighRiskClassificationShardsFanoutChanges|TestCoverageWorkflowShardsAndBaselineCache" -count=1`
- [x] `go test ./test/scripts -count=1 -timeout=20m`（使用本机 Xcode 26.0.1 工具链）
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- [x] `./scripts/policy/check-release-fragments.sh origin/main HEAD`
- [x] `git diff --check origin/main...HEAD`

## 风险与回滚

这是 CI-only 修改，不改变 DWS 运行时代码。代价是纯 Skill PR 会运行完整分片、增加 runner 消耗；收益是避免把高扇出的反向依赖覆盖任务压在单个 runner。若需回滚，可直接 revert 本 PR 提交。

Related: #1345