### PR TITLE
fix(schema): approve exact Drive and Wiki contract migrations

### DIFF
--- a/scripts/policy/schema-compat/main.go
+++ b/scripts/policy/schema-compat/main.go
@@ -91,6 +91,27 @@ type reviewedCompatibilityException struct {
 // confirmation drift into a compatible change. Each tool may have multiple
 // field transitions (e.g. confirmation + risk + effect tightened together).
 var reviewedCompatibilityExceptions = map[string][]reviewedCompatibilityException{
+	// PR #1357: align the published Drive/Wiki contract with verified runtime
+	// behavior. Publish status is read-only; unsupported publish enablement is
+	// unavailable to Agents; upload and member removal cross existing runtime
+	// confirmation gates. Each transition is pinned independently.
+	"drive/drive.publish_get": {
+		{Field: "effect", Old: "write", New: "read"},
+		{Field: "risk", Old: "medium", New: "low"},
+		{Field: "idempotency", Old: "unknown", New: "idempotent"},
+	},
+	"drive/drive.publish_set": {
+		{Field: "availability", Old: "available", New: "unavailable"},
+	},
+	"drive/drive.shortcut_publish_set": {
+		{Field: "availability", Old: "available", New: "unavailable"},
+	},
+	"drive/drive.upload": {
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+	},
+	"wiki/wiki.shortcut_member_remove": {
+		{Field: "confirmation", Old: "not_required", New: "user_required"},
+	},
 	// PR #1085: batch permission/member remove is destructive at container
 	// scope — one call can revoke access for up to 30 USER / DEPT /
 	// CONVERSATION / TAG members, and departments, chats, and role groups

--- a/scripts/policy/schema-compat/main_test.go
+++ b/scripts/policy/schema-compat/main_test.go
@@ -415,6 +415,55 @@ func TestSchemaCompatibilityRejectsContractDrift(t *testing.T) {
 	}
 }
 
+func TestCrossPlatformCoverageDriveWikiReviewedContractCorrections(t *testing.T) {
+	base := toolSchema{
+		PrimaryCLIPath: "fixture", InterfaceMode: "local", Availability: "available",
+		Parameters: map[string]parameterSchema{}, Effect: "write", Risk: "medium",
+		Confirmation: "not_required", Idempotency: "unknown",
+	}
+	for _, path := range []string{"drive/drive.publish_get", "drive/drive.publish_set", "drive/drive.shortcut_publish_set", "drive/drive.upload", "wiki/wiki.shortcut_member_remove"} {
+		t.Run(path, func(t *testing.T) {
+			current := base
+			switch path {
+			case "drive/drive.publish_get":
+				current.Effect, current.Risk, current.Idempotency = "read", "low", "idempotent"
+			case "drive/drive.publish_set", "drive/drive.shortcut_publish_set":
+				current.Availability = "unavailable"
+			default:
+				current.Confirmation = "user_required"
+			}
+			if failures := checkToolCompatibility(path, base, current); len(failures) != 0 {
+				t.Fatalf("reviewed correction rejected: %v", failures)
+			}
+			if failures := checkToolCompatibility("other/other.command", base, current); len(failures) == 0 {
+				t.Fatal("correction leaked to an unrelated tool")
+			}
+			if failures := checkToolCompatibility(path, current, base); len(failures) == 0 {
+				t.Fatal("reverse transition was accepted")
+			}
+			current.PrimaryCLIPath = "changed"
+			if failures := checkToolCompatibility(path, base, current); len(failures) == 0 {
+				t.Fatal("unrelated path drift was accepted")
+			}
+		})
+	}
+	for mask := 1; mask < 7; mask++ {
+		current := base
+		if mask&1 != 0 {
+			current.Effect = "read"
+		}
+		if mask&2 != 0 {
+			current.Risk = "low"
+		}
+		if mask&4 != 0 {
+			current.Idempotency = "idempotent"
+		}
+		if failures := checkToolCompatibility("drive/drive.publish_get", base, current); len(failures) == 0 {
+			t.Fatalf("partial correction mask %d was accepted", mask)
+		}
+	}
+}
+
 func TestSchemaCompatibilityAcceptsReviewedRemoveConfirmationHardening(t *testing.T) {
 	oldTool := baselineContract().Products["doc"].Tools["doc.create"]
 	newTool := oldTool


### PR DESCRIPTION
## Summary

为 #1357 的 Drive/Wiki 契约修正预先登记 7 项精确兼容迁移。当前权威 Schema checker 由 merge-base 主干提供，因此这些规则需要先独立审查并合入 main，再由 #1357 同步主干采用。

本 PR 基于 main@1880b0b5，只修改兼容例外表及回归测试，不修改命令声明、运行时行为、Reference、Schema wire 或 CI checker 的权威来源。

| 工具 | 字段 | 旧值 → 新值 |
|---|---|---|
| drive/drive.publish_get | effect | write → read |
| drive/drive.publish_get | risk | medium → low |
| drive/drive.publish_get | idempotency | unknown → idempotent |
| drive/drive.publish_set | availability | available → unavailable |
| drive/drive.shortcut_publish_set | availability | available → unavailable |
| drive/drive.upload | confirmation | not_required → user_required |
| wiki/wiki.shortcut_member_remove | confirmation | not_required → user_required |

查询公开状态属于只读操作；开启公开能力的 Agent 可用性收口及上传/成员移除确认修正在 #1357 实施。这里仅批准精确的字段迁移，不把任意 safety 或 availability 漂移视为兼容。publish_get 的三个字段必须完整匹配，不能拆开借用例外。

## 为什么修改，以及前后影响

| 场景 | 修改前（#1357 修复前） | #1357 修复后 | 可证明的收益与边界 |
|---|---|---|---|
| 查询文件公开状态 | 只读查询被标成 write/medium/unknown | read/low/idempotent，仍无需确认 | 修正 Agent 风险判断；不改变查询 RPC，不声称因此某个 Case 从失败变成功 |
| 开启公开能力 | 普通文件及在线文档样本未验证开启公开闭环，Schema 仍标 available | 两个开启入口标 unavailable；CLI 兼容保留，查询和关闭能力保留 | 避免向 Agent 推荐未验证能力；不等于修复了服务端公开能力，也不是通过隐藏失败样本提高成功率 |
| managed 上传 | 声明无需确认，覆盖路径另有局部门禁，发现与执行不一致 | 声明 user_required，移除覆盖分支的重复局部门禁 | 统一确认契约；正常交互可能多一个确认步骤，不承诺耗时或完成率提高 |
| Wiki 快捷成员移除 | 原生入口要求确认，shortcut 仍允许无需确认执行 | shortcut 同样要求确认 | 防止通过快捷入口绕过确认；未确认零调用、已确认调用及最终 Schema 有回归证据 |

## 关联 Case 与正确率证据

本审批 PR 只改变兼容 checker 的评审规则，业务实现仍在 #1357，因此本 PR 自身没有独立业务正确率提升。

Wiki 成员场景关联 Case 0016/0017/0036/0037/0056/0057/0076/0077。此前轨迹已经携带确认参数，不能将确认门禁修复计为这些 Case 的已证实提分；成员列表与分页的其他 Reference 改动也不能混算成本审批的收益。

Drive 公开状态、公开开启和 managed 上传的字段迁移目前没有隔离的逐 Case 前后对照，不能报告这些字段各自使多少个 Case 转为成功。现有证据支持行为及声明一致性修复，不支持单项正确率因果归因。

功能项目的整体评测记录作为背景：

| 产品 | V1 记录 | 用户选定的本轮复核记录 | 差值 |
|---|---|---|---|
| Wiki，46 Case × 两轮 | 85/92，92.39% | 90/92，97.83%（定向人工复核后） | +5 次，+5.44 个百分点 |
| Drive，106 Case × 两轮 | 199/212，93.87% | 201/212，94.81%（组合复核口径） | +2 次，+0.94 个百分点 |

以上是不同审查/运行记录的比较：Wiki 本轮对原非成功执行定向复核；Drive 是选定组合记录。不是相同 Judge 下的受控 A/B，也不是当前审批提交的新跑测。整体数字不能证明这 7 项契约迁移单独提高了关联 Case 正确率。

## Risk tier

- [ ] Documentation-only
- [ ] Standard
- [x] High-risk — 修改 Schema 兼容治理规则；使用既有精确例外机制，未放宽通用比较逻辑。

## Verification

- [x] `go test ./scripts/policy/schema-compat -count=1`：整个包通过（0.673s）。
- [x] `TestCrossPlatformCoverageDriveWikiReviewedContractCorrections`：五个工具完整迁移通过；其他工具借用、反向迁移、CLI 路径漂移及 publish_get 的六种部分迁移仍被拒绝。
- [x] 既有 `TestSchemaCompatibilityRejectsContractDrift` 保持通过。
- [x] gofmt 和 `git diff --check` 通过。
- Release fragment：N/A，仅治理规则及测试，不改变用户命令行为。
- Release-seal / packaging / generated drift / command surface：N/A，没有对应变更。
- 全量本地 suite：未重复运行，远端 high-risk CI 结果以实际 Checks 为准。

## Notes

只有两个文件，新增 70 行。此 PR 是 #1357 的前置审批，不包含 #1357 的业务实现或 Agent 性能成果。合入 main 后，#1357 仍需同步主干并重新通过完整 CI；本 PR 不代表该功能 PR 已获最终批准。
