### PR TITLE
docs: add missing beta.8 release fragments

### DIFF
--- a/.changes/1331-mcpdev-endpoint.md
+++ b/.changes/1331-mcpdev-endpoint.md
@@ -1,0 +1,7 @@
+---
+category: Fixed
+---
+
+- **Direct-runtime MCP endpoint resolution** (#1331) — restore the
+  environment-aware `mcpdev` endpoint so `dws dev mcp` commands reach the
+  backend instead of failing locally with `endpoint_not_resolved`.

--- a/.changes/1346-oa-template-management.md
+++ b/.changes/1346-oa-template-management.md
@@ -1,0 +1,8 @@
+---
+category: Added
+---
+
+- **OA approval template management** (#1346) — add
+  `dws oa approval template list` and `detail --template-code <code>` for
+  querying manageable approval templates, form schemas, and process
+  configuration.

--- a/.changes/1351-oa-approval-response-types.md
+++ b/.changes/1351-oa-approval-response-types.md
@@ -1,0 +1,7 @@
+---
+category: Fixed
+---
+
+- **OA approval list response types** (#1351) — normalize `success` to a
+  boolean and numeric error codes to `errorCode` for pending, submitted, and
+  copied approval lists while preserving business data and diagnostics.


### PR DESCRIPTION
## Summary

- add the missing release fragment for #1331 (`dws dev mcp` endpoint resolution)
- add the missing release fragment for #1346 (OA approval template list/detail)
- add the missing release fragment for #1351 (OA approval list response types)
- keep `CHANGELOG.md` unchanged; the unique `v1.0.62-beta.8` release-seal PR will render and archive these fragments together with the existing active set

## Release scope

This is release metadata only for three already-merged PRs in the frozen 18-PR beta.8 product scope. It adds no product or workflow code.

## Verification

- `git diff --check origin/main...HEAD`
- `./scripts/policy/check-release-fragments.sh origin/main HEAD`
- `./scripts/policy/open-source-audit.sh`
- `DWS_PACKAGE_VERSION=0.0.0-test go test ./test/scripts -run 'TestReleaseFragmentPolicy|TestReleasePrepareChangelog' -count=1`
